### PR TITLE
PROPOSAL - Optional env vars

### DIFF
--- a/internal/attestation/crafter/runner.go
+++ b/internal/attestation/crafter/runner.go
@@ -27,13 +27,18 @@ var ErrRunnerContextNotFound = errors.New("the runner environment doesn't match 
 type supportedRunner interface {
 	// Whether the attestation is happening in this environment
 	CheckEnv() bool
+
 	// List the env variables registered
 	ListEnvVars() []string
+	ListOptionalEnvVars() []string
+
 	// Return the list of env vars associated with this runner already resolved
 	ResolveEnvVars() map[string]string
-	String() string
+
 	// uri to the running job/workload
 	RunURI() string
+
+	String() string
 }
 
 func NewRunner(t schemaapi.CraftingSchema_Runner_RunnerType) supportedRunner {

--- a/internal/attestation/crafter/runners/azurepipeline.go
+++ b/internal/attestation/crafter/runners/azurepipeline.go
@@ -55,8 +55,12 @@ func (r *AzurePipeline) ListEnvVars() []string {
 	}
 }
 
+func (r *AzurePipeline) ListOptionalEnvVars() []string {
+	return []string{}
+}
+
 func (r *AzurePipeline) ResolveEnvVars() map[string]string {
-	return resolveEnvVars(r.ListEnvVars())
+	return resolveEnvVars(r.ListEnvVars(), r.ListOptionalEnvVars())
 }
 
 func (r *AzurePipeline) String() string {

--- a/internal/attestation/crafter/runners/circleci_build.go
+++ b/internal/attestation/crafter/runners/circleci_build.go
@@ -50,8 +50,15 @@ func (r *CircleCIBuild) ListEnvVars() []string {
 	}
 }
 
+func (r *CircleCIBuild) ListOptionalEnvVars() []string {
+	return []string{
+		// Some info about the commit
+		"CIRCLE_PR_NUMBER",
+	}
+}
+
 func (r *CircleCIBuild) ResolveEnvVars() map[string]string {
-	return resolveEnvVars(r.ListEnvVars())
+	return resolveEnvVars(r.ListEnvVars(), r.ListOptionalEnvVars())
 }
 
 func (r *CircleCIBuild) String() string {

--- a/internal/attestation/crafter/runners/circleci_build_test.go
+++ b/internal/attestation/crafter/runners/circleci_build_test.go
@@ -124,6 +124,7 @@ var circleCIBuildTestingEnvVars = map[string]string{
 	"CIRCLE_BRANCH":     "some-branch",
 	"CIRCLE_NODE_TOTAL": "3",
 	"CIRCLE_NODE_INDEX": "1",
+	"CIRCLE_PR_NUMBER":  "1337",
 }
 
 // Run the tests

--- a/internal/attestation/crafter/runners/generic.go
+++ b/internal/attestation/crafter/runners/generic.go
@@ -64,7 +64,9 @@ func resolveEnvVars(requiredEnvVars, optionalEnvVars []string) map[string]string
 
 	for _, name := range optionalEnvVars {
 		value := os.Getenv(name)
-		result[name] = value
+		if value != "" {
+			result[name] = value
+		}
 	}
 
 	return result

--- a/internal/attestation/crafter/runners/generic.go
+++ b/internal/attestation/crafter/runners/generic.go
@@ -31,9 +31,14 @@ func (r *Generic) CheckEnv() bool {
 	return true
 }
 
-// Returns a list of environment variables names. This list is used to
+// Returns a list of environment variables names. These lists are used to
 // automatically inject environment variables into the attestation.
+
 func (r *Generic) ListEnvVars() []string {
+	return []string{}
+}
+
+func (r *Generic) ListOptionalEnvVars() []string {
 	return []string{}
 }
 
@@ -49,11 +54,18 @@ func (r *Generic) RunURI() string {
 	return ""
 }
 
-func resolveEnvVars(varsL []string) map[string]string {
-	res := make(map[string]string)
-	for _, name := range varsL {
-		e := os.Getenv(name)
-		res[name] = e
+func resolveEnvVars(requiredEnvVars, optionalEnvVars []string) map[string]string {
+	result := make(map[string]string)
+
+	for _, name := range requiredEnvVars {
+		value := os.Getenv(name)
+		result[name] = value
 	}
-	return res
+
+	for _, name := range optionalEnvVars {
+		value := os.Getenv(name)
+		result[name] = value
+	}
+
+	return result
 }

--- a/internal/attestation/crafter/runners/generic_test.go
+++ b/internal/attestation/crafter/runners/generic_test.go
@@ -61,7 +61,8 @@ func TestResolveEnvVars(t *testing.T) {
 	t.Setenv("A", "a")
 	t.Setenv("C", "c")
 	t.Setenv("D", "d")
-	varsL := []string{"A", "B", "C"}
-	res := resolveEnvVars(varsL)
+	requiredEnvVars := []string{"A", "B", "C"}
+	optionalEnvVars := []string{}
+	res := resolveEnvVars(requiredEnvVars, optionalEnvVars)
 	assert.Equal(t, map[string]string{"A": "a", "B": "", "C": "c"}, res)
 }

--- a/internal/attestation/crafter/runners/githubaction.go
+++ b/internal/attestation/crafter/runners/githubaction.go
@@ -52,8 +52,12 @@ func (r *GitHubAction) ListEnvVars() []string {
 	}
 }
 
+func (r *GitHubAction) ListOptionalEnvVars() []string {
+	return []string{}
+}
+
 func (r *GitHubAction) ResolveEnvVars() map[string]string {
-	return resolveEnvVars(r.ListEnvVars())
+	return resolveEnvVars(r.ListEnvVars(), r.ListOptionalEnvVars())
 }
 
 func (r *GitHubAction) String() string {

--- a/internal/attestation/crafter/runners/gitlabpipeline.go
+++ b/internal/attestation/crafter/runners/gitlabpipeline.go
@@ -52,8 +52,12 @@ func (r *GitlabPipeline) ListEnvVars() []string {
 	}
 }
 
+func (r *GitlabPipeline) ListOptionalEnvVars() []string {
+	return []string{}
+}
+
 func (r *GitlabPipeline) ResolveEnvVars() map[string]string {
-	return resolveEnvVars(r.ListEnvVars())
+	return resolveEnvVars(r.ListEnvVars(), r.ListOptionalEnvVars())
 }
 
 func (r *GitlabPipeline) String() string {

--- a/internal/attestation/crafter/runners/jenkinsjob.go
+++ b/internal/attestation/crafter/runners/jenkinsjob.go
@@ -42,20 +42,22 @@ func (r *JenkinsJob) ListEnvVars() []string {
 		"JOB_NAME",
 		"BUILD_URL",
 
-		// Some info about the commit (Jenkins Git Plugin)
-		// NOTE: Commenting these vars out because they are not always present
-		//       and current chainloop behavior requires these to be set.
-		// "GIT_BRANCH",
-		// "GIT_COMMIT",
-
 		// Some info about the agent
 		"AGENT_WORKDIR",
 		"NODE_NAME",
 	}
 }
 
+func (r *JenkinsJob) ListOptionalEnvVars() []string {
+	return []string{
+		// Some info about the branch
+		"GIT_BRANCH",
+		"GIT_COMMIT",
+	}
+}
+
 func (r *JenkinsJob) ResolveEnvVars() map[string]string {
-	return resolveEnvVars(r.ListEnvVars())
+	return resolveEnvVars(r.ListEnvVars(), r.ListOptionalEnvVars())
 }
 
 func (r *JenkinsJob) String() string {

--- a/internal/attestation/crafter/runners/jenkinsjob_test.go
+++ b/internal/attestation/crafter/runners/jenkinsjob_test.go
@@ -111,6 +111,8 @@ var jenkinsJobTestingEnvVars = map[string]string{
 	"BUILD_URL":     "http://some-build-url/",
 	"AGENT_WORKDIR": "/home/sample/agent",
 	"NODE_NAME":     "some-node",
+	"GIT_BRANCH":    "somebranch",
+	"GIT_COMMIT":    "somecommit",
 }
 
 // Run the tests


### PR DESCRIPTION
Other possible alternatives:

1) mark the variables in `ListEnvVars` directly, for example with this:
```
return {
  {"VAR1", true},
  {"VAR2", false}
}
```
where the 2nd boolean is the required flag. The cons of this approach is that it has many implications in the deeper code of chainloop and requires a lot of changes.

2) We could just use `CheckEnv` to error if things are missing and make `ListEnvVars` non strict.