### PR TITLE
fix: close GRPC connection

### DIFF
--- a/app/controlplane/internal/biz/casclient.go
+++ b/app/controlplane/internal/biz/casclient.go
@@ -52,7 +52,8 @@ type CASClient interface {
 	CASDownloader
 }
 
-type CASClientFactory func(conf *conf.Bootstrap_CASServer, token string) (casclient.DownloaderUploader, error)
+// Function that returns a CAS client including a connection closer method
+type CASClientFactory func(conf *conf.Bootstrap_CASServer, token string) (casclient.DownloaderUploader, func() error, error)
 type CASClientOpts func(u *CASClientUseCase)
 
 func WithClientFactory(f CASClientFactory) CASClientOpts {
@@ -63,13 +64,13 @@ func WithClientFactory(f CASClientFactory) CASClientOpts {
 
 func NewCASClientUseCase(credsProvider *CASCredentialsUseCase, config *conf.Bootstrap_CASServer, l log.Logger, opts ...CASClientOpts) *CASClientUseCase {
 	// generate a client from the given configuration
-	defaultCasClientFactory := func(conf *conf.Bootstrap_CASServer, token string) (casclient.DownloaderUploader, error) {
+	defaultCasClientFactory := func(conf *conf.Bootstrap_CASServer, token string) (casclient.DownloaderUploader, func() error, error) {
 		conn, err := grpcconn.New(conf.GetGrpc().GetAddr(), token, conf.GetInsecure())
 		if err != nil {
-			return nil, fmt.Errorf("failed to create grpc connection: %w", err)
+			return nil, nil, fmt.Errorf("failed to create grpc connection: %w", err)
 		}
 
-		return casclient.New(conn), nil
+		return casclient.New(conn), conn.Close, err
 	}
 
 	uc := &CASClientUseCase{
@@ -91,10 +92,11 @@ func (uc *CASClientUseCase) Upload(ctx context.Context, secretID string, content
 	uc.logger.Infow("msg", "upload initialized", "filename", filename, "digest", digest)
 
 	// client with temporary set of credentials
-	client, err := uc.casAPIClient(secretID, casJWT.Uploader)
+	client, closeFn, err := uc.casAPIClient(secretID, casJWT.Uploader)
 	if err != nil {
 		return fmt.Errorf("failed to create cas client: %w", err)
 	}
+	defer closeFn()
 
 	status, err := client.Upload(ctx, content, filename, digest)
 	if err != nil {
@@ -109,10 +111,11 @@ func (uc *CASClientUseCase) Upload(ctx context.Context, secretID string, content
 func (uc *CASClientUseCase) Download(ctx context.Context, secretID string, w io.Writer, digest string) error {
 	uc.logger.Infow("msg", "download initialized", "digest", digest)
 
-	client, err := uc.casAPIClient(secretID, casJWT.Downloader)
+	client, closeFn, err := uc.casAPIClient(secretID, casJWT.Downloader)
 	if err != nil {
 		return fmt.Errorf("failed to create cas client: %w", err)
 	}
+	defer closeFn()
 
 	if err := client.Download(ctx, w, digest); err != nil {
 		return fmt.Errorf("failed to download content: %w", err)
@@ -124,10 +127,10 @@ func (uc *CASClientUseCase) Download(ctx context.Context, secretID string, w io.
 }
 
 // create a client with a temporary set of credentials for a specific operation
-func (uc *CASClientUseCase) casAPIClient(secretID string, role casJWT.Role) (casclient.DownloaderUploader, error) {
+func (uc *CASClientUseCase) casAPIClient(secretID string, role casJWT.Role) (casclient.DownloaderUploader, func() error, error) {
 	token, err := uc.credsProvider.GenerateTemporaryCredentials(secretID, role)
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate temporary credentials: %w", err)
+		return nil, nil, fmt.Errorf("failed to generate temporary credentials: %w", err)
 	}
 
 	// Initialize connection to CAS server
@@ -145,10 +148,11 @@ func (uc *CASClientUseCase) IsReady(ctx context.Context) (bool, error) {
 		return false, fmt.Errorf("invalid CAS client configuration: %w", err)
 	}
 
-	c, err := uc.casClientFactory(uc.casServerConf, "")
+	c, closeFn, err := uc.casClientFactory(uc.casServerConf, "")
 	if err != nil {
 		return false, fmt.Errorf("failed to create CAS client: %w", err)
 	}
+	defer closeFn()
 
 	return c.IsReady(ctx)
 }

--- a/app/controlplane/internal/biz/casclient_test.go
+++ b/app/controlplane/internal/biz/casclient_test.go
@@ -65,10 +65,10 @@ func TestIsReady(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			clientProvider := func(conf *conf.Bootstrap_CASServer, token string) (casclient.DownloaderUploader, func() error, error) {
+			clientProvider := func(conf *conf.Bootstrap_CASServer, token string) (casclient.DownloaderUploader, func(), error) {
 				c := mocks.NewDownloaderUploader(t)
 				c.On("IsReady", mock.Anything).Return(tc.casReady, nil)
-				return c, func() error { return nil }, nil
+				return c, func() {}, nil
 			}
 			uc := biz.NewCASClientUseCase(nil, tc.config, nil, biz.WithClientFactory(clientProvider))
 

--- a/app/controlplane/internal/biz/casclient_test.go
+++ b/app/controlplane/internal/biz/casclient_test.go
@@ -65,10 +65,10 @@ func TestIsReady(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			clientProvider := func(conf *conf.Bootstrap_CASServer, token string) (casclient.DownloaderUploader, error) {
+			clientProvider := func(conf *conf.Bootstrap_CASServer, token string) (casclient.DownloaderUploader, func() error, error) {
 				c := mocks.NewDownloaderUploader(t)
 				c.On("IsReady", mock.Anything).Return(tc.casReady, nil)
-				return c, nil
+				return c, func() error { return nil }, nil
 			}
 			uc := biz.NewCASClientUseCase(nil, tc.config, nil, biz.WithClientFactory(clientProvider))
 


### PR DESCRIPTION
Since last release we detected a memory leak that was affecting both the controlplane and the CAS https://github.com/chainloop-dev/chainloop/issues/68

After profiling, we noticed that the issue was that for CP<->CAS communication we create new connections each time that we **did not close**. The reason we use different connections each time is because each requests uses a different AUTH token.

This was leaving many GRPC connections alive causing memory creep. 

Before
![profile001](https://user-images.githubusercontent.com/24523/232320286-ed6b2ac4-bb08-48e7-8b17-e56f28091e6b.png)

After

![profile004](https://user-images.githubusercontent.com/24523/232320301-3199a46e-0af4-4877-8143-f99f2c1863b6.png)

Closes #68 
