### PR TITLE
fix(attestation): generic normalization function

### DIFF
--- a/app/cli/api/attestation/v1/crafting_state_test.go
+++ b/app/cli/api/attestation/v1/crafting_state_test.go
@@ -1,0 +1,109 @@
+//
+// Copyright 2023 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"testing"
+
+	schemaapi "github.com/chainloop-dev/chainloop/app/controlplane/api/workflowcontract/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeOutput(t *testing.T) {
+	artifactBasedMaterial := &Attestation_Material{
+		MaterialType: schemaapi.CraftingSchema_Material_SARIF,
+		M: &Attestation_Material_Artifact_{
+			Artifact: &Attestation_Material_Artifact{
+				Name: "name", Digest: "deadbeef", IsSubject: true, Content: []byte("content"),
+			},
+		},
+	}
+
+	artifactBasedMaterialWant := &NormalizedMaterialOutput{
+		Name: "name", Digest: "deadbeef", IsOutput: true, Content: []byte("content"),
+	}
+
+	containerMaterial := &Attestation_Material{
+		MaterialType: schemaapi.CraftingSchema_Material_CONTAINER_IMAGE,
+		M: &Attestation_Material_ContainerImage_{
+			ContainerImage: &Attestation_Material_ContainerImage{
+				Name: "name", Digest: "deadbeef", IsSubject: true,
+			},
+		},
+	}
+
+	containerMaterialWant := &NormalizedMaterialOutput{
+		Name: "name", Digest: "deadbeef", IsOutput: true,
+	}
+
+	keyValMaterial := &Attestation_Material{
+		MaterialType: schemaapi.CraftingSchema_Material_STRING,
+		M: &Attestation_Material_String_{
+			String_: &Attestation_Material_KeyVal{
+				Id: "id", Value: "value",
+			},
+		},
+	}
+
+	keyValWant := &NormalizedMaterialOutput{
+		Content: []byte("value"),
+	}
+
+	testCases := []struct {
+		name     string
+		material *Attestation_Material
+		want     *NormalizedMaterialOutput
+		wantErr  string
+	}{
+		{
+			name:    "nil material",
+			wantErr: "material not provided",
+		},
+		{
+			name:     "empty material",
+			material: &Attestation_Material{},
+			wantErr:  "unknown material: MATERIAL_TYPE_UNSPECIFIED",
+		},
+		{
+			name:     "artifact based material",
+			material: artifactBasedMaterial,
+			want:     artifactBasedMaterialWant,
+		},
+		{
+			name:     "Container image material",
+			material: containerMaterial,
+			want:     containerMaterialWant,
+		},
+		{
+			name:     "keyval material",
+			material: keyValMaterial,
+			want:     keyValWant,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := (tc.material).NormalizedOutput()
+			if tc.wantErr != "" {
+				assert.EqualError(t, err, tc.wantErr)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/attestation/renderer/chainloop/v01.go
+++ b/internal/attestation/renderer/chainloop/v01.go
@@ -116,7 +116,10 @@ func outputChainloopMaterials(att *v1.Attestation, onlyOutput bool) []*Provenanc
 		mdef := materials[mdefName]
 
 		artifactType := mdef.MaterialType
-		nMaterial := mdef.NormalizedOutput()
+		nMaterial, err := mdef.NormalizedOutput()
+		if err != nil {
+			continue
+		}
 
 		// Skip if we are expecting to show only the materials marked as output
 		if onlyOutput && !nMaterial.IsOutput {


### PR DESCRIPTION
Fixes #365

The issue was that we had a hardcoded list of material types to normalize and it was outside of the testing loop.

The issue was consistent when an user tried to use any new material type, such as the new `sarif` or `vex` types.

This code makes two things

- Change the normalization code to be less brittle and dynamic based on the structure of the material type
- Adds missing error handling


Example of successful attestation

```
┌────────────────────────────────────────────────────────────────────────────────────┐
│ Materials                                                                          │
├──────────┬─────────────────────────────────────────────────────────────────────────┤
│ Name     │ image                                                                   │
│ Type     │ CONTAINER_IMAGE                                                         │
│ Digest   │ sha256:39d48595c363755c9e00240ea74e0b6be0b5bdfb63ef2e58b9ec469e8828787d │
├──────────┼─────────────────────────────────────────────────────────────────────────┤
│ Name     │ rootfs                                                                  │
│ Type     │ ARTIFACT                                                                │
│ Filename │ sbom.cyclonedx.json                                                     │
│ Value    │                                                                         │
│ Digest   │ sha256:16159bb881eb4ab7eb5d8afc5350b0feeed1e31c0a268e355e74f9ccbe885e0c │
├──────────┼─────────────────────────────────────────────────────────────────────────┤
│ Name     │ sarif                                                                   │
│ Type     │ SARIF                                                                   │
│ Filename │ report.sarif                                                            │
│ Value    │                                                                         │
│ Digest   │ sha256:c4a63494f9289dd9fd44f841efb4f5b52765c2de6332f2d86e5f6c0340b40a95 │
├──────────┼─────────────────────────────────────────────────────────────────────────┤
│ Name     │ sbom                                                                    │
│ Type     │ SBOM_CYCLONEDX_JSON                                                     │
│ Filename │ sbom.cyclonedx.json                                                     │
│ Value    │                                                                         │
│ Digest   │ sha256:16159bb881eb4ab7eb5d8afc5350b0feeed1e31c0a268e355e74f9ccbe885e0c │
├──────────┼─────────────────────────────────────────────────────────────────────────┤
│ Name     │ vex                                                                     │
│ Type     │ OPENVEX                                                                 │
│ Filename │ openvex_v0.2.0.json                                                     │
│ Value    │                                                                         │
│ Digest   │ sha256:b4bd86d5855f94bcac0a92d3100ae7b85d050bd2e5fb9037a200e5f5f0b073a2 │
└──────────┴─────────────────────────────────────────────────────────────────────────┘

```