### PR TITLE
chore: decouple cas-client file upload

### DIFF
--- a/app/cli/internal/action/artifact_upload.go
+++ b/app/cli/internal/action/artifact_upload.go
@@ -63,7 +63,7 @@ func (a *ArtifactUpload) Run(filePath string) (*CASArtifact, error) {
 	go renderOperationStatus(context.Background(), client.ProgressStatus, info.Size())
 	defer close(client.ProgressStatus)
 
-	res, err := client.Upload(context.Background(), filePath)
+	res, err := client.UploadFile(context.Background(), filePath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/attestation/crafter/materials/artifact.go
+++ b/internal/attestation/crafter/materials/artifact.go
@@ -43,7 +43,7 @@ func NewArtifactCrafter(schema *schemaapi.CraftingSchema_Material, uploader casc
 
 // Craft will calculate the digest of the artifact, simulate an upload and return the material definition
 func (i *ArtifactCrafter) Craft(ctx context.Context, artifactPath string) (*api.Attestation_Material, error) {
-	result, err := i.uploader.Upload(ctx, artifactPath)
+	result, err := i.uploader.UploadFile(ctx, artifactPath)
 	if err != nil {
 		i.logger.Debug().Err(err)
 		return nil, err

--- a/internal/attestation/crafter/materials/artifact_test.go
+++ b/internal/attestation/crafter/materials/artifact_test.go
@@ -64,7 +64,7 @@ func TestNewArtifactCrafter(t *testing.T) {
 	}
 }
 
-func TestArtifacftCraft(t *testing.T) {
+func TestArtifactCraft(t *testing.T) {
 	assert := assert.New(t)
 	schema := &contractAPI.CraftingSchema_Material{
 		Name: "test",
@@ -75,7 +75,7 @@ func TestArtifacftCraft(t *testing.T) {
 
 	// Mock uploader
 	uploader := mUploader.NewUploader(t)
-	uploader.On("Upload", context.TODO(), "file.txt").
+	uploader.On("UploadFile", context.TODO(), "file.txt").
 		Return(&casclient.UpDownStatus{
 			Digest:   "deadbeef",
 			Filename: "file.txt",

--- a/internal/attestation/crafter/materials/cyclonedxjson.go
+++ b/internal/attestation/crafter/materials/cyclonedxjson.go
@@ -64,7 +64,7 @@ func (i *CyclonedxJSONCrafter) Craft(ctx context.Context, filePath string) (*api
 		return nil, fmt.Errorf("invalid cyclonedx sbom file: %w", ErrInvalidMaterialType)
 	}
 
-	result, err := i.uploader.Upload(ctx, filePath)
+	result, err := i.uploader.UploadFile(ctx, filePath)
 	if err != nil {
 		i.logger.Debug().Err(err)
 		return nil, err

--- a/internal/attestation/crafter/materials/cyclonedxjson_test.go
+++ b/internal/attestation/crafter/materials/cyclonedxjson_test.go
@@ -102,7 +102,7 @@ func TestCyclonedxJSONCraft(t *testing.T) {
 			// Mock uploader
 			uploader := mUploader.NewUploader(t)
 			if tc.wantErr == "" {
-				uploader.On("Upload", context.TODO(), tc.filePath).
+				uploader.On("UploadFile", context.TODO(), tc.filePath).
 					Return(&casclient.UpDownStatus{
 						Digest:   "deadbeef",
 						Filename: "sbom.cyclonedx.json",

--- a/internal/attestation/crafter/materials/spdxjson.go
+++ b/internal/attestation/crafter/materials/spdxjson.go
@@ -59,7 +59,7 @@ func (i *SPDXJSONCrafter) Craft(ctx context.Context, filePath string) (*api.Atte
 		return nil, fmt.Errorf("invalid spdx sbom file: %w", ErrInvalidMaterialType)
 	}
 
-	result, err := i.uploader.Upload(ctx, filePath)
+	result, err := i.uploader.UploadFile(ctx, filePath)
 	if err != nil {
 		i.logger.Debug().Err(err)
 		return nil, err

--- a/internal/attestation/crafter/materials/spdxjson_test.go
+++ b/internal/attestation/crafter/materials/spdxjson_test.go
@@ -102,7 +102,7 @@ func TestSPDXJSONCraft(t *testing.T) {
 			// Mock uploader
 			uploader := mUploader.NewUploader(t)
 			if tc.wantErr == "" {
-				uploader.On("Upload", context.TODO(), tc.filePath).
+				uploader.On("UploadFile", context.TODO(), tc.filePath).
 					Return(&casclient.UpDownStatus{
 						Digest:   "deadbeef",
 						Filename: "sbom.spdx.json",

--- a/internal/casclient/casclient.go
+++ b/internal/casclient/casclient.go
@@ -24,8 +24,8 @@ import (
 )
 
 type UpDownStatus struct {
-	Filepath, Filename, Digest string
-	ProcessedBytes             int64
+	Filename, Digest string
+	ProcessedBytes   int64
 }
 
 type ResourceInfo struct {
@@ -35,7 +35,8 @@ type ResourceInfo struct {
 }
 
 type Uploader interface {
-	Upload(ctx context.Context, filepath string) (*UpDownStatus, error)
+	UploadFile(ctx context.Context, filepath string) (*UpDownStatus, error)
+	Upload(ctx context.Context, r io.Reader, digest, fileName string) (*UpDownStatus, error)
 }
 
 type Downloader interface {

--- a/internal/casclient/mocks/DownloaderUploader.go
+++ b/internal/casclient/mocks/DownloaderUploader.go
@@ -31,8 +31,34 @@ func (_m *DownloaderUploader) Download(ctx context.Context, w io.Writer, digest 
 	return r0
 }
 
-// Upload provides a mock function with given fields: ctx, filepath
-func (_m *DownloaderUploader) Upload(ctx context.Context, filepath string) (*casclient.UpDownStatus, error) {
+// Upload provides a mock function with given fields: ctx, r, digest, fileName
+func (_m *DownloaderUploader) Upload(ctx context.Context, r io.Reader, digest string, fileName string) (*casclient.UpDownStatus, error) {
+	ret := _m.Called(ctx, r, digest, fileName)
+
+	var r0 *casclient.UpDownStatus
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, io.Reader, string, string) (*casclient.UpDownStatus, error)); ok {
+		return rf(ctx, r, digest, fileName)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, io.Reader, string, string) *casclient.UpDownStatus); ok {
+		r0 = rf(ctx, r, digest, fileName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*casclient.UpDownStatus)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, io.Reader, string, string) error); ok {
+		r1 = rf(ctx, r, digest, fileName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// UploadFile provides a mock function with given fields: ctx, filepath
+func (_m *DownloaderUploader) UploadFile(ctx context.Context, filepath string) (*casclient.UpDownStatus, error) {
 	ret := _m.Called(ctx, filepath)
 
 	var r0 *casclient.UpDownStatus

--- a/internal/casclient/mocks/Uploader.go
+++ b/internal/casclient/mocks/Uploader.go
@@ -7,6 +7,8 @@ import (
 
 	casclient "github.com/chainloop-dev/chainloop/internal/casclient"
 
+	io "io"
+
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -15,8 +17,34 @@ type Uploader struct {
 	mock.Mock
 }
 
-// Upload provides a mock function with given fields: ctx, filepath
-func (_m *Uploader) Upload(ctx context.Context, filepath string) (*casclient.UpDownStatus, error) {
+// Upload provides a mock function with given fields: ctx, r, digest, fileName
+func (_m *Uploader) Upload(ctx context.Context, r io.Reader, digest string, fileName string) (*casclient.UpDownStatus, error) {
+	ret := _m.Called(ctx, r, digest, fileName)
+
+	var r0 *casclient.UpDownStatus
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, io.Reader, string, string) (*casclient.UpDownStatus, error)); ok {
+		return rf(ctx, r, digest, fileName)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, io.Reader, string, string) *casclient.UpDownStatus); ok {
+		r0 = rf(ctx, r, digest, fileName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*casclient.UpDownStatus)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, io.Reader, string, string) error); ok {
+		r1 = rf(ctx, r, digest, fileName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// UploadFile provides a mock function with given fields: ctx, filepath
+func (_m *Uploader) UploadFile(ctx context.Context, filepath string) (*casclient.UpDownStatus, error) {
 	ret := _m.Called(ctx, filepath)
 
 	var r0 *casclient.UpDownStatus

--- a/internal/casclient/uploader.go
+++ b/internal/casclient/uploader.go
@@ -37,9 +37,6 @@ const defaultUploadChunkSize = 1048576 // 1MB
 
 // Uploads a given file to a CAS server
 func (c *Client) UploadFile(ctx context.Context, filepath string) (*UpDownStatus, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	// open file and calculate digest
 	f, err := os.Open(filepath)
 	if err != nil {


### PR DESCRIPTION
The CAS client will be used by the control-plane too and the upload input in such case is an io.Reader not a file.

This patch updates the Uploader interface and implementation accordingly. It also keeps the `UploadFile` method encapsulated in the casclient package since it's being used by two callers, the CLI action package and the attestation materials package.

Refs #2 