### PR TITLE
fix: enable JWT audience verification

### DIFF
--- a/app/controlplane/internal/biz/robotaccount.go
+++ b/app/controlplane/internal/biz/robotaccount.go
@@ -89,7 +89,7 @@ func (uc *RobotAccountUseCase) Create(ctx context.Context, name string, orgID, w
 		return nil, err
 	}
 
-	jwt, err := b.GenerateJWT(orgID, workflowID, res.ID.String(), jwt.DefaultAudience)
+	jwt, err := b.GenerateJWT(orgID, workflowID, res.ID.String())
 	if err != nil {
 		return nil, err
 	}

--- a/app/controlplane/internal/jwt/common.go
+++ b/app/controlplane/internal/jwt/common.go
@@ -16,5 +16,4 @@
 package jwt
 
 const DefaultIssuer = "cp.chainloop"
-const DefaultAudience = "client.chainloop"
 const CASAudience = "artifact-cas.chainloop"

--- a/app/controlplane/internal/jwt/robotaccount/robotaccount.go
+++ b/app/controlplane/internal/jwt/robotaccount/robotaccount.go
@@ -33,7 +33,6 @@ const (
 type Builder struct {
 	issuer     string
 	hmacSecret string
-	audience   string
 }
 
 type NewOpt func(b *Builder)
@@ -55,7 +54,7 @@ func WithKeySecret(hmacSecret string) NewOpt {
 // Currently we use a simple hmac encryption method meant to be continuously rotated
 // TODO: additional/alternative encryption method, i.e DSE asymetric, see CAS robot account for reference
 func NewBuilder(opts ...NewOpt) (*Builder, error) {
-	b := &Builder{audience: Audience}
+	b := &Builder{}
 	for _, opt := range opts {
 		opt(b)
 	}
@@ -80,7 +79,7 @@ func (ra *Builder) GenerateJWT(orgID, workflowID, keyID string) (string, error) 
 			// Key identifier so we can check it's revocation status
 			ID:       keyID,
 			Issuer:   ra.issuer,
-			Audience: jwt.ClaimStrings{ra.audience},
+			Audience: jwt.ClaimStrings{Audience},
 		},
 	}
 

--- a/app/controlplane/internal/jwt/robotaccount/robotaccount_test.go
+++ b/app/controlplane/internal/jwt/robotaccount/robotaccount_test.go
@@ -75,7 +75,7 @@ func TestGenerateJWT(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	token, err := b.GenerateJWT("org-id", "workflow-id", "key-id", "my-audience")
+	token, err := b.GenerateJWT("org-id", "workflow-id", "key-id")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, token)
 
@@ -91,6 +91,6 @@ func TestGenerateJWT(t *testing.T) {
 	assert.Equal(t, "workflow-id", claims.WorkflowID)
 	assert.Equal(t, "key-id", claims.ID)
 	assert.Equal(t, "my-issuer", claims.Issuer)
-	assert.Contains(t, claims.Audience, "my-audience")
+	assert.Contains(t, claims.Audience, Audience)
 	assert.Nil(t, claims.ExpiresAt)
 }

--- a/app/controlplane/internal/jwt/user/user.go
+++ b/app/controlplane/internal/jwt/user/user.go
@@ -28,7 +28,6 @@ type Builder struct {
 	issuer     string
 	hmacSecret string
 	expiration time.Duration
-	audience   string
 }
 
 type NewOpt func(b *Builder)
@@ -57,7 +56,6 @@ var SigningMethod = jwt.SigningMethodHS256
 func NewBuilder(opts ...NewOpt) (*Builder, error) {
 	b := &Builder{
 		expiration: defaultExpiration,
-		audience:   Audience,
 	}
 
 	for _, opt := range opts {
@@ -80,7 +78,7 @@ func (ra *Builder) GenerateJWT(userID string) (string, error) {
 		userID,
 		jwt.RegisteredClaims{
 			Issuer:    ra.issuer,
-			Audience:  jwt.ClaimStrings{ra.audience},
+			Audience:  jwt.ClaimStrings{Audience},
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(ra.expiration)),
 		},
 	}

--- a/app/controlplane/internal/jwt/user/user.go
+++ b/app/controlplane/internal/jwt/user/user.go
@@ -22,10 +22,13 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 )
 
+const Audience = "user-auth.chainloop"
+
 type Builder struct {
 	issuer     string
 	hmacSecret string
 	expiration time.Duration
+	audience   string
 }
 
 type NewOpt func(b *Builder)
@@ -54,6 +57,7 @@ var SigningMethod = jwt.SigningMethodHS256
 func NewBuilder(opts ...NewOpt) (*Builder, error) {
 	b := &Builder{
 		expiration: defaultExpiration,
+		audience:   Audience,
 	}
 
 	for _, opt := range opts {
@@ -71,12 +75,12 @@ func NewBuilder(opts ...NewOpt) (*Builder, error) {
 	return b, nil
 }
 
-func (ra *Builder) GenerateJWT(userID, audience string) (string, error) {
+func (ra *Builder) GenerateJWT(userID string) (string, error) {
 	claims := CustomClaims{
 		userID,
 		jwt.RegisteredClaims{
 			Issuer:    ra.issuer,
-			Audience:  jwt.ClaimStrings{audience},
+			Audience:  jwt.ClaimStrings{ra.audience},
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(ra.expiration)),
 		},
 	}

--- a/app/controlplane/internal/jwt/user/user_test.go
+++ b/app/controlplane/internal/jwt/user/user_test.go
@@ -77,7 +77,7 @@ func TestGenerateJWT(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	token, err := b.GenerateJWT("user-id", "my-audience")
+	token, err := b.GenerateJWT("user-id")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, token)
 
@@ -91,6 +91,6 @@ func TestGenerateJWT(t *testing.T) {
 	assert.True(t, tokenInfo.Valid)
 	assert.Equal(t, "user-id", claims.UserID)
 	assert.Equal(t, "my-issuer", claims.Issuer)
-	assert.Contains(t, claims.Audience, "my-audience")
+	assert.Contains(t, claims.Audience, Audience)
 	assert.WithinDuration(t, time.Now(), claims.ExpiresAt.Time, 10*time.Second)
 }

--- a/app/controlplane/internal/service/auth.go
+++ b/app/controlplane/internal/service/auth.go
@@ -350,7 +350,7 @@ func generateUserJWT(userID, passphrase string, expiration time.Duration) (strin
 		return "", err
 	}
 
-	return b.GenerateJWT(userID, jwt.DefaultAudience)
+	return b.GenerateJWT(userID)
 }
 
 func setOauthCookie(w http.ResponseWriter, name, value string) {

--- a/app/controlplane/internal/usercontext/robotaccount_middleware.go
+++ b/app/controlplane/internal/usercontext/robotaccount_middleware.go
@@ -62,6 +62,12 @@ func WithCurrentRobotAccount(robotAccountUseCase *biz.RobotAccountUseCase, logge
 				return nil, errors.New("error mapping the claims")
 			}
 
+			// Do not accept tokens that are crafted for a different audience in this system
+			// NOTE: we allow deprecated audience to not to break compatibility with previously issued robot-accounts
+			if !claims.VerifyAudience(robotaccount.Audience, true) && !claims.VerifyAudience(robotaccount.DeprecatedAudience, true) {
+				return nil, errors.New("unexpected token, invalid audience")
+			}
+
 			// Extract account ID
 			robotAccountID := claims.ID
 			if robotAccountID == "" {

--- a/app/controlplane/internal/usercontext/userorg_middleware.go
+++ b/app/controlplane/internal/usercontext/userorg_middleware.go
@@ -86,6 +86,11 @@ func WithCurrentUserAndOrgMiddleware(userUseCase biz.UserOrgFinder, logger *log.
 				return nil, errors.New("error mapping the claims")
 			}
 
+			// Do not accept tokens that are crafted for a different audience in this system
+			if !customClaims.VerifyAudience(user.Audience, true) {
+				return nil, errors.New("unexpected token, invalid audience")
+			}
+
 			userID := customClaims.UserID
 			if userID == "" {
 				return nil, errors.New("error retrieving the user information from the auth token")

--- a/app/controlplane/internal/usercontext/userorg_middleware_test.go
+++ b/app/controlplane/internal/usercontext/userorg_middleware_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz"
 	bizMocks "github.com/chainloop-dev/chainloop/app/controlplane/internal/biz/mocks"
-	"github.com/chainloop-dev/chainloop/app/controlplane/internal/jwt/user"
 	userjwtbuilder "github.com/chainloop-dev/chainloop/app/controlplane/internal/jwt/user"
 	"github.com/go-kratos/kratos/v2/log"
 	jwtmiddleware "github.com/go-kratos/kratos/v2/middleware/auth/jwt"
@@ -52,7 +51,7 @@ func TestWithCurrentUserAndOrgMiddleware(t *testing.T) {
 		{
 			name:      "logged in, user and org exists",
 			loggedIn:  true,
-			audience:  user.Audience,
+			audience:  userjwtbuilder.Audience,
 			userExist: true,
 			orgExist:  true,
 			wantErr:   false,
@@ -60,21 +59,21 @@ func TestWithCurrentUserAndOrgMiddleware(t *testing.T) {
 		{
 			name:      "logged in, user does not exist",
 			loggedIn:  true,
-			audience:  user.Audience,
+			audience:  userjwtbuilder.Audience,
 			userExist: false,
 			wantErr:   true,
 		},
 		{
 			name:      "logged in, org does not exist",
 			loggedIn:  true,
-			audience:  user.Audience,
+			audience:  userjwtbuilder.Audience,
 			userExist: true,
 			wantErr:   true,
 		},
 		{
 			name:     "not logged in",
 			loggedIn: false,
-			audience: user.Audience,
+			audience: userjwtbuilder.Audience,
 			wantErr:  true,
 		},
 	}


### PR DESCRIPTION
This patch updates the JWT generation/verification code used today for authentication and attestation (robot-accounts) to generate and verify respective custom `audience` values.

The reason for this change is in preparation for #453, where we'll be creating additional JWT tokens that are meant to be distinct from the existing authentication ones.

The changes are as follows 

## Temporary authentication tokens

The tokens result of `chainloop auth login` now have the audience `user-auth.chainloop`, existing tokens will fail to validate, but that's ok since they have 24 hours max validity.

## Robot-accounts

These tokens now have `aud=attestations.chainloop` but during verification we still support its previous value. This is to maintain compatibility with robot-accounts that are already in place. New ones will have the right `audience`