### PR TITLE
feat(org): prevent from leaving current organization

### DIFF
--- a/app/cli/cmd/organization_leave.go
+++ b/app/cli/cmd/organization_leave.go
@@ -17,6 +17,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/chainloop-dev/chainloop/app/cli/internal/action"
@@ -54,7 +55,7 @@ func newOrganizationLeaveCmd() *cobra.Command {
 			}
 
 			if membership.Current {
-				return fmt.Errorf("organization with ID %s is marked as 'current'", orgID)
+				return errors.New("can't leave the `current` organization. To leave this org, please switch to another one")
 			}
 
 			fmt.Printf("You are about to leave the organization %q\n", membership.Org.Name)

--- a/app/cli/cmd/organization_leave.go
+++ b/app/cli/cmd/organization_leave.go
@@ -53,6 +53,10 @@ func newOrganizationLeaveCmd() *cobra.Command {
 				return fmt.Errorf("organization %s not found", orgID)
 			}
 
+			if membership.Current {
+				return fmt.Errorf("organization with ID %s is marked as 'current'", orgID)
+			}
+
 			fmt.Printf("You are about to leave the organization %q\n", membership.Org.Name)
 
 			// Ask for confirmation


### PR DESCRIPTION
This is a proposal to fix the following issue:
https://github.com/chainloop-dev/chainloop/issues/456

The rationale behind this is based on what @migmartri said in the issue, i.e.:

> it's likely that we'll move away from setting current in the backend and instead be the client who sets it

I think this could be a step in the right direction, because the limitation is happening in the CLI command only.

I also noticed that there are no tests for these implementations, and I think I understand why that is. I think for the moment we could rely on end-to-end, before merging this. Test:
https://pastebin.com/HeGXrewd