### PR TITLE
feat: allow upload/downloads using API token

### DIFF
--- a/app/controlplane/internal/biz/casmapping_integration_test.go
+++ b/app/controlplane/internal/biz/casmapping_integration_test.go
@@ -40,6 +40,24 @@ const (
 )
 
 func (s *casMappingIntegrationSuite) TestCASMappingForDownloadUser() {
+	// Let's create 3 CASMappings:
+	// 1. Digest: validDigest, CASBackend: casBackend1, WorkflowRunID: workflowRun
+	// 2. Digest: validDigest, CASBackend: casBackend2, WorkflowRunID: workflowRun
+	// 3. Digest: validDigest2, CASBackend: casBackend2, WorkflowRunID: workflowRun
+	// 4. Digest: validDigest3, CASBackend: casBackend3, WorkflowRunID: workflowRun
+	// 4. Digest: validDigestPublic, CASBackend: casBackend3, WorkflowRunID: workflowRunPublic
+	_, err := s.CASMapping.Create(context.TODO(), validDigest, s.casBackend1.ID.String(), s.workflowRun.ID.String())
+	require.NoError(s.T(), err)
+	_, err = s.CASMapping.Create(context.TODO(), validDigest, s.casBackend2.ID.String(), s.workflowRun.ID.String())
+	require.NoError(s.T(), err)
+	_, err = s.CASMapping.Create(context.TODO(), validDigest2, s.casBackend2.ID.String(), s.workflowRun.ID.String())
+	require.NoError(s.T(), err)
+	_, err = s.CASMapping.Create(context.TODO(), validDigest3, s.casBackend3.ID.String(), s.workflowRun.ID.String())
+	require.NoError(s.T(), err)
+	_, err = s.CASMapping.Create(context.TODO(), validDigestPublic, s.casBackend3.ID.String(), s.publicWorkflowRun.ID.String())
+	require.NoError(s.T(), err)
+
+	// Since the userOrg1And2 is member of org1 and org2, she should be able to download
 	// both validDigest and validDigest2 from two different orgs
 	s.Run("userOrg1And2 can download validDigest from org1", func() {
 		mapping, err := s.CASMapping.FindCASMappingForDownloadByUser(context.TODO(), validDigest, s.userOrg1And2.ID)
@@ -98,6 +116,11 @@ func (s *casMappingIntegrationSuite) TestCASMappingForDownloadUser() {
 
 func (s *casMappingIntegrationSuite) TestCASMappingForDownloadByOrg() {
 	ctx := context.Background()
+	_, err := s.CASMapping.Create(ctx, validDigest, s.casBackend1.ID.String(), s.workflowRun.ID.String())
+	require.NoError(s.T(), err)
+	_, err = s.CASMapping.Create(ctx, validDigestPublic, s.casBackend3.ID.String(), s.publicWorkflowRun.ID.String())
+	require.NoError(s.T(), err)
+
 	// both validDigest and validDigest2 from two different orgs
 	s.Run("validDigest is in org1", func() {
 		mapping, err := s.CASMapping.FindCASMappingForDownloadByOrg(ctx, validDigest, []string{s.org1.ID})
@@ -368,25 +391,6 @@ func (s *casMappingIntegrationSuite) SetupTest() {
 	assert.NoError(err)
 	_, err = s.Membership.Create(ctx, s.org2.ID, s.userOrg2.ID, true)
 	assert.NoError(err)
-
-	// Let's create 3 CASMappings:
-	// 1. Digest: validDigest, CASBackend: casBackend1, WorkflowRunID: workflowRun
-	// 2. Digest: validDigest, CASBackend: casBackend2, WorkflowRunID: workflowRun
-	// 3. Digest: validDigest2, CASBackend: casBackend2, WorkflowRunID: workflowRun
-	// 4. Digest: validDigest3, CASBackend: casBackend3, WorkflowRunID: workflowRun
-	// 4. Digest: validDigestPublic, CASBackend: casBackend3, WorkflowRunID: workflowRunPublic
-	_, err = s.CASMapping.Create(context.TODO(), validDigest, s.casBackend1.ID.String(), s.workflowRun.ID.String())
-	require.NoError(s.T(), err)
-	_, err = s.CASMapping.Create(context.TODO(), validDigest, s.casBackend2.ID.String(), s.workflowRun.ID.String())
-	require.NoError(s.T(), err)
-	_, err = s.CASMapping.Create(context.TODO(), validDigest2, s.casBackend2.ID.String(), s.workflowRun.ID.String())
-	require.NoError(s.T(), err)
-	_, err = s.CASMapping.Create(context.TODO(), validDigest3, s.casBackend3.ID.String(), s.workflowRun.ID.String())
-	require.NoError(s.T(), err)
-	_, err = s.CASMapping.Create(context.TODO(), validDigestPublic, s.casBackend3.ID.String(), s.publicWorkflowRun.ID.String())
-	require.NoError(s.T(), err)
-
-	// Since the userOrg1And2 is member of org1 and org2, she should be able to download
 }
 
 func TestCASMappingIntegration(t *testing.T) {

--- a/app/controlplane/internal/biz/casmapping_integration_test.go
+++ b/app/controlplane/internal/biz/casmapping_integration_test.go
@@ -39,7 +39,7 @@ const (
 	invalidDigest     = "sha256:deadbeef"
 )
 
-func (s *casMappingIntegrationSuite) TestCASMappingForDownload() {
+func (s *casMappingIntegrationSuite) TestCASMappingForDownlod() {
 	// Let's create 3 CASMappings:
 	// 1. Digest: validDigest, CASBackend: casBackend1, WorkflowRunID: workflowRun
 	// 2. Digest: validDigest, CASBackend: casBackend2, WorkflowRunID: workflowRun
@@ -60,55 +60,55 @@ func (s *casMappingIntegrationSuite) TestCASMappingForDownload() {
 	// Since the userOrg1And2 is member of org1 and org2, she should be able to download
 	// both validDigest and validDigest2 from two different orgs
 	s.Run("userOrg1And2 can download validDigest from org1", func() {
-		mapping, err := s.CASMapping.FindCASMappingForDownload(context.TODO(), validDigest, s.userOrg1And2.ID)
+		mapping, err := s.CASMapping.FindCASMappingForDownloadByUser(context.TODO(), validDigest, s.userOrg1And2.ID)
 		s.NoError(err)
 		s.NotNil(mapping)
 		s.Equal(s.casBackend1.ID, mapping.CASBackend.ID)
 	})
 
 	s.Run("userOrg1And2 can download validDigest2 from org2", func() {
-		mapping, err := s.CASMapping.FindCASMappingForDownload(context.TODO(), validDigest2, s.userOrg1And2.ID)
+		mapping, err := s.CASMapping.FindCASMappingForDownloadByUser(context.TODO(), validDigest2, s.userOrg1And2.ID)
 		s.NoError(err)
 		s.NotNil(mapping)
 		s.Equal(s.casBackend2.ID, mapping.CASBackend.ID)
 	})
 
 	s.Run("userOrg1And2 can not download validDigest3 from org3", func() {
-		mapping, err := s.CASMapping.FindCASMappingForDownload(context.TODO(), validDigest3, s.userOrg1And2.ID)
+		mapping, err := s.CASMapping.FindCASMappingForDownloadByUser(context.TODO(), validDigest3, s.userOrg1And2.ID)
 		s.Error(err)
 		s.Nil(mapping)
 	})
 
 	s.Run("userOrg1And2 can download validDigestPublic from org3", func() {
-		mapping, err := s.CASMapping.FindCASMappingForDownload(context.TODO(), validDigestPublic, s.userOrg1And2.ID)
+		mapping, err := s.CASMapping.FindCASMappingForDownloadByUser(context.TODO(), validDigestPublic, s.userOrg1And2.ID)
 		s.NoError(err)
 		s.NotNil(mapping)
 		s.Equal(s.casBackend3.ID, mapping.CASBackend.ID)
 	})
 
 	s.Run("userOrg2 can download validDigest2 from org2", func() {
-		mapping, err := s.CASMapping.FindCASMappingForDownload(context.TODO(), validDigest2, s.userOrg2.ID)
+		mapping, err := s.CASMapping.FindCASMappingForDownloadByUser(context.TODO(), validDigest2, s.userOrg2.ID)
 		s.NoError(err)
 		s.NotNil(mapping)
 		s.Equal(s.casBackend2.ID, mapping.CASBackend.ID)
 	})
 
 	s.Run("userOrg2 can download validDigestPublic from org3", func() {
-		mapping, err := s.CASMapping.FindCASMappingForDownload(context.TODO(), validDigestPublic, s.userOrg2.ID)
+		mapping, err := s.CASMapping.FindCASMappingForDownloadByUser(context.TODO(), validDigestPublic, s.userOrg2.ID)
 		s.NoError(err)
 		s.NotNil(mapping)
 		s.Equal(s.casBackend3.ID, mapping.CASBackend.ID)
 	})
 
 	s.Run("userOrg2 can download validDigest from org2", func() {
-		mapping, err := s.CASMapping.FindCASMappingForDownload(context.TODO(), validDigest, s.userOrg2.ID)
+		mapping, err := s.CASMapping.FindCASMappingForDownloadByUser(context.TODO(), validDigest, s.userOrg2.ID)
 		s.NoError(err)
 		s.NotNil(mapping)
 		s.Equal(s.casBackend2.ID, mapping.CASBackend.ID)
 	})
 
 	s.Run("userOrg2 can not download invalidDigest", func() {
-		mapping, err := s.CASMapping.FindCASMappingForDownload(context.TODO(), invalidDigest, s.userOrg2.ID)
+		mapping, err := s.CASMapping.FindCASMappingForDownloadByUser(context.TODO(), invalidDigest, s.userOrg2.ID)
 		s.Error(err)
 		s.Nil(mapping)
 	})

--- a/app/controlplane/internal/biz/referrer.go
+++ b/app/controlplane/internal/biz/referrer.go
@@ -144,10 +144,10 @@ func (s *ReferrerUseCase) ExtractAndPersist(ctx context.Context, att *dsse.Envel
 	return nil
 }
 
-// GetFromRoot returns the referrer identified by the provided content digest, including its first-level references
+// GetFromRootUser returns the referrer identified by the provided content digest, including its first-level references
 // For example if sha:deadbeef represents an attestation, the result will contain the attestation + materials associated to it
 // It only returns referrers that belong to organizations the user is member of
-func (s *ReferrerUseCase) GetFromRoot(ctx context.Context, digest, rootKind, userID string) (*StoredReferrer, error) {
+func (s *ReferrerUseCase) GetFromRootUser(ctx context.Context, digest, rootKind, userID string) (*StoredReferrer, error) {
 	userUUID, err := uuid.Parse(userID)
 	if err != nil {
 		return nil, NewErrInvalidUUID(err)
@@ -166,6 +166,10 @@ func (s *ReferrerUseCase) GetFromRoot(ctx context.Context, digest, rootKind, use
 		orgIDs = append(orgIDs, m.OrganizationID)
 	}
 
+	return s.GetFromRoot(ctx, digest, rootKind, orgIDs)
+}
+
+func (s *ReferrerUseCase) GetFromRoot(ctx context.Context, digest, rootKind string, orgIDs []uuid.UUID) (*StoredReferrer, error) {
 	filters := make([]GetFromRootFilter, 0)
 	if rootKind != "" {
 		filters = append(filters, WithKind(rootKind))

--- a/app/controlplane/internal/biz/referrer_integration_test.go
+++ b/app/controlplane/internal/biz/referrer_integration_test.go
@@ -53,7 +53,7 @@ func (s *referrerIntegrationTestSuite) TestGetFromRootInPublicSharedIndex() {
 	s.T().Run("storing it associated with a private workflow keeps it private and not in the index", func(t *testing.T) {
 		err = s.sharedEnabledUC.ExtractAndPersist(ctx, envelope, s.workflow1.ID.String())
 		require.NoError(s.T(), err)
-		ref, err := s.Referrer.GetFromRoot(ctx, wantReferrerAtt.Digest, "", s.user.ID)
+		ref, err := s.Referrer.GetFromRootUser(ctx, wantReferrerAtt.Digest, "", s.user.ID)
 		s.NoError(err)
 		s.False(ref.InPublicWorkflow)
 		res, err := s.sharedEnabledUC.GetFromRootInPublicSharedIndex(ctx, wantReferrerAtt.Digest, "")
@@ -69,7 +69,7 @@ func (s *referrerIntegrationTestSuite) TestGetFromRootInPublicSharedIndex() {
 		err = s.sharedEnabledUC.ExtractAndPersist(ctx, envelope, s.workflow2.ID.String())
 		require.NoError(s.T(), err)
 		// It's marked as public in the internal index
-		ref, err := s.sharedEnabledUC.GetFromRoot(ctx, wantReferrerAtt.Digest, "", s.user.ID)
+		ref, err := s.sharedEnabledUC.GetFromRootUser(ctx, wantReferrerAtt.Digest, "", s.user.ID)
 		s.NoError(err)
 		s.True(ref.InPublicWorkflow)
 
@@ -165,21 +165,21 @@ func (s *referrerIntegrationTestSuite) TestExtractAndPersists() {
 	s.T().Run("it can store properly the first time", func(t *testing.T) {
 		err := s.Referrer.ExtractAndPersist(ctx, envelope, s.workflow1.ID.String())
 		s.NoError(err)
-		prevStoredRef, err = s.Referrer.GetFromRoot(ctx, wantReferrerAtt.Digest, "", s.user.ID)
+		prevStoredRef, err = s.Referrer.GetFromRootUser(ctx, wantReferrerAtt.Digest, "", s.user.ID)
 		s.NoError(err)
 	})
 
 	s.T().Run("and it's idempotent", func(t *testing.T) {
 		err := s.Referrer.ExtractAndPersist(ctx, envelope, s.workflow1.ID.String())
 		s.NoError(err)
-		ref, err := s.Referrer.GetFromRoot(ctx, wantReferrerAtt.Digest, "", s.user.ID)
+		ref, err := s.Referrer.GetFromRootUser(ctx, wantReferrerAtt.Digest, "", s.user.ID)
 		s.NoError(err)
 		// Check it's the same referrer than previously retrieved, including timestamps
 		s.Equal(prevStoredRef, ref)
 	})
 
 	s.T().Run("contains all the info", func(t *testing.T) {
-		got, err := s.Referrer.GetFromRoot(ctx, wantReferrerAtt.Digest, "", s.user.ID)
+		got, err := s.Referrer.GetFromRootUser(ctx, wantReferrerAtt.Digest, "", s.user.ID)
 		s.NoError(err)
 		// parent i.e attestation
 		s.Equal(wantReferrerAtt.Digest, got.Digest)
@@ -198,14 +198,14 @@ func (s *referrerIntegrationTestSuite) TestExtractAndPersists() {
 	})
 
 	s.T().Run("can get sha1 digests too", func(t *testing.T) {
-		got, err := s.Referrer.GetFromRoot(ctx, wantReferrerCommit.Digest, "", s.user.ID)
+		got, err := s.Referrer.GetFromRootUser(ctx, wantReferrerCommit.Digest, "", s.user.ID)
 		s.NoError(err)
 		s.Equal(wantReferrerCommit.Digest, got.Digest)
 	})
 
 	s.T().Run("can't be accessed by a second user in another org", func(t *testing.T) {
 		// the user2 has not access to org1
-		got, err := s.Referrer.GetFromRoot(ctx, wantReferrerAtt.Digest, "", s.user2.ID)
+		got, err := s.Referrer.GetFromRootUser(ctx, wantReferrerAtt.Digest, "", s.user2.ID)
 		s.True(biz.IsNotFound(err))
 		s.Nil(got)
 	})
@@ -213,7 +213,7 @@ func (s *referrerIntegrationTestSuite) TestExtractAndPersists() {
 	s.T().Run("but another workflow can be attached", func(t *testing.T) {
 		err = s.Referrer.ExtractAndPersist(ctx, envelope, s.workflow2.ID.String())
 		s.NoError(err)
-		got, err := s.Referrer.GetFromRoot(ctx, wantReferrerAtt.Digest, "", s.user.ID)
+		got, err := s.Referrer.GetFromRootUser(ctx, wantReferrerAtt.Digest, "", s.user.ID)
 		s.NoError(err)
 		require.Len(t, got.OrgIDs, 2)
 		s.Contains(got.OrgIDs, s.org1UUID)
@@ -222,7 +222,7 @@ func (s *referrerIntegrationTestSuite) TestExtractAndPersists() {
 		// and it's idempotent (no new orgs added)
 		err = s.Referrer.ExtractAndPersist(ctx, envelope, s.workflow2.ID.String())
 		s.NoError(err)
-		got, err = s.Referrer.GetFromRoot(ctx, wantReferrerAtt.Digest, "", s.user.ID)
+		got, err = s.Referrer.GetFromRootUser(ctx, wantReferrerAtt.Digest, "", s.user.ID)
 		s.NoError(err)
 		require.Len(t, got.OrgIDs, 2)
 		s.Equal([]uuid.UUID{s.org1UUID, s.org2UUID}, got.OrgIDs)
@@ -232,13 +232,13 @@ func (s *referrerIntegrationTestSuite) TestExtractAndPersists() {
 	s.T().Run("and now user2 has access to it since it has access to workflow2 in org2", func(t *testing.T) {
 		err = s.Referrer.ExtractAndPersist(ctx, envelope, s.workflow2.ID.String())
 		s.NoError(err)
-		got, err := s.Referrer.GetFromRoot(ctx, wantReferrerAtt.Digest, "", s.user2.ID)
+		got, err := s.Referrer.GetFromRootUser(ctx, wantReferrerAtt.Digest, "", s.user2.ID)
 		s.NoError(err)
 		require.Len(t, got.OrgIDs, 2)
 	})
 
 	s.T().Run("you can ask for info about materials that are subjects", func(t *testing.T) {
-		got, err := s.Referrer.GetFromRoot(ctx, wantReferrerContainerImage.Digest, "", s.user.ID)
+		got, err := s.Referrer.GetFromRootUser(ctx, wantReferrerContainerImage.Digest, "", s.user.ID)
 		s.NoError(err)
 		// parent i.e attestation
 		s.Equal(wantReferrerContainerImage.Digest, got.Digest)
@@ -252,7 +252,7 @@ func (s *referrerIntegrationTestSuite) TestExtractAndPersists() {
 	})
 
 	s.T().Run("it might not have references", func(t *testing.T) {
-		got, err := s.Referrer.GetFromRoot(ctx, wantReferrerSarif.Digest, "", s.user.ID)
+		got, err := s.Referrer.GetFromRootUser(ctx, wantReferrerSarif.Digest, "", s.user.ID)
 		s.NoError(err)
 		// parent i.e attestation
 		s.Equal(wantReferrerSarif.Digest, got.Digest)
@@ -262,7 +262,7 @@ func (s *referrerIntegrationTestSuite) TestExtractAndPersists() {
 	})
 
 	s.T().Run("or it does not exist", func(t *testing.T) {
-		got, err := s.Referrer.GetFromRoot(ctx, "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "", s.user.ID)
+		got, err := s.Referrer.GetFromRootUser(ctx, "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "", s.user.ID)
 		s.True(biz.IsNotFound(err))
 		s.Nil(got)
 	})
@@ -287,20 +287,20 @@ func (s *referrerIntegrationTestSuite) TestExtractAndPersists() {
 		s.NoError(err)
 
 		// but retrieval should fail. In the future we will ask the user to provide the artifact type in these cases of ambiguity
-		got, err := s.Referrer.GetFromRoot(ctx, wantReferrerSarif.Digest, "", s.user.ID)
+		got, err := s.Referrer.GetFromRootUser(ctx, wantReferrerSarif.Digest, "", s.user.ID)
 		s.Nil(got)
 		s.ErrorContains(err, "present in 2 kinds")
 	})
 
 	s.T().Run("it should not fail on retrieval if we filter out by one kind", func(t *testing.T) {
 		// but retrieval should fail. In the future we will ask the user to provide the artifact type in these cases of ambiguity
-		got, err := s.Referrer.GetFromRoot(ctx, wantReferrerSarif.Digest, "SARIF", s.user.ID)
+		got, err := s.Referrer.GetFromRootUser(ctx, wantReferrerSarif.Digest, "SARIF", s.user.ID)
 		s.NoError(err)
 		s.Equal(wantReferrerSarif.Digest, got.Digest)
 		s.Equal(true, got.Downloadable)
 		s.Equal("SARIF", got.Kind)
 
-		got, err = s.Referrer.GetFromRoot(ctx, wantReferrerSarif.Digest, "ARTIFACT", s.user.ID)
+		got, err = s.Referrer.GetFromRootUser(ctx, wantReferrerSarif.Digest, "ARTIFACT", s.user.ID)
 		s.NoError(err)
 		s.Equal(wantReferrerSarif.Digest, got.Digest)
 		s.Equal(true, got.Downloadable)
@@ -309,7 +309,7 @@ func (s *referrerIntegrationTestSuite) TestExtractAndPersists() {
 
 	s.T().Run("now there should a container image pointing to two attestations", func(t *testing.T) {
 		// but retrieval should fail. In the future we will ask the user to provide the artifact type in these cases of ambiguity
-		got, err := s.Referrer.GetFromRoot(ctx, wantReferrerContainerImage.Digest, "", s.user.ID)
+		got, err := s.Referrer.GetFromRootUser(ctx, wantReferrerContainerImage.Digest, "", s.user.ID)
 		s.NoError(err)
 		// it should be referenced by two attestations since it's subject of both
 		require.Len(t, got.References, 2)
@@ -320,7 +320,7 @@ func (s *referrerIntegrationTestSuite) TestExtractAndPersists() {
 	})
 
 	s.T().Run("if all associated workflows are private, the referrer is private", func(t *testing.T) {
-		got, err := s.Referrer.GetFromRoot(ctx, wantReferrerAtt.Digest, "", s.user.ID)
+		got, err := s.Referrer.GetFromRootUser(ctx, wantReferrerAtt.Digest, "", s.user.ID)
 		s.NoError(err)
 		s.False(got.InPublicWorkflow)
 		s.Equal([]uuid.UUID{s.workflow1.ID, s.workflow2.ID}, got.WorkflowIDs)
@@ -334,7 +334,7 @@ func (s *referrerIntegrationTestSuite) TestExtractAndPersists() {
 		_, err := s.Workflow.Update(ctx, s.org1.ID, s.workflow1.ID.String(), &biz.WorkflowUpdateOpts{Public: toPtrBool(true)})
 		require.NoError(t, err)
 
-		got, err := s.Referrer.GetFromRoot(ctx, wantReferrerAtt.Digest, "", s.user.ID)
+		got, err := s.Referrer.GetFromRootUser(ctx, wantReferrerAtt.Digest, "", s.user.ID)
 		s.NoError(err)
 		s.True(got.InPublicWorkflow)
 		for _, r := range got.References {

--- a/app/controlplane/internal/service/context.go
+++ b/app/controlplane/internal/service/context.go
@@ -45,14 +45,8 @@ func (s *ContextService) Current(ctx context.Context, _ *pb.ContextServiceCurren
 		return nil, err
 	}
 
-	// load either user or API token
-	currentUser, err := requireCurrentUser(ctx)
-	if err != nil && !errors.IsNotFound(err) {
-		return nil, err
-	}
-
-	currentAPIToken, err := requireAPIToken(ctx)
-	if err != nil && !errors.IsNotFound(err) {
+	currentUser, currentAPIToken, err := requireCurrentUserOrAPIToken(ctx)
+	if err != nil {
 		return nil, err
 	}
 

--- a/app/controlplane/internal/service/referrer.go
+++ b/app/controlplane/internal/service/referrer.go
@@ -17,9 +17,11 @@ package service
 
 import (
 	"context"
+	"fmt"
 
 	pb "github.com/chainloop-dev/chainloop/app/controlplane/api/controlplane/v1"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz"
+	"github.com/google/uuid"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -38,18 +40,36 @@ func NewReferrerService(uc *biz.ReferrerUseCase, opts ...NewOpt) *ReferrerServic
 }
 
 func (s *ReferrerService) DiscoverPrivate(ctx context.Context, req *pb.ReferrerServiceDiscoverPrivateRequest) (*pb.ReferrerServiceDiscoverPrivateResponse, error) {
-	currentUser, err := requireCurrentUser(ctx)
+	currentUser, currentToken, err := requireCurrentUserOrAPIToken(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	res, err := s.referrerUC.GetFromRoot(ctx, req.GetDigest(), req.GetKind(), currentUser.ID)
+	currentOrg, err := requireCurrentOrg(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// if we are logged in as user we find the referrer from the user
+	// otherwise for the current organization associated with the API token
+	var referrer *biz.StoredReferrer
+	if currentUser != nil {
+		referrer, err = s.referrerUC.GetFromRootUser(ctx, req.GetDigest(), req.GetKind(), currentUser.ID)
+	} else if currentToken != nil {
+		var orgUUID uuid.UUID
+		orgUUID, err = uuid.Parse(currentOrg.ID)
+		if err != nil {
+			return nil, fmt.Errorf("invalid org UUID: %w", err)
+		}
+
+		referrer, err = s.referrerUC.GetFromRoot(ctx, req.GetDigest(), req.GetKind(), []uuid.UUID{orgUUID})
+	}
 	if err != nil {
 		return nil, handleUseCaseErr("referrer discovery", err, s.log)
 	}
 
 	return &pb.ReferrerServiceDiscoverPrivateResponse{
-		Result: bizReferrerToPb(res),
+		Result: bizReferrerToPb(referrer),
 	}, nil
 }
 

--- a/app/controlplane/internal/service/service_test.go
+++ b/app/controlplane/internal/service/service_test.go
@@ -1,0 +1,150 @@
+//
+// Copyright 2023 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/chainloop-dev/chainloop/app/controlplane/internal/usercontext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequireCurrentUser(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("no user", func(t *testing.T) {
+		_, err := requireCurrentUser(ctx)
+		assert.Error(t, err)
+	})
+
+	t.Run("with user", func(t *testing.T) {
+		want := &usercontext.User{}
+		ctx = usercontext.WithCurrentUser(ctx, want)
+		u, err := requireCurrentUser(ctx)
+		assert.NoError(t, err)
+		require.Equal(t, want, u)
+	})
+}
+
+func TestRequireCurrentOrg(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("no org", func(t *testing.T) {
+		_, err := requireCurrentOrg(ctx)
+		assert.Error(t, err)
+	})
+
+	t.Run("with org", func(t *testing.T) {
+		want := &usercontext.Org{}
+		ctx = usercontext.WithCurrentOrg(ctx, want)
+		o, err := requireCurrentOrg(ctx)
+		assert.NoError(t, err)
+		require.Equal(t, want, o)
+	})
+}
+
+func TestRequireAPIToken(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("no token", func(t *testing.T) {
+		_, err := requireAPIToken(ctx)
+		assert.Error(t, err)
+	})
+
+	t.Run("with token", func(t *testing.T) {
+		want := &usercontext.APIToken{}
+		ctx = usercontext.WithCurrentAPIToken(ctx, want)
+		got, err := requireAPIToken(ctx)
+		assert.NoError(t, err)
+		require.Equal(t, want, got)
+	})
+}
+
+func TestRequireCurrentUserOrAPIToken(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	tesCases := []struct {
+		name     string
+		hasUser  bool
+		hasToken bool
+		wantErr  bool
+	}{
+		{
+			name:     "no user nor token",
+			hasUser:  false,
+			hasToken: false,
+			wantErr:  true,
+		},
+		{
+			name:     "with user",
+			hasUser:  true,
+			hasToken: false,
+			wantErr:  false,
+		},
+		{
+			name:     "with token",
+			hasUser:  false,
+			hasToken: true,
+			wantErr:  false,
+		},
+	}
+
+	for _, tc := range tesCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx = context.Background()
+			wantUser := &usercontext.User{}
+			wantToken := &usercontext.APIToken{}
+
+			if tc.hasUser {
+				ctx = usercontext.WithCurrentUser(ctx, wantUser)
+			}
+
+			if tc.hasToken {
+				ctx = usercontext.WithCurrentAPIToken(ctx, wantToken)
+			}
+
+			gotUser, gotToken, err := requireCurrentUserOrAPIToken(ctx)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			if tc.hasUser {
+				require.Equal(t, wantUser, gotUser)
+			} else {
+				assert.Nil(t, gotUser)
+			}
+
+			if tc.hasToken {
+				require.Equal(t, wantToken, gotToken)
+			} else {
+				assert.Nil(t, gotToken)
+			}
+		})
+	}
+
+}

--- a/app/controlplane/internal/service/service_test.go
+++ b/app/controlplane/internal/service/service_test.go
@@ -146,5 +146,4 @@ func TestRequireCurrentUserOrAPIToken(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/app/controlplane/internal/usercontext/allowlist_middleware_test.go
+++ b/app/controlplane/internal/usercontext/allowlist_middleware_test.go
@@ -59,7 +59,7 @@ func TestCheckUserInAllowList(t *testing.T) {
 			m := CheckUserInAllowList(tc.allowList)
 			ctx := context.Background()
 			if tc.user != nil {
-				ctx = withCurrentUser(ctx, tc.user)
+				ctx = WithCurrentUser(ctx, tc.user)
 			}
 
 			_, err := m(emptyHandler)(ctx, nil)

--- a/app/controlplane/internal/usercontext/apitoken_middleware.go
+++ b/app/controlplane/internal/usercontext/apitoken_middleware.go
@@ -35,7 +35,7 @@ type APIToken struct {
 	CreatedAt *time.Time
 }
 
-func withCurrentAPIToken(ctx context.Context, token *APIToken) context.Context {
+func WithCurrentAPIToken(ctx context.Context, token *APIToken) context.Context {
 	return context.WithValue(ctx, currentAPITokenCtxKey{}, token)
 }
 
@@ -114,7 +114,7 @@ func setCurrentOrgAndAPIToken(ctx context.Context, apiTokenUC *biz.APITokenUseCa
 		return nil, errors.New("organization not found")
 	}
 
-	ctx = withCurrentOrg(ctx, &Org{Name: org.Name, ID: org.ID, CreatedAt: org.CreatedAt})
-	ctx = withCurrentAPIToken(ctx, &APIToken{ID: token.ID.String(), CreatedAt: token.CreatedAt})
+	ctx = WithCurrentOrg(ctx, &Org{Name: org.Name, ID: org.ID, CreatedAt: org.CreatedAt})
+	ctx = WithCurrentAPIToken(ctx, &APIToken{ID: token.ID.String(), CreatedAt: token.CreatedAt})
 	return ctx, nil
 }

--- a/app/controlplane/internal/usercontext/currentuser_middleware.go
+++ b/app/controlplane/internal/usercontext/currentuser_middleware.go
@@ -41,7 +41,7 @@ type Org struct {
 	CreatedAt *time.Time
 }
 
-func withCurrentUser(ctx context.Context, user *User) context.Context {
+func WithCurrentUser(ctx context.Context, user *User) context.Context {
 	return context.WithValue(ctx, currentUserCtxKey{}, user)
 }
 
@@ -55,7 +55,7 @@ func CurrentUser(ctx context.Context) *User {
 	return res.(*User)
 }
 
-func withCurrentOrg(ctx context.Context, org *Org) context.Context {
+func WithCurrentOrg(ctx context.Context, org *Org) context.Context {
 	return context.WithValue(ctx, currentOrgCtxKey{}, org)
 }
 
@@ -133,8 +133,8 @@ func setCurrentOrgAndUser(ctx context.Context, userUC biz.UserOrgFinder, userID 
 		return nil, errors.New("org not found")
 	}
 
-	ctx = withCurrentOrg(ctx, &Org{Name: org.Name, ID: org.ID, CreatedAt: org.CreatedAt})
-	ctx = withCurrentUser(ctx, &User{Email: u.Email, ID: u.ID, CreatedAt: u.CreatedAt})
+	ctx = WithCurrentOrg(ctx, &Org{Name: org.Name, ID: org.ID, CreatedAt: org.CreatedAt})
+	ctx = WithCurrentUser(ctx, &User{Email: u.Email, ID: u.ID, CreatedAt: u.CreatedAt})
 
 	return ctx, nil
 }


### PR DESCRIPTION

In a previous patch we added support for API tokens #351, but these couldn't be used for download/upload artifacts to the CAS. 

This PR solves that by

- Update the cas-mapping lookup logic to accept the list of organizations directly, not just the user.
- Update the `service` endpoints to use either of those methods to lookup for the mapping.


Closes #463