### PR TITLE
fix: Choose the random port for HTTP Metrics in the development mode

### DIFF
--- a/app/controlplane/configs/config.devel.yaml
+++ b/app/controlplane/configs/config.devel.yaml
@@ -7,7 +7,7 @@ server:
     addr: 0.0.0.0:8000
     timeout: 1s
   http_metrics:
-    addr: 0.0.0.0:5000
+    addr: 0.0.0.0:0
   grpc:
     addr: 0.0.0.0:9000
     # We have some slow operations such as verifying an OCI registry


### PR DESCRIPTION
Choose the random port for HTTP Metrics in the development mode to fix the already-in-use port issues on OSX, closes #155