### PR TITLE
chore(ci): compress binaries

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,6 @@ jobs:
           cache: true
           cache-dependency-path: go.sum
 
-      - name: Test-upx
-        run: upx --version
-
       - name: Go Module tidy check
         run: |
           go mod tidy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,9 @@ jobs:
           cache: true
           cache-dependency-path: go.sum
 
+      - name: Test-upx
+        run: upx --version
+
       - name: Go Module tidy check
         run: |
           go mod tidy

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,6 +47,9 @@ builds:
     main: ./app/controlplane/plugins/core/discord-webhook/v1/cmd
     targets:
       - linux_amd64
+    hooks:
+      post:
+        - upx "{{ .Path }}"
 archives:
   - builds:
       - cli

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,6 +10,9 @@ builds:
       - -X main.Version={{ .Version }}
     targets:
       - linux_amd64
+    hooks:
+      post:
+        - upx "{{ .Path }}"
   - binary: artifact-cas
     id: artifact-cas
     main: ./app/artifact-cas/cmd
@@ -18,6 +21,9 @@ builds:
       - -X main.Version={{ .Version }}
     targets:
       - linux_amd64
+    hooks:
+      post:
+        - upx "{{ .Path }}"
   - binary: chainloop
     id: cli
     main: ./app/cli
@@ -28,6 +34,9 @@ builds:
       - darwin_arm64
       - linux_amd64
       - linux_arm64
+    hooks:
+      post:
+        - upx "{{ .Path }}"
   # Plugins build
   # NOTE: On the event of a new plugin added to the project you need to
   # 1 - Add the plugins binary to be built in this section


### PR DESCRIPTION
Enable upx compression during build.

On my local tests there is a reduction of about half the size, for example

```sh
$ upx bin/control-plane
                       Ultimate Packer for eXecutables
                          Copyright (C) 1996 - 2023
UPX 4.0.2       Markus Oberhumer, Laszlo Molnar & John Reiser   Jan 30th 2023

        File size         Ratio      Format      Name
   --------------------   ------   -----------   -----------
  59908290 ->  28271904   47.19%   linux/amd64   control-plane           
```

The discord plugin size went to 1/4 of the size. 12MB to 3MB