### PR TITLE
fix(deployment): wrong labeling templating

### DIFF
--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -4,7 +4,7 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.17.0
+version: 1.17.1
 # Do not update appVersion, this is handled automatically by the release process
 appVersion: v0.19.0
 

--- a/deployment/chainloop/templates/cas/config.configmap.yaml
+++ b/deployment/chainloop/templates/cas/config.configmap.yaml
@@ -1,8 +1,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: { { include "chainloop.cas.fullname" . } }
-  labels: { { - include "chainloop.cas.labels" . | nindent 4 } }
+  name: {{ include "chainloop.cas.fullname" . }}
+  labels:
+    {{- include "chainloop.cas.labels" . | nindent 4 }}
 data:
   server.yaml: |
     server:


### PR DESCRIPTION
The previous PR added a regression in the Helm Chart that was preventing its render.

NOTE: the issue was due to editor auto-formatting 