### PR TITLE
chore: encapsulate dependency-track biz code

### DIFF
--- a/app/controlplane/cmd/wire.go
+++ b/app/controlplane/cmd/wire.go
@@ -22,6 +22,7 @@ package main
 
 import (
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz"
+	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz/integration"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/conf"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/data"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/server"
@@ -37,9 +38,11 @@ func wireApp(*conf.Bootstrap, credentials.ReaderWriter, log.Logger) (*app, func(
 	panic(
 		wire.Build(
 			wire.Bind(new(credentials.Reader), new(credentials.ReaderWriter)),
+			wire.Bind(new(credentials.Writer), new(credentials.ReaderWriter)),
 			server.ProviderSet,
 			data.ProviderSet,
 			biz.ProviderSet,
+			integration.ProviderSet,
 			service.ProviderSet,
 			wire.Bind(new(backend.Provider), new(*oci.BackendProvider)),
 			wire.Bind(new(biz.CASClient), new(*biz.CASClientUseCase)),

--- a/app/controlplane/cmd/wire.go
+++ b/app/controlplane/cmd/wire.go
@@ -38,7 +38,6 @@ func wireApp(*conf.Bootstrap, credentials.ReaderWriter, log.Logger) (*app, func(
 	panic(
 		wire.Build(
 			wire.Bind(new(credentials.Reader), new(credentials.ReaderWriter)),
-			wire.Bind(new(credentials.Writer), new(credentials.ReaderWriter)),
 			server.ProviderSet,
 			data.ProviderSet,
 			biz.ProviderSet,

--- a/app/controlplane/cmd/wire_gen.go
+++ b/app/controlplane/cmd/wire_gen.go
@@ -8,7 +8,7 @@ package main
 
 import (
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz"
-	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz/integration/deptrack"
+	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz/integration/dependencytrack"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/conf"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/data"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/server"
@@ -90,7 +90,7 @@ func wireApp(bootstrap *conf.Bootstrap, readerWriter credentials.ReaderWriter, l
 		Opts:               v,
 	}
 	workflowRunService := service.NewWorkflowRunService(newWorkflowRunServiceOpts)
-	integration := deptrack.New(integrationUseCase, ociRepositoryUseCase, readerWriter, logger)
+	integration := dependencytrack.New(integrationUseCase, ociRepositoryUseCase, readerWriter, logger)
 	newAttestationServiceOpts := &service.NewAttestationServiceOpts{
 		WorkflowRunUC:      workflowRunUseCase,
 		WorkflowUC:         workflowUseCase,

--- a/app/controlplane/cmd/wire_gen.go
+++ b/app/controlplane/cmd/wire_gen.go
@@ -90,6 +90,7 @@ func wireApp(bootstrap *conf.Bootstrap, readerWriter credentials.ReaderWriter, l
 		Opts:               v,
 	}
 	workflowRunService := service.NewWorkflowRunService(newWorkflowRunServiceOpts)
+	integration := deptrack.New(integrationUseCase, ociRepositoryUseCase, readerWriter, logger)
 	newAttestationServiceOpts := &service.NewAttestationServiceOpts{
 		WorkflowRunUC:      workflowRunUseCase,
 		WorkflowUC:         workflowUseCase,
@@ -99,6 +100,7 @@ func wireApp(bootstrap *conf.Bootstrap, readerWriter credentials.ReaderWriter, l
 		CredsReader:        readerWriter,
 		IntegrationUseCase: integrationUseCase,
 		CasCredsUseCase:    casCredentialsUseCase,
+		DepTrackUseCase:    integration,
 		Opts:               v,
 	}
 	attestationService := service.NewAttestationService(newAttestationServiceOpts)
@@ -113,7 +115,6 @@ func wireApp(bootstrap *conf.Bootstrap, readerWriter credentials.ReaderWriter, l
 	}
 	orgMetricsService := service.NewOrgMetricsService(orgMetricsUseCase, v...)
 	ociRepositoryService := service.NewOCIRepositoryService(ociRepositoryUseCase, v...)
-	integration := deptrack.New(integrationUseCase, readerWriter)
 	integrationsService := service.NewIntegrationsService(integrationUseCase, integration, workflowUseCase, v...)
 	organizationService := service.NewOrganizationService(membershipUseCase, v...)
 	opts := &server.Opts{

--- a/app/controlplane/cmd/wire_gen.go
+++ b/app/controlplane/cmd/wire_gen.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz"
+	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz/integration/deptrack"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/conf"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/data"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/server"
@@ -112,7 +113,8 @@ func wireApp(bootstrap *conf.Bootstrap, readerWriter credentials.ReaderWriter, l
 	}
 	orgMetricsService := service.NewOrgMetricsService(orgMetricsUseCase, v...)
 	ociRepositoryService := service.NewOCIRepositoryService(ociRepositoryUseCase, v...)
-	integrationsService := service.NewIntegrationsService(integrationUseCase, workflowUseCase, v...)
+	integration := deptrack.New(integrationUseCase, readerWriter)
+	integrationsService := service.NewIntegrationsService(integrationUseCase, integration, workflowUseCase, v...)
 	organizationService := service.NewOrganizationService(membershipUseCase, v...)
 	opts := &server.Opts{
 		UserUseCase:          userUseCase,

--- a/app/controlplane/internal/biz/errors.go
+++ b/app/controlplane/internal/biz/errors.go
@@ -52,18 +52,18 @@ func IsErrInvalidUUID(err error) bool {
 	return errors.As(err, &ErrInvalidUUID{})
 }
 
-type errValidation struct {
+type ErrValidation struct {
 	err error
 }
 
-func NewErrValidation(err error) errValidation {
-	return errValidation{err}
+func NewErrValidation(err error) ErrValidation {
+	return ErrValidation{err}
 }
 
-func (e errValidation) Error() string {
+func (e ErrValidation) Error() string {
 	return fmt.Sprintf("validation error: %s", e.err.Error())
 }
 
 func IsErrValidation(err error) bool {
-	return errors.As(err, &errValidation{})
+	return errors.As(err, &ErrValidation{})
 }

--- a/app/controlplane/internal/biz/errors.go
+++ b/app/controlplane/internal/biz/errors.go
@@ -56,7 +56,7 @@ type errValidation struct {
 	err error
 }
 
-func newErrValidation(err error) errValidation {
+func NewErrValidation(err error) errValidation {
 	return errValidation{err}
 }
 

--- a/app/controlplane/internal/biz/integration.go
+++ b/app/controlplane/internal/biz/integration.go
@@ -91,6 +91,16 @@ func NewIntegrationUseCase(opts *NewIntegrationUseCaseOpts) *IntegrationUseCase 
 	return &IntegrationUseCase{opts.IRepo, opts.IaRepo, opts.WfRepo, opts.CredsRW, servicelogger.ScopedHelper(opts.Logger, "biz/integration")}
 }
 
+// Persist the integration with its configuration in the database
+func (uc *IntegrationUseCase) Create(ctx context.Context, orgID, kind string, secretID string, config *v1.IntegrationConfig) (*Integration, error) {
+	orgUUID, err := uuid.Parse(orgID)
+	if err != nil {
+		return nil, NewErrInvalidUUID(err)
+	}
+
+	return uc.integrationRepo.Create(ctx, orgUUID, kind, secretID, config)
+}
+
 func (uc *IntegrationUseCase) AddDependencyTrack(ctx context.Context, orgID, host, apiKey string, enableProjectCreation bool) (*Integration, error) {
 	orgUUID, err := uuid.Parse(orgID)
 	if err != nil {
@@ -100,7 +110,7 @@ func (uc *IntegrationUseCase) AddDependencyTrack(ctx context.Context, orgID, hos
 	// Validate Credentials before saving them
 	creds := &credentials.APICreds{Host: host, Key: apiKey}
 	if err := creds.Validate(); err != nil {
-		return nil, newErrValidation(err)
+		return nil, NewErrValidation(err)
 	}
 
 	// Create the secret in the external secrets manager
@@ -217,7 +227,7 @@ func (uc *IntegrationUseCase) AttachToWorkflow(ctx context.Context, opts *Attach
 
 	// Check that the provided attachConfiguration is compatible with the referred integration
 	if err := validateAttachment(ctx, integration, uc.credsRW, integration.Config, opts.Config); err != nil {
-		return nil, newErrValidation(err)
+		return nil, NewErrValidation(err)
 	}
 
 	return uc.integrationARepo.Create(ctx, integrationUUID, workflowUUID, opts.Config)
@@ -285,7 +295,7 @@ func validateAttachment(ctx context.Context, integration *Integration, credsR cr
 		}
 
 		if err := creds.Validate(); err != nil {
-			return newErrValidation(err)
+			return NewErrValidation(err)
 		}
 
 		// Instantiate an actual uploader to see if it would work with the current configuration

--- a/app/controlplane/internal/biz/integration/dependencytrack/dependencytrack.go
+++ b/app/controlplane/internal/biz/integration/dependencytrack/dependencytrack.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package deptrack
+package dependencytrack
 
 import (
 	"bytes"

--- a/app/controlplane/internal/biz/integration/dependencytrack/dependencytrack_test.go
+++ b/app/controlplane/internal/biz/integration/dependencytrack/dependencytrack_test.go
@@ -1,0 +1,58 @@
+//
+// Copyright 2023 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dependencytrack_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz/integration/dependencytrack"
+	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz/testhelpers"
+	cmocks "github.com/chainloop-dev/chainloop/internal/credentials/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+func (s *testSuite) TestAdd() {
+	assert := assert.New(s.T())
+	credsReader := cmocks.NewReaderWriter(s.T())
+	ctx := context.Background()
+	org, err := s.Organization.Create(ctx, "testing org")
+	assert.NoError(err)
+
+	i := dependencytrack.New(s.Integration, s.OCIRepo, credsReader, nil)
+
+	credsReader.On("SaveCredentials", ctx, org.ID, mock.Anything).Return("secret-key", nil)
+
+	got, err := i.Add(ctx, org.ID, "host", "key", true)
+
+	assert.NoError(err)
+	assert.Equal(dependencytrack.Kind, got.Kind)
+	assert.Equal(true, got.Config.GetDependencyTrack().AllowAutoCreate)
+	assert.Equal("host", got.Config.GetDependencyTrack().Domain)
+	assert.Equal("secret-key", got.SecretName)
+}
+
+// Run the tests
+func TestIntegration(t *testing.T) {
+	suite.Run(t, new(testSuite))
+}
+
+// Utility struct to hold the test suite
+type testSuite struct {
+	testhelpers.UseCasesEachTestSuite
+}

--- a/app/controlplane/internal/biz/integration/deptrack/deptrack.go
+++ b/app/controlplane/internal/biz/integration/deptrack/deptrack.go
@@ -1,0 +1,61 @@
+//
+// Copyright 2023 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deptrack
+
+import (
+	"context"
+	"fmt"
+
+	v1 "github.com/chainloop-dev/chainloop/app/controlplane/api/controlplane/v1"
+	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz"
+	"github.com/chainloop-dev/chainloop/internal/credentials"
+)
+
+type Integration struct {
+	integrationUseCase *biz.IntegrationUseCase
+	credsW             credentials.Writer
+}
+
+const Kind = "Dependency-Track"
+
+func New(integrationUC *biz.IntegrationUseCase, cw credentials.Writer) *Integration {
+	return &Integration{integrationUC, cw}
+}
+
+func (uc *Integration) Add(ctx context.Context, orgID, host, apiKey string, enableProjectCreation bool) (*biz.Integration, error) {
+	// Validate Credentials before saving them
+	creds := &credentials.APICreds{Host: host, Key: apiKey}
+	if err := creds.Validate(); err != nil {
+		return nil, biz.NewErrValidation(err)
+	}
+
+	// Create the secret in the external secrets manager
+	secretID, err := uc.credsW.SaveCredentials(ctx, orgID, creds)
+	if err != nil {
+		return nil, fmt.Errorf("storing the credentials: %w", err)
+	}
+
+	c := &v1.IntegrationConfig{
+		Config: &v1.IntegrationConfig_DependencyTrack_{
+			DependencyTrack: &v1.IntegrationConfig_DependencyTrack{
+				AllowAutoCreate: enableProjectCreation, Domain: host,
+			},
+		},
+	}
+
+	// Persist data
+	return uc.integrationUseCase.Create(ctx, orgID, Kind, secretID, c)
+}

--- a/app/controlplane/internal/biz/integration/deptrack/deptrack.go
+++ b/app/controlplane/internal/biz/integration/deptrack/deptrack.go
@@ -16,23 +16,38 @@
 package deptrack
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"sync"
+	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	v1 "github.com/chainloop-dev/chainloop/app/controlplane/api/controlplane/v1"
+	contractAPI "github.com/chainloop-dev/chainloop/app/controlplane/api/workflowcontract/v1"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz"
+	"github.com/chainloop-dev/chainloop/app/controlplane/internal/integrations/dependencytrack"
+	"github.com/chainloop-dev/chainloop/internal/attestation/renderer"
+	"github.com/chainloop-dev/chainloop/internal/blobmanager/oci"
 	"github.com/chainloop-dev/chainloop/internal/credentials"
+	"github.com/chainloop-dev/chainloop/internal/servicelogger"
+	"github.com/go-kratos/kratos/v2/log"
+	"github.com/go-openapi/errors"
+	"github.com/secure-systems-lab/go-securesystemslib/dsse"
 )
 
 type Integration struct {
-	integrationUseCase *biz.IntegrationUseCase
-	credsW             credentials.Writer
+	integrationUC       *biz.IntegrationUseCase
+	ociUC               *biz.OCIRepositoryUseCase
+	credentialsProvider credentials.ReaderWriter
+	log                 *log.Helper
 }
 
 const Kind = "Dependency-Track"
 
-func New(integrationUC *biz.IntegrationUseCase, cw credentials.Writer) *Integration {
-	return &Integration{integrationUC, cw}
+func New(integrationUC *biz.IntegrationUseCase, ociUC *biz.OCIRepositoryUseCase, creds credentials.ReaderWriter, l log.Logger) *Integration {
+	return &Integration{integrationUC, ociUC, creds, servicelogger.ScopedHelper(l, "biz/integration/deptrack")}
 }
 
 func (uc *Integration) Add(ctx context.Context, orgID, host, apiKey string, enableProjectCreation bool) (*biz.Integration, error) {
@@ -43,7 +58,7 @@ func (uc *Integration) Add(ctx context.Context, orgID, host, apiKey string, enab
 	}
 
 	// Create the secret in the external secrets manager
-	secretID, err := uc.credsW.SaveCredentials(ctx, orgID, creds)
+	secretID, err := uc.credentialsProvider.SaveCredentials(ctx, orgID, creds)
 	if err != nil {
 		return nil, fmt.Errorf("storing the credentials: %w", err)
 	}
@@ -57,5 +72,151 @@ func (uc *Integration) Add(ctx context.Context, orgID, host, apiKey string, enab
 	}
 
 	// Persist data
-	return uc.integrationUseCase.Create(ctx, orgID, Kind, secretID, c)
+	return uc.integrationUC.Create(ctx, orgID, Kind, secretID, c)
+}
+
+// Upload the SBOMs wrapped in the DSSE envelope to the configured Dependency Track instance
+func (uc *Integration) UploadSBOMs(envelope *dsse.Envelope, orgID, workflowID string) error {
+	ctx := context.Background()
+	uc.log.Infow("msg", "looking for integration", "workflowID", workflowID, "integration", Kind)
+
+	// List enabled integrations with this workflow
+	attachments, err := uc.integrationUC.ListAttachments(ctx, orgID, workflowID)
+	if err != nil {
+		return err
+	}
+
+	// Load the ones about dependency track
+	var depTrackIntegrations []*biz.IntegrationAndAttachment
+	for _, at := range attachments {
+		integration, err := uc.integrationUC.FindByIDInOrg(ctx, orgID, at.IntegrationID.String())
+		if err != nil {
+			return err
+		} else if integration == nil {
+			continue
+		}
+		if integration.Kind == Kind {
+			depTrackIntegrations = append(depTrackIntegrations, &biz.IntegrationAndAttachment{Integration: integration, IntegrationAttachment: at})
+		}
+	}
+
+	if len(depTrackIntegrations) == 0 {
+		uc.log.Infow("msg", "no attached integrations", "workflowID", workflowID, "integration", Kind)
+		return nil
+	}
+
+	predicate, err := renderer.ExtractPredicate(envelope)
+	if err != nil {
+		return err
+	}
+
+	repo, err := uc.ociUC.FindMainRepo(ctx, orgID)
+	if err != nil {
+		return err
+	} else if repo == nil {
+		return errors.NotFound("not found", "main repository not found")
+	}
+
+	backend, err := oci.NewBackendProvider(uc.credentialsProvider).FromCredentials(ctx, repo.SecretName)
+	if err != nil {
+		return err
+	}
+
+	for _, m := range predicate.Materials {
+		if m.Type != contractAPI.CraftingSchema_Material_SBOM_CYCLONEDX_JSON.String() {
+			continue
+		}
+
+		buf := bytes.NewBuffer(nil)
+		digest, ok := m.Material.SLSA.Digest["sha256"]
+		if !ok {
+			continue
+		}
+
+		uc.log.Infow("msg", "SBOM present, downloading", "workflowID", workflowID, "integration", Kind, "name", m.Name)
+		// Download SBOM
+		if err := backend.Download(ctx, buf, digest); err != nil {
+			return err
+		}
+		uc.log.Infow("msg", "SBOM downloaded", "digest", digest, "workflowID", workflowID, "integration", Kind, "name", m.Name)
+
+		// Run integrations with that sbom
+		var wg sync.WaitGroup
+		var errs = make(chan error)
+		var wgDone = make(chan bool)
+
+		for _, i := range depTrackIntegrations {
+			wg.Add(1)
+			b := backoff.NewExponentialBackOff()
+			b.MaxElapsedTime = 10 * time.Second
+
+			go func(i *biz.IntegrationAndAttachment) {
+				defer wg.Done()
+				err := backoff.RetryNotify(
+					func() error {
+						return doSendToDependencyTrack(ctx, uc.credentialsProvider, workflowID, buf, i, uc.log)
+					},
+					b,
+					func(err error, delay time.Duration) {
+						uc.log.Warnw("msg", "error uploading SBOM", "retry", delay, "error", err)
+					},
+				)
+				if err != nil {
+					errs <- err
+					log.Error(err)
+				}
+			}(i)
+		}
+
+		go func() {
+			wg.Wait()
+			close(wgDone)
+		}()
+
+		select {
+		case <-wgDone:
+			break
+		case err := <-errs:
+			return err
+		}
+	}
+
+	return nil
+}
+
+func doSendToDependencyTrack(ctx context.Context, credsReader credentials.Reader, workflowID string, sbom io.Reader, i *biz.IntegrationAndAttachment, log *log.Helper) error {
+	integrationConfig := i.Integration.Config.GetDependencyTrack()
+	attachmentConfig := i.IntegrationAttachment.Config.GetDependencyTrack()
+
+	creds := &credentials.APICreds{}
+	if err := credsReader.ReadCredentials(ctx, i.SecretName, creds); err != nil {
+		return err
+	}
+
+	log.Infow("msg", "Sending SBOM to Dependency-Track",
+		"host", integrationConfig.Domain,
+		"projectID", attachmentConfig.GetProjectId(), "projectName", attachmentConfig.GetProjectName(),
+		"workflowID", workflowID, "integration", Kind,
+	)
+
+	d, err := dependencytrack.NewSBOMUploader(integrationConfig.Domain, creds.Key, sbom, attachmentConfig.GetProjectId(), attachmentConfig.GetProjectName())
+	if err != nil {
+		return err
+	}
+
+	if err := d.Validate(ctx); err != nil {
+		return err
+	}
+
+	if err := d.Do(ctx); err != nil {
+		return err
+	}
+
+	log.Infow("msg", "SBOM Sent to Dependency-Track",
+		"host", integrationConfig.Domain,
+		"projectID", attachmentConfig.GetProjectId(), "projectName", attachmentConfig.GetProjectName(),
+		"workflowID", workflowID, "integration", Kind,
+	)
+
+	return nil
 }

--- a/app/controlplane/internal/biz/integration/integration.go
+++ b/app/controlplane/internal/biz/integration/integration.go
@@ -1,0 +1,25 @@
+//
+// Copyright 2023 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz/integration/deptrack"
+	"github.com/google/wire"
+)
+
+var ProviderSet = wire.NewSet(
+	deptrack.New,
+)

--- a/app/controlplane/internal/biz/integration/integration.go
+++ b/app/controlplane/internal/biz/integration/integration.go
@@ -16,10 +16,10 @@
 package integration
 
 import (
-	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz/integration/deptrack"
+	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz/integration/dependencytrack"
 	"github.com/google/wire"
 )
 
 var ProviderSet = wire.NewSet(
-	deptrack.New,
+	dependencytrack.New,
 )

--- a/app/controlplane/internal/biz/ocirepository.go
+++ b/app/controlplane/internal/biz/ocirepository.go
@@ -116,7 +116,7 @@ func (uc *OCIRepositoryUseCase) CreateOrUpdate(ctx context.Context, orgID, repoU
 	// Validate and store the secret in the external secrets manager
 	creds := &credentials.OCIKeypair{Repo: repoURL, Username: username, Password: password}
 	if err := creds.Validate(); err != nil {
-		return nil, newErrValidation(err)
+		return nil, NewErrValidation(err)
 	}
 
 	secretName, err := uc.credsRW.SaveCredentials(ctx, orgID, creds)

--- a/app/controlplane/internal/biz/organization_integration_test.go
+++ b/app/controlplane/internal/biz/organization_integration_test.go
@@ -117,7 +117,7 @@ func (s *OrgIntegrationTestSuite) SetupTest() {
 	assert.NoError(err)
 
 	// Integration
-	_, err = s.Integration.AddDependencyTrack(ctx, s.org.ID, "host", "key", false)
+	_, err = s.DepTrackUC.Add(ctx, s.org.ID, "host", "key", false)
 	assert.NoError(err)
 
 	// OCI repository

--- a/app/controlplane/internal/biz/testhelpers/database.go
+++ b/app/controlplane/internal/biz/testhelpers/database.go
@@ -27,6 +27,7 @@ import (
 	_ "github.com/lib/pq"
 
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz"
+	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz/integration/dependencytrack"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/conf"
 	"github.com/chainloop-dev/chainloop/internal/credentials"
 	creds "github.com/chainloop-dev/chainloop/internal/credentials/mocks"
@@ -57,6 +58,7 @@ type TestingUseCases struct {
 	WorkflowRun      *biz.WorkflowRunUseCase
 	User             *biz.UserUseCase
 	RobotAccount     *biz.RobotAccountUseCase
+	DepTrackUC       *dependencytrack.Integration
 }
 
 type newTestingOpts struct {

--- a/app/controlplane/internal/biz/testhelpers/wire.go
+++ b/app/controlplane/internal/biz/testhelpers/wire.go
@@ -22,6 +22,7 @@ package testhelpers
 
 import (
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz"
+	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz/integration"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/conf"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/data"
 	backend "github.com/chainloop-dev/chainloop/internal/blobmanager"
@@ -39,6 +40,7 @@ func WireTestData(*TestDatabase, *testing.T, log.Logger, credentials.ReaderWrite
 		wire.Build(
 			data.ProviderSet,
 			biz.ProviderSet,
+			integration.ProviderSet,
 			wire.Bind(new(backend.Provider), new(*oci.BackendProvider)),
 			wire.Bind(new(credentials.Reader), new(credentials.ReaderWriter)),
 			oci.NewBackendProvider,

--- a/app/controlplane/internal/biz/testhelpers/wire_gen.go
+++ b/app/controlplane/internal/biz/testhelpers/wire_gen.go
@@ -8,6 +8,7 @@ package testhelpers
 
 import (
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz"
+	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz/integration/dependencytrack"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/conf"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/data"
 	"github.com/chainloop-dev/chainloop/internal/blobmanager/oci"
@@ -67,6 +68,7 @@ func WireTestData(testDatabase *TestDatabase, t *testing.T, logger log.Logger, r
 	userUseCase := biz.NewUserUseCase(newUserUseCaseParams)
 	robotAccountRepo := data.NewRobotAccountRepo(dataData, logger)
 	robotAccountUseCase := biz.NewRootAccountUseCase(robotAccountRepo, workflowRepo, auth, logger)
+	integration := dependencytrack.New(integrationUseCase, ociRepositoryUseCase, readerWriter, logger)
 	testingUseCases := &TestingUseCases{
 		DB:               testDatabase,
 		L:                logger,
@@ -79,6 +81,7 @@ func WireTestData(testDatabase *TestDatabase, t *testing.T, logger log.Logger, r
 		WorkflowRun:      workflowRunUseCase,
 		User:             userUseCase,
 		RobotAccount:     robotAccountUseCase,
+		DepTrackUC:       integration,
 	}
 	return testingUseCases, func() {
 		cleanup()

--- a/app/controlplane/internal/biz/workflowcontract.go
+++ b/app/controlplane/internal/biz/workflowcontract.go
@@ -204,7 +204,7 @@ func (uc *WorkflowContractUseCase) Delete(ctx context.Context, orgID, contractID
 	}
 
 	if len(contract.WorkflowIDs) > 0 {
-		return newErrValidation(errors.New("there are associated workflows with this contract, delete them first"))
+		return NewErrValidation(errors.New("there are associated workflows with this contract, delete them first"))
 	}
 
 	// Check that the workflow to delete belongs to the provided organization

--- a/app/controlplane/internal/biz/workflowrun.go
+++ b/app/controlplane/internal/biz/workflowrun.go
@@ -201,7 +201,7 @@ func (uc *WorkflowRunUseCase) MarkAsFinished(ctx context.Context, id string, sta
 // Store the attestation digest for the workflowrun
 func (uc *WorkflowRunUseCase) AssociateAttestation(ctx context.Context, id string, ref *AttestationRef) error {
 	if ref == nil || ref.SecretRef == "" || ref.Sha256 == "" {
-		return newErrValidation(errors.New("attestation ref is nil or invalid"))
+		return NewErrValidation(errors.New("attestation ref is nil or invalid"))
 	}
 
 	runID, err := uuid.Parse(id)

--- a/app/controlplane/internal/integrations/dependencytrack/sbom.go
+++ b/app/controlplane/internal/integrations/dependencytrack/sbom.go
@@ -27,8 +27,6 @@ import (
 	"strings"
 
 	"encoding/json"
-
-	integration "github.com/chainloop-dev/chainloop/app/controlplane/internal/integrations"
 )
 
 type base struct {
@@ -47,9 +45,6 @@ type SBOMUploader struct {
 	// Either use a projectID or create a new one by name
 	projectID, projectName string
 }
-
-var _ integration.Checker = (*Integration)(nil)
-var _ integration.Doer = (*SBOMUploader)(nil)
 
 func newBase(host, apiKey string) (*base, error) {
 	if apiKey == "" {

--- a/app/controlplane/internal/service/attestation.go
+++ b/app/controlplane/internal/service/attestation.go
@@ -26,7 +26,7 @@ import (
 
 	cpAPI "github.com/chainloop-dev/chainloop/app/controlplane/api/controlplane/v1"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz"
-	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz/integration/deptrack"
+	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz/integration/dependencytrack"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/usercontext"
 	"github.com/chainloop-dev/chainloop/internal/attestation/renderer"
 	"github.com/chainloop-dev/chainloop/internal/credentials"
@@ -48,7 +48,7 @@ type AttestationService struct {
 	attestationUseCase      *biz.AttestationUseCase
 	credsReader             credentials.Reader
 	integrationUseCase      *biz.IntegrationUseCase
-	depTrackUseCase         *deptrack.Integration
+	depTrackUseCase         *dependencytrack.Integration
 	casCredsUseCase         *biz.CASCredentialsUseCase
 }
 
@@ -61,7 +61,7 @@ type NewAttestationServiceOpts struct {
 	CredsReader        credentials.Reader
 	IntegrationUseCase *biz.IntegrationUseCase
 	CasCredsUseCase    *biz.CASCredentialsUseCase
-	DepTrackUseCase    *deptrack.Integration
+	DepTrackUseCase    *dependencytrack.Integration
 	Opts               []NewOpt
 }
 

--- a/app/controlplane/internal/service/integration.go
+++ b/app/controlplane/internal/service/integration.go
@@ -20,7 +20,7 @@ import (
 
 	pb "github.com/chainloop-dev/chainloop/app/controlplane/api/controlplane/v1"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz"
-	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz/integration/deptrack"
+	deptrack "github.com/chainloop-dev/chainloop/app/controlplane/internal/biz/integration/dependencytrack"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/integrations/dependencytrack"
 	sl "github.com/chainloop-dev/chainloop/internal/servicelogger"
 	errors "github.com/go-kratos/kratos/v2/errors"

--- a/app/controlplane/internal/service/integration.go
+++ b/app/controlplane/internal/service/integration.go
@@ -20,6 +20,7 @@ import (
 
 	pb "github.com/chainloop-dev/chainloop/app/controlplane/api/controlplane/v1"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz"
+	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz/integration/deptrack"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/integrations/dependencytrack"
 	sl "github.com/chainloop-dev/chainloop/internal/servicelogger"
 	errors "github.com/go-kratos/kratos/v2/errors"
@@ -31,14 +32,16 @@ type IntegrationsService struct {
 	*service
 
 	integrationUC *biz.IntegrationUseCase
+	depTrackUC    *deptrack.Integration
 	workflowUC    *biz.WorkflowUseCase
 }
 
-func NewIntegrationsService(uc *biz.IntegrationUseCase, wuc *biz.WorkflowUseCase, opts ...NewOpt) *IntegrationsService {
+func NewIntegrationsService(uc *biz.IntegrationUseCase, deptrackUC *deptrack.Integration, wuc *biz.WorkflowUseCase, opts ...NewOpt) *IntegrationsService {
 	return &IntegrationsService{
 		service:       newService(opts...),
 		integrationUC: uc,
 		workflowUC:    wuc,
+		depTrackUC:    deptrackUC,
 	}
 }
 
@@ -59,7 +62,7 @@ func (s *IntegrationsService) AddDependencyTrack(ctx context.Context, req *pb.Ad
 		return nil, errors.BadRequest("invalid configuration", err.Error())
 	}
 
-	i, err := s.integrationUC.AddDependencyTrack(ctx, org.ID, domain, req.ApiKey, enableProjectCreation)
+	i, err := s.depTrackUC.Add(ctx, org.ID, domain, req.ApiKey, enableProjectCreation)
 	if err != nil {
 		return nil, sl.LogAndMaskErr(err, s.log)
 	}


### PR DESCRIPTION
- Decouple dependency-track code from the service layer and put it in its own package in the biz layer.
- The ultimate goal will be potentially merge /biz/integrations and /internal/integrations https://github.com/chainloop-dev/chainloop/issues/38 and this sets the stage for that.

The reason for all these changes is that next we are going to proceed with leveraging CAS instead of OCI directly for SBOM retrieval #2 