### PR TITLE
feat: Split Sentry configuration for individual services

### DIFF
--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -4,7 +4,7 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.16.0
+version: 1.16.1
 # Do not update appVersion, this is handled automatically by the release process
 appVersion: v0.18.0
 

--- a/deployment/chainloop/README.md
+++ b/deployment/chainloop/README.md
@@ -156,6 +156,7 @@ helm install [RELEASE_NAME] oci://ghcr.io/chainloop-dev/charts/chainloop \
     --set controlplane.auth.oidc.clientID=[clientID] \
     --set controlplane.auth.oidc.clientSecret=[clientSecret]
 ```
+
 ## How to guides
 
 ### Generate a ECDSA key-pair
@@ -175,13 +176,13 @@ Then, you can either provide it in a custom `values.yaml` file override
 
 ```yaml
 casJWTPrivateKey: |-
-    -----BEGIN EC PRIVATE KEY-----
-    REDACTED
-    -----END EC PRIVATE KEY-----
+  -----BEGIN EC PRIVATE KEY-----
+  REDACTED
+  -----END EC PRIVATE KEY-----
 casJWTPublicKey: |
-    -----BEGIN PUBLIC KEY-----
-    REDACTED
-    -----END PUBLIC KEY-----
+  -----BEGIN PUBLIC KEY-----
+  REDACTED
+  -----END PUBLIC KEY-----
 ```
 
 or as shown before, provide them as imperative inputs during Helm Install/Upgrade `--set casJWTPrivateKey="$(cat private.ec.key)"--set casJWTPublicKey="$(cat public.pem)"`
@@ -203,9 +204,9 @@ controlplane:
     hostname: api.cp.chainloop.dev
 
 cas:
-    ingressAPI:
-    enabled: true
-    hostname: api.cas.chainloop.dev
+  ingressAPI:
+  enabled: true
+  hostname: api.cas.chainloop.dev
 ```
 
 A complete setup that uses
@@ -223,7 +224,7 @@ controlplane:
     ingressClassName: nginx
     hostname: cp.chainloop.dev
     annotations:
-      # This depends on your configured issuer 
+      # This depends on your configured issuer
       cert-manager.io/cluster-issuer: "letsencrypt-prod"
 
   ingressAPI:
@@ -234,7 +235,7 @@ controlplane:
     annotations:
       nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
       cert-manager.io/cluster-issuer: "letsencrypt-prod"
-          
+
 cas:
   ingressAPI:
     enabled: true
@@ -262,12 +263,12 @@ postgresql:
 
 # Provide with external connection
 controlplane:
-    externalDatabase:
-        host: 1.2.3.4
-        port: 5432
-        user: chainloop
-        password: [REDACTED]
-        database: chainloop-controlplane-prod
+  externalDatabase:
+    host: 1.2.3.4
+    port: 5432
+    user: chainloop
+    password: [REDACTED]
+    database: chainloop-controlplane-prod
 ```
 
 Alternatively, if you are using [Google Cloud SQL](https://cloud.google.com/sql) and you are running Chainloop in Google Kubernetes Engine. You can connect instead via [a proxy](https://cloud.google.com/sql/docs/mysql/connect-kubernetes-engine#proxy)
@@ -281,18 +282,18 @@ postgresql:
 
 # Provide with external connection
 controlplane:
-    sqlProxy:
-        # Inject the proxy sidecar
-        enabled: true
-        ## @param controlplane.sqlProxy.connectionName Google Cloud SQL connection name
-        connectionName: "my-sql-instance"
-    # Then you'll need to configure your DB settings to use the proxy IP address
-    externalDatabase:
-        host: [proxy-sidecar-ip-address]
-        port: 5432
-        user: chainloop
-        password: [REDACTED]
-        database: chainloop-controlplane-prod
+  sqlProxy:
+    # Inject the proxy sidecar
+    enabled: true
+    ## @param controlplane.sqlProxy.connectionName Google Cloud SQL connection name
+    connectionName: "my-sql-instance"
+  # Then you'll need to configure your DB settings to use the proxy IP address
+  externalDatabase:
+    host: [proxy-sidecar-ip-address]
+    port: 5432
+    user: chainloop
+    password: [REDACTED]
+    database: chainloop-controlplane-prod
 ```
 
 ### Use AWS secret manager
@@ -301,11 +302,11 @@ You can swap the secret manager backend with the following settings
 
 ```yaml
 secretsBackend:
-    backend: awsSecretManager
-    awsSecretManager:
-        accessKey: [KEY]
-        secretKey: [SECRET]
-        region: [REGION]
+  backend: awsSecretManager
+  awsSecretManager:
+    accessKey: [KEY]
+    secretKey: [SECRET]
+    region: [REGION]
 ```
 
 ### Use GCP secret manager
@@ -314,16 +315,28 @@ You can swap the secret manager backend with the following settings
 
 ```yaml
 secretsBackend:
-    backend: gcpSecretManager
-    gcpSecretManager:
-        projectId: [PROJECT_ID]
-        serviceAccountKey: [KEY]
+  backend: gcpSecretManager
+  gcpSecretManager:
+    projectId: [PROJECT_ID]
+    serviceAccountKey: [KEY]
 ```
 
 ### Send exceptions to Sentry
 
+You can configure different sentry projects for both the controlplane and the artifact CAS
+
 ```yaml
-sentry:
+# for controlplane
+controlplane:
+  ...
+  sentry:
+    enabled: true
+    dsn: [your secret sentry project DSN URL]
+    environment: production
+# Artifact CAS
+cas:
+  ...
+  sentry:
     enabled: true
     dsn: [your secret sentry project DSN URL]
     environment: production
@@ -349,28 +362,25 @@ chainloop config save \
 
 ### Common parameters
 
-| Name                    | Description                                                                                                                                                            | Value        |
-| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
-| `kubeVersion`           | Override Kubernetes version                                                                                                                                            | `""`         |
-| `development`           | Deploys Chainloop pre-configured FOR DEVELOPMENT ONLY. It includes a Vault instance in development mode and pre-configured authentication certificates and passphrases | `false`      |
-| `GKEMonitoring.enabled` | Enable GKE podMonitoring (prometheus.io scrape) to scrape the controlplane and CAS /metrics endpoints                                                                  | `false`      |
-| `sentry.enabled`        | Enable sentry.io alerting                                                                                                                                              | `false`      |
-| `sentry.dsn`            | DSN endpoint https://docs.sentry.io/product/sentry-basics/dsn-explainer/                                                                                               | `""`         |
-| `sentry.environment`    | Environment tag                                                                                                                                                        | `production` |
+| Name                    | Description                                                                                                                                                            | Value   |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `kubeVersion`           | Override Kubernetes version                                                                                                                                            | `""`    |
+| `development`           | Deploys Chainloop pre-configured FOR DEVELOPMENT ONLY. It includes a Vault instance in development mode and pre-configured authentication certificates and passphrases | `false` |
+| `GKEMonitoring.enabled` | Enable GKE podMonitoring (prometheus.io scrape) to scrape the controlplane and CAS /metrics endpoints                                                                  | `false` |
 
 ### Secrets Backend
 
-| Name                                                | Description                                                               | Value       |
-| --------------------------------------------------- | ------------------------------------------------------------------------- | ----------- |
-| `secretsBackend.backend`                            | Secrets backend type ("vault", "awsSecretManager" or "gcpSecretManager")  | `vault`     |
-| `secretsBackend.secretPrefix`                       | Prefix that will be pre-pended to all secrets in the storage backend      | `chainloop` |
-| `secretsBackend.vault.address`                      | Vault address                                                             |             |
-| `secretsBackend.vault.token`                        | Vault authentication token                                                |             |
-| `secretsBackend.awsSecretManager.accessKey`         | AWS Access KEY ID                                                         |             |
-| `secretsBackend.awsSecretManager.secretKey`         | AWS Secret Key                                                            |             |
-| `secretsBackend.awsSecretManager.region`            | AWS Secret Manager Region                                                 |             |
-| `secretsBackend.gcpSecretManager.projectId`         | GCP Project ID                                                            |             |
-| `secretsBackend.gcpSecretManager.serviceAccountKey` | GCP Auth Key                                                              |             |
+| Name                                                | Description                                                              | Value       |
+| --------------------------------------------------- | ------------------------------------------------------------------------ | ----------- |
+| `secretsBackend.backend`                            | Secrets backend type ("vault", "awsSecretManager" or "gcpSecretManager") | `vault`     |
+| `secretsBackend.secretPrefix`                       | Prefix that will be pre-pended to all secrets in the storage backend     | `chainloop` |
+| `secretsBackend.vault.address`                      | Vault address                                                            |             |
+| `secretsBackend.vault.token`                        | Vault authentication token                                               |             |
+| `secretsBackend.awsSecretManager.accessKey`         | AWS Access KEY ID                                                        |             |
+| `secretsBackend.awsSecretManager.secretKey`         | AWS Secret Key                                                           |             |
+| `secretsBackend.awsSecretManager.region`            | AWS Secret Manager Region                                                |             |
+| `secretsBackend.gcpSecretManager.projectId`         | GCP Project ID                                                           |             |
+| `secretsBackend.gcpSecretManager.serviceAccountKey` | GCP Auth Key                                                             |             |
 
 ### Authentication
 
@@ -381,12 +391,13 @@ chainloop config save \
 
 ### Control Plane
 
-| Name                            | Description                                                                         | Value                                           |
-| ------------------------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------- |
-| `controlplane.replicaCount`     | Number of replicas                                                                  | `2`                                             |
-| `controlplane.image.repository` | FQDN uri for the image                                                              | `ghcr.io/chainloop-dev/chainloop/control-plane` |
-| `controlplane.image.tag`        | Image tag (immutable tags are recommended). If no set chart.appVersion will be used |                                                 |
-| `controlplane.pluginsDir`       | Directory where to look for plugins                                                 | `/plugins`                                      |
+| Name                                 | Description                                                                             | Value                                           |
+| ------------------------------------ | --------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| `controlplane.replicaCount`          | Number of replicas                                                                      | `2`                                             |
+| `controlplane.image.repository`      | FQDN uri for the image                                                                  | `ghcr.io/chainloop-dev/chainloop/control-plane` |
+| `controlplane.image.tag`             | Image tag (immutable tags are recommended). If no set chart.appVersion will be used     |                                                 |
+| `controlplane.tlsConfig.secret.name` | name of a secret containing TLS certificate to be used by the controlplane grpc server. | `""`                                            |
+| `controlplane.pluginsDir`            | Directory where to look for plugins                                                     | `/plugins`                                      |
 
 ### Control Plane Database
 
@@ -453,25 +464,29 @@ chainloop config save \
 
 ### Controlplane Misc
 
-| Name                                                         | Description                        | Value   |
-| ------------------------------------------------------------ | ---------------------------------- | ------- |
-| `controlplane.resources.limits.cpu`                          | Container resource limits CPU      | `250m`  |
-| `controlplane.resources.limits.memory`                       | Container resource limits memory   | `512Mi` |
-| `controlplane.resources.requests.cpu`                        | Container resource requests CPU    | `250m`  |
-| `controlplane.resources.requests.memory`                     | Container resource requests memory | `512Mi` |
-| `controlplane.autoscaling.enabled`                           | Enable deployment autoscaling      | `false` |
-| `controlplane.autoscaling.minReplicas`                       | Minimum number of replicas         | `1`     |
-| `controlplane.autoscaling.maxReplicas`                       | Maximum number of replicas         | `100`   |
-| `controlplane.autoscaling.targetCPUUtilizationPercentage`    | Target CPU percentage              | `80`    |
-| `controlplane.autoscaling.targetMemoryUtilizationPercentage` | Target CPU memory                  | `80`    |
+| Name                                                         | Description                                                              | Value        |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------ | ------------ |
+| `controlplane.resources.limits.cpu`                          | Container resource limits CPU                                            | `250m`       |
+| `controlplane.resources.limits.memory`                       | Container resource limits memory                                         | `512Mi`      |
+| `controlplane.resources.requests.cpu`                        | Container resource requests CPU                                          | `250m`       |
+| `controlplane.resources.requests.memory`                     | Container resource requests memory                                       | `512Mi`      |
+| `controlplane.autoscaling.enabled`                           | Enable deployment autoscaling                                            | `false`      |
+| `controlplane.autoscaling.minReplicas`                       | Minimum number of replicas                                               | `1`          |
+| `controlplane.autoscaling.maxReplicas`                       | Maximum number of replicas                                               | `100`        |
+| `controlplane.autoscaling.targetCPUUtilizationPercentage`    | Target CPU percentage                                                    | `80`         |
+| `controlplane.autoscaling.targetMemoryUtilizationPercentage` | Target CPU memory                                                        | `80`         |
+| `controlplane.sentry.enabled`                                | Enable sentry.io alerting                                                | `false`      |
+| `controlplane.sentry.dsn`                                    | DSN endpoint https://docs.sentry.io/product/sentry-basics/dsn-explainer/ | `""`         |
+| `controlplane.sentry.environment`                            | Environment tag                                                          | `production` |
 
 ### Artifact Content Addressable (CAS) API
 
-| Name                   | Description                                                                         | Value                                          |
-| ---------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------- |
-| `cas.replicaCount`     | Number of replicas                                                                  | `2`                                            |
-| `cas.image.repository` | FQDN uri for the image                                                              | `ghcr.io/chainloop-dev/chainloop/artifact-cas` |
-| `cas.image.tag`        | Image tag (immutable tags are recommended). If no set chart.appVersion will be used |                                                |
+| Name                        | Description                                                                             | Value                                          |
+| --------------------------- | --------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| `cas.replicaCount`          | Number of replicas                                                                      | `2`                                            |
+| `cas.image.repository`      | FQDN uri for the image                                                                  | `ghcr.io/chainloop-dev/chainloop/artifact-cas` |
+| `cas.image.tag`             | Image tag (immutable tags are recommended). If no set chart.appVersion will be used     |                                                |
+| `cas.tlsConfig.secret.name` | name of a secret containing TLS certificate to be used by the controlplane grpc server. | `""`                                           |
 
 ### CAS Networking
 
@@ -515,19 +530,22 @@ chainloop config save \
 
 ### CAS Misc
 
-| Name                                                | Description                        | Value   |
-| --------------------------------------------------- | ---------------------------------- | ------- |
-| `cas.resources.limits.cpu`                          | Container resource limits CPU      | `250m`  |
-| `cas.resources.limits.memory`                       | Container resource limits memory   | `512Mi` |
-| `cas.resources.requests.cpu`                        | Container resource requests CPU    | `250m`  |
-| `cas.resources.requests.memory`                     | Container resource requests memory | `512Mi` |
-| `cas.autoscaling.enabled`                           | Enable deployment autoscaling      | `false` |
-| `cas.autoscaling.minReplicas`                       | Minimum number of replicas         | `1`     |
-| `cas.autoscaling.maxReplicas`                       | Maximum number of replicas         | `100`   |
-| `cas.autoscaling.targetCPUUtilizationPercentage`    | Target CPU percentage              | `80`    |
-| `cas.autoscaling.targetMemoryUtilizationPercentage` | Target CPU memory                  | `80`    |
+| Name                                                | Description                                                              | Value        |
+| --------------------------------------------------- | ------------------------------------------------------------------------ | ------------ |
+| `cas.resources.limits.cpu`                          | Container resource limits CPU                                            | `250m`       |
+| `cas.resources.limits.memory`                       | Container resource limits memory                                         | `512Mi`      |
+| `cas.resources.requests.cpu`                        | Container resource requests CPU                                          | `250m`       |
+| `cas.resources.requests.memory`                     | Container resource requests memory                                       | `512Mi`      |
+| `cas.autoscaling.enabled`                           | Enable deployment autoscaling                                            | `false`      |
+| `cas.autoscaling.minReplicas`                       | Minimum number of replicas                                               | `1`          |
+| `cas.autoscaling.maxReplicas`                       | Maximum number of replicas                                               | `100`        |
+| `cas.autoscaling.targetCPUUtilizationPercentage`    | Target CPU percentage                                                    | `80`         |
+| `cas.autoscaling.targetMemoryUtilizationPercentage` | Target CPU memory                                                        | `80`         |
+| `cas.sentry.enabled`                                | Enable sentry.io alerting                                                | `false`      |
+| `cas.sentry.dsn`                                    | DSN endpoint https://docs.sentry.io/product/sentry-basics/dsn-explainer/ | `""`         |
+| `cas.sentry.environment`                            | Environment tag                                                          | `production` |
 
-### Dependencies 
+### Dependencies
 
 | Name                                 | Description                                                                                            | Value          |
 | ------------------------------------ | ------------------------------------------------------------------------------------------------------ | -------------- |
@@ -539,7 +557,6 @@ chainloop config save \
 | `postgresql.auth.existingSecret`     | Name of existing secret to use for PostgreSQL credentials                                              | `""`           |
 | `vault.server.dev.enabled`           | Enable development mode (unsealed, in-memory, insecure)                                                | `true`         |
 | `vault.server.dev.devRootToken`      | Connection token                                                                                       | `notapassword` |
-
 
 ## License
 

--- a/deployment/chainloop/templates/_helpers.tpl
+++ b/deployment/chainloop/templates/_helpers.tpl
@@ -274,6 +274,13 @@ null
 {{- end -}}
 {{- end -}}
 
+{{- define "chainloop.sentry" -}}
+observability:
+  sentry:
+    dsn: {{ required "Sentry DSN required" .dsn | quote }}
+    environment: {{ required "Sentry environment required" .environment | quote }}
+{{- end -}}
+
 {{/*
 ##############################################################################
 sql-proxy helpers

--- a/deployment/chainloop/templates/cas/config.secret.yaml
+++ b/deployment/chainloop/templates/cas/config.secret.yaml
@@ -6,12 +6,9 @@ metadata:
     {{- include "chainloop.cas.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  {{- if and .Values.sentry .Values.sentry.enabled }}
+  {{- if and .Values.cas.sentry .Values.cas.sentry.enabled }}
   config.observability.yaml: |
-    observability:
-      sentry:
-        dsn: {{ required "Sentry DSN required" .Values.sentry.dsn | quote }}
-        environment: {{ required "Sentry environment required" .Values.sentry.environment | quote }}
+    {{- include "chainloop.sentry" .Values.cas.sentry | nindent 4 }}
   {{- end }}
   config.secret.yaml: |
     credentials_service: {{- include "chainloop.credentials_service_settings" . | indent 6 }}

--- a/deployment/chainloop/templates/controlplane/config.secret.yaml
+++ b/deployment/chainloop/templates/controlplane/config.secret.yaml
@@ -11,11 +11,11 @@ data:
   generated_jws_hmac_secret: {{ $hmacpass }}
 stringData:
   {{- if and .Values.sentry .Values.sentry.enabled }}
+    {{- fail "configuring sentry at the top level is no longer supported. Add the configuration to the controlplane section in the values.yaml file" }}
+  {{- end -}}
+  {{- if and .Values.controlplane.sentry .Values.controlplane.sentry.enabled }}
   config.observability.yaml: |
-    observability:
-      sentry:
-        dsn: {{ required "Sentry DSN required" .Values.sentry.dsn | quote }}
-        environment: {{ required "Sentry environment required" .Values.sentry.environment | quote }}
+    {{- include "chainloop.sentry" .Values.controlplane.sentry | nindent 4 }}
   {{- end }}
   config.secret.yaml: |
     data:

--- a/deployment/chainloop/values.yaml
+++ b/deployment/chainloop/values.yaml
@@ -17,20 +17,12 @@ development: false
 GKEMonitoring:
   enabled: false
 
-## @param sentry.enabled Enable sentry.io alerting
-## @param sentry.dsn DSN endpoint https://docs.sentry.io/product/sentry-basics/dsn-explainer/
-## @param sentry.environment Environment tag
-sentry:
-  enabled: false
-  dsn: ""
-  environment: production
-
 ## @section Secrets Backend
 ##
 
 ## Location where to store sensitive data. If development.true? and no overrides provided, the setup will connect to a development instance of Vault
 secretsBackend:
-  ## @param secretsBackend.backend Secrets backend type ("vault", "awsSecretManager" or "gcpSecretManager") 
+  ## @param secretsBackend.backend Secrets backend type ("vault", "awsSecretManager" or "gcpSecretManager")
   ##
   backend: "vault" # "awsSecretManager"
   ## @param secretsBackend.secretPrefix Prefix that will be pre-pended to all secrets in the storage backend
@@ -90,7 +82,7 @@ casJWTPublicKey: ""
 
 ## @section Control Plane
 ###################################
-##          CONTROL PLANE         #    
+##          CONTROL PLANE         #
 ###################################
 controlplane:
   ## @param controlplane.replicaCount Number of replicas
@@ -103,7 +95,7 @@ controlplane:
     # Overrides the image tag whose default is the chart appVersion.
     # tag: latest
 
-  ## @param controlplane.secret.name name of a secret containing TLS certificate to be used by the controlplane grpc server.
+  ## @param controlplane.tlsConfig.secret.name name of a secret containing TLS certificate to be used by the controlplane grpc server.
   tlsConfig:
     secret:
       # the secret must contains 2 keys: tls.crt and tls.key respectively containing the certificate and private key.
@@ -151,7 +143,7 @@ controlplane:
   sqlProxy:
     ## @param controlplane.sqlProxy.enabled Enable sidecar to connect to DB via Google Cloud SQL proxy
     enabled: false
-    ## @param controlplane.sqlProxy.connectionName Google Cloud SQL connection name 
+    ## @param controlplane.sqlProxy.connectionName Google Cloud SQL connection name
     connectionName: ""
     ## @param controlplane.sqlProxy.resources Sidecar container resources
     resources: {}
@@ -169,7 +161,7 @@ controlplane:
       url: ""
       clientID: ""
       clientSecret: ""
- 
+
   ## @section Control Plane Networking
   service:
     ## @param controlplane.service.type Service type
@@ -181,7 +173,8 @@ controlplane:
     ## @extra controlplane.service.nodePorts.http Node port for HTTP. NOTE: choose port between <30000-32767>
     # nodePorts:
     #   http: "30800"
-    annotations: {}
+    annotations:
+      {}
       ## @skip controlplane.service.annotations
 
   serviceAPI:
@@ -332,7 +325,7 @@ controlplane:
       ## @skip controlplane.ingressAPI.annotations.nginx.ingress.kubernetes.io/backend-protocol
       ## Tell Nginx Ingress Controller to expect gRPC traffic
       nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
-    
+
     ## @param controlplane.ingressAPI.tls Enable TLS configuration for the host defined at `controlplane.ingress.hostname` parameter
     ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.controlplane.ingress.hostname }}`
     ## You can:
@@ -433,10 +426,18 @@ controlplane:
     maxReplicas: 100
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
- 
+
+  ## @param controlplane.sentry.enabled Enable sentry.io alerting
+  ## @param controlplane.sentry.dsn DSN endpoint https://docs.sentry.io/product/sentry-basics/dsn-explainer/
+  ## @param controlplane.sentry.environment Environment tag
+  sentry:
+    enabled: false
+    dsn: ""
+    environment: production
+
 ## @section Artifact Content Addressable (CAS) API
 ##################################
-#         Artifacts CAS          #    
+#         Artifacts CAS          #
 ##################################
 cas:
   ## @param cas.replicaCount Number of replicas
@@ -476,7 +477,8 @@ cas:
     ## @extra cas.service.nodePorts.http Node port for HTTP. NOTE: choose port between <30000-32767>
     # nodePorts:
     #   http: "30800"
-    annotations: {}
+    annotations:
+      {}
       ## @skip cas.service.annotations
 
   serviceAPI:
@@ -626,13 +628,13 @@ cas:
     annotations:
       # Nginx Ingress settings
       ## @skip cas.ingressAPI.annotations.nginx.ingress.kubernetes.io/proxy-body-size
-      # Limit file uploads/downloads to 100MB. Alternatively you can disable this limitation by setting it to 0 
+      # Limit file uploads/downloads to 100MB. Alternatively you can disable this limitation by setting it to 0
       # Even though we send data in chunks of 1MB, this size refers to all the data sent during the whole streaming session
       nginx.ingress.kubernetes.io/proxy-body-size: "100m"
       ## @skip cas.ingressAPI.annotations.nginx.ingress.kubernetes.io/backend-protocol
       ## Tell Nginx Ingress Controller to expect gRPC traffic
       nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
-    
+
     ## @param cas.ingressAPI.tls Enable TLS configuration for the host defined at `controlplane.ingress.hostname` parameter
     ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.controlplane.ingress.hostname }}`
     ## You can:
@@ -733,10 +735,18 @@ cas:
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
 
-## @section Dependencies 
+  ## @param cas.sentry.enabled Enable sentry.io alerting
+  ## @param cas.sentry.dsn DSN endpoint https://docs.sentry.io/product/sentry-basics/dsn-explainer/
+  ## @param cas.sentry.environment Environment tag
+  sentry:
+    enabled: false
+    dsn: ""
+    environment: production
+
+## @section Dependencies
 # ##################################
-# #          Dependencies          #   
-# ##################################
+# #          Dependencies          #
+##################################
 
 ## PostgreSQL chart configuration
 ## ref: https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
@@ -754,7 +764,6 @@ postgresql:
     password: "chainlooppwd"
     database: "chainloop-cp"
     existingSecret: ""
-
 
 # Vault server running in development mode --set development=true
 # IMPORTANT: This is not meant to run in production


### PR DESCRIPTION
**Overview**:
This PR addresses the issue chainloop-dev/chainloop#104. It introduces a division in the Sentry configuration to make it distinct for each service. This change ensures that top-level configured helm charts will not render and provides guidance on correcting the issue.

**Additional Changes**:
- Adjustments have been made to the readme. The helm-generator has removed extraneous spaces and empty lines. This is for better consistency and clarity.

