### PR TITLE
fix(ci): bump to cosign 2.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,12 +24,15 @@ jobs:
       CONTAINER_IMAGE_CP: ghcr.io/chainloop-dev/chainloop/control-plane:${{ github.ref_name }}
       CONTAINER_IMAGE_CAS: ghcr.io/chainloop-dev/chainloop/artifact-cas:${{ github.ref_name }}
     steps:
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@v2.5.0
-
       - name: Install Chainloop
         run: |
           curl -sfL https://docs.chainloop.dev/install.sh | bash -s -- --version v${{ env.CHAINLOOP_VERSION }}
+
+      # TODO(miguel) Move once the next release of chainloop is out and recorded in rekor
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@main
+        with:
+          cosign-release: 'v2.0.2'
 
       - name: Download jq
         run: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,6 +47,7 @@ signs:
         "sign-blob",
         "--key=env://COSIGN_KEY",
         "--output-signature=${signature}",
+        "--yes",
         "${artifact}",
       ]
     artifacts: all
@@ -54,7 +55,7 @@ signs:
 docker_signs:
   # COSIGN_PASSWORD is also required to be present
   - cmd: cosign
-    args: ["sign", "--key=env://COSIGN_KEY", "${artifact}"]
+    args: ["sign", "--key=env://COSIGN_KEY", "--yes", "${artifact}"]
     artifacts: all
 
 dockers:


### PR DESCRIPTION
Update the installer to get a 2.x version of cosign

Next we'll trigger a release to get a rekor recorded (pun intended) release that will work in the current installation script 

Refs #116 