### PR TITLE
feat(dependency-track): support global annotations in project name

### DIFF
--- a/app/controlplane/plugins/core/dependency-track/v1/extension.go
+++ b/app/controlplane/plugins/core/dependency-track/v1/extension.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"text/template"
 
 	schemaapi "github.com/chainloop-dev/chainloop/app/controlplane/api/workflowcontract/v1"
@@ -236,6 +237,17 @@ type annotations struct {
 	Annotations map[string]string
 }
 
+// Make annotations keys case insensitive
+// that way you can define templates such as {{ material.annotations.myAnnotation }} or {{ material.annotations.MyAnnotation }} and they will both work
+func toCaseInsensitive(in map[string]string) map[string]string {
+	for k, v := range in {
+		in[strings.Title(k)] = v
+		in[strings.ToLower(k)] = v
+	}
+
+	return in
+}
+
 // Resolve the project name template.
 // We currently support the following template variables:
 // - {{ .Attestation.Annotations.<key> }} for global annotations
@@ -243,8 +255,8 @@ type annotations struct {
 // For example, project-name => {{ material.annotations.my_annotation }}
 func resolveProjectName(projectNameTpl string, attAnnotations, sbomAnnotations map[string]string) (string, error) {
 	data := &interpolationContext{
-		Material:    &annotations{sbomAnnotations},
-		Attestation: &annotations{attAnnotations},
+		Material:    &annotations{toCaseInsensitive(sbomAnnotations)},
+		Attestation: &annotations{toCaseInsensitive(attAnnotations)},
 	}
 
 	// The project name can contain template variables, useful to include annotations for example

--- a/app/controlplane/plugins/core/dependency-track/v1/extension.go
+++ b/app/controlplane/plugins/core/dependency-track/v1/extension.go
@@ -242,7 +242,6 @@ type annotations struct {
 func toCaseInsensitive(in map[string]string) map[string]string {
 	for k, v := range in {
 		in[strings.Title(k)] = v
-		in[strings.ToLower(k)] = v
 	}
 
 	return in

--- a/app/controlplane/plugins/core/dependency-track/v1/extension_test.go
+++ b/app/controlplane/plugins/core/dependency-track/v1/extension_test.go
@@ -113,6 +113,11 @@ func TestResolveProjectName(t *testing.T) {
 			want:        "hola",
 		},
 		{
+			name:        "lower case",
+			projectName: "{{.Material.Annotations.hello}}",
+			want:        "hola",
+		},
+		{
 			name:        "interpolated string",
 			projectName: "{{.Material.Annotations.Hello}}-project",
 			want:        "hola-project",
@@ -122,11 +127,6 @@ func TestResolveProjectName(t *testing.T) {
 			projectName: "{{.Material.Annotations.noVal}}",
 			want:        "",
 			wantErr:     true,
-		},
-		{
-			name:        "lower case",
-			projectName: "{{.Material.Annotations.hello}}",
-			want:        "hola",
 		},
 		{
 			name:        "interpolated string global",
@@ -139,15 +139,15 @@ func TestResolveProjectName(t *testing.T) {
 			want:        "project-hola-1.2.3",
 		},
 		{
-			name:        "uppercase",
+			name:        "uppercase global",
 			projectName: "{{.Attestation.Annotations.Version}}",
 			want:        "1.2.3",
 		},
 	}
 
 	sbomAnnotation := map[string]string{
-		"Hello": "hola",
-		"World": "mundo",
+		"hello": "hola",
+		"world": "mundo",
 	}
 
 	attAnnotation := map[string]string{

--- a/app/controlplane/plugins/core/dependency-track/v1/extension_test.go
+++ b/app/controlplane/plugins/core/dependency-track/v1/extension_test.go
@@ -128,17 +128,31 @@ func TestResolveProjectName(t *testing.T) {
 			projectName: "{{.Material.Annotations.hello}}",
 			wantErr:     true,
 		},
+		{
+			name:        "interpolated string global",
+			projectName: "project-{{.Attestation.Annotations.version}}",
+			want:        "project-1.2.3",
+		},
+		{
+			name:        "interpolated combination global",
+			projectName: "project-{{.Material.Annotations.Hello}}-{{.Attestation.Annotations.version}}",
+			want:        "project-hola-1.2.3",
+		},
 	}
 
-	data := map[string]string{
+	sbomAnnotation := map[string]string{
 		"Hello": "hola",
 		"World": "mundo",
+	}
+
+	attAnnotation := map[string]string{
+		"version": "1.2.3",
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			var err error
-			got, err := resolveProjectName(tc.projectName, data)
+			got, err := resolveProjectName(tc.projectName, attAnnotation, sbomAnnotation)
 			if tc.wantErr {
 				assert.Error(t, err)
 				return

--- a/app/controlplane/plugins/core/dependency-track/v1/extension_test.go
+++ b/app/controlplane/plugins/core/dependency-track/v1/extension_test.go
@@ -124,9 +124,9 @@ func TestResolveProjectName(t *testing.T) {
 			wantErr:     true,
 		},
 		{
-			name:        "non-existing-case",
+			name:        "lower case",
 			projectName: "{{.Material.Annotations.hello}}",
-			wantErr:     true,
+			want:        "hola",
 		},
 		{
 			name:        "interpolated string global",
@@ -137,6 +137,11 @@ func TestResolveProjectName(t *testing.T) {
 			name:        "interpolated combination global",
 			projectName: "project-{{.Material.Annotations.Hello}}-{{.Attestation.Annotations.version}}",
 			want:        "project-hola-1.2.3",
+		},
+		{
+			name:        "uppercase",
+			projectName: "{{.Attestation.Annotations.Version}}",
+			want:        "1.2.3",
 		},
 	}
 

--- a/internal/attestation/renderer/chainloop/chainloop.go
+++ b/internal/attestation/renderer/chainloop/chainloop.go
@@ -35,6 +35,7 @@ const builderIDFmt = "chainloop.dev/cli/%s@%s"
 
 // NormalizablePredicate represents a common interface of how to extract materials and env vars
 type NormalizablePredicate interface {
+	GetAnnotations() map[string]string
 	GetEnvVars() map[string]string
 	GetMaterials() []*NormalizedMaterial
 	GetRunLink() string
@@ -194,4 +195,8 @@ func (p *ProvenancePredicateCommon) GetEnvVars() map[string]string {
 
 func (p *ProvenancePredicateCommon) GetRunLink() string {
 	return p.RunnerURL
+}
+
+func (p *ProvenancePredicateCommon) GetAnnotations() map[string]string {
+	return p.Annotations
 }


### PR DESCRIPTION
Allows leveraging global annotations in the dependency-track project name.

For example, let's assume we have the following contract with both material (called component) and global annotations (branch)

```json
cat /tmp/schema-old.json                        
{
        "schemaVersion":  "v1",
        "annotations":  [
                {
                        "name":  "branch",
                        "value": "stable"
                }
        ],
        "materials":  [
                {
                        "type":  "SBOM_CYCLONEDX_JSON",
                        "name":  "controlplane-sbom",
                        "annotations":  [
                                {
                                        "name":  "component",
                                        "value":  "controlplane"
                                }
                        ]
                },
                {
                        "type":  "SBOM_CYCLONEDX_JSON",
                        "name":  "cas-sbom",
                        "annotations":  [
                                {
                                        "name":  "component",
                                        "value":  "cas"
                                }
                        ]
                }
        ]
}
```

You can now attach the dependency-track instance to leverage both types of annotations

```bash
$ chainloop integration attached add .... 
--opt projectName="{{.Material.Annotations.component}}-{{ .Attestation.Annotations.branch }}"  
```

This will push the SBOMs to different projects based on those annotations.

![image](https://github.com/chainloop-dev/chainloop/assets/24523/81aae924-25a9-4888-9f3b-56ce399703eb)

