### PR TITLE
fix: spurious compute requests

### DIFF
--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -3,7 +3,7 @@ name: chainloop
 description: Chainloop is an open source software supply chain control plane, a single source of truth for artifacts plus a declarative attestation crafting process.
 
 type: application
-version: 1.0.2
+version: 1.0.3
 appVersion: v0.8.98
 
 dependencies:

--- a/deployment/chainloop/values.yaml
+++ b/deployment/chainloop/values.yaml
@@ -384,8 +384,6 @@ controlplane:
   resources:
     # GKE auto-pilot min
     # https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests#min-max-requests
-    cpu: 250m
-    memory: 512Mi
     requests:
       cpu: 250m
       memory: 512Mi
@@ -557,8 +555,6 @@ cas:
   resources:
     # GKE auto-pilot min
     # https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests#min-max-requests
-    cpu: 250m
-    memory: 512Mi
     requests:
       cpu: 250m
       memory: 512Mi


### PR DESCRIPTION
The values.yaml file contained some invalid keys which produced the following output

```
W0417 16:34:53.726444 1867189 warnings.go:70] unknown field "spec.template.spec.containers[0].resources.cpu"                                      
W0417 16:34:53.726456 1867189 warnings.go:70] unknown field "spec.template.spec.containers[0].resources.memory"
W0417 16:34:53.740349 1867189 warnings.go:70] unknown field "spec.template.spec.containers[0].resources.cpu"
W0417 16:34:53.740363 1867189 warnings.go:70] unknown field "spec.template.spec.containers[0].resources.memory"  
```

refs #15 