### PR TITLE
feat(referrer): support same digest for two different kinds

### DIFF
--- a/app/controlplane/internal/biz/errors.go
+++ b/app/controlplane/internal/biz/errors.go
@@ -91,3 +91,19 @@ func (e ErrUnauthorized) Error() string {
 func IsErrUnauthorized(err error) bool {
 	return errors.As(err, &ErrUnauthorized{})
 }
+
+// A referrer with the same digest points to two different artifact types
+// and we require filtering out which one
+type ErrAmbiguousReferrer struct {
+	digest string
+	// what kinds contain duplicates
+	kinds []string
+}
+
+func NewErrReferrerAmbiguous(digest string, kinds []string) error {
+	return ErrAmbiguousReferrer{digest, kinds}
+}
+
+func (e ErrAmbiguousReferrer) Error() string {
+	return fmt.Sprintf("digest %s present in two kinds %q", e.digest, e.kinds)
+}

--- a/app/controlplane/internal/biz/errors.go
+++ b/app/controlplane/internal/biz/errors.go
@@ -105,5 +105,5 @@ func NewErrReferrerAmbiguous(digest string, kinds []string) error {
 }
 
 func (e ErrAmbiguousReferrer) Error() string {
-	return fmt.Sprintf("digest %s present in two kinds %q", e.digest, e.kinds)
+	return fmt.Sprintf("digest %s present in %d kinds %q", e.digest, len(e.kinds), e.kinds)
 }

--- a/app/controlplane/internal/biz/referrer.go
+++ b/app/controlplane/internal/biz/referrer.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"sort"
@@ -124,6 +125,10 @@ func (s *ReferrerUseCase) GetFromRoot(ctx context.Context, digest string, userID
 
 	ref, err := s.repo.GetFromRoot(ctx, digest, orgIDs)
 	if err != nil {
+		if errors.As(err, &ErrAmbiguousReferrer{}) {
+			return nil, NewErrValidation(fmt.Errorf("please provide the referrer kind: %w", err))
+		}
+
 		return nil, fmt.Errorf("getting referrer from root: %w", err)
 	} else if ref == nil {
 		return nil, NewErrNotFound("referrer")

--- a/app/controlplane/internal/biz/referrer_integration_test.go
+++ b/app/controlplane/internal/biz/referrer_integration_test.go
@@ -201,7 +201,7 @@ func (s *referrerIntegrationTestSuite) TestExtractAndPersists() {
 		// but retrieval should fail. In the future we will ask the user to provide the artifact type in these cases of ambiguity
 		got, err := s.Referrer.GetFromRoot(ctx, wantReferrerSarif.Digest, s.user.ID)
 		s.Nil(got)
-		s.ErrorContains(err, "found more than one referrer with digest")
+		s.ErrorContains(err, "present in 2 kinds")
 	})
 
 	s.T().Run("now there should a container image pointing to two attestations", func(t *testing.T) {

--- a/app/controlplane/internal/biz/referrer_test.go
+++ b/app/controlplane/internal/biz/referrer_test.go
@@ -37,44 +37,95 @@ func (s *referrerTestSuite) TestExtractReferrers() {
 			name:      "basic",
 			inputPath: "testdata/attestations/full.json",
 			want: ReferrerMap{
-				"sha256:1a077137aef7ca208b80c339769d0d7eecacc2850368e56e834cda1750ce413a": &Referrer{
+				newRef("sha256:1a077137aef7ca208b80c339769d0d7eecacc2850368e56e834cda1750ce413a", "ATTESTATION"): &Referrer{
 					Digest:       "sha256:1a077137aef7ca208b80c339769d0d7eecacc2850368e56e834cda1750ce413a",
 					Kind:         "ATTESTATION",
 					Downloadable: true,
-					References: []string{
-						"sha256:264f55a6ff9cec2f4742a9faacc033b29f65c04dd4480e71e23579d484288d61",
-						"sha256:16159bb881eb4ab7eb5d8afc5350b0feeed1e31c0a268e355e74f9ccbe885e0c",
+					References: []*ReferrerReference{
+						{
+							Digest: "sha256:264f55a6ff9cec2f4742a9faacc033b29f65c04dd4480e71e23579d484288d61",
+							Kind:   "CONTAINER_IMAGE",
+						},
+						{
+							Digest: "sha256:16159bb881eb4ab7eb5d8afc5350b0feeed1e31c0a268e355e74f9ccbe885e0c",
+							Kind:   "SBOM_CYCLONEDX_JSON",
+						},
 					},
 				},
-				"sha256:16159bb881eb4ab7eb5d8afc5350b0feeed1e31c0a268e355e74f9ccbe885e0c": &Referrer{
+				newRef("sha256:16159bb881eb4ab7eb5d8afc5350b0feeed1e31c0a268e355e74f9ccbe885e0c", "SBOM_CYCLONEDX_JSON"): &Referrer{
 					Digest:       "sha256:16159bb881eb4ab7eb5d8afc5350b0feeed1e31c0a268e355e74f9ccbe885e0c",
 					Kind:         "SBOM_CYCLONEDX_JSON",
 					Downloadable: true,
 				},
-				"sha256:264f55a6ff9cec2f4742a9faacc033b29f65c04dd4480e71e23579d484288d61": &Referrer{
+				newRef("sha256:264f55a6ff9cec2f4742a9faacc033b29f65c04dd4480e71e23579d484288d61", "CONTAINER_IMAGE"): &Referrer{
 					Digest: "sha256:264f55a6ff9cec2f4742a9faacc033b29f65c04dd4480e71e23579d484288d61",
 					Kind:   "CONTAINER_IMAGE",
 				},
 			},
 		},
 		{
-			name:      "basic",
+			name:      "with string value material to be discarded",
 			inputPath: "testdata/attestations/with-string.json",
 			want: ReferrerMap{
 				// the git commit a subject in the attestation
-				"sha1:58442b61a6564df94857ff69ad7c340c55703e20": &Referrer{
+				newRef("sha1:58442b61a6564df94857ff69ad7c340c55703e20", "GIT_HEAD_COMMIT"): &Referrer{
 					Digest: "sha1:58442b61a6564df94857ff69ad7c340c55703e20",
 					Kind:   "GIT_HEAD_COMMIT",
-					References: []string{
-						"sha256:507dddb505ceb53fb32cde31f9935c9a3ebc7b7d82f36101de638b1ab9367344",
+					References: []*ReferrerReference{
+						{
+							Digest: "sha256:507dddb505ceb53fb32cde31f9935c9a3ebc7b7d82f36101de638b1ab9367344",
+							Kind:   "ATTESTATION",
+						},
 					},
 				},
-				"sha256:507dddb505ceb53fb32cde31f9935c9a3ebc7b7d82f36101de638b1ab9367344": &Referrer{
-					Digest: "sha256:507dddb505ceb53fb32cde31f9935c9a3ebc7b7d82f36101de638b1ab9367344",
-					Kind:   "ATTESTATION",
-					References: []string{
-						"sha1:58442b61a6564df94857ff69ad7c340c55703e20",
+				newRef("sha256:507dddb505ceb53fb32cde31f9935c9a3ebc7b7d82f36101de638b1ab9367344", "ATTESTATION"): &Referrer{
+					Digest:       "sha256:507dddb505ceb53fb32cde31f9935c9a3ebc7b7d82f36101de638b1ab9367344",
+					Kind:         "ATTESTATION",
+					Downloadable: true,
+					References: []*ReferrerReference{
+						{
+							Digest: "sha1:58442b61a6564df94857ff69ad7c340c55703e20",
+							Kind:   "GIT_HEAD_COMMIT",
+						},
 					},
+				},
+			},
+		},
+		{
+			name:      "with two materials with same digest",
+			inputPath: "testdata/attestations/with-duplicated-sha.json",
+			want: ReferrerMap{
+				newRef("sha256:47e94045e8ffb5ea9a4939a03a21c5ad26f4ea7d463ac6ec46dac15349f45b3f", "ATTESTATION"): &Referrer{
+					Digest:       "sha256:47e94045e8ffb5ea9a4939a03a21c5ad26f4ea7d463ac6ec46dac15349f45b3f",
+					Kind:         "ATTESTATION",
+					Downloadable: true,
+					References: []*ReferrerReference{
+						{
+							Digest: "sha256:264f55a6ff9cec2f4742a9faacc033b29f65c04dd4480e71e23579d484288d61",
+							Kind:   "CONTAINER_IMAGE",
+						},
+						{
+							Digest: "sha256:264f55a6ff9cec2f4742a9faacc033b29f65c04dd4480e71e23579d484288d61",
+							Kind:   "SBOM_CYCLONEDX_JSON",
+						},
+						{
+							Digest: "sha256:16159bb881eb4ab7eb5d8afc5350b0feeed1e31c0a268e355e74f9ccbe885e0c",
+							Kind:   "SBOM_CYCLONEDX_JSON",
+						},
+					},
+				},
+				newRef("sha256:264f55a6ff9cec2f4742a9faacc033b29f65c04dd4480e71e23579d484288d61", "CONTAINER_IMAGE"): &Referrer{
+					Digest: "sha256:264f55a6ff9cec2f4742a9faacc033b29f65c04dd4480e71e23579d484288d61",
+					Kind:   "CONTAINER_IMAGE",
+				},
+				newRef("sha256:16159bb881eb4ab7eb5d8afc5350b0feeed1e31c0a268e355e74f9ccbe885e0c", "SBOM_CYCLONEDX_JSON"): &Referrer{
+					Digest:       "sha256:16159bb881eb4ab7eb5d8afc5350b0feeed1e31c0a268e355e74f9ccbe885e0c",
+					Kind:         "SBOM_CYCLONEDX_JSON",
+					Downloadable: true,
+				},
+				newRef("sha256:264f55a6ff9cec2f4742a9faacc033b29f65c04dd4480e71e23579d484288d61", "SBOM_CYCLONEDX_JSON"): &Referrer{
+					Digest:       "sha256:264f55a6ff9cec2f4742a9faacc033b29f65c04dd4480e71e23579d484288d61",
+					Kind:         "SBOM_CYCLONEDX_JSON",
 					Downloadable: true,
 				},
 			},
@@ -83,59 +134,77 @@ func (s *referrerTestSuite) TestExtractReferrers() {
 			name:      "with git subject",
 			inputPath: "testdata/attestations/with-git-subject.json",
 			want: ReferrerMap{
-				"sha256:fbd9335f55d83d8aaf9ab1a539b0f2a87b444e8c54f34c9a1ca9d7df15605db4": &Referrer{
+				newRef("sha256:fbd9335f55d83d8aaf9ab1a539b0f2a87b444e8c54f34c9a1ca9d7df15605db4", "CONTAINER_IMAGE"): &Referrer{
 					Digest: "sha256:fbd9335f55d83d8aaf9ab1a539b0f2a87b444e8c54f34c9a1ca9d7df15605db4",
 					Kind:   "CONTAINER_IMAGE",
 					// the container image is a subject in the attestation
-					References: []string{
-						"sha256:ad704d286bcad6e155e71c33d48247931231338396acbcd9769087530085b2a2",
+					References: []*ReferrerReference{
+						{
+							Digest: "sha256:ad704d286bcad6e155e71c33d48247931231338396acbcd9769087530085b2a2",
+							Kind:   "ATTESTATION",
+						},
 					},
 				},
-				"sha1:78ac366c9e8a300d51808d581422ca61f7b5b721": &Referrer{
+				newRef("sha1:78ac366c9e8a300d51808d581422ca61f7b5b721", "GIT_HEAD_COMMIT"): &Referrer{
 					Digest: "sha1:78ac366c9e8a300d51808d581422ca61f7b5b721",
 					Kind:   "GIT_HEAD_COMMIT",
 					// the git commit a subject in the attestation
-					References: []string{
-						"sha256:ad704d286bcad6e155e71c33d48247931231338396acbcd9769087530085b2a2",
+					References: []*ReferrerReference{
+						{
+							Digest: "sha256:ad704d286bcad6e155e71c33d48247931231338396acbcd9769087530085b2a2",
+							Kind:   "ATTESTATION",
+						},
 					},
 				},
-				"sha256:385c4188b9c080499413f2e0fa0b3951ed107b5f0cb35c2f2b1f07a7be9a7512": &Referrer{
+				newRef("sha256:385c4188b9c080499413f2e0fa0b3951ed107b5f0cb35c2f2b1f07a7be9a7512", "ARTIFACT"): &Referrer{
 					Digest:       "sha256:385c4188b9c080499413f2e0fa0b3951ed107b5f0cb35c2f2b1f07a7be9a7512",
 					Kind:         "ARTIFACT",
 					Downloadable: true,
 				},
-				"sha256:c4a63494f9289dd9fd44f841efb4f5b52765c2de6332f2d86e5f6c0340b40a95": &Referrer{
+				newRef("sha256:c4a63494f9289dd9fd44f841efb4f5b52765c2de6332f2d86e5f6c0340b40a95", "SARIF"): &Referrer{
 					Digest:       "sha256:c4a63494f9289dd9fd44f841efb4f5b52765c2de6332f2d86e5f6c0340b40a95",
 					Kind:         "SARIF",
 					Downloadable: true,
 				},
-				"sha256:16159bb881eb4ab7eb5d8afc5350b0feeed1e31c0a268e355e74f9ccbe885e0c": &Referrer{
+				newRef("sha256:16159bb881eb4ab7eb5d8afc5350b0feeed1e31c0a268e355e74f9ccbe885e0c", "SBOM_CYCLONEDX_JSON"): &Referrer{
 					Digest:       "sha256:16159bb881eb4ab7eb5d8afc5350b0feeed1e31c0a268e355e74f9ccbe885e0c",
 					Kind:         "SBOM_CYCLONEDX_JSON",
 					Downloadable: true,
 				},
-				"sha256:b4bd86d5855f94bcac0a92d3100ae7b85d050bd2e5fb9037a200e5f5f0b073a2": &Referrer{
+				newRef("sha256:b4bd86d5855f94bcac0a92d3100ae7b85d050bd2e5fb9037a200e5f5f0b073a2", "OPENVEX"): &Referrer{
 					Digest:       "sha256:b4bd86d5855f94bcac0a92d3100ae7b85d050bd2e5fb9037a200e5f5f0b073a2",
 					Kind:         "OPENVEX",
 					Downloadable: true,
 				},
-				"sha256:ad704d286bcad6e155e71c33d48247931231338396acbcd9769087530085b2a2": &Referrer{
+				newRef("sha256:ad704d286bcad6e155e71c33d48247931231338396acbcd9769087530085b2a2", "ATTESTATION"): &Referrer{
 					Digest:       "sha256:ad704d286bcad6e155e71c33d48247931231338396acbcd9769087530085b2a2",
 					Kind:         "ATTESTATION",
 					Downloadable: true,
-					References: []string{
-						// container image
-						"sha256:fbd9335f55d83d8aaf9ab1a539b0f2a87b444e8c54f34c9a1ca9d7df15605db4",
-						// artifact
-						"sha256:385c4188b9c080499413f2e0fa0b3951ed107b5f0cb35c2f2b1f07a7be9a7512",
-						// sarif
-						"sha256:c4a63494f9289dd9fd44f841efb4f5b52765c2de6332f2d86e5f6c0340b40a95",
-						// sbom
-						"sha256:16159bb881eb4ab7eb5d8afc5350b0feeed1e31c0a268e355e74f9ccbe885e0c",
-						// openvex
-						"sha256:b4bd86d5855f94bcac0a92d3100ae7b85d050bd2e5fb9037a200e5f5f0b073a2",
-						// git head commit
-						"sha1:78ac366c9e8a300d51808d581422ca61f7b5b721",
+					References: []*ReferrerReference{
+						{
+							Digest: "sha256:fbd9335f55d83d8aaf9ab1a539b0f2a87b444e8c54f34c9a1ca9d7df15605db4",
+							Kind:   "CONTAINER_IMAGE",
+						},
+						{
+							Digest: "sha256:385c4188b9c080499413f2e0fa0b3951ed107b5f0cb35c2f2b1f07a7be9a7512",
+							Kind:   "ARTIFACT",
+						},
+						{
+							Digest: "sha256:c4a63494f9289dd9fd44f841efb4f5b52765c2de6332f2d86e5f6c0340b40a95",
+							Kind:   "SARIF",
+						},
+						{
+							Digest: "sha256:16159bb881eb4ab7eb5d8afc5350b0feeed1e31c0a268e355e74f9ccbe885e0c",
+							Kind:   "SBOM_CYCLONEDX_JSON",
+						},
+						{
+							Digest: "sha256:b4bd86d5855f94bcac0a92d3100ae7b85d050bd2e5fb9037a200e5f5f0b073a2",
+							Kind:   "OPENVEX",
+						},
+						{
+							Digest: "sha1:78ac366c9e8a300d51808d581422ca61f7b5b721",
+							Kind:   "GIT_HEAD_COMMIT",
+						},
 					},
 				},
 			},

--- a/app/controlplane/internal/biz/referrer_test.go
+++ b/app/controlplane/internal/biz/referrer_test.go
@@ -31,17 +31,17 @@ func (s *referrerTestSuite) TestExtractReferrers() {
 		name      string
 		inputPath string
 		expectErr bool
-		want      ReferrerMap
+		want      []*Referrer
 	}{
 		{
 			name:      "basic",
 			inputPath: "testdata/attestations/full.json",
-			want: ReferrerMap{
-				newRef("sha256:1a077137aef7ca208b80c339769d0d7eecacc2850368e56e834cda1750ce413a", "ATTESTATION"): &Referrer{
+			want: []*Referrer{
+				{
 					Digest:       "sha256:1a077137aef7ca208b80c339769d0d7eecacc2850368e56e834cda1750ce413a",
 					Kind:         "ATTESTATION",
 					Downloadable: true,
-					References: []*ReferrerReference{
+					References: []*Referrer{
 						{
 							Digest: "sha256:264f55a6ff9cec2f4742a9faacc033b29f65c04dd4480e71e23579d484288d61",
 							Kind:   "CONTAINER_IMAGE",
@@ -52,40 +52,40 @@ func (s *referrerTestSuite) TestExtractReferrers() {
 						},
 					},
 				},
-				newRef("sha256:16159bb881eb4ab7eb5d8afc5350b0feeed1e31c0a268e355e74f9ccbe885e0c", "SBOM_CYCLONEDX_JSON"): &Referrer{
+				{
+					Digest: "sha256:264f55a6ff9cec2f4742a9faacc033b29f65c04dd4480e71e23579d484288d61",
+					Kind:   "CONTAINER_IMAGE",
+				},
+				{
 					Digest:       "sha256:16159bb881eb4ab7eb5d8afc5350b0feeed1e31c0a268e355e74f9ccbe885e0c",
 					Kind:         "SBOM_CYCLONEDX_JSON",
 					Downloadable: true,
-				},
-				newRef("sha256:264f55a6ff9cec2f4742a9faacc033b29f65c04dd4480e71e23579d484288d61", "CONTAINER_IMAGE"): &Referrer{
-					Digest: "sha256:264f55a6ff9cec2f4742a9faacc033b29f65c04dd4480e71e23579d484288d61",
-					Kind:   "CONTAINER_IMAGE",
 				},
 			},
 		},
 		{
 			name:      "with string value material to be discarded",
 			inputPath: "testdata/attestations/with-string.json",
-			want: ReferrerMap{
-				// the git commit a subject in the attestation
-				newRef("sha1:58442b61a6564df94857ff69ad7c340c55703e20", "GIT_HEAD_COMMIT"): &Referrer{
-					Digest: "sha1:58442b61a6564df94857ff69ad7c340c55703e20",
-					Kind:   "GIT_HEAD_COMMIT",
-					References: []*ReferrerReference{
-						{
-							Digest: "sha256:507dddb505ceb53fb32cde31f9935c9a3ebc7b7d82f36101de638b1ab9367344",
-							Kind:   "ATTESTATION",
-						},
-					},
-				},
-				newRef("sha256:507dddb505ceb53fb32cde31f9935c9a3ebc7b7d82f36101de638b1ab9367344", "ATTESTATION"): &Referrer{
+			want: []*Referrer{
+				{
 					Digest:       "sha256:507dddb505ceb53fb32cde31f9935c9a3ebc7b7d82f36101de638b1ab9367344",
 					Kind:         "ATTESTATION",
 					Downloadable: true,
-					References: []*ReferrerReference{
+					References: []*Referrer{
 						{
 							Digest: "sha1:58442b61a6564df94857ff69ad7c340c55703e20",
 							Kind:   "GIT_HEAD_COMMIT",
+						},
+					},
+				},
+				// the git commit a subject in the attestation
+				{
+					Digest: "sha1:58442b61a6564df94857ff69ad7c340c55703e20",
+					Kind:   "GIT_HEAD_COMMIT",
+					References: []*Referrer{
+						{
+							Digest: "sha256:507dddb505ceb53fb32cde31f9935c9a3ebc7b7d82f36101de638b1ab9367344",
+							Kind:   "ATTESTATION",
 						},
 					},
 				},
@@ -94,12 +94,12 @@ func (s *referrerTestSuite) TestExtractReferrers() {
 		{
 			name:      "with two materials with same digest",
 			inputPath: "testdata/attestations/with-duplicated-sha.json",
-			want: ReferrerMap{
-				newRef("sha256:47e94045e8ffb5ea9a4939a03a21c5ad26f4ea7d463ac6ec46dac15349f45b3f", "ATTESTATION"): &Referrer{
+			want: []*Referrer{
+				{
 					Digest:       "sha256:47e94045e8ffb5ea9a4939a03a21c5ad26f4ea7d463ac6ec46dac15349f45b3f",
 					Kind:         "ATTESTATION",
 					Downloadable: true,
-					References: []*ReferrerReference{
+					References: []*Referrer{
 						{
 							Digest: "sha256:264f55a6ff9cec2f4742a9faacc033b29f65c04dd4480e71e23579d484288d61",
 							Kind:   "CONTAINER_IMAGE",
@@ -114,16 +114,16 @@ func (s *referrerTestSuite) TestExtractReferrers() {
 						},
 					},
 				},
-				newRef("sha256:264f55a6ff9cec2f4742a9faacc033b29f65c04dd4480e71e23579d484288d61", "CONTAINER_IMAGE"): &Referrer{
+				{
 					Digest: "sha256:264f55a6ff9cec2f4742a9faacc033b29f65c04dd4480e71e23579d484288d61",
 					Kind:   "CONTAINER_IMAGE",
 				},
-				newRef("sha256:16159bb881eb4ab7eb5d8afc5350b0feeed1e31c0a268e355e74f9ccbe885e0c", "SBOM_CYCLONEDX_JSON"): &Referrer{
+				{
 					Digest:       "sha256:16159bb881eb4ab7eb5d8afc5350b0feeed1e31c0a268e355e74f9ccbe885e0c",
 					Kind:         "SBOM_CYCLONEDX_JSON",
 					Downloadable: true,
 				},
-				newRef("sha256:264f55a6ff9cec2f4742a9faacc033b29f65c04dd4480e71e23579d484288d61", "SBOM_CYCLONEDX_JSON"): &Referrer{
+				{
 					Digest:       "sha256:264f55a6ff9cec2f4742a9faacc033b29f65c04dd4480e71e23579d484288d61",
 					Kind:         "SBOM_CYCLONEDX_JSON",
 					Downloadable: true,
@@ -133,54 +133,17 @@ func (s *referrerTestSuite) TestExtractReferrers() {
 		{
 			name:      "with git subject",
 			inputPath: "testdata/attestations/with-git-subject.json",
-			want: ReferrerMap{
-				newRef("sha256:fbd9335f55d83d8aaf9ab1a539b0f2a87b444e8c54f34c9a1ca9d7df15605db4", "CONTAINER_IMAGE"): &Referrer{
-					Digest: "sha256:fbd9335f55d83d8aaf9ab1a539b0f2a87b444e8c54f34c9a1ca9d7df15605db4",
-					Kind:   "CONTAINER_IMAGE",
-					// the container image is a subject in the attestation
-					References: []*ReferrerReference{
-						{
-							Digest: "sha256:ad704d286bcad6e155e71c33d48247931231338396acbcd9769087530085b2a2",
-							Kind:   "ATTESTATION",
-						},
-					},
-				},
-				newRef("sha1:78ac366c9e8a300d51808d581422ca61f7b5b721", "GIT_HEAD_COMMIT"): &Referrer{
-					Digest: "sha1:78ac366c9e8a300d51808d581422ca61f7b5b721",
-					Kind:   "GIT_HEAD_COMMIT",
-					// the git commit a subject in the attestation
-					References: []*ReferrerReference{
-						{
-							Digest: "sha256:ad704d286bcad6e155e71c33d48247931231338396acbcd9769087530085b2a2",
-							Kind:   "ATTESTATION",
-						},
-					},
-				},
-				newRef("sha256:385c4188b9c080499413f2e0fa0b3951ed107b5f0cb35c2f2b1f07a7be9a7512", "ARTIFACT"): &Referrer{
+			want: []*Referrer{
+				{
 					Digest:       "sha256:385c4188b9c080499413f2e0fa0b3951ed107b5f0cb35c2f2b1f07a7be9a7512",
 					Kind:         "ARTIFACT",
 					Downloadable: true,
 				},
-				newRef("sha256:c4a63494f9289dd9fd44f841efb4f5b52765c2de6332f2d86e5f6c0340b40a95", "SARIF"): &Referrer{
-					Digest:       "sha256:c4a63494f9289dd9fd44f841efb4f5b52765c2de6332f2d86e5f6c0340b40a95",
-					Kind:         "SARIF",
-					Downloadable: true,
-				},
-				newRef("sha256:16159bb881eb4ab7eb5d8afc5350b0feeed1e31c0a268e355e74f9ccbe885e0c", "SBOM_CYCLONEDX_JSON"): &Referrer{
-					Digest:       "sha256:16159bb881eb4ab7eb5d8afc5350b0feeed1e31c0a268e355e74f9ccbe885e0c",
-					Kind:         "SBOM_CYCLONEDX_JSON",
-					Downloadable: true,
-				},
-				newRef("sha256:b4bd86d5855f94bcac0a92d3100ae7b85d050bd2e5fb9037a200e5f5f0b073a2", "OPENVEX"): &Referrer{
-					Digest:       "sha256:b4bd86d5855f94bcac0a92d3100ae7b85d050bd2e5fb9037a200e5f5f0b073a2",
-					Kind:         "OPENVEX",
-					Downloadable: true,
-				},
-				newRef("sha256:ad704d286bcad6e155e71c33d48247931231338396acbcd9769087530085b2a2", "ATTESTATION"): &Referrer{
+				{
 					Digest:       "sha256:ad704d286bcad6e155e71c33d48247931231338396acbcd9769087530085b2a2",
 					Kind:         "ATTESTATION",
 					Downloadable: true,
-					References: []*ReferrerReference{
+					References: []*Referrer{
 						{
 							Digest: "sha256:fbd9335f55d83d8aaf9ab1a539b0f2a87b444e8c54f34c9a1ca9d7df15605db4",
 							Kind:   "CONTAINER_IMAGE",
@@ -206,6 +169,43 @@ func (s *referrerTestSuite) TestExtractReferrers() {
 							Kind:   "GIT_HEAD_COMMIT",
 						},
 					},
+				},
+				{
+					Digest: "sha256:fbd9335f55d83d8aaf9ab1a539b0f2a87b444e8c54f34c9a1ca9d7df15605db4",
+					Kind:   "CONTAINER_IMAGE",
+					// the container image is a subject in the attestation
+					References: []*Referrer{
+						{
+							Digest: "sha256:ad704d286bcad6e155e71c33d48247931231338396acbcd9769087530085b2a2",
+							Kind:   "ATTESTATION",
+						},
+					},
+				},
+				{
+					Digest: "sha1:78ac366c9e8a300d51808d581422ca61f7b5b721",
+					Kind:   "GIT_HEAD_COMMIT",
+					// the git commit a subject in the attestation
+					References: []*Referrer{
+						{
+							Digest: "sha256:ad704d286bcad6e155e71c33d48247931231338396acbcd9769087530085b2a2",
+							Kind:   "ATTESTATION",
+						},
+					},
+				},
+				{
+					Digest:       "sha256:b4bd86d5855f94bcac0a92d3100ae7b85d050bd2e5fb9037a200e5f5f0b073a2",
+					Kind:         "OPENVEX",
+					Downloadable: true,
+				},
+				{
+					Digest:       "sha256:c4a63494f9289dd9fd44f841efb4f5b52765c2de6332f2d86e5f6c0340b40a95",
+					Kind:         "SARIF",
+					Downloadable: true,
+				},
+				{
+					Digest:       "sha256:16159bb881eb4ab7eb5d8afc5350b0feeed1e31c0a268e355e74f9ccbe885e0c",
+					Kind:         "SBOM_CYCLONEDX_JSON",
+					Downloadable: true,
 				},
 			},
 		},

--- a/app/controlplane/internal/data/referrer.go
+++ b/app/controlplane/internal/data/referrer.go
@@ -41,10 +41,6 @@ func NewReferrerRepo(data *Data, logger log.Logger) biz.ReferrerRepo {
 
 type storedReferrerMap map[string]*ent.Referrer
 
-func newRef(digest, kind string) string {
-	return fmt.Sprintf("%s-%s", kind, digest)
-}
-
 func (r *ReferrerRepo) Save(ctx context.Context, referrers []*biz.Referrer, orgID uuid.UUID) error {
 	// Start transaction
 	tx, err := r.data.db.Tx(ctx)


### PR DESCRIPTION
This PR 

- Improves the ingestion code to allow storing two referrers with the same digest but different kinds. it includes some refactoring too.
- Updates the retrieval code to return a well-known error that: 
  - makes the API return a validation error instead of a server error
  - shows actionable information to the user of what's available.

For example, now, on retrieval we get.

```
$ chainloop discover -d sha256:ebe2e6ffab93f4b2e2743d3557bd094427ea059adc78cfe2cd330a72f61731e8
ERR validation error: please provide the referrer kind: failed to get referrer: digest sha256:ebe2e6ffab93f4b2e2743d3557bd094427ea059adc78cfe2cd330a72f61731e8
 present in two kinds ["SBOM_CYCLONEDX_JSON" "ARTIFACT"]
```

In a future patch, the user will be able to filter out by kind.