### PR TITLE
fix(ci): package chart only on changes main branch

### DIFF
--- a/.github/workflows/package_chart.yaml
+++ b/.github/workflows/package_chart.yaml
@@ -3,7 +3,8 @@ name: Package Helm Chart
 on:
   # Only push Helm Chart if the deployment templates have changed
   push:
-    branch: main
+    branches:
+      - main
     paths:
       - deployment/chainloop/**
 


### PR DESCRIPTION
There was a bug in the package-chart github action workflow file that wasn't limiting runs to only the main branch. Thanks @danlishka for bringing this up! 