### PR TITLE
fix: show downloading message during redirect

### DIFF
--- a/app/controlplane/internal/service/casredirect.go
+++ b/app/controlplane/internal/service/casredirect.go
@@ -159,7 +159,7 @@ func (s *CASRedirectService) HTTPDownload(ctx khttp.Context) error {
 	// the UX for the user is like the browser got stuck
 	ctx.Response().Header().Set("Refresh", "1;url="+urlResponse.Result.Url)
 	ctx.Response().WriteHeader(http.StatusFound)
-	fmt.Fprintln(ctx.Response(), "Downloading...")
+	fmt.Fprintln(ctx.Response(), "Your download will begin shortly...")
 
 	return nil
 }

--- a/app/controlplane/internal/service/casredirect.go
+++ b/app/controlplane/internal/service/casredirect.go
@@ -153,7 +153,14 @@ func (s *CASRedirectService) HTTPDownload(ctx khttp.Context) error {
 	}
 
 	// perform redirect
-	http.Redirect(ctx.Response(), ctx.Request(), urlResponse.Result.Url, http.StatusTemporaryRedirect)
+	// In order ton show a redirect message in the page before the redirection,
+	// we need to use a Refresh Header instead of a vanilla redirect (via location change)
+	// We want to show a message because in some cases the download will be shown as downloadable and hence
+	// the UX for the user is like the browser got stuck
+	ctx.Response().Header().Set("Refresh", "1;url="+urlResponse.Result.Url)
+	ctx.Response().WriteHeader(http.StatusFound)
+	fmt.Fprintln(ctx.Response(), "Downloading...")
+
 	return nil
 }
 


### PR DESCRIPTION
This will show a `downloading` message when the download URL is put. 

This is useful to fix an issue we found when the OIDC roundtrip was not finishing.
![Peek 2023-09-05 23-07](https://github.com/chainloop-dev/chainloop/assets/24523/fc1b5364-d055-4101-aeb6-f1a12f3c9057)

