### PR TITLE
fix(cas): return 404 error if artifact does not exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,7 @@
+include common.mk
+
 VERSION=$(shell git describe --tags --always)
-
 API_PROTO_FILES=$(shell find api -name *.proto)
-
-.PHONY: init
-# init env
-init:
-	go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.30.0
-	go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3.0
-	go install github.com/envoyproxy/protoc-gen-validate@v1.0.1
-	go install github.com/go-kratos/kratos/cmd/protoc-gen-go-errors/v2@latest
-	go install github.com/go-kratos/kratos/cmd/protoc-gen-go-http/v2@latest
-	go install github.com/google/wire/cmd/wire@latest
-	go install github.com/vektra/mockery/v2@v2.20.0
-	go install ariga.io/atlas/cmd/atlas@v0.12.0
-	go install github.com/bufbuild/buf/cmd/buf@v1.10.0
 
 .PHONY: api
 # generate api proto
@@ -54,22 +42,3 @@ lint:
 # All tests, both unit and integration
 test: 
 	go test ./... 
-
-# show help
-help:
-	@echo ''
-	@echo 'Usage:'
-	@echo ' make [target]'
-	@echo ''
-	@echo 'Targets:'
-	@awk '/^[a-zA-Z\-_0-9]+:/ { \
-	helpMessage = match(lastLine, /^# (.*)/); \
-		if (helpMessage) { \
-			helpCommand = substr($$1, 0, index($$1, ":")-1); \
-			helpMessage = substr(lastLine, RSTART + 2, RLENGTH); \
-			printf "\033[36m%-22s\033[0m %s\n", helpCommand,helpMessage; \
-		} \
-	} \
-	{ lastLine = $$0 }' $(MAKEFILE_LIST)
-
-.DEFAULT_GOAL := help

--- a/app/artifact-cas/Makefile
+++ b/app/artifact-cas/Makefile
@@ -1,13 +1,13 @@
-VERSION=$(shell git describe --tags --always)
+include ../../common.mk
 
 .PHONY: config
 # generate config proto
-config:
+config: check-buf-tool
 	cd ./internal/conf && buf generate
 
 .PHONY: api
 # generate api proto
-api:
+api: check-buf-tool
 	cd ./api && buf generate
 
 .PHONY: build
@@ -30,14 +30,14 @@ test:
 
 .PHONY: lint
 # lint
-lint:
+lint: check-golangci-lint-tool check-buf-tool
 	golangci-lint run
 	buf lint api
 	buf lint internal/conf
 
 .PHONY: generate
 # generate
-generate:
+generate: check-wire-tool api config
 	go generate ./...
 
 .PHONY: all
@@ -45,22 +45,3 @@ generate:
 all:
 	make config;
 	make generate;
-
-# show help
-help:
-	@echo ''
-	@echo 'Usage:'
-	@echo ' make [target]'
-	@echo ''
-	@echo 'Targets:'
-	@awk '/^[a-zA-Z\-_0-9]+:/ { \
-	helpMessage = match(lastLine, /^# (.*)/); \
-		if (helpMessage) { \
-			helpCommand = substr($$1, 0, index($$1, ":")-1); \
-			helpMessage = substr(lastLine, RSTART + 2, RLENGTH); \
-			printf "\033[36m%-22s\033[0m %s\n", helpCommand,helpMessage; \
-		} \
-	} \
-	{ lastLine = $$0 }' $(MAKEFILE_LIST)
-
-.DEFAULT_GOAL := help

--- a/app/artifact-cas/internal/service/resource.go
+++ b/app/artifact-cas/internal/service/resource.go
@@ -21,7 +21,7 @@ import (
 	v1 "github.com/chainloop-dev/chainloop/app/artifact-cas/api/cas/v1"
 	backend "github.com/chainloop-dev/chainloop/internal/blobmanager"
 	sl "github.com/chainloop-dev/chainloop/internal/servicelogger"
-	"github.com/go-openapi/errors"
+	"github.com/go-kratos/kratos/v2/errors"
 )
 
 type ResourceService struct {

--- a/app/cli/main.go
+++ b/app/cli/main.go
@@ -38,7 +38,7 @@ func main() {
 	}
 }
 
-// handle predefinided errors and handle types so we can tailor the experience
+// handle predefined errors and handle types so we can tailor the experience
 func errorInfo(err error, logger zerolog.Logger) (string, int) {
 	var msg string
 	exitCode := 1

--- a/app/controlplane/Makefile
+++ b/app/controlplane/Makefile
@@ -1,13 +1,13 @@
-VERSION=$(shell git describe --tags --always)
+include ../../common.mk
 
 .PHONY: config
 # generate config proto bindings
-config:
+config: check-buf-tool
 	cd ./internal/conf && buf generate
 
 .PHONY: api
 # generate api proto bindings
-api:
+api: check-buf-tool
 	cd ./api && buf generate
 
 .PHONY: build
@@ -28,13 +28,13 @@ local_db = postgres://postgres:@localhost:5432/controlplane?sslmode=disable
 
 .PHONY: migration_apply
 # run migrations against local db
-migration_apply:
+migration_apply: check-atlas-tool
 	atlas migrate status --dir ${local_migrations_dir} --url ${local_db}
 	atlas migrate apply --dir ${local_migrations_dir} --url ${local_db}
 
 .PHONY: migration_new
 # generate new migration if needed from the current ent schema
-migration_new:
+migration_new: check-atlas-tool
 	atlas migrate diff --dir ${local_migrations_dir} --to "ent://internal/data/ent/schema" --dev-url "docker://postgres/15/test?search_path=public"
 
 .PHONY: test
@@ -49,14 +49,14 @@ test-unit:
 
 .PHONY: lint
 # lint
-lint:
+lint: check-golangci-lint-tool check-buf-tool
 	buf lint api
 	buf lint internal/conf
 	golangci-lint run
 
 .PHONY: generate
 # generate proto bindings, wire injectors, and ent models
-generate: api config
+generate: check-wire-tool api config
 	go generate ./...
 
 .PHONY: all
@@ -69,22 +69,3 @@ all:
 # Visualize data model
 visualize-data-model:
 	xdg-open internal/data/ent/schema-viz.html
-
-# show help
-help:
-	@echo ''
-	@echo 'Usage:'
-	@echo ' make [target]'
-	@echo ''
-	@echo 'Targets:'
-	@awk '/^[a-zA-Z\-_0-9]+:/ { \
-	helpMessage = match(lastLine, /^# (.*)/); \
-		if (helpMessage) { \
-			helpCommand = substr($$1, 0, index($$1, ":")-1); \
-			helpMessage = substr(lastLine, RSTART + 2, RLENGTH); \
-			printf "\033[36m%-22s\033[0m %s\n", helpCommand,helpMessage; \
-		} \
-	} \
-	{ lastLine = $$0 }' $(MAKEFILE_LIST)
-
-.DEFAULT_GOAL := help

--- a/common.mk
+++ b/common.mk
@@ -1,0 +1,62 @@
+VERSION=$(shell git describe --tags --always)
+
+.PHONY: init
+# init env
+init:
+	go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.30.0
+	go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3.0
+	go install github.com/envoyproxy/protoc-gen-validate@v1.0.1
+	go install github.com/go-kratos/kratos/cmd/protoc-gen-go-errors/v2@latest
+	go install github.com/go-kratos/kratos/cmd/protoc-gen-go-http/v2@latest
+	go install github.com/google/wire/cmd/wire@latest
+	go install github.com/vektra/mockery/v2@v2.20.0
+	go install ariga.io/atlas/cmd/atlas@v0.12.0
+	go install github.com/bufbuild/buf/cmd/buf@v1.10.0
+
+# show help
+help:
+	@echo ''
+	@echo 'Usage:'
+	@echo ' make [target]'
+	@echo ''
+	@echo 'Targets:'
+	@awk '/^[a-zA-Z\-_0-9]+:/ { \
+	helpMessage = match(lastLine, /^# (.*)/); \
+		if (helpMessage) { \
+			helpCommand = substr($$1, 0, index($$1, ":")-1); \
+			helpMessage = substr(lastLine, RSTART + 2, RLENGTH); \
+			printf "\033[36m%-22s\033[0m %s\n", helpCommand,helpMessage; \
+		} \
+	} \
+	{ lastLine = $$0 }' $(MAKEFILE_LIST)
+
+.DEFAULT_GOAL := help
+
+.PHONY: check-goreleaser-tool
+check-atlas-tool:
+	@if ! command -v atlas >/dev/null 2>&1; then \
+		echo "altas is not installed. Please run \"make init\" or install the tool manually."; \
+		exit 1; \
+	fi
+
+.PHONY: check-wire-tool
+check-wire-tool:
+	@if ! command -v wire >/dev/null 2>&1; then \
+		echo "wire is not installed. Please run \"make init\" or install the tool manually."; \
+		exit 1; \
+	fi
+
+.PHONY: check-golangci-lint-tool
+check-golangci-lint-tool:
+	@if ! command -v golangci-lint >/dev/null 2>&1; then \
+		echo "golangci-lint is not installed. Please run \"make init\" or install the tool manually."; \
+		exit 1; \
+	fi
+
+.PHONY: check-buf-tool
+check-buf-tool:
+	@if ! command -v buf >/dev/null 2>&1; then \
+		echo "buf is not installed. Please run \"make init\" or install the tool manually."; \
+		exit 1; \
+	fi
+

--- a/internal/blobmanager/errors.go
+++ b/internal/blobmanager/errors.go
@@ -1,0 +1,37 @@
+//
+// Copyright 2023 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import (
+	"errors"
+	"fmt"
+)
+
+type ErrNotFound struct {
+	entity string
+}
+
+func NewErrNotFound(entity string) ErrNotFound {
+	return ErrNotFound{entity}
+}
+
+func (e ErrNotFound) Error() string {
+	return fmt.Sprintf("%s not found", e.entity)
+}
+
+func IsNotFound(err error) bool {
+	return errors.As(err, &ErrNotFound{})
+}

--- a/internal/blobmanager/oci/backend_test.go
+++ b/internal/blobmanager/oci/backend_test.go
@@ -181,7 +181,7 @@ func (s *testSuite) TestDescribe() {
 			name:    "not found",
 			digest:  "deadbeef",
 			wantErr: true,
-			errMsg:  "Unknown name",
+			errMsg:  "not found",
 		},
 		{
 			name:   "valid image",


### PR DESCRIPTION
Handles the fact that an image doesn't exist in the CAS instead of returning a generic error and notifying the exception manager. 

This patch also includes some makefile refactoring to check that some of the new tools required are in place.