### PR TITLE
chore(api): enable request time histogram

### DIFF
--- a/app/artifact-cas/internal/server/grpc.go
+++ b/app/artifact-cas/internal/server/grpc.go
@@ -32,6 +32,7 @@ import (
 	jwtMiddleware "github.com/go-kratos/kratos/v2/middleware/auth/jwt"
 	"github.com/go-kratos/kratos/v2/middleware/selector"
 	jwt "github.com/golang-jwt/jwt/v4"
+	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/genproto/googleapis/bytestream"
 
 	"github.com/go-kratos/kratos/v2/log"
@@ -91,6 +92,10 @@ func NewGRPCServer(c *conf.Server, authConf *conf.Auth, byteService *service.Byt
 		),
 		grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor),
 	}
+
+	// Opt-in histogram metrics for the interceptor
+	// Since we track uploads / downloads we'll increase the buckets
+	grpc_prometheus.EnableHandlingTimeHistogram(grpc_prometheus.WithHistogramBuckets(prometheus.ExponentialBucketsRange(0.5, 60, 8)))
 
 	if c.Grpc.Network != "" {
 		opts = append(opts, grpc.Network(c.Grpc.Network))

--- a/app/controlplane/internal/server/grpc.go
+++ b/app/controlplane/internal/server/grpc.go
@@ -74,6 +74,9 @@ type Opts struct {
 
 // NewGRPCServer new a gRPC server.
 func NewGRPCServer(opts *Opts) (*grpc.Server, error) {
+	// Opt-in histogram metrics for the interceptor
+	grpc_prometheus.EnableHandlingTimeHistogram()
+
 	var serverOpts = []grpc.ServerOption{
 		grpc.Middleware(craftMiddleware(opts)...),
 		grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor),


### PR DESCRIPTION
This patch enables an additional Prometheus histogram with the total time per request.

For example, upload times

```
grpc_server_handling_seconds_sum{grpc_method="Read",grpc_service="google.bytestream.ByteStream",grpc_type="server_stream"} 24.683958404000002
grpc_server_handling_seconds_count{grpc_method="Read",grpc_service="google.bytestream.ByteStream",grpc_type="server_stream"} 2
```

or client stream uploads

```
grpc_server_handling_seconds_sum{grpc_method="Write",grpc_service="google.bytestream.ByteStream",grpc_type="client_stream"} 10.418738306000002
grpc_server_handling_seconds_count{grpc_method="Write",grpc_service="google.bytestream.ByteStream",grpc_type="client_stream"} 4
```

This patch also tweaks the histogram buckets on the CAS case since those requests have different time baselines (uploads, download streaming)