### PR TITLE
fix: extend http download timeout

### DIFF
--- a/app/artifact-cas/configs/config.devel.yaml
+++ b/app/artifact-cas/configs/config.devel.yaml
@@ -5,11 +5,13 @@
 server:
   http:
     addr: 0.0.0.0:8001
-    timeout: 5s
+    # Timeouts for http downloads
+    # grpc downloads/uploads don't require this because they don't have timeouts
+    timeout: 300s
   grpc:
     addr: 0.0.0.0:9001
-    # Some cas backends are slow, so we need to increase the timeout
-    # for example, Azure Blob Storage describe takes more than 1 second to respond sometimes
+    # Some unary RPCs are slow, so we need to increase the timeout
+    # For example, Azure Blob Storage describe takes more than 1 second to respond sometimes
     timeout: 5s
   http_metrics:
     addr: 0.0.0.0:5001

--- a/app/artifact-cas/internal/service/download.go
+++ b/app/artifact-cas/internal/service/download.go
@@ -91,6 +91,10 @@ func (s *DownloadService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// if the buffer contains the actual data we expect we proceed with sending it to the browser
+	// Set headers
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", info.FileName))
+	w.Header().Set("Content-Length", strconv.FormatInt(info.Size, 10))
 	s.log.Infow("msg", "download initialized", "digest", wantChecksum, "size", bytefmt.ByteSize(uint64(info.Size)))
 
 	gotChecksum := sha256.New()
@@ -119,11 +123,6 @@ func (s *DownloadService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, msg, http.StatusUnauthorized)
 		return
 	}
-
-	// if the buffer contains the actual data we expect we proceed with sending it to the browser
-	// Set headers
-	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", info.FileName))
-	w.Header().Set("Content-Length", strconv.FormatInt(info.Size, 10))
 
 	if _, err := io.Copy(w, buf); err != nil {
 		http.Error(w, sl.LogAndMaskErr(err, s.log).Error(), http.StatusInternalServerError)

--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -4,7 +4,7 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.17.1
+version: 1.17.2
 # Do not update appVersion, this is handled automatically by the release process
 appVersion: v0.19.0
 

--- a/deployment/chainloop/templates/cas/config.configmap.yaml
+++ b/deployment/chainloop/templates/cas/config.configmap.yaml
@@ -9,7 +9,9 @@ data:
     server:
       http:
         addr: 0.0.0.0:8000
-        timeout: 1s
+        # Timeouts for http downloads
+        # grpc downloads/uploads don't require this because they don't have timeouts
+        timeout: 300s
       grpc:
         {{- if .Values.cas.tlsConfig.secret.name  }}
         tls_config:
@@ -17,6 +19,7 @@ data:
           private_key: /data/server-certs/tls.key
         {{- end }}
         addr: 0.0.0.0:9000
+        # Some unary RPCs are slow, so we need to increase the timeout
         timeout: 5s
       http_metrics:
         addr: 0.0.0.0:5000


### PR DESCRIPTION
The issue in fact is a misconfiguration in the helm Chart and only Azure Blob Storage is affected.

The reason Azure is the only affected is because in its implementation we in fact use the parent `context` which by default has a `timeout`. The OCI implementation doesn't use context (it should)

The reason it only affects the HTTP endpoint is because grpc downloads don't have timeouts, http one does.

Fixes #366 