### PR TITLE
feat(extensions): add Discord extension and additional metadata

### DIFF
--- a/app/cli/cmd/attached_integration_list.go
+++ b/app/cli/cmd/attached_integration_list.go
@@ -53,22 +53,33 @@ func attachedIntegrationListTableOutput(attachments []*action.AttachedIntegratio
 	fmt.Println("Integrations attached to workflows")
 	t := newTableWriter()
 	t.AppendHeader(table.Row{"ID", "Kind", "Config", "Attached At", "Workflow"})
-	for _, i := range attachments {
-		wf := i.Workflow
-		integration := i.Integration
+	for _, attachment := range attachments {
+		wf := attachment.Workflow
+		integration := attachment.Integration
 
-		var options []string
-		if i.Config != nil {
-			maps.Copy(i.Config, integration.Config)
-			for k, v := range i.Config {
-				if v == "" {
-					continue
-				}
-				options = append(options, fmt.Sprintf("%s: %v", k, v))
-			}
+		// Merge attachment and integration configs
+
+		// If there are not attachment configuration then create an empty map
+		if attachment.Config == nil {
+			attachment.Config = make(map[string]any)
 		}
 
-		t.AppendRow(table.Row{i.ID, integration.Kind, strings.Join(options, "\n"), i.CreatedAt.Format(time.RFC822), wf.NamespacedName()})
+		if integration.Config == nil {
+			integration.Config = make(map[string]any)
+		}
+
+		var options []string
+		maps.Copy(attachment.Config, integration.Config)
+
+		// Show it as key-value pairs
+		for k, v := range attachment.Config {
+			if v == "" {
+				continue
+			}
+			options = append(options, fmt.Sprintf("%s: %v", k, v))
+		}
+
+		t.AppendRow(table.Row{attachment.ID, integration.Kind, strings.Join(options, "\n"), attachment.CreatedAt.Format(time.RFC822), wf.NamespacedName()})
 		t.AppendSeparator()
 	}
 

--- a/app/cli/cmd/attached_integration_list.go
+++ b/app/cli/cmd/attached_integration_list.go
@@ -57,8 +57,8 @@ func attachedIntegrationListTableOutput(attachments []*action.AttachedIntegratio
 		wf := attachment.Workflow
 		integration := attachment.Integration
 
-		// Merge attachment and integration configs
-		// If there are not attachment configuration then create an empty map
+		// Merge attachment and integration configs to show them in the same table
+		// If the same key exists in both configs, the value in attachment config will be used
 		if attachment.Config == nil {
 			attachment.Config = make(map[string]any)
 		}
@@ -68,10 +68,10 @@ func attachedIntegrationListTableOutput(attachments []*action.AttachedIntegratio
 		}
 
 		var options []string
-		maps.Copy(attachment.Config, integration.Config)
+		maps.Copy(integration.Config, attachment.Config)
 
 		// Show it as key-value pairs
-		for k, v := range attachment.Config {
+		for k, v := range integration.Config {
 			if v == "" {
 				continue
 			}

--- a/app/cli/cmd/attached_integration_list.go
+++ b/app/cli/cmd/attached_integration_list.go
@@ -58,7 +58,6 @@ func attachedIntegrationListTableOutput(attachments []*action.AttachedIntegratio
 		integration := attachment.Integration
 
 		// Merge attachment and integration configs
-
 		// If there are not attachment configuration then create an empty map
 		if attachment.Config == nil {
 			attachment.Config = make(map[string]any)

--- a/app/cli/cmd/available_integration_list.go
+++ b/app/cli/cmd/available_integration_list.go
@@ -47,8 +47,6 @@ func availableIntegrationListTableOutput(items []*action.AvailableIntegrationIte
 		return nil
 	}
 
-	fmt.Println("Available integrations ready to be used during registration")
-
 	t := newTableWriter()
 	t.AppendHeader(table.Row{"ID", "Version", "Description"})
 	for _, i := range items {

--- a/app/controlplane/cmd/wire_gen.go
+++ b/app/controlplane/cmd/wire_gen.go
@@ -97,7 +97,7 @@ func wireApp(bootstrap *conf.Bootstrap, readerWriter credentials.ReaderWriter, l
 		cleanup()
 		return nil, nil, err
 	}
-	fanOutDispatcher := dispatcher.New(integrationUseCase, readerWriter, casClientUseCase, availableExtensions, logger)
+	fanOutDispatcher := dispatcher.New(integrationUseCase, workflowUseCase, readerWriter, casClientUseCase, availableExtensions, logger)
 	newAttestationServiceOpts := &service.NewAttestationServiceOpts{
 		WorkflowRunUC:      workflowRunUseCase,
 		WorkflowUC:         workflowUseCase,

--- a/app/controlplane/extensions/core/discord/v1/README.md
+++ b/app/controlplane/extensions/core/discord/v1/README.md
@@ -1,20 +1,22 @@
-# Discord extension
+# Discord Webhook Extension
 
-You can use this template as a placeholder to create your own fan-out extension.
+Send attestations to Discord using webhooks.
 ## How to use it
 
-These are the required steps
+1. To get started, you need to register the extension in your Chainloop organization.
 
-### Setup:
+```console
+$ chainloop integration registered add discord-webhook --opt webhook=[webhookURL]
+```
 
-- Copy and rename the folder to your extension name
-- Replace all the occurrences of `template` with your extension name
+optionally you can specify a custom username
 
-### Implementation
+```console
+$ chainloop integration registered add discord-webhook --opt webhook=[webhookURL] --opt username=[username]
+```
 
-- Define the API request payloads for both Registration and Attachment
-- Implement the [FanOutExtension interface](https://github.com/chainloop-dev/chainloop/blob/main/app/controlplane/extensions/sdk/v1/fanout.go#L55). The template comes prefilled with some commented out code.
+2. Attach the integration to your workflow.
 
-### Enable extension for
-
-- Add it to the list of available extensions [here](`../../../../../extensions.go`). This will make this extension available the next time the control plane starts.
+```console
+chainloop integration attached add --workflow $WID --integration $IID
+```

--- a/app/controlplane/extensions/core/discord/v1/README.md
+++ b/app/controlplane/extensions/core/discord/v1/README.md
@@ -1,0 +1,20 @@
+# Discord extension
+
+You can use this template as a placeholder to create your own fan-out extension.
+## How to use it
+
+These are the required steps
+
+### Setup:
+
+- Copy and rename the folder to your extension name
+- Replace all the occurrences of `template` with your extension name
+
+### Implementation
+
+- Define the API request payloads for both Registration and Attachment
+- Implement the [FanOutExtension interface](https://github.com/chainloop-dev/chainloop/blob/main/app/controlplane/extensions/sdk/v1/fanout.go#L55). The template comes prefilled with some commented out code.
+
+### Enable extension for
+
+- Add it to the list of available extensions [here](`../../../../../extensions.go`). This will make this extension available the next time the control plane starts.

--- a/app/controlplane/extensions/core/discord/v1/discord.go
+++ b/app/controlplane/extensions/core/discord/v1/discord.go
@@ -1,0 +1,260 @@
+//
+// Copyright 2023 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discord
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"mime/multipart"
+	"net/http"
+
+	"github.com/chainloop-dev/chainloop/app/controlplane/extensions/sdk/v1"
+	"github.com/go-kratos/kratos/v2/log"
+)
+
+type Integration struct {
+	*sdk.FanOutIntegration
+}
+
+// 1 - API schema definitions
+type registrationRequest struct {
+	WebhookURL string `json:"webhook" jsonschema:"format=uri,description=URL of the discord webhook"`
+	Username   string `json:"username,omitempty" jsonschema:"minLenght=1,description=Override the default username of the webhook	"`
+}
+
+type attachmentRequest struct{}
+
+// 2 - Configuration state
+type registrationState struct {
+	// Information from the webhook
+	WebhookName  string `json:"name"`
+	WebhookOwner string `json:"owner"`
+
+	// Username to be used while posting the message
+	Username string `json:"username"`
+}
+
+func New(l log.Logger) (sdk.FanOut, error) {
+	base, err := sdk.NewFanOut(
+		&sdk.NewParams{
+			ID:          "discord-webhook",
+			Version:     "0.1",
+			Description: "Send attestations to Discord",
+			Logger:      l,
+			InputSchema: &sdk.InputSchema{
+				Registration: registrationRequest{},
+				Attachment:   attachmentRequest{},
+			},
+		},
+		sdk.WithEnvelope(),
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &Integration{base}, nil
+}
+
+type webhookResponse struct {
+	Name string `json:"name"`
+	User struct {
+		Username string `json:"username"`
+	} `json:"user"`
+}
+
+// Register is executed when a operator wants to register a specific instance of this integration with their Chainloop organization
+func (i *Integration) Register(_ context.Context, req *sdk.RegistrationRequest) (*sdk.RegistrationResponse, error) {
+	i.Logger.Info("registration requested")
+
+	var request *registrationRequest
+	if err := sdk.FromConfig(req.Payload, &request); err != nil {
+		return nil, fmt.Errorf("invalid registration request: %w", err)
+	}
+
+	// Test the webhook URL and extract some information from it to use it as reference for the user
+	resp, err := http.Get(request.WebhookURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid webhook URL: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var webHookInfo webhookResponse
+	if err := json.NewDecoder(resp.Body).Decode(&webHookInfo); err != nil {
+		return nil, fmt.Errorf("invalid webhook URL: %w", err)
+	}
+
+	// Configuration State
+	config, err := sdk.ToConfig(&registrationState{
+		WebhookName:  webHookInfo.Name,
+		WebhookOwner: webHookInfo.User.Username,
+		Username:     request.Username,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshalling configuration: %w", err)
+	}
+
+	return &sdk.RegistrationResponse{
+		Configuration: config,
+		// We treat the webhook URL as a sensitive field so we store it in the credentials storage
+		Credentials: &sdk.Credentials{Password: request.WebhookURL},
+	}, nil
+}
+
+// Attachment is executed when to attach a registered instance of this integration to a specific workflow
+func (i *Integration) Attach(_ context.Context, _ *sdk.AttachmentRequest) (*sdk.AttachmentResponse, error) {
+	i.Logger.Info("attachment requested")
+	return &sdk.AttachmentResponse{}, nil
+}
+
+// Execute will be instantiate when either an attestation or a material has been received
+// It's up to the extension builder to differentiate between inputs
+func (i *Integration) Execute(_ context.Context, req *sdk.ExecutionRequest) error {
+	i.Logger.Info("execution requested")
+
+	if err := validateExecuteRequest(req); err != nil {
+		return fmt.Errorf("running validation: %w", err)
+	}
+
+	var config *registrationState
+	if err := sdk.FromConfig(req.RegistrationInfo.Configuration, &config); err != nil {
+		return fmt.Errorf("invalid registration config: %w", err)
+	}
+
+	attestationJSON, err := json.MarshalIndent(req.Input.Attestation.Statement, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error marshaling JSON: %w", err)
+	}
+
+	webhookURL := req.RegistrationInfo.Credentials.Password
+	if err := executeWebhook(webhookURL, config.Username, attestationJSON); err != nil {
+		return fmt.Errorf("error executing webhook: %w", err)
+	}
+
+	i.Logger.Info("execution finished")
+	return nil
+}
+
+// Send attestation to Discord
+
+// https://discord.com/developers/docs/reference#uploading-files
+// --boundary
+// Content-Disposition: form-data; name="payload_json"
+// Content-Type: application/json
+//
+//	{
+//	  "content": "New attestation!",
+//	  "attachments": [{
+//	      "id": 0,
+//	      "filename": "attestation.json"
+//	  }]
+//	}
+//
+// --boundary
+// Content-Disposition: form-data; name="files[0]"; filename="statement.json"
+// --boundary
+func executeWebhook(webhookURL, username string, jsonStatement []byte) error {
+	var b bytes.Buffer
+	multipartWriter := multipart.NewWriter(&b)
+
+	// webhook POST payload JSON
+	payload := payloadJSON{
+		Content:  "New attestation!",
+		Username: username,
+		Attachments: []payloadAttachment{
+			{
+				ID:       0,
+				Filename: "attestation.json",
+			},
+		},
+	}
+
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshalling payload: %w", err)
+	}
+
+	payloadWriter, err := multipartWriter.CreateFormField("payload_json")
+	if err != nil {
+		return fmt.Errorf("creating payload form field: %w", err)
+	}
+
+	if _, err := payloadWriter.Write(payloadJSON); err != nil {
+		return fmt.Errorf("writing payload form field: %w", err)
+	}
+
+	// attach attestation JSON
+	attachmentWriter, err := multipartWriter.CreateFormFile("files[0]", "statement.json")
+	if err != nil {
+		return fmt.Errorf("creating attachment form field: %w", err)
+	}
+
+	if _, err := attachmentWriter.Write(jsonStatement); err != nil {
+		return fmt.Errorf("writing attachment form field: %w", err)
+	}
+
+	// Needed to dump the content of the multipartWriter to the buffer
+	multipartWriter.Close()
+
+	// #nosec G107 - we are using a constant API URL that is not user input at this stage
+	r, err := http.Post(webhookURL, multipartWriter.FormDataContentType(), &b)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != http.StatusOK {
+		b, _ := ioutil.ReadAll(r.Body)
+		return fmt.Errorf("non-OK HTTP status while calling the webhook: %d, body: %s", r.StatusCode, string(b))
+	}
+
+	return nil
+}
+
+type payloadJSON struct {
+	Content     string              `json:"content"`
+	Username    string              `json:"username,omitempty"`
+	Attachments []payloadAttachment `json:"attachments"`
+}
+
+type payloadAttachment struct {
+	ID       int    `json:"id"`
+	Filename string `json:"filename"`
+}
+
+func validateExecuteRequest(req *sdk.ExecutionRequest) error {
+	if req == nil || req.Input == nil {
+		return errors.New("execution input not received")
+	}
+
+	if req.Input.Attestation == nil {
+		return errors.New("execution input invalid, envelope is nil")
+	}
+
+	if req.RegistrationInfo == nil || req.RegistrationInfo.Configuration == nil {
+		return errors.New("missing registration configuration")
+	}
+
+	if req.RegistrationInfo.Credentials == nil {
+		return errors.New("missing credentials")
+	}
+
+	return nil
+}

--- a/app/controlplane/extensions/core/discord/v1/discord.go
+++ b/app/controlplane/extensions/core/discord/v1/discord.go
@@ -50,7 +50,7 @@ type registrationState struct {
 	WebhookOwner string `json:"owner"`
 
 	// Username to be used while posting the message
-	Username string `json:"username"`
+	Username string `json:"username,omitempty"`
 }
 
 func New(l log.Logger) (sdk.FanOut, error) {

--- a/app/controlplane/extensions/core/discord/v1/discord.go
+++ b/app/controlplane/extensions/core/discord/v1/discord.go
@@ -149,6 +149,7 @@ func (i *Integration) Execute(_ context.Context, req *sdk.ExecutionRequest) erro
 	tplData := &templateContent{
 		WorkflowID:      metadata.WorkflowID,
 		WorkflowName:    metadata.WorkflowName,
+		WorkflowRunID:   metadata.WorkflowRunID,
 		WorkflowProject: metadata.WorkflowProject,
 		RunnerLink:      req.Input.Attestation.Predicate.GetRunLink(),
 	}
@@ -270,7 +271,7 @@ func validateExecuteRequest(req *sdk.ExecutionRequest) error {
 }
 
 type templateContent struct {
-	WorkflowID, WorkflowName, WorkflowProject, RunnerLink string
+	WorkflowID, WorkflowName, WorkflowProject, WorkflowRunID, RunnerLink string
 }
 
 func renderContent(metadata *templateContent) string {
@@ -286,8 +287,9 @@ func renderContent(metadata *templateContent) string {
 
 const msgTemplate = `
 New attestation received!
-- workflow: {{.WorkflowProject}}/{{.WorkflowName}}
+- Workflow: {{.WorkflowProject}}/{{.WorkflowName}}
+- Workflow Run: {{.WorkflowRunID}}
 {{- if .RunnerLink }}
-- link to run: {{.RunnerLink}}
+- Link to runner: {{.RunnerLink}}
 {{end}}
 `

--- a/app/controlplane/extensions/core/discord/v1/discord.go
+++ b/app/controlplane/extensions/core/discord/v1/discord.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"mime/multipart"
 	"net/http"
 	"strings"
@@ -231,7 +231,7 @@ func executeWebhook(webhookURL, usernameOverride string, jsonStatement []byte, m
 	defer r.Body.Close()
 
 	if r.StatusCode != http.StatusOK {
-		b, _ := ioutil.ReadAll(r.Body)
+		b, _ := io.ReadAll(r.Body)
 		return fmt.Errorf("non-OK HTTP status while calling the webhook: %d, body: %s", r.StatusCode, string(b))
 	}
 

--- a/app/controlplane/extensions/core/discord/v1/discord_test.go
+++ b/app/controlplane/extensions/core/discord/v1/discord_test.go
@@ -1,0 +1,130 @@
+//
+// Copyright 2023 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discord
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateRegistrationInput(t *testing.T) {
+	testCases := []struct {
+		name   string
+		input  map[string]interface{}
+		errMsg string
+	}{
+		{
+			name:   "not ok, missing required property",
+			input:  map[string]interface{}{},
+			errMsg: "missing properties: 'webhook'",
+		},
+		{
+			name:   "not ok, random properties",
+			input:  map[string]interface{}{"foo": "bar"},
+			errMsg: "additionalProperties 'foo' not allowed",
+		},
+		{
+			name:  "ok, all properties",
+			input: map[string]interface{}{"webhook": "http://repo.io", "username": "u"},
+		},
+		{
+			name:  "ok, only required properties",
+			input: map[string]interface{}{"webhook": "http://repo.io"},
+		},
+		{
+			name:   "not ok, empty username",
+			input:  map[string]interface{}{"webhook": "http://repo.io", "username": ""},
+			errMsg: "length must be >= 1, but got 0",
+		},
+		{
+			name:  "ok, webhook with path",
+			input: map[string]interface{}{"webhook": "http://repo/foo/bar"},
+		},
+		{
+			name:   "not ok, invalid webhook, missing protocol",
+			input:  map[string]interface{}{"webhook": "repo.io"},
+			errMsg: "is not valid 'uri'",
+		},
+		{
+			name:   "not ok, empty webhook",
+			input:  map[string]interface{}{"webhook": ""},
+			errMsg: "is not valid 'uri'",
+		},
+	}
+
+	integration, err := New(nil)
+	require.NoError(t, err)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload, err := json.Marshal(tc.input)
+			require.NoError(t, err)
+
+			err = integration.ValidateRegistrationRequest(payload)
+			if tc.errMsg != "" {
+				assert.ErrorContains(t, err, tc.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRenderContent(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    *templateContent
+		expected string
+	}{
+		{
+			name: "all fields",
+			input: &templateContent{
+				WorkflowID:      "deadbeef",
+				WorkflowName:    "test",
+				WorkflowProject: "project",
+				RunnerLink:      "http://runner.io",
+			},
+			expected: `New attestation received!
+- workflow: project/test
+- link to run: http://runner.io`,
+		},
+		{
+			name: "no runner link",
+			input: &templateContent{
+				WorkflowID:      "deadbeef",
+				WorkflowName:    "test",
+				WorkflowProject: "project",
+			},
+			expected: `New attestation received!
+- workflow: project/test`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := renderContent(tc.input)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestNewIntegration(t *testing.T) {
+	_, err := New(nil)
+	assert.NoError(t, err)
+}

--- a/app/controlplane/extensions/core/discord/v1/discord_test.go
+++ b/app/controlplane/extensions/core/discord/v1/discord_test.go
@@ -95,24 +95,26 @@ func TestRenderContent(t *testing.T) {
 		{
 			name: "all fields",
 			input: &templateContent{
-				WorkflowID:      "deadbeef",
+				WorkflowRunID:   "deadbeef",
 				WorkflowName:    "test",
 				WorkflowProject: "project",
 				RunnerLink:      "http://runner.io",
 			},
 			expected: `New attestation received!
-- workflow: project/test
-- link to run: http://runner.io`,
+- Workflow: project/test
+- Workflow Run: deadbeef
+- Link to runner: http://runner.io`,
 		},
 		{
 			name: "no runner link",
 			input: &templateContent{
-				WorkflowID:      "deadbeef",
+				WorkflowRunID:   "deadbeef",
 				WorkflowName:    "test",
 				WorkflowProject: "project",
 			},
 			expected: `New attestation received!
-- workflow: project/test`,
+- Workflow: project/test
+- Workflow Run: deadbeef`,
 		},
 	}
 

--- a/app/controlplane/extensions/extensions.go
+++ b/app/controlplane/extensions/extensions.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/chainloop-dev/chainloop/app/controlplane/extensions/core/dependencytrack/v1"
+	"github.com/chainloop-dev/chainloop/app/controlplane/extensions/core/discord/v1"
 	"github.com/chainloop-dev/chainloop/app/controlplane/extensions/core/ociregistry/v1"
 	"github.com/chainloop-dev/chainloop/app/controlplane/extensions/core/smtp/v1"
 	"github.com/chainloop-dev/chainloop/app/controlplane/extensions/sdk/v1"
@@ -36,6 +37,7 @@ func Load(l log.Logger) (sdk.AvailableExtensions, error) {
 		dependencytrack.New,
 		smtp.New,
 		ociregistry.New,
+		discord.New,
 	}
 
 	return doLoad(toEnable, l)

--- a/app/controlplane/extensions/sdk/v1/fanout.go
+++ b/app/controlplane/extensions/sdk/v1/fanout.go
@@ -112,6 +112,8 @@ type ChainloopMetadata struct {
 	WorkflowID      string
 	WorkflowName    string
 	WorkflowProject string
+
+	WorkflowRunID string
 }
 
 // ExecutionRequest is the request to execute the integration

--- a/app/controlplane/extensions/sdk/v1/fanout.go
+++ b/app/controlplane/extensions/sdk/v1/fanout.go
@@ -109,7 +109,9 @@ type AttachmentResponse struct {
 }
 
 type ChainloopMetadata struct {
-	WorkflowID string
+	WorkflowID      string
+	WorkflowName    string
+	WorkflowProject string
 }
 
 // ExecutionRequest is the request to execute the integration

--- a/app/controlplane/internal/dispatcher/dispatcher.go
+++ b/app/controlplane/internal/dispatcher/dispatcher.go
@@ -153,7 +153,7 @@ func (d *FanOutDispatcher) calculateDispatchQueue(ctx context.Context, orgID, wo
 	return &dispatchQueue{materials: materialDispatch, attestations: attestationDispatch}, nil
 }
 
-type DispatcherOpts struct {
+type RunOpts struct {
 	Envelope           *dsse.Envelope
 	OrgID              string
 	WorkflowID         string
@@ -162,7 +162,7 @@ type DispatcherOpts struct {
 }
 
 // Run attestation and materials to the attached integrations
-func (d *FanOutDispatcher) Run(ctx context.Context, opts *DispatcherOpts) error {
+func (d *FanOutDispatcher) Run(ctx context.Context, opts *RunOpts) error {
 	// Calculate metadata
 	wf, err := d.wfUC.FindByID(ctx, opts.WorkflowID)
 	if err != nil {

--- a/app/controlplane/internal/dispatcher/dispatcher_test.go
+++ b/app/controlplane/internal/dispatcher/dispatcher_test.go
@@ -227,7 +227,7 @@ func (s *dispatcherTestSuite) SetupTest() {
 
 	// Register the integrations in the dispatcher
 	registeredIntegrations := sdk.AvailableExtensions{s.cdxIntegrationBackend, s.anyIntegrationBackend, s.ociIntegrationBackend}
-	s.dispatcher = New(s.Integration, nil, mocks.NewCASClient(s.T()), registeredIntegrations, s.L)
+	s.dispatcher = New(s.Integration, nil, nil, mocks.NewCASClient(s.T()), registeredIntegrations, s.L)
 }
 
 type mockedIntegration struct {

--- a/app/controlplane/internal/service/attestation.go
+++ b/app/controlplane/internal/service/attestation.go
@@ -206,7 +206,7 @@ func (s *AttestationService) Store(ctx context.Context, req *cpAPI.AttestationSe
 	}()
 
 	go func() {
-		if err := s.integrationDispatcher.Run(context.TODO(), &dispatcher.DispatcherOpts{
+		if err := s.integrationDispatcher.Run(context.TODO(), &dispatcher.RunOpts{
 			Envelope: envelope, OrgID: robotAccount.OrgID, WorkflowID: robotAccount.WorkflowID, DownloadSecretName: repo.SecretName, WorkflowRunID: req.WorkflowRunId,
 		}); err != nil {
 			_ = sl.LogAndMaskErr(err, s.log)

--- a/app/controlplane/internal/service/attestation.go
+++ b/app/controlplane/internal/service/attestation.go
@@ -206,7 +206,9 @@ func (s *AttestationService) Store(ctx context.Context, req *cpAPI.AttestationSe
 	}()
 
 	go func() {
-		if err := s.integrationDispatcher.Run(context.TODO(), envelope, robotAccount.OrgID, robotAccount.WorkflowID, repo.SecretName); err != nil {
+		if err := s.integrationDispatcher.Run(context.TODO(), &dispatcher.DispatcherOpts{
+			Envelope: envelope, OrgID: robotAccount.OrgID, WorkflowID: robotAccount.WorkflowID, DownloadSecretName: repo.SecretName, WorkflowRunID: req.WorkflowRunId,
+		}); err != nil {
 			_ = sl.LogAndMaskErr(err, s.log)
 		}
 	}()

--- a/internal/attestation/renderer/chainloop/chainloop.go
+++ b/internal/attestation/renderer/chainloop/chainloop.go
@@ -37,6 +37,7 @@ const builderIDFmt = "chainloop.dev/cli/%s@%s"
 type NormalizablePredicate interface {
 	GetEnvVars() map[string]string
 	GetMaterials() []*NormalizedMaterial
+	GetRunLink() string
 }
 
 type NormalizedMaterial struct {
@@ -180,4 +181,8 @@ func extractPredicate(statement *in_toto.Statement, v any) error {
 // Implement NormalizablePredicate interface
 func (p *ProvenancePredicateCommon) GetEnvVars() map[string]string {
 	return p.Env
+}
+
+func (p *ProvenancePredicateCommon) GetRunLink() string {
+	return p.RunnerURL
 }


### PR DESCRIPTION
Extension that leverages Discord webhooks to send attestations. 

The inputs at registration time are a required webhook URL and an optional username override

```console
$ chainloop integration available describe --id discord-webhook

Available integrations ready to be used during registration
┌─────────────────┬─────────┬──────────────────────────────┐
│ ID              │ VERSION │ DESCRIPTION                  │
├─────────────────┼─────────┼──────────────────────────────┤
│ discord-webhook │ 0.1     │ Send attestations to Discord │
└─────────────────┴─────────┴──────────────────────────────┘
┌───────────────────────────────────────────────────────────────────────────────────────┐
│ Registration inputs                                                                   │
├──────────┬──────────────┬──────────┬──────────────────────────────────────────────────┤
│ FIELD    │ TYPE         │ REQUIRED │ DESCRIPTION                                      │
├──────────┼──────────────┼──────────┼──────────────────────────────────────────────────┤
│ username │ string       │ no       │ Override the default username of the webhook     │
│ webhook  │ string (uri) │ yes      │ URL of the discord webhook                       │
└──────────┴──────────────┴──────────┴──────────────────────────────────────────────────┘
```

The result is a message that includes some metadata in the content body and an attached intoto attestation.

![image](https://github.com/chainloop-dev/chainloop/assets/24523/a82654bf-759b-4dc0-a96f-6eabede53193)


This patch also includes some improvements in the sdk. we now inject additional workflow information (name, project) as well as the runnerURL. refs #174 cc/ @danlishka 

That new data is used to craft the resulting message.

Another interesting aspect about the implementation, is that during registration I fetch information about the webhook itself (i.e name set in discord) so we can clearly differentiate them.

```console
$ chainloop integration registered list                        
┌──────────────────────────────────────┬─────────────────┬─────────────────┬──────────────────────────────────────────────────────────────────────────────────────┬─────────────────────┐
│ ID                                   │ DESCRIPTION     │ KIND            │ CONFIG                                                                               │ CREATED AT          │
├──────────────────────────────────────┼─────────────────┼─────────────────┼──────────────────────────────────────────────────────────────────────────────────────┼─────────────────────┤
│ 16fff68c-a017-46fe-8937-df7b7c9d7d20 │                 │ discord-webhook │ name: Chainloop webhook                                                              │ 15 Jun 23 15:19 UTC │
│                                      │                 │                 │ owner: migmartri                                                                     │                     │
│                                      │                 │                 │ username: miguel-test                                                                │                     │
├──────────────────────────────────────┼─────────────────┼─────────────────┼────────────────────────────────────────────
```

Closes #176 