### PR TITLE
chore(ci): check generated controlplane migrations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,17 @@ jobs:
           go mod tidy
           git diff --exit-code -- go.mod go.sum
 
+      # Generate any possible migration from a schema change that way
+      # we can detect any migration file that has not been checked in to git
+      # This could happen if the developer ran make generate but didn't run make migration_new
+      - name: Generate migrations
+        if: ${{ matrix.app == 'controlplane' }}
+        run: |
+          wget -q https://release.ariga.io/atlas/atlas-linux-amd64-latest -O /tmp/atlas
+          sudo install /tmp/atlas /usr/local/bin/atlas
+
+          make -C app/controlplane migration_new
+
       # Check that the generated ent code is up to date
       # see https://entgo.io/docs/ci/
       - uses: ent/contrib/ci@master


### PR DESCRIPTION
Run the migrations generation make target in the CI. That way we will detect any migration that has not been generated and or checked in yet.

refs #28 