### PR TITLE
fix(slack): add empty line before escape lines

### DIFF
--- a/app/controlplane/plugins/core/slack-webhook/v1/slack_webhook.go
+++ b/app/controlplane/plugins/core/slack-webhook/v1/slack_webhook.go
@@ -101,7 +101,7 @@ func (i *Integration) Execute(_ context.Context, req *sdk.ExecutionRequest) erro
 		return fmt.Errorf("error summarizing the request: %w", err)
 	}
 
-	msg := fmt.Sprintf("\nNew attestation received!```\n%s\n```\n", summary)
+	msg := fmt.Sprintf("\nNew attestation received!\n```\n%s\n```\n", summary)
 	webhookURL := req.RegistrationInfo.Credentials.Password
 
 	if err := executeWebhook(webhookURL, msg); err != nil {


### PR DESCRIPTION
We've noticed that some notifications are not rendering properly, and although it's not clear why some other do, we've detected that during the previous refactoring, the new line before the escape ticks were removed.