### PR TITLE
fix: stabilize materials output

### DIFF
--- a/app/cli/cmd/attestation_push.go
+++ b/app/cli/cmd/attestation_push.go
@@ -56,7 +56,7 @@ func newAttestationPushCmd() *cobra.Command {
 				return fmt.Errorf("getting executable information: %w", err)
 			}
 			a := action.NewAttestationPush(&action.AttestationPushOpts{
-				ActionsOpts: actionOpts, KeyPath: pkPath, CLIversion: info.Version, CLIDigest: info.Digest,
+				ActionsOpts: actionOpts, KeyPath: pkPath, CLIVersion: info.Version, CLIDigest: info.Digest,
 			})
 
 			res, err := a.Run()

--- a/app/cli/internal/action/attestation_push.go
+++ b/app/cli/internal/action/attestation_push.go
@@ -28,7 +28,7 @@ import (
 
 type AttestationPushOpts struct {
 	*ActionsOpts
-	KeyPath, CLIversion, CLIDigest string
+	KeyPath, CLIVersion, CLIDigest string
 }
 
 type AttestationPush struct {
@@ -42,7 +42,7 @@ func NewAttestationPush(cfg *AttestationPushOpts) *AttestationPush {
 		ActionsOpts: cfg.ActionsOpts,
 		c:           crafter.NewCrafter(crafter.WithLogger(&cfg.Logger)),
 		keyPath:     cfg.KeyPath,
-		cliVersion:  cfg.CLIversion,
+		cliVersion:  cfg.CLIVersion,
 		cliDigest:   cfg.CLIDigest,
 	}
 }
@@ -64,7 +64,7 @@ func (action *AttestationPush) Run() (interface{}, error) {
 
 	action.Logger.Debug().Msg("validation completed")
 
-	renderer, err := renderer.NewAttestationRenderer(action.c.CraftingState, action.keyPath, action.cliVersion, action.cliDigest, &action.Logger)
+	renderer, err := renderer.NewAttestationRenderer(action.c.CraftingState, action.keyPath, action.cliVersion, action.cliDigest, renderer.WithLogger(action.Logger))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/attestation/renderer/testdata/attestation.output.v0.1.json
+++ b/internal/attestation/renderer/testdata/attestation.output.v0.1.json
@@ -1,0 +1,79 @@
+{
+  "_type": "https://in-toto.io/Statement/v0.1",
+  "predicateType": "chainloop.dev/attestation/v0.1",
+  "subject": [
+    {
+      "name": "chainloop.dev/workflow/foo",
+      "digest": {
+        "sha256": "6cd649c6105e12a235510a585371eb69c8c9ee797d8dc80d30695828ca116b00"
+      }
+    },
+    {
+      "name": "index.docker.io/bitnami/nginx",
+      "digest": {
+        "sha256": "580ac09da7771920dfd0c214964e7bfe4c27903bcbe075769a4044a67c9a390a"
+      }
+    }
+  ],
+  "predicate": {
+    "metadata": {
+      "name": "foo",
+      "project": "bar",
+      "team": "",
+      "initializedAt": "2023-05-03T17:22:12.743426076Z",
+      "finishedAt": "2023-05-03T19:27:51.352850152+02:00",
+      "workflowRunID": "",
+      "workflowID": "54ea7c5c-7592-48ac-9a9f-084b72447184"
+    },
+    "materials": [
+      {
+        "name": "build-ref",
+        "type": "STRING",
+        "material": {
+          "stringVal": "a-string"
+        }
+      },
+      {
+        "name": "rootfs",
+        "type": "ARTIFACT",
+        "material": {
+          "slsa": {
+            "uri": "Makefile",
+            "digest": {
+              "sha256": "cfc7d8e24d21ade921d720228ad1693de59dab45ff679606940be75b7bf660dc"
+            }
+          }
+        }
+      },
+      {
+        "name": "skynet-control-plane",
+        "type": "CONTAINER_IMAGE",
+        "material": {
+          "slsa": {
+            "uri": "index.docker.io/bitnami/nginx",
+            "digest": {
+              "sha256": "580ac09da7771920dfd0c214964e7bfe4c27903bcbe075769a4044a67c9a390a"
+            }
+          }
+        }
+      },
+      {
+        "name": "skynet-sbom",
+        "type": "SBOM_CYCLONEDX_JSON",
+        "material": {
+          "slsa": {
+            "uri": "sbom.cyclonedx.json",
+            "digest": {
+              "sha256": "16159bb881eb4ab7eb5d8afc5350b0feeed1e31c0a268e355e74f9ccbe885e0c"
+            }
+          }
+        }
+      }
+    ],
+    "builder": {
+      "id": "chainloop.dev/cli/dev@sha256:59e14f1a9de709cdd0e91c36b33e54fcca95f7dba1dc7169a7f81986e02108e5"
+    },
+    "buildType": "chainloop.dev/workflowrun/v0.1",
+    "runnerType": "GITHUB_ACTION"
+  }
+}

--- a/internal/attestation/renderer/testdata/attestation.source.json
+++ b/internal/attestation/renderer/testdata/attestation.source.json
@@ -1,0 +1,84 @@
+{
+  "inputSchema": {
+    "schemaVersion": "v1",
+    "materials": [
+      {
+        "type": "CONTAINER_IMAGE",
+        "name": "skynet-control-plane",
+        "output": true
+      },
+      {
+        "type": "ARTIFACT",
+        "name": "rootfs"
+      },
+      {
+        "type": "ARTIFACT",
+        "name": "dockerfile",
+        "optional": true
+      },
+      {
+        "type": "STRING",
+        "name": "build-ref"
+      },
+      {
+        "type": "SBOM_CYCLONEDX_JSON",
+        "name": "skynet-sbom"
+      }
+    ],
+    "envAllowList": [
+      "CUSTOM_VAR"
+    ],
+    "runner": {
+      "type": "GITHUB_ACTION"
+    }
+  },
+  "attestation": {
+    "initializedAt": "2023-05-03T17:22:12.743426076Z",
+    "workflow": {
+      "name": "foo",
+      "project": "bar",
+      "workflowId": "54ea7c5c-7592-48ac-9a9f-084b72447184",
+      "schemaRevision": "1"
+    },
+    "materials": {
+      "build-ref": {
+        "string": {
+          "id": "build-ref",
+          "value": "a-string"
+        },
+        "addedAt": "2023-05-03T17:23:27.113091137Z",
+        "materialType": "STRING"
+      },
+      "rootfs": {
+        "artifact": {
+          "id": "rootfs",
+          "name": "Makefile",
+          "digest": "sha256:cfc7d8e24d21ade921d720228ad1693de59dab45ff679606940be75b7bf660dc"
+        },
+        "addedAt": "2023-05-03T17:23:13.548426342Z",
+        "materialType": "ARTIFACT"
+      },
+      "skynet-control-plane": {
+        "containerImage": {
+          "id": "skynet-control-plane",
+          "name": "index.docker.io/bitnami/nginx",
+          "digest": "sha256:580ac09da7771920dfd0c214964e7bfe4c27903bcbe075769a4044a67c9a390a",
+          "isSubject": true
+        },
+        "addedAt": "2023-05-03T17:22:49.616972571Z",
+        "materialType": "CONTAINER_IMAGE"
+      },
+      "skynet-sbom": {
+        "artifact": {
+          "id": "skynet-sbom",
+          "name": "sbom.cyclonedx.json",
+          "digest": "sha256:16159bb881eb4ab7eb5d8afc5350b0feeed1e31c0a268e355e74f9ccbe885e0c"
+        },
+        "addedAt": "2023-05-03T17:24:31.956266292Z",
+        "materialType": "SBOM_CYCLONEDX_JSON"
+      }
+    },
+    "runnerType": "GITHUB_ACTION"
+  },
+  "dryRun": true
+}


### PR DESCRIPTION
Adds some tests to make sure we don't break compatibility once we move to the new in-toto 1.0 resource descriptors. As a side effect of making the test stable I made some updates on the rendering order and default inputs. 

Refs #60 