### PR TITLE
chore(ci): bump golangci-lint version and update code to meet new requirements

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,12 +31,15 @@ jobs:
       - name: Lint main module
         uses: golangci/golangci-lint-action@v3
         if: ${{ matrix.app == 'main-module' }}
+        with:
+          version: v1.52
 
       - name: Lint ${{ matrix.app }}
         uses: golangci/golangci-lint-action@v3
         if: ${{ matrix.app != 'main-module' }}
         with:
           working-directory: app/${{ matrix.app }}
+          version: v1.52
 
   lint-protos:
     runs-on: ubuntu-latest

--- a/app/artifact-cas/internal/service/status.go
+++ b/app/artifact-cas/internal/service/status.go
@@ -30,10 +30,10 @@ func NewStatusService(version string) *StatusService {
 	return &StatusService{version: version}
 }
 
-func (s *StatusService) Statusz(ctx context.Context, req *pb.StatuszRequest) (*pb.StatuszResponse, error) {
+func (s *StatusService) Statusz(_ context.Context, _ *pb.StatuszRequest) (*pb.StatuszResponse, error) {
 	return &pb.StatuszResponse{}, nil
 }
 
-func (s *StatusService) Infoz(ctx context.Context, req *pb.InfozRequest) (*pb.InfozResponse, error) {
+func (s *StatusService) Infoz(_ context.Context, _ *pb.InfozRequest) (*pb.InfozResponse, error) {
 	return &pb.InfozResponse{Version: s.version}, nil
 }

--- a/app/cli/cmd/output.go
+++ b/app/cli/cmd/output.go
@@ -18,6 +18,7 @@ package cmd
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 
@@ -65,7 +66,7 @@ func encodeJSONToWriter(v interface{}, w io.Writer) error {
 	encoder := json.NewEncoder(w)
 	encoder.SetIndent("", "   ")
 	if err := encoder.Encode(v); err != nil {
-		return err
+		return fmt.Errorf("failed to encode output: %w", err)
 	}
 
 	return nil

--- a/app/cli/cmd/root.go
+++ b/app/cli/cmd/root.go
@@ -85,7 +85,7 @@ func NewRootCmd(l zerolog.Logger) *cobra.Command {
 			return nil
 		},
 		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
-			return cleanup(logger, actionOpts.CPConnection)
+			return cleanup(actionOpts.CPConnection)
 		},
 	}
 
@@ -167,7 +167,7 @@ func newActionOpts(logger zerolog.Logger, conn *grpc.ClientConn) *action.Actions
 	return &action.ActionsOpts{CPConnection: conn, Logger: logger}
 }
 
-func cleanup(logger zerolog.Logger, conn *grpc.ClientConn) error {
+func cleanup(conn *grpc.ClientConn) error {
 	if conn != nil {
 		if err := conn.Close(); err != nil {
 			return err

--- a/app/cli/cmd/workflow_integration_list.go
+++ b/app/cli/cmd/workflow_integration_list.go
@@ -54,9 +54,9 @@ func integrationAttachmentListTableOutput(attachments []*action.IntegrationAttac
 	t.AppendHeader(table.Row{"ID", "Kind", "Config", "Attached At", "Workflow"})
 	for _, i := range attachments {
 		wf := i.Workflow
-		int := i.Integration
+		integration := i.Integration
 
-		maps.Copy(i.Config, int.Config)
+		maps.Copy(i.Config, integration.Config)
 		var options []string
 		for k, v := range i.Config {
 			if v == "" {
@@ -64,7 +64,7 @@ func integrationAttachmentListTableOutput(attachments []*action.IntegrationAttac
 			}
 			options = append(options, fmt.Sprintf("%s: %v", k, v))
 		}
-		t.AppendRow(table.Row{i.ID, int.Kind, strings.Join(options, "\n"), i.CreatedAt.Format(time.RFC822), wf.NamespacedName()})
+		t.AppendRow(table.Row{i.ID, integration.Kind, strings.Join(options, "\n"), i.CreatedAt.Format(time.RFC822), wf.NamespacedName()})
 		t.AppendSeparator()
 	}
 

--- a/app/cli/cmd/workflow_robotaccount_create.go
+++ b/app/cli/cmd/workflow_robotaccount_create.go
@@ -32,11 +32,7 @@ func newWorkflowRobotAccountCreateCmd() *cobra.Command {
 				return err
 			}
 
-			if err := encodeOutput([]*action.WorkflowRobotAccountItem{res}, robotAccountListTableOutput); err != nil {
-				return err
-			}
-
-			return nil
+			return encodeOutput([]*action.WorkflowRobotAccountItem{res}, robotAccountListTableOutput)
 		},
 	}
 

--- a/app/cli/internal/action/artifact_download.go
+++ b/app/cli/internal/action/artifact_download.go
@@ -81,7 +81,7 @@ func (a *ArtifactDownload) Run(downloadPath, digest string) error {
 	a.Logger.Info().Str("name", info.Filename).Str("to", downloadPath).Msg("downloading file")
 
 	// render progress bar
-	go renderOperationStatus(ctx, client.ProgressStatus, a.Logger, info.Size)
+	go renderOperationStatus(ctx, client.ProgressStatus, info.Size)
 	defer close(client.ProgressStatus)
 
 	err = client.Download(ctx, w, h.Hex)
@@ -103,7 +103,7 @@ func (a *ArtifactDownload) Run(downloadPath, digest string) error {
 	return nil
 }
 
-func renderOperationStatus(ctx context.Context, progressChan casclient.ProgressStatusChan, output io.Writer, totalSize int64) {
+func renderOperationStatus(ctx context.Context, progressChan casclient.ProgressStatusChan, totalSize int64) {
 	pw := progress.NewWriter()
 	pw.Style().Visibility.ETA = true
 	pw.Style().Visibility.Speed = true

--- a/app/cli/internal/action/artifact_upload.go
+++ b/app/cli/internal/action/artifact_upload.go
@@ -60,7 +60,7 @@ func (a *ArtifactUpload) Run(filePath string) (*CASArtifact, error) {
 	}
 
 	// render progress bar
-	go renderOperationStatus(context.Background(), client.ProgressStatus, a.Logger, info.Size())
+	go renderOperationStatus(context.Background(), client.ProgressStatus, info.Size())
 	defer close(client.ProgressStatus)
 
 	res, err := client.Upload(context.Background(), filePath)

--- a/app/controlplane/api/controlplane/v1/integrations_config.go
+++ b/app/controlplane/api/controlplane/v1/integrations_config.go
@@ -34,11 +34,9 @@ func (x *IntegrationConfig) Scan(src any) error {
 		return nil
 	}
 	if b, ok := src.([]byte); ok {
-		if err := proto.Unmarshal(b, x); err != nil {
-			return err
-		}
-		return nil
+		return proto.Unmarshal(b, x)
 	}
+
 	return fmt.Errorf("unexpected type %T", src)
 }
 
@@ -52,10 +50,8 @@ func (x *IntegrationAttachmentConfig) Scan(src any) error {
 		return nil
 	}
 	if b, ok := src.([]byte); ok {
-		if err := proto.Unmarshal(b, x); err != nil {
-			return err
-		}
-		return nil
+		return proto.Unmarshal(b, x)
 	}
+
 	return fmt.Errorf("unexpected type %T", src)
 }

--- a/app/controlplane/cmd/main.go
+++ b/app/controlplane/cmd/main.go
@@ -133,7 +133,7 @@ type app struct {
 	runsExpirer *biz.WorkflowRunExpirerUseCase
 }
 
-func filterSensitiveArgs(level log.Level, keyvals ...interface{}) bool {
+func filterSensitiveArgs(_ log.Level, keyvals ...interface{}) bool {
 	for i := 0; i < len(keyvals); i++ {
 		if keyvals[i] == "operation" {
 			switch keyvals[i+1] {

--- a/app/controlplane/cmd/wire_gen.go
+++ b/app/controlplane/cmd/wire_gen.go
@@ -80,7 +80,7 @@ func wireApp(confServer *conf.Server, auth *conf.Auth, confData *conf.Data, read
 		Opts:               v,
 	}
 	workflowRunService := service.NewWorkflowRunService(newWorkflowRunServiceOpts)
-	casCredentialsUseCase, err := biz.NewCASCredentialsUseCase(auth, logger)
+	casCredentialsUseCase, err := biz.NewCASCredentialsUseCase(auth)
 	if err != nil {
 		cleanup()
 		return nil, nil, err

--- a/app/controlplane/internal/biz/cascredentials.go
+++ b/app/controlplane/internal/biz/cascredentials.go
@@ -22,15 +22,13 @@ import (
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/conf"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/jwt"
 	robotaccount "github.com/chainloop-dev/chainloop/internal/robotaccount/cas"
-
-	"github.com/go-kratos/kratos/v2/log"
 )
 
 type CASCredentialsUseCase struct {
 	jwtBuilder *robotaccount.Builder
 }
 
-func NewCASCredentialsUseCase(c *conf.Auth, logger log.Logger) (*CASCredentialsUseCase, error) {
+func NewCASCredentialsUseCase(c *conf.Auth) (*CASCredentialsUseCase, error) {
 	const defaultExpirationTime = 10 * time.Second
 
 	builder, err := robotaccount.NewBuilder(
@@ -46,6 +44,6 @@ func NewCASCredentialsUseCase(c *conf.Auth, logger log.Logger) (*CASCredentialsU
 	return &CASCredentialsUseCase{builder}, nil
 }
 
-func (uc *CASCredentialsUseCase) GenerateTemporaryCredentials(ctx context.Context, orgID, secretID string, role robotaccount.Role) (string, error) {
+func (uc *CASCredentialsUseCase) GenerateTemporaryCredentials(_ context.Context, secretID string, role robotaccount.Role) (string, error) {
 	return uc.jwtBuilder.GenerateJWT(secretID, jwt.CASAudience, role)
 }

--- a/app/controlplane/internal/integrations/dependencytrack/sbom.go
+++ b/app/controlplane/internal/integrations/dependencytrack/sbom.go
@@ -93,7 +93,7 @@ const bomUploadPermission = "BOM_UPLOAD"
 const viewPortfolioPermission = "VIEW_PORTFOLIO"
 const projectCreationPermission = "PROJECT_CREATION_UPLOAD"
 
-func (d *Integration) Validate(ctx context.Context) error {
+func (d *Integration) Validate(_ context.Context) error {
 	resp, err := teamPermissionsRequest(d.host, d.apiKey)
 	if err != nil {
 		return err
@@ -148,7 +148,7 @@ func (d *SBOMUploader) Validate(ctx context.Context) error {
 	return nil
 }
 
-func (d *SBOMUploader) Do(ctx context.Context) error {
+func (d *SBOMUploader) Do(_ context.Context) error {
 	// Now we know that we can upload
 	values := map[string]io.Reader{
 		"bom": d.sbom,

--- a/app/controlplane/internal/server/grpc.go
+++ b/app/controlplane/internal/server/grpc.go
@@ -133,7 +133,7 @@ func craftMiddleware(opts *Opts) []middleware.Middleware {
 			// 3 - Make sure its account is fully functional
 			selector.Server(
 				usercontext.CheckUserInAllowList(opts.AuthConfig.AllowList),
-				usercontext.CheckOrgRequirements(opts.OCIRepositoryUseCase, logHelper),
+				usercontext.CheckOrgRequirements(opts.OCIRepositoryUseCase),
 			).Match(requireFullyConfiguredOrgMatcher()).Build(),
 		).Match(requireCurrentUserMatcher()).Build(),
 	)

--- a/app/controlplane/internal/service/attestation.go
+++ b/app/controlplane/internal/service/attestation.go
@@ -202,11 +202,7 @@ func (s *AttestationService) Store(ctx context.Context, req *cpAPI.AttestationSe
 
 				s.log.Infow("msg", "attestation associated", "digest", digest, "runID", req.WorkflowRunId)
 
-				if err := s.wrUseCase.MarkAsFinished(ctx, req.WorkflowRunId, biz.WorkflowRunSuccess, ""); err != nil {
-					return err
-				}
-
-				return nil
+				return s.wrUseCase.MarkAsFinished(ctx, req.WorkflowRunId, biz.WorkflowRunSuccess, "")
 			},
 			b,
 			func(_ error, delay time.Duration) {
@@ -276,7 +272,7 @@ func (s *AttestationService) Cancel(ctx context.Context, req *cpAPI.AttestationS
 
 // There is another endpoint to get credentials via casCredentialsService.Get
 // This one is kept since it leverages robot-accounts in the context of a workflow
-func (s *AttestationService) GetUploadCreds(ctx context.Context, req *cpAPI.AttestationServiceGetUploadCredsRequest) (*cpAPI.AttestationServiceGetUploadCredsResponse, error) {
+func (s *AttestationService) GetUploadCreds(ctx context.Context, _ *cpAPI.AttestationServiceGetUploadCredsRequest) (*cpAPI.AttestationServiceGetUploadCredsResponse, error) {
 	robotAccount := usercontext.CurrentRobotAccount(ctx)
 	if robotAccount == nil {
 		return nil, errors.NotFound("not found", "robot account not found")
@@ -296,7 +292,7 @@ func (s *AttestationService) GetUploadCreds(ctx context.Context, req *cpAPI.Atte
 		return nil, errors.NotFound("not found", "main repository not found")
 	}
 
-	t, err := s.casCredsUseCase.GenerateTemporaryCredentials(ctx, wf.OrgID.String(), repo.SecretName, casJWT.Uploader)
+	t, err := s.casCredsUseCase.GenerateTemporaryCredentials(ctx, repo.SecretName, casJWT.Uploader)
 	if err != nil {
 		return nil, sl.LogAndMaskErr(err, s.log)
 	}

--- a/app/controlplane/internal/service/auth.go
+++ b/app/controlplane/internal/service/auth.go
@@ -299,7 +299,7 @@ func setOauthCookie(w http.ResponseWriter, name, value string) {
 }
 
 // DeleteAccount deletes an account
-func (svc *AuthService) DeleteAccount(ctx context.Context, req *pb.AuthServiceDeleteAccountRequest) (*pb.AuthServiceDeleteAccountResponse, error) {
+func (svc *AuthService) DeleteAccount(ctx context.Context, _ *pb.AuthServiceDeleteAccountRequest) (*pb.AuthServiceDeleteAccountResponse, error) {
 	user, _, err := loadCurrentUserAndOrg(ctx)
 	if err != nil {
 		return nil, err

--- a/app/controlplane/internal/service/cascredential.go
+++ b/app/controlplane/internal/service/cascredential.go
@@ -67,7 +67,7 @@ func (s *CASCredentialsService) Get(ctx context.Context, req *pb.CASCredentialsS
 		return nil, errors.NotFound("not found", "main repository not found")
 	}
 
-	t, err := s.casUC.GenerateTemporaryCredentials(ctx, currentOrg.ID, repo.SecretName, role)
+	t, err := s.casUC.GenerateTemporaryCredentials(ctx, repo.SecretName, role)
 	if err != nil {
 		return nil, sl.LogAndMaskErr(err, s.log)
 	}

--- a/app/controlplane/internal/service/integration.go
+++ b/app/controlplane/internal/service/integration.go
@@ -67,7 +67,7 @@ func (s *IntegrationsService) AddDependencyTrack(ctx context.Context, req *pb.Ad
 	return &pb.AddDependencyTrackResponse{Result: bizIntegrationToPb(i)}, nil
 }
 
-func (s *IntegrationsService) List(ctx context.Context, req *pb.IntegrationsServiceListRequest) (*pb.IntegrationsServiceListResponse, error) {
+func (s *IntegrationsService) List(ctx context.Context, _ *pb.IntegrationsServiceListRequest) (*pb.IntegrationsServiceListResponse, error) {
 	_, org, err := loadCurrentUserAndOrg(ctx)
 	if err != nil {
 		return nil, err

--- a/app/controlplane/internal/service/organization.go
+++ b/app/controlplane/internal/service/organization.go
@@ -40,7 +40,7 @@ func NewOrganizationService(uc *biz.MembershipUseCase, opts ...NewOpt) *Organiza
 	}
 }
 
-func (s *OrganizationService) ListMemberships(ctx context.Context, req *pb.OrganizationServiceListMembershipsRequest) (*pb.OrganizationServiceListMembershipsResponse, error) {
+func (s *OrganizationService) ListMemberships(ctx context.Context, _ *pb.OrganizationServiceListMembershipsRequest) (*pb.OrganizationServiceListMembershipsResponse, error) {
 	currentUser, _, err := loadCurrentUserAndOrg(ctx)
 	if err != nil {
 		return nil, err

--- a/app/controlplane/internal/service/status.go
+++ b/app/controlplane/internal/service/status.go
@@ -30,10 +30,10 @@ func NewStatusService(logingURL, version string) *StatusService {
 	return &StatusService{loginURL: logingURL, version: version}
 }
 
-func (s *StatusService) Statusz(ctx context.Context, req *pb.StatuszRequest) (*pb.StatuszResponse, error) {
+func (s *StatusService) Statusz(_ context.Context, _ *pb.StatuszRequest) (*pb.StatuszResponse, error) {
 	return &pb.StatuszResponse{}, nil
 }
 
-func (s *StatusService) Infoz(ctx context.Context, req *pb.InfozRequest) (*pb.InfozResponse, error) {
+func (s *StatusService) Infoz(_ context.Context, _ *pb.InfozRequest) (*pb.InfozResponse, error) {
 	return &pb.InfozResponse{LoginUrl: s.loginURL, Version: s.version}, nil
 }

--- a/app/controlplane/internal/usercontext/orgrequirements_middleware.go
+++ b/app/controlplane/internal/usercontext/orgrequirements_middleware.go
@@ -21,14 +21,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-kratos/kratos/v2/log"
-
 	v1 "github.com/chainloop-dev/chainloop/app/controlplane/api/controlplane/v1"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz"
 	"github.com/go-kratos/kratos/v2/middleware"
 )
 
-func CheckOrgRequirements(uc biz.OCIRepositoryReader, logger *log.Helper) middleware.Middleware {
+func CheckOrgRequirements(uc biz.OCIRepositoryReader) middleware.Middleware {
 	return func(handler middleware.Handler) middleware.Handler {
 		return func(ctx context.Context, req interface{}) (interface{}, error) {
 			org := CurrentOrg(ctx)


### PR DESCRIPTION
Golangci-lint 1.52 enabled additional checks by default. This patch updates the code to meet those new requirements

In addition to that, we also now pin the version of the tool in the CI to prevent upgrade failures.
