### PR TITLE
chore: clear some unintended trailing spaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ lint:
 
 .PHONY: test
 # All tests, both unit and integration
-test: 
-	go test ./... 
+test:
+	go test ./...
 
 .PHONY: build_devel
 # build for development testing

--- a/app/cli/cmd/workflow_create.go
+++ b/app/cli/cmd/workflow_create.go
@@ -91,7 +91,11 @@ func newWorkflowCreateCmd() *cobra.Command {
 
 			// Print the Robot Account Token
 			if workflowRA.RobotAccountID != "" {
-				fmt.Printf("\nThis is automatically generated Robot Account Token (ID: %s). Save the following token since it will not printed again: \n\n %s\n\n", workflowRA.RobotAccountID, workflowRA.RobotAccountKey)
+				fmt.Printf(
+					"\nThis is an automatically generated Robot Account Token (ID: %s). Save the following token since it will not printed again: \n\n%s\n\n",
+					workflowRA.RobotAccountID,
+					workflowRA.RobotAccountKey,
+				)
 			}
 
 			return nil


### PR DESCRIPTION
This PR just removes some unwanted spaces from a message and from the makefile.