### PR TITLE
chore(oci registry): show validation error during save

### DIFF
--- a/app/controlplane/internal/service/ocirepository.go
+++ b/app/controlplane/internal/service/ocirepository.go
@@ -50,10 +50,10 @@ func (s *OCIRepositoryService) Save(ctx context.Context, req *pb.OCIRepositorySe
 	username := req.GetKeyPair().Username
 	password := req.GetKeyPair().Password
 
-	// Create credentials
+	// Create and validate credentials
 	k, err := ociauth.NewCredentials(req.Repository, username, password)
 	if err != nil {
-		return nil, sl.LogAndMaskErr(err, s.log)
+		return nil, errors.BadRequest("wrong credentials", err.Error())
 	}
 
 	// Check credentials

--- a/internal/ociauth/auth.go
+++ b/internal/ociauth/auth.go
@@ -17,6 +17,7 @@ package ociauth
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -31,7 +32,7 @@ type Credentials struct {
 func NewCredentials(repoURI, username, password string) (authn.Keychain, error) {
 	repo, err := name.NewRepository(repoURI)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("invalid repository URI: %w", err)
 	}
 
 	// NOTE: NewRepository parses incorrectly URIs with schemas


### PR DESCRIPTION
During OCI registry save, we now

- Capture and returns validation error with plain message instead of generic 500 error
- Do not send an exception to sentry in that case 

Before (CLI output)

```
ERR server error
```

After

```
ERR invalid repository URI: repository can only contain the characters `abcdefghijklmnopqrstuvwxyz0123456789_-./`: [REPO_URI]
```



Closes #105 