### PR TITLE
fix(ci): pin go version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,12 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version-file: go.mod
+          # go-version-file: go.mod
+          # for now pin the verify action to 1.20.5
+          # due to issue with testcontainers
+          # https://github.com/golang/go/issues/61431
+          # https://github.com/testcontainers/testcontainers-go/issues/1359
+          go-version: '1.20.5'
           cache: true
           cache-dependency-path: go.sum
 


### PR DESCRIPTION
It seems that the issue appears in the latest version of go. Pinning to the previous one until there is a fix upstream https://github.com/testcontainers/testcontainers-go/issues/1359

refs #255 