### PR TITLE
fix(runner): remove optional env variable from the requirements

### DIFF
--- a/internal/attestation/crafter/runners/circleci_build.go
+++ b/internal/attestation/crafter/runners/circleci_build.go
@@ -43,7 +43,6 @@ func (r *CircleCIBuild) ListEnvVars() []string {
 
 		// Some info about the commit
 		"CIRCLE_BRANCH",
-		"CIRCLE_PR_NUMBER",
 
 		// Some info about the agent
 		"CIRCLE_NODE_TOTAL",

--- a/internal/attestation/crafter/runners/circleci_build_test.go
+++ b/internal/attestation/crafter/runners/circleci_build_test.go
@@ -92,7 +92,6 @@ func (s *circleCIBuildSuite) TestListEnvVars() {
 		"CIRCLE_BUILD_URL",
 		"CIRCLE_JOB",
 		"CIRCLE_BRANCH",
-		"CIRCLE_PR_NUMBER",
 		"CIRCLE_NODE_TOTAL",
 		"CIRCLE_NODE_INDEX",
 	}, s.runner.ListEnvVars())
@@ -123,7 +122,6 @@ var circleCIBuildTestingEnvVars = map[string]string{
 	"CIRCLE_BUILD_URL":  "http://some-build-url/",
 	"CIRCLE_JOB":        "some-job",
 	"CIRCLE_BRANCH":     "some-branch",
-	"CIRCLE_PR_NUMBER":  "1337",
 	"CIRCLE_NODE_TOTAL": "3",
 	"CIRCLE_NODE_INDEX": "1",
 }


### PR DESCRIPTION
Main issue:
https://github.com/chainloop-dev/chainloop/issues/433

I am removing the environment variable CIRCLE_PR_NUMBER from the required because it's set only in very specific scenarios. Everything else is working. I artificially set this env variable to make the runner work from within CircleCI and it worked just fine:
![image](https://github.com/chainloop-dev/chainloop/assets/11213785/39ae007d-96fa-46ad-9610-eb1437d1b44d)
