### PR TITLE
fix(cas): not found error

### DIFF
--- a/app/artifact-cas/internal/service/download.go
+++ b/app/artifact-cas/internal/service/download.go
@@ -78,7 +78,7 @@ func (s *DownloadService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	info, err := b.Describe(ctx, hash.Hex)
 	if err != nil && backend.IsNotFound(err) {
-		http.Error(w, err.Error(), http.StatusNotFound)
+		http.Error(w, "not found", http.StatusNotFound)
 		return
 	} else if err != nil {
 		http.Error(w, sl.LogAndMaskErr(err, s.log).Error(), http.StatusInternalServerError)

--- a/app/artifact-cas/internal/service/download.go
+++ b/app/artifact-cas/internal/service/download.go
@@ -78,7 +78,7 @@ func (s *DownloadService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	info, err := b.Describe(ctx, hash.Hex)
 	if err != nil && backend.IsNotFound(err) {
-		http.Error(w, "not found", http.StatusNotFound)
+		http.Error(w, "artifact not found", http.StatusNotFound)
 		return
 	} else if err != nil {
 		http.Error(w, sl.LogAndMaskErr(err, s.log).Error(), http.StatusInternalServerError)


### PR DESCRIPTION
Replaces `image not found` for `not found`

The culprit of this bug is that the underlying implementation was returning a 404 and the reason being that the OCI image is not found.

From the CAS API POV, we do not care about the implementation details but just that the artifact is not found.

Good catch @danlishka, for some reason I thought it was my browser interpreting the mimetype as image 🤦🏼 

 