### PR TITLE
fix(release): do not fail if we can not attest a material

### DIFF
--- a/.github/workflows/contracts/releases.cue
+++ b/.github/workflows/contracts/releases.cue
@@ -4,6 +4,7 @@ materials: [
 	{type: "ARTIFACT", name: "cli-linux-amd64", output:           true},
 	{type: "ARTIFACT", name: "control-plane-linux-amd64", output: true},
 	{type: "ARTIFACT", name: "artifact-cas-linux-amd64", output:  true},
+	{type: "ARTIFACT", name: "chainloop-plugin-discord-webhook-linux-amd64"},
 	// Container images
 	{type: "CONTAINER_IMAGE", name: "control-plane-image", output: true},
 	{type: "CONTAINER_IMAGE", name: "artifact-cas-image", output:  true},

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,10 +101,11 @@ jobs:
         run: |
           # Binaries x86_64
           # TODO: add the rest of binaries
+          # NOTE that we are not making the attestation fail if the material is not found. We will fail on "att push"
           echo -n '${{ steps.release.outputs.artifacts }}' | jq -r '.[] | select(.type=="Binary" and .goos=="linux" and .goarch=="amd64") | { "name": "\(.extra.ID)-\(.goos)-\(.goarch)", "path":"\(.path)"} | @base64' | while read i; do
               BINARY_NAME=$(echo "${i}" | base64 --decode | jq -r ${1} .name)
               BINARY_PATH=$(echo "${i}" | base64 --decode | jq -r ${1} .path)
-              chainloop attestation add --name ${BINARY_NAME} --value ${BINARY_PATH} 
+              chainloop attestation add --name ${BINARY_NAME} --value ${BINARY_PATH} || true
             done
 
       - name: Finish and Record Attestation


### PR DESCRIPTION
Fixes https://github.com/chainloop-dev/chainloop/actions/runs/5507743809/jobs/10038247997

The issue was that now we are also building plugin binaries. Then we iterate over them and try to add them as pieces of evidence. Such pieces of evidence are not in the contract (yet).

This patch basically will do a graceful recover and move on. The verification will happen at `att push` where we make sure the required materials are in place.