### PR TITLE
feat(attestation): add annotations to subject materials

### DIFF
--- a/internal/attestation/renderer/chainloop/testdata/attestation.output-2.v0.2.json
+++ b/internal/attestation/renderer/chainloop/testdata/attestation.output-2.v0.2.json
@@ -17,6 +17,10 @@
       "name": "index.docker.io/bitnami/nginx",
       "digest": {
         "sha256": "fbd9335f55d83d8aaf9ab1a539b0f2a87b444e8c54f34c9a1ca9d7df15605db4"
+      },
+      "annotations": {
+        "chainloop.material.name": "image",
+        "chainloop.material.type": "CONTAINER_IMAGE"
       }
     }
   ],

--- a/internal/attestation/renderer/chainloop/testdata/attestation.output.v0.2.json
+++ b/internal/attestation/renderer/chainloop/testdata/attestation.output.v0.2.json
@@ -7,11 +7,15 @@
         "sha256": "b403d1bb2b7739495df20f6d3838956333b04a66bc81d43bc7c64cee1433b604"
       }                                                                        
     },                                                                         
-    {                                                                                                                                                         
-      "name": "index.docker.io/bitnami/nginx",                                
-      "digest": {                                                              
+    {
+      "name": "index.docker.io/bitnami/nginx",
+      "digest": {
         "sha256": "580ac09da7771920dfd0c214964e7bfe4c27903bcbe075769a4044a67c9a390a"
-      }                                                                        
+      },
+      "annotations": {
+        "chainloop.material.name": "skynet-control-plane",
+        "chainloop.material.type": "CONTAINER_IMAGE"
+      }
     }                                                                          
   ],                                                                           
   "predicate_type": "chainloop.dev/attestation/v0.2",                                                                                                         

--- a/internal/attestation/renderer/chainloop/v02.go
+++ b/internal/attestation/renderer/chainloop/v02.go
@@ -101,8 +101,9 @@ func (r *RendererV02) subject() ([]*intoto.ResourceDescriptor, error) {
 	for _, m := range normalizedMaterials {
 		if m.Digest != nil {
 			subject = append(subject, &intoto.ResourceDescriptor{
-				Name:   m.Name,
-				Digest: m.Digest,
+				Name:        m.Name,
+				Digest:      m.Digest,
+				Annotations: m.Annotations,
 			})
 		}
 	}


### PR DESCRIPTION
Propagate material annotations to subject structs. This will enable enhanced ingestion upstream. 

In another patch, a similar feature #383 will be handled for our custom git head subject. 