### PR TITLE
chore(ci): use new installation script

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,11 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref_type == 'tag' # Guard to make sure we are releasing once
     permissions:
-      id-token: write # required to use OIDC and retrieve Google Cloud Credentials
-      contents: write # required for goreleaser
+      contents: write # required for goreleaser to upload the release assets
       packages: write # to push container images
     env:
-      CHAINLOOP_VERSION: 0.8.89
+      CHAINLOOP_VERSION: 0.8.92
       CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT }}
       CONTAINER_IMAGE_CP: ghcr.io/chainloop-dev/chainloop/control-plane:${{ github.ref_name }}
       CONTAINER_IMAGE_CAS: ghcr.io/chainloop-dev/chainloop/artifact-cas:${{ github.ref_name }}
@@ -29,7 +28,7 @@ jobs:
 
       - name: Install Chainloop
         run: |
-          curl -sfL https://chainloop.dev/install.sh | bash -s -- --version v${{ env.CHAINLOOP_VERSION }}
+          curl -sfL https://docs.chainloop.dev/install.sh | bash -s -- --version v${{ env.CHAINLOOP_VERSION }}
 
       - name: Download jq
         run: |
@@ -44,15 +43,6 @@ jobs:
       - name: Initialize Attestation
         run: |
           chainloop attestation init
-
-      # TODO: remove once we move the releases and the installation script to Github
-      - name: "Configure Google Cloud credentials"
-        id: "auth-google"
-        uses: "google-github-actions/auth@v0"
-        with:
-          token_format: "access_token"
-          workload_identity_provider: projects/1044976554810/locations/global/workloadIdentityPools/chainloop-github-pool/providers/github-provider
-          service_account: chainloop-release-github@bedrock-371810.iam.gserviceaccount.com
 
       - name: Docker login to Github Packages
         uses: docker/login-action@v2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,12 +51,6 @@ signs:
       ]
     artifacts: all
 
-# TODO: remove once we move the releases and the installation script to Github
-blobs:
-  - provider: gs
-    bucket: chainloop-releases-public
-    folder: "cli/{{ .Version }}"
-
 docker_signs:
   # COSIGN_PASSWORD is also required to be present
   - cmd: cosign


### PR DESCRIPTION
The official installation script has been added to a public repository under a new location `https://docs.chainloop.dev/install.sh` https://github.com/chainloop-dev/docs/pull/76

This new script leverages publicly available GitHub releases and hence we do not need to push artifacts to Google Blob Storage anymore.

Closes #7 