### PR TITLE
chore(plugins): enable smtp and dependency-track

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,6 +50,22 @@ builds:
     hooks:
       post:
         - upx "{{ .Path }}"
+  - binary: chainloop-plugin-smtp
+    id: chainloop-plugin-smtp
+    main: ./app/controlplane/plugins/core/smtp/v1/cmd
+    targets:
+      - linux_amd64
+    hooks:
+      post:
+        - upx "{{ .Path }}"
+  - binary: chainloop-plugin-dependency-track
+    id: chainloop-plugin-dependency-track
+    main: ./app/controlplane/plugins/core/dependency-track/v1/cmd
+    targets:
+      - linux_amd64
+    hooks:
+      post:
+        - upx "{{ .Path }}"
 archives:
   - builds:
       - cli
@@ -85,6 +101,8 @@ dockers:
     ids:
       - control-plane
       - chainloop-plugin-discord-webhook
+      - chainloop-plugin-smtp
+      - chainloop-plugin-dependency-track
     image_templates:
       - "ghcr.io/chainloop-dev/chainloop/control-plane:{{ .Tag }}"
       - "ghcr.io/chainloop-dev/chainloop/control-plane:latest"

--- a/app/controlplane/Dockerfile.goreleaser
+++ b/app/controlplane/Dockerfile.goreleaser
@@ -9,6 +9,8 @@ COPY ./control-plane /
 # NOTE: they are built by go-releaser in the builds section
 # Make sure to update it acordingly if you add more plugins
 COPY ./chainloop-plugin-discord-webhook /plugins/
+COPY ./chainloop-plugin-dependency-track /plugins/
+COPY ./chainloop-plugin-smtp /plugins/
 # tmp is required for the plugins to run
 COPY --from=builder /tmp /tmp
 

--- a/app/controlplane/plugins/core/Makefile
+++ b/app/controlplane/plugins/core/Makefile
@@ -1,0 +1,15 @@
+# Find plugins subdirectories that have a makefile
+SUBDIRS := $(patsubst %Makefile,%,$(wildcard */v1/Makefile))
+
+TARGETS := build
+
+.SECONDEXPANSION:
+
+$(TARGETS): %: subdirs
+
+subdirs: $(SUBDIRS)
+
+$(SUBDIRS):
+	$(MAKE) -C $@ $(MAKECMDGOALS)
+
+.PHONY: subdirs $(SUBDIRS) $(TARGETS)

--- a/app/controlplane/plugins/core/dependency-track/v1/Makefile
+++ b/app/controlplane/plugins/core/dependency-track/v1/Makefile
@@ -1,0 +1,2 @@
+MKFILE_PATH := $(lastword $(MAKEFILE_LIST))
+include ../../common.mk

--- a/app/controlplane/plugins/core/dependency-track/v1/cmd/main.go
+++ b/app/controlplane/plugins/core/dependency-track/v1/cmd/main.go
@@ -1,0 +1,31 @@
+// Copyright 2023 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"log"
+
+	dependencytrack "github.com/chainloop-dev/chainloop/app/controlplane/plugins/core/dependency-track/v1"
+	"github.com/chainloop-dev/chainloop/app/controlplane/plugins/sdk/v1/plugin"
+)
+
+// Plugin entrypoint
+func main() {
+	if err := plugin.Serve(&plugin.ServeOpts{
+		Factory: dependencytrack.New,
+	}); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/app/controlplane/plugins/core/smtp/v1/Makefile
+++ b/app/controlplane/plugins/core/smtp/v1/Makefile
@@ -1,0 +1,2 @@
+MKFILE_PATH := $(lastword $(MAKEFILE_LIST))
+include ../../common.mk

--- a/app/controlplane/plugins/core/smtp/v1/cmd/main.go
+++ b/app/controlplane/plugins/core/smtp/v1/cmd/main.go
@@ -1,0 +1,31 @@
+// Copyright 2023 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"log"
+
+	"github.com/chainloop-dev/chainloop/app/controlplane/plugins/core/smtp/v1"
+	"github.com/chainloop-dev/chainloop/app/controlplane/plugins/sdk/v1/plugin"
+)
+
+// Plugin entrypoint
+func main() {
+	if err := plugin.Serve(&plugin.ServeOpts{
+		Factory: smtp.New,
+	}); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
Package `dependency-track` and `smtp` plugins in the upstream container image.

Refs #195 