### PR TITLE
feat: release CLI as container image

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -107,6 +107,12 @@ dockers:
     image_templates:
       - "ghcr.io/chainloop-dev/chainloop/artifact-cas:{{ .Tag }}"
       - "ghcr.io/chainloop-dev/chainloop/artifact-cas:latest"
+  - dockerfile: app/cli/Dockerfile.goreleaser
+    ids:
+      - cli
+    image_templates:
+      - "ghcr.io/chainloop-dev/chainloop/cli:{{ .Tag }}"
+      - "ghcr.io/chainloop-dev/chainloop/cli:latest"
 
 release:
   extra_files:

--- a/app/cli/Dockerfile.goreleaser
+++ b/app/cli/Dockerfile.goreleaser
@@ -1,0 +1,8 @@
+FROM golang:1.21@sha256:afccce40fb4a6b6a80d0386d6296737c68207f8d69086d0e16aa9cb9dbb753db AS builder
+
+FROM scratch
+
+COPY ./chainloop /
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+ENTRYPOINT [ "./chainloop"]


### PR DESCRIPTION
This patch extends our release process to also contain the CLI encapsulated in a container image. 

The main reason to do this is to have a simple mechanism to explore the integration of Chainloop in a Dagger pipeline without the need for refactoring on our end (extracting attestation libraries outside of `internal` module path).