### PR TITLE
chore: Bump Chart Version v0.15.0

### DIFF
--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -4,9 +4,9 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.9.1
+version: 1.10.0
 # Do not update appVersion, this is handled automatically by the release process
-appVersion: v0.14.0
+appVersion: v0.15.0
 
 dependencies:
   - name: common


### PR DESCRIPTION
Note: our automated process actually failed for some reason https://github.com/chainloop-dev/chainloop/actions/runs/5714627160/job/15482450268 so I am triggering the release myself.