### PR TITLE
feat(extensions sdk): add statement and predicate context

### DIFF
--- a/app/controlplane/extensions/core/ociregistry/v1/ociregistry.go
+++ b/app/controlplane/extensions/core/ociregistry/v1/ociregistry.go
@@ -179,7 +179,7 @@ func (i *Integration) Execute(ctx context.Context, req *sdk.ExecutionRequest) er
 	i.Logger.Infow("msg", "Uploading attestation", "repo", registrationConfig.Repository, "workflowID", req.WorkflowID)
 
 	// Perform the upload of the json marshalled attestation
-	jsonContent, err := json.Marshal(req.Input.DSSEnvelope)
+	jsonContent, err := json.Marshal(req.Input.Attestation.Envelope)
 	if err != nil {
 		return fmt.Errorf("marshaling the envelope: %w", err)
 	}
@@ -206,7 +206,7 @@ func validateExecuteRequest(req *sdk.ExecutionRequest) error {
 		return errors.New("execution input not received")
 	}
 
-	if req.Input.DSSEnvelope == nil {
+	if req.Input.Attestation == nil {
 		return errors.New("execution input invalid, the envelope is empty")
 	}
 

--- a/app/controlplane/extensions/core/smtp/v1/extension.go
+++ b/app/controlplane/extensions/core/smtp/v1/extension.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/chainloop-dev/chainloop/app/controlplane/extensions/sdk/v1"
 	"github.com/go-kratos/kratos/v2/log"
-	"github.com/in-toto/in-toto-golang/in_toto"
 )
 
 type Integration struct {
@@ -160,16 +159,8 @@ func (i *Integration) Execute(_ context.Context, req *sdk.ExecutionRequest) erro
 		return errors.New("invalid attachment configuration")
 	}
 
-	// get the attestation
-	decodedPayload, err := req.Input.DSSEnvelope.DecodeB64Payload()
-	if err != nil {
-		return err
-	}
-	statement := &in_toto.Statement{}
-	if err := json.Unmarshal(decodedPayload, statement); err != nil {
-		return fmt.Errorf("un-marshaling predicate: %w", err)
-	}
-	jsonBytes, err := json.MarshalIndent(statement, "", "  ")
+	// marshal the statement
+	jsonBytes, err := json.MarshalIndent(req.Input.Attestation.Statement, "", "  ")
 	if err != nil {
 		return fmt.Errorf("error marshaling JSON: %w", err)
 	}
@@ -196,7 +187,7 @@ This email has been delivered via integration %s version %s.
 }
 
 func validateExecuteRequest(req *sdk.ExecutionRequest) error {
-	if req == nil || req.Input == nil || req.Input.DSSEnvelope == nil {
+	if req == nil || req.Input == nil || req.Input.Attestation == nil {
 		return errors.New("invalid input")
 	}
 

--- a/app/controlplane/extensions/sdk/v1/fanout.go
+++ b/app/controlplane/extensions/sdk/v1/fanout.go
@@ -27,6 +27,7 @@ import (
 	"github.com/chainloop-dev/chainloop/internal/attestation/renderer/chainloop"
 	"github.com/chainloop-dev/chainloop/internal/servicelogger"
 	"github.com/go-kratos/kratos/v2/log"
+	"github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/invopop/jsonschema"
 	schema_validator "github.com/santhosh-tekuri/jsonschema/v5"
 
@@ -122,8 +123,14 @@ type ExecutionRequest struct {
 // An execute method will receive either the envelope or a material as input
 // The material will contain its content as well as the metadata
 type ExecuteInput struct {
-	DSSEnvelope *dsse.Envelope
+	Attestation *ExecuteAttestation
 	Material    *ExecuteMaterial
+}
+
+type ExecuteAttestation struct {
+	Envelope  *dsse.Envelope
+	Statement *in_toto.Statement
+	Predicate chainloop.NormalizablePredicate
 }
 
 type ExecuteMaterial struct {


### PR DESCRIPTION
This patch makes two main changes

- Adds additional context to the execution by also injecting a decoded intoto statement and a normalized predicate, which then can be used to quickly access the env variables and materials.
- Sends this information always, even if the trigger was a material. 

Closes #174 