### PR TITLE
feat(ci): package and push Helm Chart

### DIFF
--- a/.github/workflows/package_chart.yaml
+++ b/.github/workflows/package_chart.yaml
@@ -1,16 +1,17 @@
 name: Package Helm Chart
 
 on:
-  pull_request:
+  # Only push Helm Chart if the deployment templates have changed
   push:
-    # branch: main
+    branch: main
+    paths:
+      - deployment/chainloop/**
 
 jobs:
   package:
     name: Package and push Helm Chart
     runs-on: ubuntu-latest
     permissions:
-      contents: write
       packages: write
     steps:
       - name: Docker login to Github Packages

--- a/.github/workflows/package_chart.yaml
+++ b/.github/workflows/package_chart.yaml
@@ -21,8 +21,6 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@v3
-        with:
-          version: 3.*
 
       - name: Package Chart
         run: helm package deployment/chainloop/

--- a/.github/workflows/package_chart.yaml
+++ b/.github/workflows/package_chart.yaml
@@ -10,6 +10,7 @@ jobs:
     name: Package and push Helm Chart
     runs-on: ubuntu-latest
     permissions:
+      contents: write
       packages: write
     steps:
       - name: Docker login to Github Packages
@@ -21,6 +22,8 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@v3
+
+      - uses: actions/checkout@v3
 
       - name: Package Chart
         run: helm package deployment/chainloop/

--- a/.github/workflows/package_chart.yaml
+++ b/.github/workflows/package_chart.yaml
@@ -1,0 +1,35 @@
+name: Package Helm Chart
+
+on:
+  pull_request:
+  push:
+    # branch: main
+
+jobs:
+  package:
+    name: Package and push Helm Chart
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Docker login to Github Packages
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: 3.*
+
+      - name: Package Chart
+        run: helm package deployment/chainloop/
+
+      - name: Push Chart
+        run: |
+          for pkg in chainloop*.tgz; do
+            helm push ${pkg} oci://ghcr.io/chainloop-dev/charts
+          done
+        


### PR DESCRIPTION
Add action that packages and pushes to OCI any new change in the deployment template (chart)


The Helm Chart once pushed can be installed via `helm install oci://ghcr.io/chainloop-dev/chart`
 
Refs #64 