### PR TITLE
feat(cas): Azure Blob Storage support

### DIFF
--- a/app/artifact-cas/cmd/main.go
+++ b/app/artifact-cas/cmd/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/chainloop-dev/chainloop/app/artifact-cas/internal/conf"
 	"github.com/chainloop-dev/chainloop/app/artifact-cas/internal/server"
 	backend "github.com/chainloop-dev/chainloop/internal/blobmanager"
+	"github.com/chainloop-dev/chainloop/internal/blobmanager/azureblob"
 	"github.com/chainloop-dev/chainloop/internal/blobmanager/oci"
 	"github.com/chainloop-dev/chainloop/internal/credentials"
 	"github.com/chainloop-dev/chainloop/internal/credentials/manager"
@@ -64,11 +65,12 @@ type app struct {
 }
 
 func loadCASBackendProviders(creader credentials.Reader) backend.Providers {
-	// Currently only OCI is supported
-	// Here we will load the rest of providers, S3, GCS, etc
-	p := oci.NewBackendProvider(creader)
+	// Initialize CAS backend providers
+	ociProvider := oci.NewBackendProvider(creader)
+	azureBlobProvider := azureblob.NewBackendProvider(creader)
 	return backend.Providers{
-		p.ID(): p,
+		ociProvider.ID():       ociProvider,
+		azureBlobProvider.ID(): azureBlobProvider,
 	}
 }
 

--- a/app/artifact-cas/configs/config.devel.yaml
+++ b/app/artifact-cas/configs/config.devel.yaml
@@ -5,10 +5,12 @@
 server:
   http:
     addr: 0.0.0.0:8001
-    timeout: 1s
+    timeout: 5s
   grpc:
     addr: 0.0.0.0:9001
-    timeout: 1s
+    # Some cas backends are slow, so we need to increase the timeout
+    # for example, Azure Blob Storage describe takes more than 1 second to respond sometimes
+    timeout: 5s
   http_metrics:
     addr: 0.0.0.0:5001
 

--- a/app/artifact-cas/internal/service/bytestream.go
+++ b/app/artifact-cas/internal/service/bytestream.go
@@ -113,7 +113,7 @@ func (s *ByteStreamService) Write(stream bytestream.ByteStream_WriteServer) erro
 		return sl.LogAndMaskErr(err, s.log)
 	}
 
-	s.log.Infow("msg", "artifact received, uploading now to OCI backend", "name", req.resource.FileName, "digest", req.resource.Digest, "size", buffer.size)
+	s.log.Infow("msg", "artifact received, uploading now to backend", "name", req.resource.FileName, "digest", req.resource.Digest, "size", buffer.size)
 	if err := backend.Upload(ctx, buffer, req.resource); err != nil {
 		return sl.LogAndMaskErr(err, s.log)
 	}

--- a/app/artifact-cas/internal/service/bytestream.go
+++ b/app/artifact-cas/internal/service/bytestream.go
@@ -18,8 +18,11 @@ package service
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/gob"
+	"fmt"
+	"hash"
 	"io"
 
 	"errors"
@@ -151,7 +154,7 @@ func (s *ByteStreamService) Read(req *bytestream.ReadRequest, stream bytestream.
 	}
 
 	// streamwriter will stream chunks of data to the client
-	sw := &streamWriter{stream, s.log, req.ResourceName}
+	sw := &streamWriter{stream, s.log, req.ResourceName, sha256.New()}
 	if err := backend.Download(ctx, sw, req.ResourceName); err != nil {
 		if errors.Is(err, context.Canceled) {
 			s.log.Infow("msg", "download canceled", "digest", req.ResourceName)
@@ -159,6 +162,11 @@ func (s *ByteStreamService) Read(req *bytestream.ReadRequest, stream bytestream.
 		}
 
 		return sl.LogAndMaskErr(err, s.log)
+	}
+
+	// check if the file has been tampered with and notify the client
+	if sw.GetChecksum() != req.ResourceName {
+		return kerrors.Unauthorized("checksum", fmt.Sprintf("checksum mismatch: got=%s, want=%s", sw.GetChecksum(), req.ResourceName))
 	}
 
 	s.log.Infow("msg", "download finished", "digest", req.ResourceName)
@@ -269,11 +277,24 @@ func decodeResource(b64encoded string) (*v1.CASResource, error) {
 type streamWriter struct {
 	stream bytestream.ByteStream_ReadServer
 	log    *log.Helper
-	digest string
+	// expected wantChecksum of the data being sent
+	wantChecksum string
+	// calculated gotChecksum of the data sent
+	gotChecksum hash.Hash
 }
 
 // Send the chunk of data through the bytestream
 func (sw *streamWriter) Write(data []byte) (int, error) {
-	sw.log.Debugw("msg", "sending download chunk", "digest", sw.digest, "chunkSize", len(data))
+	sw.log.Debugw("msg", "sending download chunk", "digest", sw.wantChecksum, "chunkSize", len(data))
+
+	// Update the checksum of the data being sent
+	if _, err := sw.gotChecksum.Write(data); err != nil {
+		return 0, err
+	}
 	return len(data), sw.stream.Send(&bytestream.ReadResponse{Data: data})
+}
+
+// GetChecksum retrieves the sha256 checksum of the read contents
+func (sw *streamWriter) GetChecksum() string {
+	return fmt.Sprintf("%x", sw.gotChecksum.Sum(nil))
 }

--- a/app/artifact-cas/internal/service/service.go
+++ b/app/artifact-cas/internal/service/service.go
@@ -40,7 +40,7 @@ func (s *commonService) loadBackend(ctx context.Context, providerType, secretID 
 	// get the OCI provider from the map
 	p, ok := s.backends[providerType]
 	if !ok || p == nil {
-		return nil, kerrors.NotFound("backend provider", providerType)
+		return nil, kerrors.NotFound("backend provider", fmt.Sprintf("backend %q not found", providerType))
 	}
 
 	s.log.Infow("msg", "selected provider", "provider", providerType)

--- a/app/cli/cmd/casbackend.go
+++ b/app/cli/cmd/casbackend.go
@@ -41,7 +41,7 @@ func newCASBackendAddCmd() *cobra.Command {
 	cmd.PersistentFlags().Bool("default", false, "set the backend as default in your organization")
 	cmd.PersistentFlags().String("description", "", "descriptive information for this registration")
 
-	cmd.AddCommand(newCASBackendAddOCICmd())
+	cmd.AddCommand(newCASBackendAddOCICmd(), newCASBackendAddAzureBlobStorageCmd())
 	return cmd
 }
 

--- a/app/cli/cmd/casbackend.go
+++ b/app/cli/cmd/casbackend.go
@@ -54,7 +54,7 @@ func newCASBackendUpdateCmd() *cobra.Command {
 	cmd.PersistentFlags().Bool("default", false, "set the backend as default in your organization")
 	cmd.PersistentFlags().String("description", "", "descriptive information for this registration")
 
-	cmd.AddCommand(newCASBackendUpdateOCICmd(), newCASBackendUpdateInlineCmd())
+	cmd.AddCommand(newCASBackendUpdateOCICmd(), newCASBackendUpdateInlineCmd(), newCASBackendUpdateAzureBlobCmd())
 	return cmd
 }
 

--- a/app/cli/cmd/casbackend_add_azureblob.go
+++ b/app/cli/cmd/casbackend_add_azureblob.go
@@ -1,0 +1,88 @@
+//
+// Copyright 2023 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/chainloop-dev/chainloop/app/cli/internal/action"
+	"github.com/chainloop-dev/chainloop/internal/blobmanager/azureblob"
+	"github.com/go-kratos/kratos/v2/log"
+	"github.com/spf13/cobra"
+)
+
+func newCASBackendAddAzureBlobStorageCmd() *cobra.Command {
+	var storageAccountName, tenantID, clientID, clientSecret string
+	cmd := &cobra.Command{
+		Use:   "azure-blob",
+		Short: "Register a Azure Blob Storage CAS Backend",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// If we are setting the default, we list existing CAS backends
+			// and ask the user to confirm the rewrite
+			isDefault, err := cmd.Flags().GetBool("default")
+			cobra.CheckErr(err)
+
+			description, err := cmd.Flags().GetString("description")
+			cobra.CheckErr(err)
+
+			if isDefault {
+				if confirmed, err := confirmDefaultCASBackendOverride(actionOpts, ""); err != nil {
+					return err
+				} else if !confirmed {
+					log.Info("Aborting...")
+					return nil
+				}
+			}
+
+			opts := &action.NewCASBackendAddOpts{
+				Location:    storageAccountName,
+				Provider:    azureblob.ProviderID,
+				Description: description,
+				Credentials: map[string]any{
+					"tenantID":     tenantID,
+					"clientID":     clientID,
+					"clientSecret": clientSecret,
+				},
+				Default: isDefault,
+			}
+
+			res, err := action.NewCASBackendAdd(actionOpts).Run(opts)
+			if err != nil {
+				return err
+			} else if res == nil {
+				return nil
+			}
+
+			return encodeOutput([]*action.CASBackendItem{res}, casBackendListTableOutput)
+		},
+	}
+
+	cmd.Flags().StringVar(&storageAccountName, "storage-account", "", "Storage Account Name")
+	err := cmd.MarkFlagRequired("storage-account")
+	cobra.CheckErr(err)
+
+	cmd.Flags().StringVar(&tenantID, "tenant", "", "Active Directory Tenant ID")
+	err = cmd.MarkFlagRequired("tenant")
+	cobra.CheckErr(err)
+
+	cmd.Flags().StringVar(&clientID, "client-id", "", "Service Principal Client ID")
+	err = cmd.MarkFlagRequired("client-id")
+	cobra.CheckErr(err)
+
+	cmd.Flags().StringVar(&clientSecret, "client-secret", "", "Service Principal Client Secret")
+	err = cmd.MarkFlagRequired("client-secret")
+	cobra.CheckErr(err)
+
+	return cmd
+}

--- a/app/controlplane/cmd/main.go
+++ b/app/controlplane/cmd/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/chainloop-dev/chainloop/app/controlplane/plugins"
 	"github.com/chainloop-dev/chainloop/app/controlplane/plugins/sdk/v1"
 	backends "github.com/chainloop-dev/chainloop/internal/blobmanager"
+	"github.com/chainloop-dev/chainloop/internal/blobmanager/azureblob"
 	"github.com/chainloop-dev/chainloop/internal/blobmanager/oci"
 	"github.com/chainloop-dev/chainloop/internal/credentials"
 	"github.com/chainloop-dev/chainloop/internal/credentials/manager"
@@ -172,10 +173,11 @@ func maskArgs(keyvals []interface{}) {
 
 func loadCASBackendProviders(creader credentials.Reader) backends.Providers {
 	// Initialize CAS backend providers
-	// For now we only have OCI as a backend provider
-	p := oci.NewBackendProvider(creader)
+	ociProvider := oci.NewBackendProvider(creader)
+	azureBlobProvider := azureblob.NewBackendProvider(creader)
 	return backends.Providers{
-		p.ID(): p,
+		ociProvider.ID():       ociProvider,
+		azureBlobProvider.ID(): azureBlobProvider,
 	}
 }
 

--- a/app/controlplane/internal/biz/casbackend.go
+++ b/app/controlplane/internal/biz/casbackend.go
@@ -24,6 +24,8 @@ import (
 	"time"
 
 	backend "github.com/chainloop-dev/chainloop/internal/blobmanager"
+	"github.com/chainloop-dev/chainloop/internal/blobmanager/azureblob"
+	"github.com/chainloop-dev/chainloop/internal/blobmanager/oci"
 	"github.com/chainloop-dev/chainloop/internal/credentials"
 	"github.com/chainloop-dev/chainloop/internal/servicelogger"
 	"github.com/go-kratos/kratos/v2/log"
@@ -33,9 +35,7 @@ import (
 type CASBackendProvider string
 
 const (
-	CASBackendOCI             CASBackendProvider = "OCI"
-	CASBackendAzureBlob       CASBackendProvider = "AzureBlob"
-	CASBackendDefaultMaxBytes int64              = 100 * 1024 * 1024 // 100MB
+	CASBackendDefaultMaxBytes int64 = 100 * 1024 * 1024 // 100MB
 	// Inline, embedded CAS backend
 	CASBackendInline                CASBackendProvider = "INLINE"
 	CASBackendInlineDefaultMaxBytes int64              = 500 * 1024 // 500KB
@@ -470,7 +470,7 @@ func (uc *CASBackendUseCase) PerformValidation(ctx context.Context, id string) (
 
 // Implements https://pkg.go.dev/entgo.io/ent/schema/field#EnumValues
 func (CASBackendProvider) Values() (kinds []string) {
-	for _, s := range []CASBackendProvider{CASBackendOCI, CASBackendAzureBlob, CASBackendInline} {
+	for _, s := range []CASBackendProvider{azureblob.ProviderID, oci.ProviderID, CASBackendInline} {
 		kinds = append(kinds, string(s))
 	}
 

--- a/app/controlplane/internal/biz/casbackend.go
+++ b/app/controlplane/internal/biz/casbackend.go
@@ -34,6 +34,7 @@ type CASBackendProvider string
 
 const (
 	CASBackendOCI             CASBackendProvider = "OCI"
+	CASBackendAzureBlob       CASBackendProvider = "AzureBlob"
 	CASBackendDefaultMaxBytes int64              = 100 * 1024 * 1024 // 100MB
 	// Inline, embedded CAS backend
 	CASBackendInline                CASBackendProvider = "INLINE"
@@ -469,7 +470,7 @@ func (uc *CASBackendUseCase) PerformValidation(ctx context.Context, id string) (
 
 // Implements https://pkg.go.dev/entgo.io/ent/schema/field#EnumValues
 func (CASBackendProvider) Values() (kinds []string) {
-	for _, s := range []CASBackendProvider{CASBackendOCI, CASBackendInline} {
+	for _, s := range []CASBackendProvider{CASBackendOCI, CASBackendAzureBlob, CASBackendInline} {
 		kinds = append(kinds, string(s))
 	}
 

--- a/app/controlplane/internal/biz/casbackend_integration_test.go
+++ b/app/controlplane/internal/biz/casbackend_integration_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz/testhelpers"
+	"github.com/chainloop-dev/chainloop/internal/blobmanager/oci"
 	creds "github.com/chainloop-dev/chainloop/internal/credentials/mocks"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -33,7 +34,7 @@ import (
 
 const location = "my-location"
 const description = "my-description"
-const backendType = biz.CASBackendOCI
+const backendType = oci.ProviderID
 
 func (s *CASBackendIntegrationTestSuite) TestCreate() {
 	assert := assert.New(s.T())
@@ -326,11 +327,11 @@ func (s *CASBackendIntegrationTestSuite) SetupTest() {
 	s.orgNoBackend, err = s.Organization.Create(ctx, "testing org 3, no backends")
 	assert.NoError(err)
 
-	s.casBackend1, err = s.CASBackend.Create(ctx, s.orgOne.ID, "my-location", "backend 1 description", biz.CASBackendOCI, nil, true)
+	s.casBackend1, err = s.CASBackend.Create(ctx, s.orgOne.ID, "my-location", "backend 1 description", backendType, nil, true)
 	assert.NoError(err)
-	s.casBackend2, err = s.CASBackend.Create(ctx, s.orgTwo.ID, "my-location 2", "backend 2 description", biz.CASBackendOCI, nil, true)
+	s.casBackend2, err = s.CASBackend.Create(ctx, s.orgTwo.ID, "my-location 2", "backend 2 description", backendType, nil, true)
 	assert.NoError(err)
-	s.casBackend3, err = s.CASBackend.Create(ctx, s.orgTwo.ID, "my-location 3", "backend 3 description", biz.CASBackendOCI, nil, false)
+	s.casBackend3, err = s.CASBackend.Create(ctx, s.orgTwo.ID, "my-location 3", "backend 3 description", backendType, nil, false)
 	assert.NoError(err)
 }
 

--- a/app/controlplane/internal/biz/casbackend_test.go
+++ b/app/controlplane/internal/biz/casbackend_test.go
@@ -73,7 +73,7 @@ func (s *casBackendTestSuite) TestFindDefaultBackendFound() {
 }
 
 func (s *casBackendTestSuite) TestSaveInvalidUUID() {
-	repo, err := s.useCase.CreateOrUpdate(context.Background(), s.invalidUUID, "", "", "", biz.CASBackendOCI, true)
+	repo, err := s.useCase.CreateOrUpdate(context.Background(), s.invalidUUID, "", "", "", backendType, true)
 	assert.True(s.T(), biz.IsErrInvalidUUID(err))
 	assert.Nil(s.T(), repo)
 }
@@ -83,18 +83,18 @@ func (s *casBackendTestSuite) TestSaveDefaultBackendAlreadyExist() {
 	assert := assert.New(s.T())
 	const repoName, username, password = "repo", "username", "pass"
 
-	r := &biz.CASBackend{ID: s.validUUID, Provider: biz.CASBackendOCI}
+	r := &biz.CASBackend{ID: s.validUUID, Provider: backendType}
 	ctx := context.Background()
 	s.repo.On("FindDefaultBackend", ctx, s.validUUID).Return(r, nil)
 	s.credsRW.On("SaveCredentials", ctx, s.validUUID.String(), mock.Anything).Return("secret-key", nil)
 	s.repo.On("Update", ctx, &biz.CASBackendUpdateOpts{
 		ID: s.validUUID,
 		CASBackendOpts: &biz.CASBackendOpts{
-			Location: repoName, SecretName: "secret-key", Default: true, Provider: biz.CASBackendOCI,
+			Location: repoName, SecretName: "secret-key", Default: true, Provider: backendType,
 		},
 	}).Return(r, nil)
 
-	gotRepo, err := s.useCase.CreateOrUpdate(ctx, s.validUUID.String(), repoName, username, password, biz.CASBackendOCI, true)
+	gotRepo, err := s.useCase.CreateOrUpdate(ctx, s.validUUID.String(), repoName, username, password, backendType, true)
 	assert.NoError(err)
 	assert.Equal(gotRepo, r)
 }
@@ -112,11 +112,11 @@ func (s *casBackendTestSuite) TestSaveDefaultBackendOk() {
 	s.repo.On("Create", ctx, &biz.CASBackendCreateOpts{
 		CASBackendOpts: &biz.CASBackendOpts{
 			OrgID:    s.validUUID,
-			Location: repo, SecretName: "secret-key", Default: true, Provider: biz.CASBackendOCI,
+			Location: repo, SecretName: "secret-key", Default: true, Provider: backendType,
 		},
 	}).Return(newRepo, nil)
 
-	gotRepo, err := s.useCase.CreateOrUpdate(ctx, s.validUUID.String(), repo, username, password, biz.CASBackendOCI, true)
+	gotRepo, err := s.useCase.CreateOrUpdate(ctx, s.validUUID.String(), repo, username, password, backendType, true)
 	assert.NoError(err)
 	assert.Equal(gotRepo, newRepo)
 }
@@ -124,7 +124,7 @@ func (s *casBackendTestSuite) TestSaveDefaultBackendOk() {
 func (s *casBackendTestSuite) TestPerformValidation() {
 	assert := assert.New(s.T())
 	t := s.T()
-	validRepo := &biz.CASBackend{ID: s.validUUID, ValidationStatus: biz.CASBackendValidationOK, Provider: biz.CASBackendOCI}
+	validRepo := &biz.CASBackend{ID: s.validUUID, ValidationStatus: biz.CASBackendValidationOK, Provider: backendType}
 
 	t.Run("invalid uuid", func(t *testing.T) {
 		err := s.useCase.PerformValidation(context.Background(), s.invalidUUID)

--- a/app/controlplane/internal/biz/casmapping_integration_test.go
+++ b/app/controlplane/internal/biz/casmapping_integration_test.go
@@ -309,16 +309,16 @@ func (s *casMappingIntegrationSuite) SetupTest() {
 	// Create casBackend in the database
 	s.org1, err = s.Organization.Create(ctx, "testing org 1 with one backend")
 	assert.NoError(err)
-	s.casBackend1, err = s.CASBackend.Create(ctx, s.org1.ID, "my-location", "backend 1 description", biz.CASBackendOCI, nil, true)
+	s.casBackend1, err = s.CASBackend.Create(ctx, s.org1.ID, "my-location", "backend 1 description", backendType, nil, true)
 	assert.NoError(err)
 	s.org2, err = s.Organization.Create(ctx, "testing org 2")
 	assert.NoError(err)
-	s.casBackend2, err = s.CASBackend.Create(ctx, s.org2.ID, "my-location", "backend 1 description", biz.CASBackendOCI, nil, true)
+	s.casBackend2, err = s.CASBackend.Create(ctx, s.org2.ID, "my-location", "backend 1 description", backendType, nil, true)
 	assert.NoError(err)
 	// Create casBackend associated with an org which users are not member of
 	s.orgNoUsers, err = s.Organization.Create(ctx, "org without users")
 	assert.NoError(err)
-	s.casBackend3, err = s.CASBackend.Create(ctx, s.orgNoUsers.ID, "my-location", "backend 1 description", biz.CASBackendOCI, nil, true)
+	s.casBackend3, err = s.CASBackend.Create(ctx, s.orgNoUsers.ID, "my-location", "backend 1 description", backendType, nil, true)
 	assert.NoError(err)
 
 	// Create workflowRun in the database

--- a/app/controlplane/internal/biz/organization_integration_test.go
+++ b/app/controlplane/internal/biz/organization_integration_test.go
@@ -128,7 +128,7 @@ func (s *OrgIntegrationTestSuite) SetupTest() {
 	assert.NoError(err)
 
 	// OCI repository
-	_, err = s.CASBackend.CreateOrUpdate(ctx, s.org.ID, "repo", "username", "pass", biz.CASBackendOCI, true)
+	_, err = s.CASBackend.CreateOrUpdate(ctx, s.org.ID, "repo", "username", "pass", backendType, true)
 	assert.NoError(err)
 
 	// Workflow + contract

--- a/app/controlplane/internal/biz/workflowrun_integration_test.go
+++ b/app/controlplane/internal/biz/workflowrun_integration_test.go
@@ -248,7 +248,7 @@ func (s *workflowRunIntegrationTestSuite) SetupTest() {
 	s.contractVersion, err = s.WorkflowContract.Describe(ctx, s.org.ID, s.workflowOrg1.ContractID.String(), 0)
 	assert.NoError(err)
 
-	s.casBackend, err = s.CASBackend.CreateOrUpdate(ctx, s.org.ID, "repo", "username", "pass", biz.CASBackendOCI, true)
+	s.casBackend, err = s.CASBackend.CreateOrUpdate(ctx, s.org.ID, "repo", "username", "pass", backendType, true)
 	assert.NoError(err)
 
 	// Let's create 3 runs, one in org1 and 2 in org2 (one public)

--- a/app/controlplane/internal/data/ent/casbackend/casbackend.go
+++ b/app/controlplane/internal/data/ent/casbackend/casbackend.go
@@ -115,7 +115,7 @@ var (
 // ProviderValidator is a validator for the "provider" field enum values. It is called by the builders before save.
 func ProviderValidator(pr biz.CASBackendProvider) error {
 	switch pr {
-	case "OCI", "INLINE":
+	case "OCI", "AzureBlob", "INLINE":
 		return nil
 	default:
 		return fmt.Errorf("casbackend: invalid enum value for provider field: %q", pr)

--- a/app/controlplane/internal/data/ent/casbackend/casbackend.go
+++ b/app/controlplane/internal/data/ent/casbackend/casbackend.go
@@ -115,7 +115,7 @@ var (
 // ProviderValidator is a validator for the "provider" field enum values. It is called by the builders before save.
 func ProviderValidator(pr biz.CASBackendProvider) error {
 	switch pr {
-	case "OCI", "AzureBlob", "INLINE":
+	case "AzureBlob", "OCI", "INLINE":
 		return nil
 	default:
 		return fmt.Errorf("casbackend: invalid enum value for provider field: %q", pr)

--- a/app/controlplane/internal/data/ent/migrate/schema.go
+++ b/app/controlplane/internal/data/ent/migrate/schema.go
@@ -12,7 +12,7 @@ var (
 	CasBackendsColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeUUID, Unique: true},
 		{Name: "location", Type: field.TypeString},
-		{Name: "provider", Type: field.TypeEnum, Enums: []string{"OCI", "AzureBlob", "INLINE"}},
+		{Name: "provider", Type: field.TypeEnum, Enums: []string{"AzureBlob", "OCI", "INLINE"}},
 		{Name: "description", Type: field.TypeString, Nullable: true},
 		{Name: "secret_name", Type: field.TypeString},
 		{Name: "created_at", Type: field.TypeTime, Default: "CURRENT_TIMESTAMP"},

--- a/app/controlplane/internal/data/ent/migrate/schema.go
+++ b/app/controlplane/internal/data/ent/migrate/schema.go
@@ -12,7 +12,7 @@ var (
 	CasBackendsColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeUUID, Unique: true},
 		{Name: "location", Type: field.TypeString},
-		{Name: "provider", Type: field.TypeEnum, Enums: []string{"OCI", "INLINE"}},
+		{Name: "provider", Type: field.TypeEnum, Enums: []string{"OCI", "AzureBlob", "INLINE"}},
 		{Name: "description", Type: field.TypeString, Nullable: true},
 		{Name: "secret_name", Type: field.TypeString},
 		{Name: "created_at", Type: field.TypeTime, Default: "CURRENT_TIMESTAMP"},

--- a/app/controlplane/internal/service/casbackend.go
+++ b/app/controlplane/internal/service/casbackend.go
@@ -86,7 +86,7 @@ func (s *CASBackendService) Create(ctx context.Context, req *pb.CASBackendServic
 	}
 
 	// For now we only support one backend which is set as default
-	res, err := s.uc.Create(ctx, currentOrg.ID, req.Location, req.Description, biz.CASBackendOCI, creds, req.Default)
+	res, err := s.uc.Create(ctx, currentOrg.ID, req.Location, req.Description, biz.CASBackendProvider(req.Provider), creds, req.Default)
 	if err != nil {
 		return nil, handleUseCaseErr(casBackendEntity, err, s.log)
 	}

--- a/deployment/chainloop/templates/cas/config.configmap.yaml
+++ b/deployment/chainloop/templates/cas/config.configmap.yaml
@@ -1,9 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "chainloop.cas.fullname" . }}
-  labels:
-    {{- include "chainloop.cas.labels" . | nindent 4 }}
+  name: { { include "chainloop.cas.fullname" . } }
+  labels: { { - include "chainloop.cas.labels" . | nindent 4 } }
 data:
   server.yaml: |
     server:
@@ -17,6 +16,6 @@ data:
           private_key: /data/server-certs/tls.key
         {{- end }}
         addr: 0.0.0.0:9000
-        timeout: 1s
+        timeout: 5s
       http_metrics:
         addr: 0.0.0.0:5000

--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,8 @@ require (
 
 require (
 	cloud.google.com/go/storage v1.32.0
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.0
+	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.1.0
 	github.com/invopop/jsonschema v0.7.0
 	github.com/jackc/pgx/v5 v5.4.3
 	github.com/muesli/reflow v0.3.0
@@ -78,6 +80,9 @@ require (
 require (
 	cloud.google.com/go/pubsub v1.33.0 // indirect
 	dario.cat/mergo v1.0.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.1 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 // indirect
+	github.com/AzureAD/microsoft-authentication-library-for-go v1.0.0 // indirect
 	github.com/anchore/go-struct-converter v0.0.0-20230627203149-c72ef8859ca9 // indirect
 	github.com/cockroachdb/apd/v3 v3.2.0 // indirect
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
@@ -89,10 +94,12 @@ require (
 	github.com/gorilla/handlers v1.5.1 // indirect
 	github.com/hashicorp/go-hclog v1.5.0 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481 // indirect
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/package-url/packageurl-go v0.1.1 // indirect
+	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
 	github.com/pkg/xattr v0.4.9 // indirect
 	go.opentelemetry.io/otel/metric v1.17.0 // indirect
 	gopkg.in/go-jose/go-jose.v2 v2.6.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,7 @@ require (
 
 require (
 	cloud.google.com/go/storage v1.32.0
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.1.0
 	github.com/invopop/jsonschema v0.7.0
@@ -80,7 +81,6 @@ require (
 require (
 	cloud.google.com/go/pubsub v1.33.0 // indirect
 	dario.cat/mergo v1.0.0 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.0.0 // indirect
 	github.com/anchore/go-struct-converter v0.0.0-20230627203149-c72ef8859ca9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -90,10 +90,14 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.0 h1:vcYCAze6p19qBW7MhZybI
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.0/go.mod h1:OQeznEEkTZ9OrhHJoDD8ZDq51FHgXjqtP9z6bEwBq9U=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 h1:sXr+ck84g/ZlZUOZiNELInmMgOsuGwdjjVkEIde0OtY=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0/go.mod h1:okt5dMMTOFjX/aovMlrjvvXoPMBVSPzk9185BT0+eZM=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.2.0 h1:Ma67P/GGprNwsslzEH6+Kb8nybI8jpDTm4Wmzu2ReK8=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.2.0/go.mod h1:c+Lifp3EDEamAkPVzMooRNOK6CZjNSdEnf1A7jsI9u4=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.0.0 h1:yfJe15aSwEQ6Oo6J+gdfdulPNoZ3TEhmbhLIoxZcA+U=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.0.0/go.mod h1:Q28U+75mpCaSCDowNEmhIo/rmgdkqmkmzI7N6TGR4UY=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v0.8.0 h1:T028gtTPiYt/RMUfs8nVsAL7FDQrfLlrm/NnRG/zcC4=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v0.8.0/go.mod h1:cw4zVQgBby0Z5f2v0itn6se2dDP17nTjbZFXW5uPyHA=
+github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.1.0 h1:nVocQV40OQne5613EeLayJiRAJuKlBGy+m22qWG+WRg=
+github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.1.0/go.mod h1:7QJP7dr2wznCMeqIrhMgWGf7XpAQnVrJqDm9nvV3Cu4=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.0.0 h1:OBhqkivkhkMqLPymWEppkm7vgPQY2XsHoEkaMQ0AdZY=
@@ -277,6 +281,8 @@ github.com/digitorus/pkcs7 v0.0.0-20230818184609-3a137a874352 h1:ge14PCmCvPjpMQM
 github.com/digitorus/pkcs7 v0.0.0-20230818184609-3a137a874352/go.mod h1:SKVExuS+vpu2l9IoOc0RwqE7NYnb0JlcFHFnEJkVDzc=
 github.com/digitorus/timestamp v0.0.0-20230821155606-d1ad5ca9624c h1:kgG83Hfj3YXkUbrihwBxDc0COzP1ZejiDSr4/fItT0E=
 github.com/digitorus/timestamp v0.0.0-20230821155606-d1ad5ca9624c/go.mod h1:GvWntX9qiTlOud0WkQ6ewFm0LPy5JUR1Xo0Ngbd1w6Y=
+github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
+github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/docker/cli v24.0.5+incompatible h1:WeBimjvS0eKdH4Ygx+ihVq1Q++xg36M/rMi4aXAvodc=
 github.com/docker/cli v24.0.5+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
@@ -1502,6 +1508,7 @@ golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603125802-9665404d3644/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/blobmanager/azureblob/backend.go
+++ b/internal/blobmanager/azureblob/backend.go
@@ -44,16 +44,10 @@ func NewBackend(creds *Credentials) (*Backend, error) {
 		return nil, fmt.Errorf("failed to create Azure Service principal Credential: %w", err)
 	}
 
-	// Container name is optional
-	container := creds.Container
-	if container == "" {
-		container = "chainloop"
-	}
-
 	return &Backend{
 		storageAccountName: creds.StorageAccountName,
 		credentials:        credential,
-		container:          container,
+		container:          creds.Container,
 	}, nil
 }
 

--- a/internal/blobmanager/azureblob/backend.go
+++ b/internal/blobmanager/azureblob/backend.go
@@ -1,0 +1,89 @@
+//
+// Copyright 2023 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azureblob
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
+	pb "github.com/chainloop-dev/chainloop/app/artifact-cas/api/cas/v1"
+	backend "github.com/chainloop-dev/chainloop/internal/blobmanager"
+)
+
+type Backend struct {
+	client *azblob.Client
+}
+
+var _ backend.UploaderDownloader = (*Backend)(nil)
+var errNotImplemented = errors.New("not implemented")
+
+const defaultContainerName = "chainloop"
+
+func NewBackend(creds *Credentials) (*Backend, error) {
+	credential, err := azidentity.NewClientSecretCredential(creds.TenantID, creds.ClientID, creds.ClientSecret, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Azure Service principal Credential: %w", err)
+	}
+
+	url := fmt.Sprintf("https://%s.blob.core.windows.net/", creds.StorageAccountName)
+	client, err := azblob.NewClient(url, credential, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Azure Blob Storage client: %w", err)
+	}
+
+	return &Backend{client: client}, nil
+}
+
+// Exists check that the artifact is already present in the repository and it points to the
+// same image digest, meaning it has not been re-pushed/replaced
+// This method is very naive so signatures will be used in future releases
+func (b *Backend) Exists(_ context.Context, digest string) (bool, error) {
+	return false, errNotImplemented
+}
+
+func (b *Backend) Upload(_ context.Context, r io.Reader, resource *pb.CASResource) error {
+	return errNotImplemented
+}
+
+func (b *Backend) Describe(_ context.Context, digest string) (*pb.CASResource, error) {
+	return nil, errNotImplemented
+}
+
+func (b *Backend) Download(_ context.Context, w io.Writer, digest string) error {
+	return errNotImplemented
+}
+
+// CheckWritePermissions performs an actual write to the repository to check that the credentials
+func (b *Backend) CheckWritePermissions(ctx context.Context) error {
+	// Create container name
+	_, err := b.client.CreateContainer(ctx, defaultContainerName, nil)
+	if err != nil && !bloberror.HasCode(err, bloberror.ContainerAlreadyExists) {
+		return fmt.Errorf("failed to create Blob storage Container: %w", err)
+	}
+
+	// Touch a file
+	_, err = b.client.UploadBuffer(ctx, defaultContainerName, "healthCheck", nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed write to Blob Storage: %w", err)
+	}
+
+	return nil
+}

--- a/internal/blobmanager/azureblob/provider.go
+++ b/internal/blobmanager/azureblob/provider.go
@@ -51,12 +51,11 @@ func (p *BackendProvider) FromCredentials(ctx context.Context, secretName string
 		return nil, fmt.Errorf("invalid credentials retrieved from storage: %w", err)
 	}
 
-	// TODO: return AzureBlob backend
-	return nil, nil
+	return NewBackend(creds)
 }
 
 func (p *BackendProvider) ValidateAndExtractCredentials(storageAccount string, credsJSON []byte) (any, error) {
-	var creds Credentials
+	var creds *Credentials
 	if err := json.Unmarshal(credsJSON, &creds); err != nil {
 		return nil, fmt.Errorf("unmarshaling credentials: %w", err)
 	}
@@ -67,23 +66,15 @@ func (p *BackendProvider) ValidateAndExtractCredentials(storageAccount string, c
 		return nil, fmt.Errorf("invalid credentials: %w", err)
 	}
 
-	// Create and validate credentials
-	// TODO: do an actual check
-	//	k, err := ociauth.NewCredentials(storageAccount, creds.Username, creds.Password)
-	//	if err != nil {
-	//		return nil, fmt.Errorf("creating credentials: %w", err)
-	//	}
-	//
-	//	// Check credentials
-	//	b, err := NewBackend(storageAccount, &RegistryOptions{Keychain: k})
-	//	if err != nil {
-	//		return nil, fmt.Errorf("checking credentials: %w", err)
-	//	}
-	//
-	//	if err := b.CheckWritePermissions(context.TODO()); err != nil {
-	//		return nil, fmt.Errorf("checking write permissions: %w", err)
-	//	}
-	//
+	b, err := NewBackend(creds)
+	if err != nil {
+		return nil, fmt.Errorf("creating backend: %w", err)
+	}
+
+	if err := b.CheckWritePermissions(context.TODO()); err != nil {
+		return nil, fmt.Errorf("checking write permissions: %w", err)
+	}
+
 	return creds, nil
 }
 

--- a/internal/blobmanager/azureblob/provider.go
+++ b/internal/blobmanager/azureblob/provider.go
@@ -1,0 +1,122 @@
+//
+// Copyright 2023 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azureblob
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	backend "github.com/chainloop-dev/chainloop/internal/blobmanager"
+	"github.com/chainloop-dev/chainloop/internal/credentials"
+)
+
+type BackendProvider struct {
+	cReader credentials.Reader
+}
+
+var _ backend.Provider = (*BackendProvider)(nil)
+
+func NewBackendProvider(cReader credentials.Reader) *BackendProvider {
+	return &BackendProvider{cReader: cReader}
+}
+
+const ProviderID = "AzureBlob"
+
+func (p *BackendProvider) ID() string {
+	return ProviderID
+}
+
+func (p *BackendProvider) FromCredentials(ctx context.Context, secretName string) (backend.UploaderDownloader, error) {
+	creds := &Credentials{}
+	if err := p.cReader.ReadCredentials(ctx, secretName, creds); err != nil {
+		return nil, err
+	}
+
+	if err := creds.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid credentials retrieved from storage: %w", err)
+	}
+
+	// TODO: return AzureBlob backend
+	return nil, nil
+}
+
+func (p *BackendProvider) ValidateAndExtractCredentials(storageAccount string, credsJSON []byte) (any, error) {
+	var creds Credentials
+	if err := json.Unmarshal(credsJSON, &creds); err != nil {
+		return nil, fmt.Errorf("unmarshaling credentials: %w", err)
+	}
+
+	// We are currently storing the storageAccount in the secret as well
+	creds.StorageAccountName = storageAccount
+	if err := creds.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid credentials: %w", err)
+	}
+
+	// Create and validate credentials
+	// TODO: do an actual check
+	//	k, err := ociauth.NewCredentials(storageAccount, creds.Username, creds.Password)
+	//	if err != nil {
+	//		return nil, fmt.Errorf("creating credentials: %w", err)
+	//	}
+	//
+	//	// Check credentials
+	//	b, err := NewBackend(storageAccount, &RegistryOptions{Keychain: k})
+	//	if err != nil {
+	//		return nil, fmt.Errorf("checking credentials: %w", err)
+	//	}
+	//
+	//	if err := b.CheckWritePermissions(context.TODO()); err != nil {
+	//		return nil, fmt.Errorf("checking write permissions: %w", err)
+	//	}
+	//
+	return creds, nil
+}
+
+type Credentials struct {
+	// Storage Account Name
+	StorageAccountName string
+	// Active Directory Tenant ID
+	TenantID string
+	// Registered application / service principal client ID
+	ClientID string
+	// Registered application / service principal client secret
+	ClientSecret string
+}
+
+var ErrValidation = errors.New("credentials validation error")
+
+// Validate that the APICreds has all its properties set
+func (c *Credentials) Validate() error {
+	if c.StorageAccountName == "" {
+		return fmt.Errorf("%w: missing storage account name", ErrValidation)
+	}
+
+	if c.TenantID == "" {
+		return fmt.Errorf("%w: missing tenant ID", ErrValidation)
+	}
+
+	if c.ClientID == "" {
+		return fmt.Errorf("%w: missing client ID", ErrValidation)
+	}
+
+	if c.ClientSecret == "" {
+		return fmt.Errorf("%w: missing client secret", ErrValidation)
+	}
+
+	return nil
+}

--- a/internal/blobmanager/azureblob/provider_test.go
+++ b/internal/blobmanager/azureblob/provider_test.go
@@ -187,11 +187,9 @@ func TestExtractCreds(t *testing.T) {
 					ClientID:           "test",
 					ClientSecret:       "test",
 				}, creds)
-
 			}
 		})
 	}
-
 }
 
 func TestProviderID(t *testing.T) {

--- a/internal/blobmanager/azureblob/provider_test.go
+++ b/internal/blobmanager/azureblob/provider_test.go
@@ -1,0 +1,199 @@
+//
+// Copyright 2023 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azureblob
+
+import (
+	"context"
+	"testing"
+
+	"github.com/chainloop-dev/chainloop/internal/credentials/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestValidate(t *testing.T) {
+	testCases := []struct {
+		name    string
+		creds   *Credentials
+		wantErr bool
+	}{
+		{
+			name: "valid credentials",
+			creds: &Credentials{
+				StorageAccountName: "test",
+				Container:          "test",
+				TenantID:           "test",
+				ClientID:           "test",
+				ClientSecret:       "test",
+			},
+		},
+		{
+			name: "missing storage account",
+			creds: &Credentials{
+				StorageAccountName: "",
+				Container:          "test",
+				TenantID:           "test",
+				ClientID:           "test",
+				ClientSecret:       "test",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing container",
+			creds: &Credentials{
+				StorageAccountName: "test",
+				Container:          "",
+				TenantID:           "test",
+				ClientID:           "test",
+				ClientSecret:       "test",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing tenant id",
+			creds: &Credentials{
+				StorageAccountName: "test",
+				Container:          "test",
+				TenantID:           "",
+				ClientID:           "test",
+				ClientSecret:       "test",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing client id",
+			creds: &Credentials{
+				StorageAccountName: "test",
+				Container:          "test",
+				TenantID:           "test",
+				ClientID:           "",
+				ClientSecret:       "test",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing client secret",
+			creds: &Credentials{
+				StorageAccountName: "test",
+				Container:          "test",
+				TenantID:           "test",
+				ClientID:           "test",
+				ClientSecret:       "",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.creds.Validate()
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestFromCredentials(t *testing.T) {
+	ctx := context.Background()
+	assert := assert.New(t)
+	r := mocks.NewReader(t)
+	const storageAccount, container, tenant, clientID, clientSecret = "storage", "container", "container", "clientID", "clientSecret"
+
+	r.On("ReadCredentials", ctx, "secretName", mock.AnythingOfType("*azureblob.Credentials")).Return(nil).Run(
+		func(args mock.Arguments) {
+			credentials := args.Get(2).(*Credentials)
+			credentials.StorageAccountName = storageAccount
+			credentials.Container = container
+			credentials.TenantID = tenant
+			credentials.ClientID = clientID
+			credentials.ClientSecret = clientSecret
+		})
+
+	_, err := NewBackendProvider(r).FromCredentials(ctx, "secretName")
+	assert.NoError(err)
+}
+
+func TestExtractCreds(t *testing.T) {
+	tetCases := []struct {
+		name      string
+		location  string
+		credsJSON []byte
+		wantErr   bool
+	}{
+		{
+			name:     "valid credentials",
+			location: "account/container",
+			credsJSON: []byte(`{
+				"storageAccountName": "test",
+				"container": "test",
+				"tenantID": "test",
+				"clientID": "test",
+				"clientSecret": "test"
+			}`),
+		},
+		{
+			name:     "invalid location, missing container",
+			location: "account",
+			wantErr:  true,
+			credsJSON: []byte(`{
+				"storageAccountName": "test",
+				"container": "test",
+				"tenantID": "test",
+				"clientID": "test",
+				"clientSecret": ""
+			}`),
+		},
+		{
+			name:     "invalid credentials, missing secret",
+			location: "account/container",
+			credsJSON: []byte(`{
+				"storageAccountName": "test",
+				"container": "test",
+				"tenantID": "test",
+				"clientID": "test",
+				"clientSecret": ""
+			}`),
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tetCases {
+		t.Run(tc.name, func(t *testing.T) {
+			creds, err := extractCreds(tc.location, tc.credsJSON)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, &Credentials{
+					StorageAccountName: "account",
+					Container:          "container",
+					TenantID:           "test",
+					ClientID:           "test",
+					ClientSecret:       "test",
+				}, creds)
+
+			}
+		})
+	}
+
+}
+
+func TestProviderID(t *testing.T) {
+	assert.Equal(t, "AzureBlob", NewBackendProvider(nil).ID())
+}

--- a/internal/blobmanager/backend.go
+++ b/internal/blobmanager/backend.go
@@ -18,8 +18,17 @@ package backend
 import (
 	"context"
 	"io"
+	"net/http"
+	"strings"
 
 	v1 "github.com/chainloop-dev/chainloop/app/artifact-cas/api/cas/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+const (
+	AuthorAnnotation = "chainloop.dev"
+	// Default prefix for the blobmanager
+	DefaultPrefix = "chainloop"
 )
 
 type Uploader interface {
@@ -53,3 +62,8 @@ type Provider interface {
 }
 
 type Providers map[string]Provider
+
+// Detect the media type based on the provided content
+func DetectedMediaType(b []byte) types.MediaType {
+	return types.MediaType(strings.Split(http.DetectContentType(b), ";")[0])
+}

--- a/internal/blobmanager/oci/backend_test.go
+++ b/internal/blobmanager/oci/backend_test.go
@@ -99,7 +99,7 @@ func (s *testSuite) TestNewBackend() {
 				assert.NotNil(t, got)
 				assert.Equal(t, tc.repo, got.repo)
 				if tc.prefix == "" {
-					assert.Equal(t, defaultPrefix, got.prefix)
+					assert.Equal(t, "chainloop", got.prefix)
 				} else {
 					assert.Equal(t, tc.prefix, got.prefix)
 				}

--- a/internal/robotaccount/cas/robotaccount_test.go
+++ b/internal/robotaccount/cas/robotaccount_test.go
@@ -136,7 +136,7 @@ func TestNewBuilder(t *testing.T) {
 			}
 
 			if tc.expiration != 0 {
-				assert.Equal(&tc.expiration, b.expiration)
+				assert.Equal(tc.expiration, *b.expiration)
 			}
 		})
 	}


### PR DESCRIPTION
Adds support for Azure Blob Storage as Content Addressable Storage backend.

In practice this means:

Users can now onboard their Azure Storage Account with Chainloop

```sh
$ chainloop cas-backend add azure-blob \
  --client-id [servicePrincipalID]
  --client-secret [servicePrincipalSecret]
  --tenant [Active directory tenant]\
  --storage-account [Storage Account name]
  --container [optional Storage account container]
```
  
once done, it will appear in your list of registered backends

```console
$ chainloop cas-backend ls

──────────────────────────────────────┬─────────────────────────────────────┬───────────┬─────────────────────────────────────┬───────────────┬─────────┐
│ ID                                   │ LOCATION                            │ PROVIDER  │ DESCRIPTION                         │ LIMITS        │ DEFAULT │
├──────────────────────────────────────┼─────────────────────────────────────┼───────────┼─────────────────────────────────────┼───────────────┼─────────┤
│ 43471279-495e-4c85-975f-822e1619e029 │ chainlooptestcas/chainloop          │ AzureBlob │                                     │ MaxSize: 100M │ true    │
├──────────────────────────────────────┼─────────────────────────────────────┼───────────┼─────────────────────────────────────┼───────────────┼─────────┤
```

At this point there is nothing else that an user needs to do, the system automatically will upload attestations and pieces of evidence to the storageAccount/container automatically :)

![image](https://github.com/chainloop-dev/chainloop/assets/24523/a1ab0b55-24e4-46ba-bdc4-ff1cafc47716)

Note that you can use this backend in combination of an OCI one, meaning that files that have been uploaded to an OCI backend are still accessible and routed accordingly

![image](https://github.com/chainloop-dev/chainloop/assets/24523/e9490595-a65f-49b4-959e-4ee330a9ea61)


Refs #357 