### PR TITLE
feat(deployment): allow to configure TLS certificate for gRPC servers

### DIFF
--- a/deployment/chainloop/templates/cas/config.configmap.yaml
+++ b/deployment/chainloop/templates/cas/config.configmap.yaml
@@ -11,6 +11,11 @@ data:
         addr: 0.0.0.0:8000
         timeout: 1s
       grpc:
+        {{- if .Values.cas.tlsConfig.secret.name  }}
+        tls_config:
+          certificate: /data/server-certs/tls.crt
+          private_key: /data/server-certs/tls.key
+        {{- end }}
         addr: 0.0.0.0:9000
         timeout: 1s
       http_metrics:

--- a/deployment/chainloop/templates/cas/deployment.yaml
+++ b/deployment/chainloop/templates/cas/deployment.yaml
@@ -62,6 +62,10 @@ spec:
             - name: gcp-secretmanager-serviceaccountkey
               mountPath: /gcp-secrets
             {{- end }}
+            {{- if .Values.cas.tlsConfig.secret.name  }}
+            - name: server-certs
+              mountPath: /data/server-certs
+            {{- end }}
       volumes:
         - name: config
           projected:
@@ -73,6 +77,11 @@ spec:
         - name: jwt-public-key
           secret:
             secretName: {{ include "chainloop.cas.fullname" . }}-jwt-public-key
+        {{- if .Values.cas.tlsConfig.secret.name  }}
+        - name: server-certs
+          secret:
+            secretName: {{ .Values.cas.tlsConfig.secret.name  }}
+        {{- end }}
         {{- if eq "gcpSecretManager" .Values.secretsBackend.backend  }}
         - name: gcp-secretmanager-serviceaccountkey
           secret:

--- a/deployment/chainloop/templates/controlplane/config.configmap.yaml
+++ b/deployment/chainloop/templates/controlplane/config.configmap.yaml
@@ -24,6 +24,11 @@ data:
       grpc:
         addr: 0.0.0.0:9000
         timeout: 10s
+        {{- if .Values.controlplane.tlsConfig.secret.name  }}
+        tls_config:
+          certificate: /data/server-certs/tls.crt
+          private_key: /data/server-certs/tls.key
+        {{- end }}
     cas_server:
       grpc:
         addr: {{ printf "%s-api:%.0f" (include "chainloop.cas.fullname" .) .Values.cas.serviceAPI.port }}

--- a/deployment/chainloop/templates/controlplane/deployment.yaml
+++ b/deployment/chainloop/templates/controlplane/deployment.yaml
@@ -85,6 +85,10 @@ spec:
               mountPath: /tmp
             - name: jwt-cas-private-key
               mountPath: /secrets
+            {{- if .Values.controlplane.tlsConfig.secret.name  }}
+            - name: server-certs
+              mountPath: /data/server-certs
+            {{- end }}
             {{- if eq "gcpSecretManager" .Values.secretsBackend.backend  }}
             - name: gcp-secretmanager-serviceaccountkey
               mountPath: /gcp-secrets
@@ -103,6 +107,11 @@ spec:
         - name: jwt-cas-private-key
           secret:
             secretName: {{ include "chainloop.controlplane.fullname" . }}-jwt-cas
+        {{- if .Values.controlplane.tlsConfig.secret.name  }}
+        - name: server-certs
+          secret:
+            secretName: {{ .Values.controlplane.tlsConfig.secret.name  }}
+        {{- end }}
         {{- if eq "gcpSecretManager" .Values.secretsBackend.backend  }}
         - name: gcp-secretmanager-serviceaccountkey
           secret:

--- a/deployment/chainloop/values.yaml
+++ b/deployment/chainloop/values.yaml
@@ -103,6 +103,12 @@ controlplane:
     # Overrides the image tag whose default is the chart appVersion.
     # tag: latest
 
+  ## @param controlplane.secret.name name of a secret containing TLS certificate to be used by the controlplane grpc server.
+  tlsConfig:
+    secret:
+      # the secret must contains 2 keys: tls.crt and tls.key respectively containing the certificate and private key.
+      name: ""
+
   ## @param controlplane.pluginsDir Directory where to look for plugins
   pluginsDir: /plugins
 
@@ -442,6 +448,12 @@ cas:
     repository: ghcr.io/chainloop-dev/chainloop/artifact-cas
     # Overrides the image tag whose default is the chart appVersion.
     # tag: latest
+
+  ## @param cas.tlsConfig.secret.name name of a secret containing TLS certificate to be used by the controlplane grpc server.
+  tlsConfig:
+    secret:
+      # the secret must contains 2 keys: tls.crt and tls.key respectively containing the certificate and private key.
+      name: ""
 
   ## @skip cas.serviceAccount
   serviceAccount:


### PR DESCRIPTION
The helm chart now allows to specify a sercret name where a TLS certificate and key are store. If specified, it mounts the secret in the pods and update the configuration to enable TLS on the servers.

```diff
@@ -180,6 +180,9 @@
         addr: 0.0.0.0:8000
         timeout: 1s
       grpc:
+        tls_config:
+          certificate: /data/server-certs/tls.crt
+          private_key: /data/server-certs/tls.key
         addr: 0.0.0.0:9000
         timeout: 1s
       http_metrics:
@@ -209,6 +212,9 @@
       grpc:
         addr: 0.0.0.0:9000
         timeout: 10s
+        tls_config:
+          certificate: /data/server-certs/tls.crt
+          private_key: /data/server-certs/tls.key
     cas_server:
       grpc:
         addr: foo-chainloop-cas-api:80
@@ -390,6 +396,8 @@
               mountPath: "/tmp"
             - name: gcp-secretmanager-serviceaccountkey
               mountPath: /gcp-secrets
+            - name: server-certs
+              mountPath: /data/server-certs
       volumes:
         - name: config
           projected:
@@ -401,6 +409,9 @@
         - name: jwt-public-key
           secret:
             secretName: foo-chainloop-cas-jwt-public-key
+        - name: server-certs
+          secret:
+            secretName: server_certs
         - name: gcp-secretmanager-serviceaccountkey
           secret:
             secretName: foo-chainloop-controlplane-gcp-secretmanager-serviceaccountkey
@@ -504,6 +515,8 @@
               mountPath: /tmp
             - name: jwt-cas-private-key
               mountPath: /secrets
+            - name: server-certs
+              mountPath: /data/server-certs
             - name: gcp-secretmanager-serviceaccountkey
               mountPath: /gcp-secrets
       volumes:
@@ -520,6 +533,9 @@
         - name: jwt-cas-private-key
           secret:
             secretName: foo-chainloop-controlplane-jwt-cas
+        - name: server-certs
+          secret:
+            secretName: server_certs
         - name: gcp-secretmanager-serviceaccountkey
           secret:
             secretName: foo-chainloop-controlplane-gcp-secretmanager-serviceaccountkey
```
