### PR TITLE
fix(docs): links in integrations table

### DIFF
--- a/app/controlplane/plugins/sdk/readme-generator/main.go
+++ b/app/controlplane/plugins/sdk/readme-generator/main.go
@@ -88,8 +88,8 @@ func updateIntegrationsIndex(plugins sdk.AvailablePlugins) error {
 		}
 
 		// We need to full URL path because we render this file in the website
-		const repoBase = "https://github.com/chainloop-dev/chainloop/tree/main/app/controlplane/plugins/core"
-		pathToPlugin := filepath.Join(repoBase, p.Describe().ID, "v1")
+		const repoBase = "https://github.com/chainloop-dev/chainloop/blob/main/app/controlplane/plugins/core"
+		pathToPlugin := fmt.Sprintf("%s/%s/%s/%s", repoBase, p.Describe().ID, "v1", "README.md")
 
 		indexTable += fmt.Sprintf("| [%s](%s) | %s | %s | %s |\n", info.ID, pathToPlugin, info.Version, info.Description, strings.Join(subscribedMaterials, ", "))
 	}

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -10,10 +10,10 @@ Below you can find the list of currently available integrations. If you can't fi
 
 | ID | Version | Description | Material Requirement |
 | --- | --- | --- | --- |
-| [dependency-track](https:/github.com/chainloop-dev/chainloop/tree/main/app/controlplane/plugins/core/dependency-track/v1) | 1.2 | Send CycloneDX SBOMs to your Dependency-Track instance | SBOM_CYCLONEDX_JSON |
-| [smtp](https:/github.com/chainloop-dev/chainloop/tree/main/app/controlplane/plugins/core/smtp/v1) | 1.0 | Send emails with information about a received attestation |  |
-| [oci-registry](https:/github.com/chainloop-dev/chainloop/tree/main/app/controlplane/plugins/core/oci-registry/v1) | 1.0 | Send attestations to a compatible OCI registry |  |
-| [discord-webhook](https:/github.com/chainloop-dev/chainloop/tree/main/app/controlplane/plugins/core/discord-webhook/v1) | 1.1 | Send attestations to Discord |  |
+| [dependency-track](https://github.com/chainloop-dev/chainloop/blob/main/app/controlplane/plugins/core/dependency-track/v1/README.md) | 1.2 | Send CycloneDX SBOMs to your Dependency-Track instance | SBOM_CYCLONEDX_JSON |
+| [smtp](https://github.com/chainloop-dev/chainloop/blob/main/app/controlplane/plugins/core/smtp/v1/README.md) | 1.0 | Send emails with information about a received attestation |  |
+| [oci-registry](https://github.com/chainloop-dev/chainloop/blob/main/app/controlplane/plugins/core/oci-registry/v1/README.md) | 1.0 | Send attestations to a compatible OCI registry |  |
+| [discord-webhook](https://github.com/chainloop-dev/chainloop/blob/main/app/controlplane/plugins/core/discord-webhook/v1/README.md) | 1.1 | Send attestations to Discord |  |
 
 ## How to use integrations
 


### PR DESCRIPTION
Fixes the table links.

Before I didn't notice about this issue because I could see the right link in the code and the missing `/` was sneaky. The problem was the user of `filepath.join`

Now I can point to Readme file as well so docusaurus will not complain

Refs #38 