### PR TITLE
deploy(referrers): add public index configuration

### DIFF
--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -4,7 +4,7 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.23.0
+version: 1.23.1
 # Do not update appVersion, this is handled automatically by the release process
 appVersion: v0.30.0
 

--- a/deployment/chainloop/README.md
+++ b/deployment/chainloop/README.md
@@ -439,13 +439,16 @@ chainloop config save \
 
 ### Control Plane
 
-| Name                                 | Description                                                                             | Value                                           |
-| ------------------------------------ | --------------------------------------------------------------------------------------- | ----------------------------------------------- |
-| `controlplane.replicaCount`          | Number of replicas                                                                      | `2`                                             |
-| `controlplane.image.repository`      | FQDN uri for the image                                                                  | `ghcr.io/chainloop-dev/chainloop/control-plane` |
-| `controlplane.image.tag`             | Image tag (immutable tags are recommended). If no set chart.appVersion will be used     |                                                 |
-| `controlplane.tlsConfig.secret.name` | name of a secret containing TLS certificate to be used by the controlplane grpc server. | `""`                                            |
-| `controlplane.pluginsDir`            | Directory where to look for plugins                                                     | `/plugins`                                      |
+| Name                                           | Description                                                                                     | Value                                           |
+| ---------------------------------------------- | ----------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| `controlplane.replicaCount`                    | Number of replicas                                                                              | `2`                                             |
+| `controlplane.image.repository`                | FQDN uri for the image                                                                          | `ghcr.io/chainloop-dev/chainloop/control-plane` |
+| `controlplane.image.tag`                       | Image tag (immutable tags are recommended). If no set chart.appVersion will be used             |                                                 |
+| `controlplane.tlsConfig.secret.name`           | name of a secret containing TLS certificate to be used by the controlplane grpc server.         | `""`                                            |
+| `controlplane.pluginsDir`                      | Directory where to look for plugins                                                             | `/plugins`                                      |
+| `controlplane.referrerSharedIndex`             | Configure the shared, public index API endpoint that can be used to discover metadata referrers |                                                 |
+| `controlplane.referrerSharedIndex.enabled`     | Enable index API endpoint                                                                       | `false`                                         |
+| `controlplane.referrerSharedIndex.allowedOrgs` | List of UUIDs of organizations that are allowed to publish to the shared index                  | `[]`                                            |
 
 ### Control Plane Database
 

--- a/deployment/chainloop/templates/controlplane/config.configmap.yaml
+++ b/deployment/chainloop/templates/controlplane/config.configmap.yaml
@@ -35,3 +35,5 @@ data:
       insecure: true
       download_url: {{ include "chainloop.cas.external_url" . }}/download
     plugins_dir: {{ .Values.controlplane.pluginsDir }}
+    referrer_shared_index:
+      {{- toYaml .Values.controlplane.referrerSharedIndex | nindent 6 }}

--- a/deployment/chainloop/values.yaml
+++ b/deployment/chainloop/values.yaml
@@ -114,6 +114,13 @@ controlplane:
   ## @param controlplane.pluginsDir Directory where to look for plugins
   pluginsDir: /plugins
 
+  ## @extra controlplane.referrerSharedIndex Configure the shared, public index API endpoint that can be used to discover metadata referrers
+  ## @param controlplane.referrerSharedIndex.enabled Enable index API endpoint
+  ## @param controlplane.referrerSharedIndex.allowedOrgs List of UUIDs of organizations that are allowed to publish to the shared index
+  referrerSharedIndex:
+    enabled: false
+    allowedOrgs: []
+
   # Database migration
   ## @skip controlplane.migration
   migration:


### PR DESCRIPTION
Adds support to configuring, at deployment time, the organizations allowlist for our public index #441

```diff
 helm template foo deployment/chainloop -f ~/Desktop/values.local.yaml > /tmp/after.yaml && diff -u /tmp/before.yaml /tmp/after.yaml
--- /tmp/before.yaml    2023-11-17 10:39:47.695002643 +0100
+++ /tmp/after.yaml     2023-11-17 11:09:51.669551058 +0100
@@ -232,6 +232,9 @@
       insecure: true
       download_url: /download
     plugins_dir: /plugins
+    referrer_shared_index:
+      allowedOrgs: []
+      enabled: false
```

Closes #435  