### PR TITLE
refactor: consolidate credentials service interface

### DIFF
--- a/app/cli/cmd/workflow_contract_describe.go
+++ b/app/cli/cmd/workflow_contract_describe.go
@@ -70,8 +70,8 @@ func encodeContractOutput(run *action.WorkflowContractWithVersionItem) error {
 
 	switch flagOutputFormat {
 	case formatContract:
-		marshaller := protojson.MarshalOptions{Indent: "  "}
-		rawBody, err := marshaller.Marshal(run.Revision.BodyV1)
+		marshaler := protojson.MarshalOptions{Indent: "  "}
+		rawBody, err := marshaler.Marshal(run.Revision.BodyV1)
 		if err != nil {
 			return err
 		}
@@ -86,8 +86,8 @@ func encodeContractOutput(run *action.WorkflowContractWithVersionItem) error {
 func contractDescribeTableOutput(contractWithVersion *action.WorkflowContractWithVersionItem) error {
 	revision := contractWithVersion.Revision
 
-	marshaller := protojson.MarshalOptions{Indent: "  "}
-	rawBody, err := marshaller.Marshal(revision.BodyV1)
+	marshaler := protojson.MarshalOptions{Indent: "  "}
+	rawBody, err := marshaler.Marshal(revision.BodyV1)
 	if err != nil {
 		return err
 	}

--- a/app/cli/internal/action/workflow_run_describe.go
+++ b/app/cli/internal/action/workflow_run_describe.go
@@ -122,7 +122,7 @@ func (action *WorkflowRunDescribe) Run(runID string, verify bool, publicKey stri
 	}
 
 	if err := json.Unmarshal(decodedPayload, statement); err != nil {
-		return nil, fmt.Errorf("unmarshalling predicate: %w", err)
+		return nil, fmt.Errorf("un-marshaling predicate: %w", err)
 	}
 
 	var predicate *renderer.ChainloopProvenancePredicateV1
@@ -159,12 +159,12 @@ func (action *WorkflowRunDescribe) Run(runID string, verify bool, publicKey stri
 func extractPredicateV1(statement *in_toto.Statement) (*renderer.ChainloopProvenancePredicateV1, error) {
 	jsonPredicate, err := json.Marshal(statement.Predicate)
 	if err != nil {
-		return nil, fmt.Errorf("unmarshalling predicate: %w", err)
+		return nil, fmt.Errorf("un-marshaling predicate: %w", err)
 	}
 
 	predicate := &renderer.ChainloopProvenancePredicateV1{}
 	if err := json.Unmarshal(jsonPredicate, predicate); err != nil {
-		return nil, fmt.Errorf("unmarshalling predicate: %w", err)
+		return nil, fmt.Errorf("un-marshaling predicate: %w", err)
 	}
 
 	return predicate, nil

--- a/app/controlplane/internal/biz/attestation.go
+++ b/app/controlplane/internal/biz/attestation.go
@@ -85,7 +85,7 @@ func doUploadToOCI(ctx context.Context, backend backend.Uploader, runID string, 
 	fileName := fmt.Sprintf("attestation-%s.json", runID)
 	jsonContent, err := json.Marshal(envelope)
 	if err != nil {
-		return "", fmt.Errorf("marshalling the envelope: %w", err)
+		return "", fmt.Errorf("marshaling the envelope: %w", err)
 	}
 
 	hash := sha256.New()

--- a/app/controlplane/internal/biz/ocirepository_test.go
+++ b/app/controlplane/internal/biz/ocirepository_test.go
@@ -85,7 +85,7 @@ func (s *ociRepositoryTestSuite) TestSaveMainRepoAlreadyExist() {
 	r := &biz.OCIRepository{ID: s.validUUID.String()}
 	ctx := context.Background()
 	s.repo.On("FindMainRepo", ctx, s.validUUID).Return(r, nil)
-	s.credsRW.On("SaveOCICreds", ctx, s.validUUID.String(), mock.Anything).Return("secret-key", nil)
+	s.credsRW.On("SaveCredentials", ctx, s.validUUID.String(), mock.Anything).Return("secret-key", nil)
 	s.repo.On("Update", ctx, &biz.OCIRepoUpdateOpts{
 		ID: s.validUUID,
 		OCIRepoOpts: &biz.OCIRepoOpts{
@@ -105,7 +105,7 @@ func (s *ociRepositoryTestSuite) TestSaveMainRepoOk() {
 	const repo, username, password = "repo", "username", "pass"
 
 	s.repo.On("FindMainRepo", ctx, s.validUUID).Return(nil, nil)
-	s.credsRW.On("SaveOCICreds", ctx, s.validUUID.String(), mock.Anything).Return("secret-key", nil)
+	s.credsRW.On("SaveCredentials", ctx, s.validUUID.String(), mock.Anything).Return("secret-key", nil)
 
 	newRepo := &biz.OCIRepository{}
 	s.repo.On("Create", ctx, &biz.OCIRepoCreateOpts{

--- a/app/controlplane/internal/biz/organization_integration_test.go
+++ b/app/controlplane/internal/biz/organization_integration_test.go
@@ -53,8 +53,8 @@ func (s *OrgIntegrationTestSuite) TestDeleteOrg() {
 
 	s.T().Run("org, integrations and repositories deletion", func(t *testing.T) {
 		// Mock calls to credentials deletion for both the integration and the OCI repository
-		s.mockedCredsReaderWriter.On("DeleteCreds", ctx, "stored-integration-secret").Return(nil)
-		s.mockedCredsReaderWriter.On("DeleteCreds", ctx, "stored-OCI-secret").Return(nil)
+		s.mockedCredsReaderWriter.On("DeleteCredentials", ctx, "stored-integration-secret").Return(nil)
+		s.mockedCredsReaderWriter.On("DeleteCredentials", ctx, "stored-OCI-secret").Return(nil)
 
 		err := s.Organization.Delete(ctx, s.org.ID)
 		assert.NoError(err)
@@ -102,12 +102,12 @@ func (s *OrgIntegrationTestSuite) SetupTest() {
 
 	// Dependency-track integration credentials
 	s.mockedCredsReaderWriter.On(
-		"SaveAPICreds", ctx, mock.Anything, &credentials.APICreds{Host: "host", Key: "key"},
+		"SaveCredentials", ctx, mock.Anything, &credentials.APICreds{Host: "host", Key: "key"},
 	).Return("stored-integration-secret", nil)
 
 	// OCI repository credentials
 	s.mockedCredsReaderWriter.On(
-		"SaveOCICreds", ctx, mock.Anything, &credentials.OCIKeypair{Repo: "repo", Username: "username", Password: "pass"},
+		"SaveCredentials", ctx, mock.Anything, &credentials.OCIKeypair{Repo: "repo", Username: "username", Password: "pass"},
 	).Return("stored-OCI-secret", nil)
 
 	s.TestingUseCases = testhelpers.NewTestingUseCases(t, testhelpers.WithCredsReaderWriter(s.mockedCredsReaderWriter))

--- a/app/controlplane/internal/service/attestation.go
+++ b/app/controlplane/internal/service/attestation.go
@@ -503,7 +503,7 @@ func doSendToDependencyTrack(ctx context.Context, credsReader credentials.Reader
 	attachmentConfig := i.IntegrationAttachment.Config.GetDependencyTrack()
 
 	creds := &credentials.APICreds{}
-	if err := credsReader.ReadAPICreds(ctx, i.SecretName, creds); err != nil {
+	if err := credsReader.ReadCredentials(ctx, i.SecretName, creds); err != nil {
 		return err
 	}
 

--- a/app/controlplane/internal/service/attestation.go
+++ b/app/controlplane/internal/service/attestation.go
@@ -312,7 +312,7 @@ func extractPredicate(envelope *dsse.Envelope) (*renderer.ChainloopProvenancePre
 
 	statement := &in_toto.Statement{}
 	if err := json.Unmarshal(decodedPayload, statement); err != nil {
-		return nil, fmt.Errorf("unmarshalling predicate: %w", err)
+		return nil, fmt.Errorf("un-marshaling predicate: %w", err)
 	}
 
 	var predicate *renderer.ChainloopProvenancePredicateV1
@@ -370,12 +370,12 @@ func extractMaterials(in []*renderer.ChainloopProvenanceMaterial) []*cpAPI.Attes
 func extractPredicateV1(statement *in_toto.Statement) (*renderer.ChainloopProvenancePredicateV1, error) {
 	jsonPredicate, err := json.Marshal(statement.Predicate)
 	if err != nil {
-		return nil, fmt.Errorf("unmarshalling predicate: %w", err)
+		return nil, fmt.Errorf("un-marshaling predicate: %w", err)
 	}
 
 	predicate := &renderer.ChainloopProvenancePredicateV1{}
 	if err := json.Unmarshal(jsonPredicate, predicate); err != nil {
-		return nil, fmt.Errorf("unmarshalling predicate: %w", err)
+		return nil, fmt.Errorf("un-marshaling predicate: %w", err)
 	}
 
 	return predicate, nil

--- a/internal/attestation/crafter/crafter.go
+++ b/internal/attestation/crafter/crafter.go
@@ -87,7 +87,7 @@ func NewCrafter(opts ...NewOpt) *Crafter {
 type InitOpts struct {
 	// Control plane workflow metadata
 	WfInfo *api.WorkflowMetadata
-	// already marshalled schema
+	// already marshaled schema
 	SchemaV1 *schemaapi.CraftingSchema
 	// do not record, upload or push attestation
 	DryRun bool
@@ -243,8 +243,8 @@ func initialCraftingState(schema *schemaapi.CraftingSchema, wf *api.WorkflowMeta
 }
 
 func persistCraftingState(craftState *api.CraftingState, stateFilePath string) error {
-	marshaller := protojson.MarshalOptions{Indent: "  "}
-	raw, err := marshaller.Marshal(craftState)
+	marshaler := protojson.MarshalOptions{Indent: "  "}
+	raw, err := marshaler.Marshal(craftState)
 	if err != nil {
 		return err
 	}

--- a/internal/blobmanager/oci/provider.go
+++ b/internal/blobmanager/oci/provider.go
@@ -17,6 +17,7 @@ package oci
 
 import (
 	"context"
+	"fmt"
 
 	backend "github.com/chainloop-dev/chainloop/internal/blobmanager"
 	"github.com/chainloop-dev/chainloop/internal/credentials"
@@ -35,8 +36,12 @@ func NewBackendProvider(cReader credentials.Reader) *BackendProvider {
 
 func (p *BackendProvider) FromCredentials(ctx context.Context, secretName string) (backend.UploaderDownloader, error) {
 	creds := &credentials.OCIKeypair{}
-	if err := p.cReader.ReadOCICreds(ctx, secretName, creds); err != nil {
+	if err := p.cReader.ReadCredentials(ctx, secretName, creds); err != nil {
 		return nil, err
+	}
+
+	if err := creds.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid credentials retrieved from storage: %w", err)
 	}
 
 	k, err := ociauth.NewCredentials(creds.Repo, creds.Username, creds.Password)

--- a/internal/blobmanager/oci/provider_test.go
+++ b/internal/blobmanager/oci/provider_test.go
@@ -32,7 +32,7 @@ func TestFromCredentials(t *testing.T) {
 	r := mocks.NewReader(t)
 	const repo, password, username = "repo", "password", "username"
 
-	r.On("ReadOCICreds", ctx, "secretName", mock.AnythingOfType("*credentials.OCIKeypair")).Return(nil).Run(
+	r.On("ReadCredentials", ctx, "secretName", mock.AnythingOfType("*credentials.OCIKeypair")).Return(nil).Run(
 		func(args mock.Arguments) {
 			credentials := args.Get(2).(*credentials.OCIKeypair)
 			credentials.Repo = repo

--- a/internal/credentials/aws/secretmanager.go
+++ b/internal/credentials/aws/secretmanager.go
@@ -84,14 +84,14 @@ func NewManager(opts *NewManagerOpts) (*Manager, error) {
 }
 
 // Save Credentials, this is a generic function that can be used to save any type of credentials
-// as long as they can be passed to json.Marshall
+// as long as they can be passed to json.Marshal
 func (m *Manager) SaveCredentials(ctx context.Context, orgID string, creds any) (string, error) {
 	secretName := strings.Join([]string{m.secretPrefix, orgID, uuid.Generate().String()}, "/")
 
 	// Store the credentials as json key pairs
 	c, err := json.Marshal(creds)
 	if err != nil {
-		return "", fmt.Errorf("marshalling credentials to be stored: %w", err)
+		return "", fmt.Errorf("marshaling credentials to be stored: %w", err)
 	}
 
 	if _, err = m.client.CreateSecret(ctx, &secretsmanager.CreateSecretInput{

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -40,7 +40,6 @@ type Writer interface {
 }
 
 type Reader interface {
-	// credentials must implement marshall/unmarshall
 	ReadCredentials(ctx context.Context, secretName string, credentials any) error
 }
 

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -34,16 +34,14 @@ type ReaderWriter interface {
 	Writer
 }
 
-// TODO: Add generics
 type Writer interface {
-	SaveAPICreds(ctx context.Context, org string, creds *APICreds) (string, error)
-	SaveOCICreds(ctx context.Context, org string, creds *OCIKeypair) (string, error)
-	DeleteCreds(ctx context.Context, credID string) error
+	SaveCredentials(ctx context.Context, org string, credentials any) (string, error)
+	DeleteCredentials(ctx context.Context, credID string) error
 }
 
 type Reader interface {
-	ReadAPICreds(ctx context.Context, secretName string, creds *APICreds) error
-	ReadOCICreds(ctx context.Context, secretName string, creds *OCIKeypair) error
+	// credentials must implement marshall/unmarshall
+	ReadCredentials(ctx context.Context, secretName string, credentials any) error
 }
 
 var ErrNotFound = errors.New("credentials not found")

--- a/internal/credentials/credentials_test.go
+++ b/internal/credentials/credentials_test.go
@@ -1,0 +1,76 @@
+//
+// Copyright 2023 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package credentials_test
+
+import (
+	"testing"
+
+	"github.com/chainloop-dev/chainloop/internal/credentials"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateAPICreds(t *testing.T) {
+	assert := assert.New(t)
+
+	testCases := []struct {
+		name      string
+		input     *credentials.APICreds
+		wantError bool
+	}{
+		{"empty secret", &credentials.APICreds{}, true},
+		{"missing host", &credentials.APICreds{Host: "", Key: "p"}, true},
+		{"missing key", &credentials.APICreds{Host: "host", Key: ""}, true},
+		{"valid creds", &credentials.APICreds{Host: "h", Key: "p"}, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.input.Validate()
+			if tc.wantError {
+				assert.Error(err)
+			} else {
+				assert.NoError(err)
+			}
+		})
+	}
+}
+
+func TestValidateOCIKeyPair(t *testing.T) {
+	assert := assert.New(t)
+
+	testCases := []struct {
+		name      string
+		input     *credentials.OCIKeypair
+		wantError bool
+	}{
+		{"empty secret", &credentials.OCIKeypair{}, true},
+		{"missing repo", &credentials.OCIKeypair{Username: "un", Password: "p"}, true},
+		{"missing username", &credentials.OCIKeypair{Username: "", Password: "p", Repo: "repo"}, true},
+		{"missing password", &credentials.OCIKeypair{Username: "u", Password: "", Repo: "repo"}, true},
+		{"valid creds", &credentials.OCIKeypair{Username: "u", Password: "p", Repo: "repo"}, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.input.Validate()
+			if tc.wantError {
+				assert.Error(err)
+			} else {
+				assert.NoError(err)
+			}
+		})
+	}
+}

--- a/internal/credentials/mocks/Reader.go
+++ b/internal/credentials/mocks/Reader.go
@@ -5,7 +5,6 @@ package mocks
 import (
 	context "context"
 
-	credentials "github.com/chainloop-dev/chainloop/internal/credentials"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -14,27 +13,13 @@ type Reader struct {
 	mock.Mock
 }
 
-// ReadAPICreds provides a mock function with given fields: ctx, secretName, creds
-func (_m *Reader) ReadAPICreds(ctx context.Context, secretName string, creds *credentials.APICreds) error {
-	ret := _m.Called(ctx, secretName, creds)
+// ReadCredentials provides a mock function with given fields: ctx, secretName, _a2
+func (_m *Reader) ReadCredentials(ctx context.Context, secretName string, _a2 interface{}) error {
+	ret := _m.Called(ctx, secretName, _a2)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, *credentials.APICreds) error); ok {
-		r0 = rf(ctx, secretName, creds)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// ReadOCICreds provides a mock function with given fields: ctx, secretName, creds
-func (_m *Reader) ReadOCICreds(ctx context.Context, secretName string, creds *credentials.OCIKeypair) error {
-	ret := _m.Called(ctx, secretName, creds)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, *credentials.OCIKeypair) error); ok {
-		r0 = rf(ctx, secretName, creds)
+	if rf, ok := ret.Get(0).(func(context.Context, string, interface{}) error); ok {
+		r0 = rf(ctx, secretName, _a2)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/internal/credentials/mocks/ReaderWriter.go
+++ b/internal/credentials/mocks/ReaderWriter.go
@@ -5,7 +5,6 @@ package mocks
 import (
 	context "context"
 
-	credentials "github.com/chainloop-dev/chainloop/internal/credentials"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -14,8 +13,8 @@ type ReaderWriter struct {
 	mock.Mock
 }
 
-// DeleteCreds provides a mock function with given fields: ctx, credID
-func (_m *ReaderWriter) DeleteCreds(ctx context.Context, credID string) error {
+// DeleteCredentials provides a mock function with given fields: ctx, credID
+func (_m *ReaderWriter) DeleteCredentials(ctx context.Context, credID string) error {
 	ret := _m.Called(ctx, credID)
 
 	var r0 error
@@ -28,13 +27,13 @@ func (_m *ReaderWriter) DeleteCreds(ctx context.Context, credID string) error {
 	return r0
 }
 
-// ReadAPICreds provides a mock function with given fields: ctx, secretName, creds
-func (_m *ReaderWriter) ReadAPICreds(ctx context.Context, secretName string, creds *credentials.APICreds) error {
-	ret := _m.Called(ctx, secretName, creds)
+// ReadCredentials provides a mock function with given fields: ctx, secretName, _a2
+func (_m *ReaderWriter) ReadCredentials(ctx context.Context, secretName string, _a2 interface{}) error {
+	ret := _m.Called(ctx, secretName, _a2)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, *credentials.APICreds) error); ok {
-		r0 = rf(ctx, secretName, creds)
+	if rf, ok := ret.Get(0).(func(context.Context, string, interface{}) error); ok {
+		r0 = rf(ctx, secretName, _a2)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -42,61 +41,23 @@ func (_m *ReaderWriter) ReadAPICreds(ctx context.Context, secretName string, cre
 	return r0
 }
 
-// ReadOCICreds provides a mock function with given fields: ctx, secretName, creds
-func (_m *ReaderWriter) ReadOCICreds(ctx context.Context, secretName string, creds *credentials.OCIKeypair) error {
-	ret := _m.Called(ctx, secretName, creds)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, *credentials.OCIKeypair) error); ok {
-		r0 = rf(ctx, secretName, creds)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// SaveAPICreds provides a mock function with given fields: ctx, org, creds
-func (_m *ReaderWriter) SaveAPICreds(ctx context.Context, org string, creds *credentials.APICreds) (string, error) {
-	ret := _m.Called(ctx, org, creds)
+// SaveCredentials provides a mock function with given fields: ctx, org, _a2
+func (_m *ReaderWriter) SaveCredentials(ctx context.Context, org string, _a2 interface{}) (string, error) {
+	ret := _m.Called(ctx, org, _a2)
 
 	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, *credentials.APICreds) (string, error)); ok {
-		return rf(ctx, org, creds)
+	if rf, ok := ret.Get(0).(func(context.Context, string, interface{}) (string, error)); ok {
+		return rf(ctx, org, _a2)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, *credentials.APICreds) string); ok {
-		r0 = rf(ctx, org, creds)
+	if rf, ok := ret.Get(0).(func(context.Context, string, interface{}) string); ok {
+		r0 = rf(ctx, org, _a2)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, *credentials.APICreds) error); ok {
-		r1 = rf(ctx, org, creds)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// SaveOCICreds provides a mock function with given fields: ctx, org, creds
-func (_m *ReaderWriter) SaveOCICreds(ctx context.Context, org string, creds *credentials.OCIKeypair) (string, error) {
-	ret := _m.Called(ctx, org, creds)
-
-	var r0 string
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, *credentials.OCIKeypair) (string, error)); ok {
-		return rf(ctx, org, creds)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, *credentials.OCIKeypair) string); ok {
-		r0 = rf(ctx, org, creds)
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, string, *credentials.OCIKeypair) error); ok {
-		r1 = rf(ctx, org, creds)
+	if rf, ok := ret.Get(1).(func(context.Context, string, interface{}) error); ok {
+		r1 = rf(ctx, org, _a2)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/internal/credentials/mocks/Writer.go
+++ b/internal/credentials/mocks/Writer.go
@@ -5,7 +5,6 @@ package mocks
 import (
 	context "context"
 
-	credentials "github.com/chainloop-dev/chainloop/internal/credentials"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -14,8 +13,8 @@ type Writer struct {
 	mock.Mock
 }
 
-// DeleteCreds provides a mock function with given fields: ctx, credID
-func (_m *Writer) DeleteCreds(ctx context.Context, credID string) error {
+// DeleteCredentials provides a mock function with given fields: ctx, credID
+func (_m *Writer) DeleteCredentials(ctx context.Context, credID string) error {
 	ret := _m.Called(ctx, credID)
 
 	var r0 error
@@ -28,47 +27,23 @@ func (_m *Writer) DeleteCreds(ctx context.Context, credID string) error {
 	return r0
 }
 
-// SaveAPICreds provides a mock function with given fields: ctx, org, creds
-func (_m *Writer) SaveAPICreds(ctx context.Context, org string, creds *credentials.APICreds) (string, error) {
-	ret := _m.Called(ctx, org, creds)
+// SaveCredentials provides a mock function with given fields: ctx, org, _a2
+func (_m *Writer) SaveCredentials(ctx context.Context, org string, _a2 interface{}) (string, error) {
+	ret := _m.Called(ctx, org, _a2)
 
 	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, *credentials.APICreds) (string, error)); ok {
-		return rf(ctx, org, creds)
+	if rf, ok := ret.Get(0).(func(context.Context, string, interface{}) (string, error)); ok {
+		return rf(ctx, org, _a2)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, *credentials.APICreds) string); ok {
-		r0 = rf(ctx, org, creds)
+	if rf, ok := ret.Get(0).(func(context.Context, string, interface{}) string); ok {
+		r0 = rf(ctx, org, _a2)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, *credentials.APICreds) error); ok {
-		r1 = rf(ctx, org, creds)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// SaveOCICreds provides a mock function with given fields: ctx, org, creds
-func (_m *Writer) SaveOCICreds(ctx context.Context, org string, creds *credentials.OCIKeypair) (string, error) {
-	ret := _m.Called(ctx, org, creds)
-
-	var r0 string
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, *credentials.OCIKeypair) (string, error)); ok {
-		return rf(ctx, org, creds)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, *credentials.OCIKeypair) string); ok {
-		r0 = rf(ctx, org, creds)
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, string, *credentials.OCIKeypair) error); ok {
-		r1 = rf(ctx, org, creds)
+	if rf, ok := ret.Get(1).(func(context.Context, string, interface{}) error); ok {
+		r1 = rf(ctx, org, _a2)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/internal/credentials/vault/keyval.go
+++ b/internal/credentials/vault/keyval.go
@@ -136,8 +136,6 @@ func (m *Manager) ReadCredentials(ctx context.Context, secretID string, creds an
 		return fmt.Errorf("converting secret to struct: %w", err)
 	}
 
-	fmt.Printf("READING %+v", creds)
-
 	return nil
 }
 


### PR DESCRIPTION
Updates the credentials Reader/Writer Interface to have a single method regardless of the kind of payload stored. The responsibility of the marshalling type check is on the caller size. 

Closes #22 