### PR TITLE
fix(deployment): chart should work with old version of code

### DIFF
--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -4,7 +4,7 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.10.3
+version: 1.10.4
 # Do not update appVersion, this is handled automatically by the release process
 appVersion: v0.15.0
 

--- a/deployment/chainloop/templates/cas/config.secret.yaml
+++ b/deployment/chainloop/templates/cas/config.secret.yaml
@@ -17,4 +17,6 @@ stringData:
     credentials_service: {{- include "chainloop.credentials_service_settings" . | indent 6 }}
     auth:
       public_key_path: "/tmp/cas.public.pem"
+      # Deprecated, use public_key_path instead. Remove option once release of the app 0.15+ is out.
+      robot_account_public_key_path: "/tmp/cas.public.pem"
     # TODO: add observability


### PR DESCRIPTION
https://github.com/chainloop-dev/chainloop/pull/294 introduced a change in the configuration which was assumed to be used in the next version of the helm Chart.

This code change has not been released yet so the Chart instead now contains the old and the new version so it works with both.