### PR TITLE
feat(deployment): Azure KeyVault support

### DIFF
--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -4,7 +4,7 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.19.0
+version: 1.19.1
 # Do not update appVersion, this is handled automatically by the release process
 appVersion: v0.20.0
 

--- a/deployment/chainloop/README.md
+++ b/deployment/chainloop/README.md
@@ -383,17 +383,21 @@ chainloop config save \
 
 ### Secrets Backend
 
-| Name                                                | Description                                                              | Value       |
-| --------------------------------------------------- | ------------------------------------------------------------------------ | ----------- |
-| `secretsBackend.backend`                            | Secrets backend type ("vault", "awsSecretManager" or "gcpSecretManager") | `vault`     |
-| `secretsBackend.secretPrefix`                       | Prefix that will be pre-pended to all secrets in the storage backend     | `chainloop` |
-| `secretsBackend.vault.address`                      | Vault address                                                            |             |
-| `secretsBackend.vault.token`                        | Vault authentication token                                               |             |
-| `secretsBackend.awsSecretManager.accessKey`         | AWS Access KEY ID                                                        |             |
-| `secretsBackend.awsSecretManager.secretKey`         | AWS Secret Key                                                           |             |
-| `secretsBackend.awsSecretManager.region`            | AWS Secret Manager Region                                                |             |
-| `secretsBackend.gcpSecretManager.projectId`         | GCP Project ID                                                           |             |
-| `secretsBackend.gcpSecretManager.serviceAccountKey` | GCP Auth Key                                                             |             |
+| Name                                                | Description                                                                               | Value       |
+| --------------------------------------------------- | ----------------------------------------------------------------------------------------- | ----------- |
+| `secretsBackend.backend`                            | Secrets backend type ("vault", "awsSecretManager" or "gcpSecretManager", "azureKeyVault") | `vault`     |
+| `secretsBackend.secretPrefix`                       | Prefix that will be pre-pended to all secrets in the storage backend                      | `chainloop` |
+| `secretsBackend.vault.address`                      | Vault address                                                                             |             |
+| `secretsBackend.vault.token`                        | Vault authentication token                                                                |             |
+| `secretsBackend.awsSecretManager.accessKey`         | AWS Access KEY ID                                                                         |             |
+| `secretsBackend.awsSecretManager.secretKey`         | AWS Secret Key                                                                            |             |
+| `secretsBackend.awsSecretManager.region`            | AWS Secret Manager Region                                                                 |             |
+| `secretsBackend.gcpSecretManager.projectId`         | GCP Project ID                                                                            |             |
+| `secretsBackend.gcpSecretManager.serviceAccountKey` | GCP Auth Key                                                                              |             |
+| `secretsBackend.azureKeyVault.tenantID`             | Active Directory Tenant ID                                                                |             |
+| `secretsBackend.azureKeyVault.clientID`             | Registered application / service principal client ID                                      |             |
+| `secretsBackend.azureKeyVault.clientSecret`         | Service principal client secret                                                           |             |
+| `secretsBackend.azureKeyVault.vaultURI`             | Azure Key Vault URL                                                                       |             |
 
 ### Authentication
 

--- a/deployment/chainloop/templates/_helpers.tpl
+++ b/deployment/chainloop/templates/_helpers.tpl
@@ -85,7 +85,7 @@ gcpSecretManager:
   {{- fail ".Values.secretsBackend.gcpSecretManager.serviceAccountKey not set" }}
   {{- end }}
 {{- else if eq .backend "azureKeyVault" }}
-azureKeyVault:
+azure_key_vault:
   tenant_id: {{ required "AD tenantID required" .azureKeyVault.tenantID | quote }}
   client_id: {{ required "Service principal ID required" .azureKeyVault.clientID | quote }}
   client_secret: {{ required "Service principal secret required" .azureKeyVault.clientSecret | quote }}

--- a/deployment/chainloop/templates/_helpers.tpl
+++ b/deployment/chainloop/templates/_helpers.tpl
@@ -84,7 +84,12 @@ gcpSecretManager:
   {{- if eq .gcpSecretManager.serviceAccountKey "" }}
   {{- fail ".Values.secretsBackend.gcpSecretManager.serviceAccountKey not set" }}
   {{- end }}
-
+{{- else if eq .backend "azureKeyVault" }}
+azureKeyVault:
+  tenant_id: {{ required "AD tenantID required" .azureKeyVault.tenantID | quote }}
+  client_id: {{ required "Service principal ID required" .azureKeyVault.clientID | quote }}
+  client_secret: {{ required "Service principal secret required" .azureKeyVault.clientSecret | quote }}
+  vault_uri: {{ required "Azure Vault URL required" .azureKeyVault.vaultURI | quote }}
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/deployment/chainloop/values.yaml
+++ b/deployment/chainloop/values.yaml
@@ -645,6 +645,7 @@ cas:
       ## @skip cas.ingressAPI.annotations.nginx.ingress.kubernetes.io/backend-protocol
       ## Tell Nginx Ingress Controller to expect gRPC traffic
       nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+      ## @skip cas.ingressAPI.annotations.nginx.ingress.kubernetes.io/client-body-buffer-size
       # Improve upload speed by adding client buffering used by http2 control-flows
       # https://github.com/chainloop-dev/chainloop/issues/375
       nginx.ingress.kubernetes.io/client-body-buffer-size: "3M"

--- a/deployment/chainloop/values.yaml
+++ b/deployment/chainloop/values.yaml
@@ -22,9 +22,9 @@ GKEMonitoring:
 
 ## Location where to store sensitive data. If development.true? and no overrides provided, the setup will connect to a development instance of Vault
 secretsBackend:
-  ## @param secretsBackend.backend Secrets backend type ("vault", "awsSecretManager" or "gcpSecretManager")
+  ## @param secretsBackend.backend Secrets backend type ("vault", "awsSecretManager" or "gcpSecretManager", "azureKeyVault")
   ##
-  backend: "vault" # "awsSecretManager"
+  backend: "vault" # "awsSecretManager | gcpSecretManager | azureKeyVault"
   ## @param secretsBackend.secretPrefix Prefix that will be pre-pended to all secrets in the storage backend
   ##
   secretPrefix: "chainloop"
@@ -52,6 +52,17 @@ secretsBackend:
   # gcpSecretManager:
   #   projectId: ""
   #   serviceAccountKey: ""
+
+  ## @extra secretsBackend.azureKeyVault.tenantID Active Directory Tenant ID
+  ## @extra secretsBackend.azureKeyVault.clientID Registered application / service principal client ID
+  ## @extra secretsBackend.azureKeyVault.clientSecret Service principal client secret
+  ## @extra secretsBackend.azureKeyVault.vaultURI Azure Key Vault URL
+  ##
+  # azureKeyVault:
+  #   tenantID: ""
+  #   clientID: ""
+  #   clientSecret: ""
+  #   vaultURI: ""
 
 ## @section Authentication
 ##


### PR DESCRIPTION
Update Helm Chart to support configuring Azure KeyVault, depends on #388 

This is the result of adding the following configuration to the values.yaml file

```yaml
secretsBackend:
  backend: azureKeyVault
  azureKeyVault:
    tenantID: [REDACTED]
    clientID: [REDACTED]
    clientSecret: [REDACTED]
    vaultURI: https://[REDACTED].vault.azure.net/
```

![image](https://github.com/chainloop-dev/chainloop/assets/24523/6fe0df86-d4cf-499e-ad84-c4589c700e39)


Closes #357 