### PR TITLE
fix: nil pointer guard when no attestation is present

### DIFF
--- a/app/controlplane/internal/service/attestation.go
+++ b/app/controlplane/internal/service/attestation.go
@@ -244,7 +244,7 @@ func (s *AttestationService) GetUploadCreds(ctx context.Context, _ *cpAPI.Attest
 }
 
 func bizAttestationToPb(att *biz.Attestation) (*cpAPI.AttestationItem, error) {
-	if att.Envelope == nil {
+	if att == nil || att.Envelope == nil {
 		return nil, nil
 	}
 


### PR DESCRIPTION
Closes #184 

Now the CLI shows `there was an issue retrieving the attestation` which was the original behavior, or "there is an attestation in progress"  

```console
$chainloop wf run describe --id 0c27d5d0-cc38-418c-a933-46b9ef02a532
┌───────────────────────────────────────────────────────┐
│ Workflow                                              │
├────────────────┬──────────────────────────────────────┤
│ ID             │ 548995cd-e64a-4f7f-bb6b-789f8fc07afb │
│ Name           │ test                                 │
│ Team           │                                      │
│ Project        │ baz                                  │
├────────────────┼──────────────────────────────────────┤
│ Workflow Run   │                                      │
├────────────────┼──────────────────────────────────────┤
│ ID             │ 0c27d5d0-cc38-418c-a933-46b9ef02a532 │
│ Initialized At │ 15 Jun 23 15:18 UTC                  │
│ Finished At    │ 15 Jun 23 15:18 UTC                  │
│ State          │ success                              │
│ Runner Link    │                                      │
└────────────────┴──────────────────────────────────────┘
WRN there was an issue retrieving the attestation

```