### PR TITLE
chore(deps): Bump the anchore/sbom-action version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,14 +75,14 @@ jobs:
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
           COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
 
-      - uses: anchore/sbom-action@78fc58e266e87a38d4194b2137a3d4e9bcaf7ca1 # v0.14.3
+      - uses: anchore/sbom-action@c6aed38a4323b393d05372c58a74c39ae8386d02 # v0.15.6
         with:
           image: ${{ env.CONTAINER_IMAGE_CP }}
           format: cyclonedx-json
           artifact-name: controlplane.cyclonedx.json
           output-file: /tmp/sbom.cp.cyclonedx.json
 
-      - uses: anchore/sbom-action@78fc58e266e87a38d4194b2137a3d4e9bcaf7ca1 # v0.14.3
+      - uses: anchore/sbom-action@c6aed38a4323b393d05372c58a74c39ae8386d02 # v0.15.6
         with:
           image: ${{ env.CONTAINER_IMAGE_CAS }}
           format: cyclonedx-json


### PR DESCRIPTION
Bump anchore/sbom-action from v0.14.3 to v0.15.6 to use the latest version of syft.

Refs #479