### PR TITLE
fix(authZ): propagate new policies across replicas

### DIFF
--- a/app/controlplane/internal/authz/authz.go
+++ b/app/controlplane/internal/authz/authz.go
@@ -17,15 +17,18 @@
 package authz
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
 	_ "embed"
 
+	psqlwatcher "github.com/IguteChung/casbin-psql-watcher"
 	"github.com/casbin/casbin/v2"
 	"github.com/casbin/casbin/v2/model"
 	"github.com/casbin/casbin/v2/persist"
 	fileadapter "github.com/casbin/casbin/v2/persist/file-adapter"
+
 	entadapter "github.com/casbin/ent-adapter"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/conf"
 )
@@ -121,6 +124,25 @@ func NewDatabaseEnforcer(c *conf.Data_Database) (*Enforcer, error) {
 	e, err := newEnforcer(a)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create enforcer: %w", err)
+	}
+
+	// watch for policy changes in database and update enforcer
+	w, err := psqlwatcher.NewWatcherWithConnString(context.Background(), c.Source, psqlwatcher.Option{Verbose: true})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create watcher: %w", err)
+	}
+
+	if err = e.SetWatcher(w); err != nil {
+		return nil, fmt.Errorf("failed to set watcher: %w", err)
+	}
+
+	if err = w.SetUpdateCallback(func(string) {
+		// When there is a change in the policy, we load the in-memory policy for the current enforcer
+		if err := e.LoadPolicy(); err != nil {
+			fmt.Printf("failed to load policy: %v", err)
+		}
+	}); err != nil {
+		return nil, fmt.Errorf("failed to set update callback: %w", err)
 	}
 
 	return e, nil

--- a/app/controlplane/internal/authz/authz.go
+++ b/app/controlplane/internal/authz/authz.go
@@ -127,7 +127,7 @@ func NewDatabaseEnforcer(c *conf.Data_Database) (*Enforcer, error) {
 	}
 
 	// watch for policy changes in database and update enforcer
-	w, err := psqlwatcher.NewWatcherWithConnString(context.Background(), c.Source, psqlwatcher.Option{Verbose: true})
+	w, err := psqlwatcher.NewWatcherWithConnString(context.Background(), c.Source, psqlwatcher.Option{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create watcher: %w", err)
 	}

--- a/app/controlplane/internal/biz/testhelpers/database.go
+++ b/app/controlplane/internal/biz/testhelpers/database.go
@@ -179,7 +179,7 @@ func (db *TestDatabase) ConnectionString(t *testing.T) string {
 	return fmt.Sprintf("postgres://postgres:postgres@127.0.0.1:%d/postgres", db.Port(t))
 }
 
-func newConfData(db *TestDatabase, t *testing.T) *conf.Data {
+func NewConfData(db *TestDatabase, t *testing.T) *conf.Data {
 	return &conf.Data{Database: &conf.Data_Database{Driver: "pgx", Source: db.ConnectionString(t)}}
 }
 

--- a/app/controlplane/internal/biz/testhelpers/wire.go
+++ b/app/controlplane/internal/biz/testhelpers/wire.go
@@ -44,7 +44,7 @@ func WireTestData(*TestDatabase, *testing.T, log.Logger, credentials.ReaderWrite
 			wire.Value(&conf.ReferrerSharedIndex{}),
 			wire.Struct(new(TestingUseCases), "*"),
 			wire.Struct(new(TestingRepos), "*"),
-			newConfData,
+			NewConfData,
 			authz.NewDatabaseEnforcer,
 			wire.FieldsOf(new(*conf.Data), "Database"),
 		),

--- a/app/controlplane/internal/biz/testhelpers/wire_gen.go
+++ b/app/controlplane/internal/biz/testhelpers/wire_gen.go
@@ -27,7 +27,7 @@ import (
 
 // wireTestData init testing data
 func WireTestData(testDatabase *TestDatabase, t *testing.T, logger log.Logger, readerWriter credentials.ReaderWriter, builder *robotaccount.Builder, auth *conf.Auth, availablePlugins sdk.AvailablePlugins, providers backend.Providers) (*TestingUseCases, func(), error) {
-	confData := newConfData(testDatabase, t)
+	confData := NewConfData(testDatabase, t)
 	dataData, cleanup, err := data.NewData(confData, logger)
 	if err != nil {
 		return nil, nil, err

--- a/go.mod
+++ b/go.mod
@@ -116,6 +116,7 @@ require (
 	github.com/jackc/pgproto3/v2 v2.3.2 // indirect
 	github.com/jackc/pgtype v1.14.0 // indirect
 	github.com/jackc/pgx/v4 v4.18.1 // indirect
+	github.com/jackc/puddle/v2 v2.2.1 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
@@ -151,6 +152,7 @@ require (
 	cloud.google.com/go/iam v1.1.4 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/keyvault/azsecrets v0.12.0
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
+	github.com/IguteChung/casbin-psql-watcher v1.0.0
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c // indirect
 	github.com/ThalesIgnite/crypto11 v1.2.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/CycloneDX/cyclonedx-go v0.8.0/go.mod h1:K2bA+324+Og0X84fA8HhN2X066K7B
 github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
+github.com/IguteChung/casbin-psql-watcher v1.0.0 h1:GO5RvdHq5WZfuKt03Frk4/SvYvikMI5V1zjSt1P1suM=
+github.com/IguteChung/casbin-psql-watcher v1.0.0/go.mod h1:mwQYBxiYGO05U8vogls8gf3KnOmdlc7GOLX7tS/V2TU=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
@@ -855,6 +857,8 @@ github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0f
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.3.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
+github.com/jackc/puddle/v2 v2.2.1 h1:RhxXJtFG022u4ibrCSMSiu5aOq1i77R3OHKNJj77OAk=
+github.com/jackc/puddle/v2 v2.2.1/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jedib0t/go-pretty/v6 v6.4.7 h1:lwiTJr1DEkAgzljsUsORmWsVn5MQjt1BPJdPCtJ6KXE=


### PR DESCRIPTION
Adds a watcher that triggers the reload of the policies when any other casbin replica has injected/removed a policy in the DB. 

Fixes #483 

cc/ @fgallina 