### PR TITLE
chore(extensions): fail on extension load

### DIFF
--- a/app/controlplane/extensions/extensions.go
+++ b/app/controlplane/extensions/extensions.go
@@ -48,6 +48,7 @@ func doLoad(extensions []sdk.FanOutFactory, l log.Logger) (sdk.AvailableExtensio
 
 	for _, f := range extensions {
 		d, err := f(l)
+		// For now we fail, once we load plugins we should warn and skip instead
 		if err != nil {
 			return nil, fmt.Errorf("failed to load extension: %w", err)
 		}


### PR DESCRIPTION
Update the loader code to fail instead of skip in the case of extension load failure.

Skipping is useful if/when we load third-party extensions in the form of plugins. But since for now we are implementing the extensions as part of the core, it's best to fail to detect errors during the development cycle. 

Refs #38 