### PR TITLE
fix(dispatcher): do not fail if credentials are missing

### DIFF
--- a/app/controlplane/internal/dispatcher/dispatcher.go
+++ b/app/controlplane/internal/dispatcher/dispatcher.go
@@ -172,7 +172,8 @@ func (d *FanOutDispatcher) initDispatchQueue(ctx context.Context, orgID, workflo
 		creds := &sdk.Credentials{}
 		if dbIntegration.SecretName != "" {
 			if err := d.credentialsProvider.ReadCredentials(ctx, dbIntegration.SecretName, creds); err != nil {
-				return nil, fmt.Errorf("reading credentials: %w", err)
+				d.log.Warn("msg", "error reading credentials", "err", err.Error())
+				continue
 			}
 		}
 


### PR DESCRIPTION
If during the integrations dispatch process one of the integrations can't find the credentials external dependency, it gets skipped instead of failing the execution.