### PR TITLE
chore(ci): update Chainloop contract

### DIFF
--- a/.github/workflows/contracts/releases.cue
+++ b/.github/workflows/contracts/releases.cue
@@ -9,7 +9,23 @@ materials: [
 	{type: "CONTAINER_IMAGE", name: "control-plane-image", output: true},
 	{type: "CONTAINER_IMAGE", name: "artifact-cas-image", output:  true},
 	// SBOMS for those container images
-	{type: "SBOM_CYCLONEDX_JSON", name: "sbom-control-plane"},
-	{type: "SBOM_CYCLONEDX_JSON", name: "sbom-artifact-cas"},
+	{
+		type: "SBOM_CYCLONEDX_JSON", name: "sbom-control-plane"
+		annotations: [
+			{
+				name:  "component"
+				value: "control-plane"
+			},
+		]
+	},
+	{
+		type: "SBOM_CYCLONEDX_JSON", name: "sbom-artifact-cas"
+		annotations: [
+			{
+				name:  "component"
+				value: "cas"
+			},
+		]
+	},
 ]
 runner: type: "GITHUB_ACTION"


### PR DESCRIPTION
Include annotations in the Chainloop release contract. Note that this PR should be landed and applied once the new release of Chainloop that contains annotations support is live.

refs #252 