### PR TITLE
Revert "chore: bump Chainloop CLI version (#334)"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
       packages: write # to push container images
       pull-requests: write
     env:
-      CHAINLOOP_VERSION: 0.17.0
+      CHAINLOOP_VERSION: 0.15.0
       CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT }}
       CONTAINER_IMAGE_CP: ghcr.io/chainloop-dev/chainloop/control-plane:${{ github.ref_name }}
       CONTAINER_IMAGE_CAS: ghcr.io/chainloop-dev/chainloop/artifact-cas:${{ github.ref_name }}


### PR DESCRIPTION
This reverts commit af1fa6e9d67853672c138de5468ff9c9cbf72b09.

My bad, that release is no longer available 🤦🏼 