### PR TITLE
feat(deployment): support downloading redirect

### DIFF
--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -4,7 +4,7 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.10.4
+version: 1.10.5
 # Do not update appVersion, this is handled automatically by the release process
 appVersion: v0.15.0
 

--- a/deployment/chainloop/templates/_helpers.tpl
+++ b/deployment/chainloop/templates/_helpers.tpl
@@ -100,24 +100,6 @@ null
 {{- end -}}
 
 {{/*
-Figure out the external URL the controlplane can be reached at
-This endpoint is used for the CLI to know where to go for log in
-NOTE: Load balancer service type is not supported
-*/}}
-{{- define "chainloop.controlplane.external_url" -}}
-{{- $service := .Values.controlplane.service }}
-{{- $ingress := .Values.controlplane.ingress }}
-
-{{- if (and $ingress $ingress.enabled $ingress.hostname) }}
-{{- printf "%s://%s" (ternary "https" "http" $ingress.tls ) $ingress.hostname }}
-{{- else if (and (eq $service.type "NodePort") $service.nodePorts (not (empty $service.nodePorts.http))) }}
-{{- printf "http://localhost:%s" $service.nodePorts.http }}
-{{- else -}}
-null
-{{- end -}}
-{{- end -}}
-
-{{/*
 ##############################################################################
 Controlplane helpers
 ##############################################################################
@@ -269,6 +251,24 @@ Return the Postgresql user
 {{- end -}}
 
 {{/*
+Figure out the external URL the controlplane can be reached at
+This endpoint is used for the CLI to know where to go for log in
+NOTE: Load balancer service type is not supported
+*/}}
+{{- define "chainloop.controlplane.external_url" -}}
+{{- $service := .Values.controlplane.service }}
+{{- $ingress := .Values.controlplane.ingress }}
+
+{{- if (and $ingress $ingress.enabled $ingress.hostname) }}
+{{- printf "%s://%s" (ternary "https" "http" $ingress.tls ) $ingress.hostname }}
+{{- else if (and (eq $service.type "NodePort") $service.nodePorts (not (empty $service.nodePorts.http))) }}
+{{- printf "http://localhost:%s" $service.nodePorts.http }}
+{{- else -}}
+null
+{{- end -}}
+{{- end -}}
+
+{{/*
 ##############################################################################
 CAS Helpers
 ##############################################################################
@@ -316,3 +316,19 @@ Create the name of the service account to use
 {{- default "default" .Values.cas.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+External URL the CAS can be reached at
+This endpoint is used for the cas to redirect downloads
+NOTE: Load balancer service type is not supported
+*/}}
+{{- define "chainloop.cas.external_url" -}}
+{{- $service := .Values.cas.service }}
+{{- $ingress := .Values.cas.ingress }}
+
+{{- if (and $ingress $ingress.enabled $ingress.hostname) }}
+{{- printf "%s://%s" (ternary "https" "http" $ingress.tls ) $ingress.hostname }}
+{{- else if (and (eq $service.type "NodePort") $service.nodePorts (not (empty $service.nodePorts.http))) }}
+{{- printf "http://localhost:%s" $service.nodePorts.http }}
+{{- end -}}
+{{- end -}}

--- a/deployment/chainloop/templates/controlplane/config.configmap.yaml
+++ b/deployment/chainloop/templates/controlplane/config.configmap.yaml
@@ -28,4 +28,5 @@ data:
       grpc:
         addr: {{ printf "%s-api:%.0f" (include "chainloop.cas.fullname" .) .Values.cas.serviceAPI.port }}
       insecure: true
+      download_url: {{ include "chainloop.cas.external_url" . }}/download
     plugins_dir: {{ .Values.controlplane.pluginsDir }}

--- a/deployment/chainloop/templates/controlplane/config.configmap.yaml
+++ b/deployment/chainloop/templates/controlplane/config.configmap.yaml
@@ -17,7 +17,7 @@ data:
     server:
       http:
         addr: 0.0.0.0:8000
-        timeout: 1s
+        timeout: 10s
         external_url: {{ include "chainloop.controlplane.external_url" . }}
       http_metrics:
         addr: 0.0.0.0:5000


### PR DESCRIPTION
Updates the deployment to be able to leverage the features implemented here #307 

```diff
@@ -207,7 +207,7 @@                                                            
     server:                                                                   
       http:         
         addr: 0.0.0.0:8000
-        timeout: 1s
+        timeout: 10s                                                          
         external_url: http://cp.chainloop.dev
       http_metrics:                                                           
         addr: 0.0.0.0:5000                                                    
@@ -218,6 +218,7 @@                                                            
       grpc:                                                                   
         addr: test-chainloop-cas-api:80  
       insecure: true
+      download_url: https://cas.local.chainloop.dev/download
     plugins_dir: /plugins
 ---
```

Refs #293 