### PR TITLE
feat(deployment): enable SSL during migration

### DIFF
--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -4,7 +4,7 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.9.0
+version: 1.9.1
 # Do not update appVersion, this is handled automatically by the release process
 appVersion: v0.14.0
 

--- a/deployment/chainloop/templates/_helpers.tpl
+++ b/deployment/chainloop/templates/_helpers.tpl
@@ -182,7 +182,8 @@ Return the Postgresql connection string
 Return the Postgresql connection string for Atlas migration
 */}}
 {{- define "controlplane.database.atlas_connection_string" -}}
-{{- printf "postgres://%s:%s@%s:%s/%s?sslmode=disable" (include "controlplane.database.user" .) (include "controlplane.database.escapedPassword" .) (include "controlplane.database.host" .) (include "controlplane.database.port" .) (include "controlplane.database.name" .) }}
+{{- $connStr := printf "postgres://%s:%s@%s:%s/%s" (include "controlplane.database.user" .) (include "controlplane.database.escapedPassword" .) (include "controlplane.database.host" .) (include "controlplane.database.port" .) (include "controlplane.database.name" .) }}
+{{- .Values.controlplane.migration.ssl | ternary $connStr (printf "%s?sslmode=disable" $connStr) }}
 {{- end -}}
 
 {{/*

--- a/deployment/chainloop/values.yaml
+++ b/deployment/chainloop/values.yaml
@@ -113,6 +113,8 @@ controlplane:
       repository: ghcr.io/chainloop-dev/chainloop/control-plane-migrations
       # Overrides the image tag whose default is the chart appVersion.
     # tag: latest
+    # Run the migration job forcing SSL, required in AWS RDS for PostgreSQL 15
+    ssl: false
 
   ## @skip controlplane.serviceAccount
   serviceAccount:


### PR DESCRIPTION
New flag that allows enabling sslmode during database migration. This is required for PostgreSQL 15 on AWS RDS 

This is the effect of enabling the flag

```diff
--- /tmp/before.yaml    2023-07-25 11:34:46.356110212 +0200
+++ /tmp/after.yaml     2023-07-25 11:43:03.134694777 +0200
@@ -1203,6 +1203,6 @@
             - migrate
             - apply
             - --url
-            - "postgres://chainloop:chainlooppwd@foo-postgresql:5432/chainloop-cp?sslmode=disable"
+            - "postgres://chainloop:chainlooppwd@foo-postgresql:5432/chainloop-cp"
             - --dir
             - file:///migrations
```