### PR TITLE
feat(slack): truncate message

### DIFF
--- a/app/controlplane/plugins/core/slack-webhook/v1/slack_webhook.go
+++ b/app/controlplane/plugins/core/slack-webhook/v1/slack_webhook.go
@@ -96,7 +96,9 @@ func (i *Integration) Execute(_ context.Context, req *sdk.ExecutionRequest) erro
 		return fmt.Errorf("running validation: %w", err)
 	}
 
-	summary, err := sdk.SummaryTable(req)
+	// 4000 is the max size of a Slack message
+	// if the message is larger than that, we will truncate it
+	summary, err := sdk.SummaryTable(req, sdk.WithMaxSize(4000))
 	if err != nil {
 		return fmt.Errorf("error summarizing the request: %w", err)
 	}

--- a/app/controlplane/plugins/sdk/v1/helpers.go
+++ b/app/controlplane/plugins/sdk/v1/helpers.go
@@ -27,7 +27,6 @@ import (
 
 type renderer struct {
 	render  func(t table.Writer) string
-	format  string
 	maxSize int
 }
 
@@ -52,7 +51,6 @@ func WithFormat(format string) RenderOpt {
 			return fmt.Errorf("unsupported format %s", format)
 		}
 
-		r.format = format
 		return nil
 	}
 }
@@ -68,7 +66,7 @@ func newRenderer(opts ...RenderOpt) (*renderer, error) {
 	r := &renderer{
 		render: func(t table.Writer) string {
 			return t.Render()
-		}, format: "text",
+		},
 	}
 
 	for _, opt := range opts {

--- a/app/controlplane/plugins/sdk/v1/helpers_test.go
+++ b/app/controlplane/plugins/sdk/v1/helpers_test.go
@@ -42,6 +42,12 @@ func (s *helperTestSuite) TestSummaryTable() {
 			outputPath: "testdata/attestations/full.txt",
 		},
 		{
+			name:       "truncated text",
+			inputPath:  "testdata/attestations/full.json",
+			renderOpts: []RenderOpt{WithMaxSize(2000)},
+			outputPath: "testdata/attestations/truncated.txt",
+		},
+		{
 			name:       "full markdown",
 			inputPath:  "testdata/attestations/full.json",
 			renderOpts: []RenderOpt{WithFormat("markdown")},

--- a/app/controlplane/plugins/sdk/v1/testdata/attestations/truncated.txt
+++ b/app/controlplane/plugins/sdk/v1/testdata/attestations/truncated.txt
@@ -1,0 +1,37 @@
+┌─────────────────────────────────────┐
+│ Workflow                            │
+├──────────────┬──────────────────────┤
+│ ID           │ deadbeef             │
+│ Name         │ test-workflow        │
+│ Team         │ test-team            │
+│ Project      │ test-project         │
+├──────────────┼──────────────────────┤
+│ Workflow Run │                      │
+├──────────────┼──────────────────────┤
+│ ID           │ beefdead             │
+│ Started At   │ 22 Nov 21 00:00 UTC  │
+│ Finished At  │ 22 Nov 21 00:10 UTC  │
+│ State        │ success              │
+│ Runner Link  │ chainloop.dev/runner │
+│ Annotations  │ ------               │
+│              │ branch: stable       │
+│              │ toplevel: true       │
+└──────────────┴──────────────────────┘
+┌────────────────────────────────────────────────────────────────────────────────┐
+│ Materials                                                                      │
+├─────────────┬──────────────────────────────────────────────────────────────────┤
+│ Name        │ image                                                            │
+│ Type        │ CONTAINER_IMAGE                                                  │
+│ Value       │ index.docker.io/bitnami/nginx                                    │
+│ Digest      │ 264f55a6ff9cec2f4742a9faacc033b29f65c04dd4480e71e23579d484288d61 │
+├─────────────┼──────────────────────────────────────────────────────────────────┤
+│ Name        │ skynet-sbom                                                      │
+│ Type        │ SBOM_CYCLONEDX_JSON                                              │
+│ Value       │ sbom.cyclonedx.json                                              │
+│ Digest      │ 16159bb881eb4ab7eb5d8afc5350b0feeed1e31c0a268e355e74f9ccbe885e0c │
+│ Annotations │ ------                                                           │
+│             │ component: nginx                              ... (truncated)
+
+Get Full Attestation
+
+$ chainloop workflow run describe --id beefdead -o statement


### PR DESCRIPTION
Add render option to truncate the output table to a number of runes. A 4000 chars limit is then set to the Slack message to prevent #272 

The truncate is slightly smart since it leaves the footer where the command to get the attestation info stays intact.

![image](https://github.com/chainloop-dev/chainloop/assets/24523/162f5261-0813-42a2-8152-516bb56eb3ba)

Note: ideally, eventually, we should do custom markup for Slack using Slack blocks, but this feature at least prevents broken rendering in the case of overflow.

Closes #272 
