### PR TITLE
fix(azure): existing file regression

### DIFF
--- a/internal/blobmanager/azureblob/backend.go
+++ b/internal/blobmanager/azureblob/backend.go
@@ -84,8 +84,7 @@ func resourceName(digest string) string {
 // Exists check that the artifact is already present in the repository
 func (b *Backend) Exists(ctx context.Context, digest string) (bool, error) {
 	_, err := b.Describe(ctx, digest)
-	notFoundErr := &backend.ErrNotFound{}
-	if err != nil && errors.As(err, &notFoundErr) {
+	if err != nil && backend.IsNotFound(err) {
 		return false, nil
 	}
 

--- a/internal/blobmanager/s3/backend.go
+++ b/internal/blobmanager/s3/backend.go
@@ -91,8 +91,7 @@ func NewBackend(creds *Credentials, connOpts ...ConnOpt) (*Backend, error) {
 // Exists check that the artifact is already present in the repository
 func (b *Backend) Exists(ctx context.Context, digest string) (bool, error) {
 	_, err := b.Describe(ctx, digest)
-	notFoundErr := &backend.ErrNotFound{}
-	if err != nil && errors.As(err, &notFoundErr) {
+	if err != nil && backend.IsNotFound(err) {
 		return false, nil
 	}
 
@@ -129,7 +128,7 @@ func (b *Backend) Describe(ctx context.Context, digest string) (*pb.CASResource,
 	var awsErr awserr.Error
 	if err != nil {
 		if errors.As(err, &awsErr) && awsErr.Code() == "NotFound" {
-			return nil, &backend.ErrNotFound{}
+			return nil, backend.NewErrNotFound("artifact")
 		}
 
 		return nil, fmt.Errorf("failed to read from bucket: %w", err)

--- a/internal/blobmanager/s3/backend_test.go
+++ b/internal/blobmanager/s3/backend_test.go
@@ -117,8 +117,7 @@ func (s *testSuite) TestDescribe() {
 	s.T().Run("doesn't exist", func(t *testing.T) {
 		artifact, err := s.backend.Describe(context.Background(), "aabbccddeeff")
 		s.Error(err)
-		notFoundErr := &backend.ErrNotFound{}
-		s.ErrorAs(err, &notFoundErr)
+		s.True(backend.IsNotFound(err))
 		s.Nil(artifact)
 	})
 


### PR DESCRIPTION
This change https://github.com/chainloop-dev/chainloop/pull/390/files?diff=split&w=0#r1360718603 introduced a regression in the Azure code.

The problem was that in Azure, we were returning a pointer to a custom error (instead of the error value), confusing `errors.As`.

This change makes sure we return always a concrete type and we leverage the already existing backend.isNotFound method.  