### PR TITLE
chore: add OpenSSF scorecard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Chainloop
 
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/chainloop-dev/chainloop/badge)](https://securityscorecards.dev/viewer/?uri=github.com/chainloop-dev/chainloop)
 [![Go Report Card](https://goreportcard.com/badge/github.com/chainloop-dev/chainloop)](https://goreportcard.com/report/github.com/chainloop-dev/chainloop)
 ![Test passing](https://github.com/chainloop-dev/chainloop/actions/workflows/test.yml/badge.svg?branch=main)
 [![Chat on Discord](https://img.shields.io/discord/1037381970189111326?logo=discord)](https://discord.gg/f7atkaZact)


### PR DESCRIPTION
![image](https://github.com/chainloop-dev/chainloop/assets/24523/43e0f37d-d76b-4152-bd1a-41e7eb1761bb)

We can improve it later on, it will also get better over time since it does average commits