### PR TITLE
refactor(cli): modularize current state management code

### DIFF
--- a/app/cli/cmd/attestation_add.go
+++ b/app/cli/cmd/attestation_add.go
@@ -55,7 +55,7 @@ func newAttestationAddCmd() *cobra.Command {
 				return err
 			}
 
-			if err := a.Run(name, value, annotations); err != nil {
+			if err := a.Run("", name, value, annotations); err != nil {
 				if errors.Is(err, action.ErrAttestationNotInitialized) {
 					return err
 				}

--- a/app/cli/cmd/attestation_add.go
+++ b/app/cli/cmd/attestation_add.go
@@ -17,6 +17,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -37,13 +38,16 @@ func newAttestationAddCmd() *cobra.Command {
 			useWorkflowRobotAccount: "true",
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			a := action.NewAttestationAdd(
+			a, err := action.NewAttestationAdd(
 				&action.AttestationAddOpts{
 					ActionsOpts:        actionOpts,
 					CASURI:             viper.GetString(confOptions.CASAPI.viperKey),
 					ConnectionInsecure: flagInsecure,
 				},
 			)
+			if err != nil {
+				return fmt.Errorf("failed to load action: %w", err)
+			}
 
 			// Extract annotations
 			annotations, err := extractAnnotations(annotationsFlag)

--- a/app/cli/cmd/attestation_init.go
+++ b/app/cli/cmd/attestation_init.go
@@ -38,16 +38,19 @@ func newAttestationInitCmd() *cobra.Command {
 			useWorkflowRobotAccount: "true",
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			a := action.NewAttestationInit(
+			a, err := action.NewAttestationInit(
 				&action.AttestationInitOpts{
 					ActionsOpts: actionOpts,
 					Override:    replaceRun,
 					DryRun:      attestationDryRun,
 				},
 			)
+			if err != nil {
+				return fmt.Errorf("failed to initialize attestation: %w", err)
+			}
 
 			// Initialize it
-			err := a.Run(contractRevision)
+			err = a.Run(contractRevision)
 			if err != nil {
 				if errors.Is(err, action.ErrAttestationAlreadyExist) {
 					return err
@@ -61,7 +64,12 @@ func newAttestationInitCmd() *cobra.Command {
 			logger.Info().Msg("Attestation initialized! now you can check its status or add materials to it")
 
 			// Show the status information
-			res, err := action.NewAttestationStatus(&action.AttestationStatusOpts{ActionsOpts: actionOpts}).Run()
+			statusAction, err := action.NewAttestationStatus(&action.AttestationStatusOpts{ActionsOpts: actionOpts})
+			if err != nil {
+				return newGracefulError(err)
+			}
+
+			res, err := statusAction.Run()
 			if err != nil {
 				return newGracefulError(err)
 			}

--- a/app/cli/cmd/attestation_init.go
+++ b/app/cli/cmd/attestation_init.go
@@ -26,7 +26,6 @@ import (
 
 func newAttestationInitCmd() *cobra.Command {
 	var (
-		replaceRun        bool
 		contractRevision  int
 		attestationDryRun bool
 	)
@@ -41,7 +40,6 @@ func newAttestationInitCmd() *cobra.Command {
 			a, err := action.NewAttestationInit(
 				&action.AttestationInitOpts{
 					ActionsOpts: actionOpts,
-					Override:    replaceRun,
 					DryRun:      attestationDryRun,
 				},
 			)
@@ -69,7 +67,7 @@ func newAttestationInitCmd() *cobra.Command {
 				return newGracefulError(err)
 			}
 
-			res, err := statusAction.Run()
+			res, err := statusAction.Run("")
 			if err != nil {
 				return newGracefulError(err)
 			}
@@ -78,7 +76,6 @@ func newAttestationInitCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVarP(&replaceRun, "replace", "f", false, "replace any existing run")
 	cmd.Flags().BoolVar(&attestationDryRun, "dry-run", false, "do not record attestation in the control plane, useful for development")
 	cmd.Flags().IntVar(&contractRevision, "contract-revision", 0, "revision of the contract to retrieve, \"latest\" by default")
 

--- a/app/cli/cmd/attestation_push.go
+++ b/app/cli/cmd/attestation_push.go
@@ -61,9 +61,12 @@ func newAttestationPushCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("getting executable information: %w", err)
 			}
-			a := action.NewAttestationPush(&action.AttestationPushOpts{
+			a, err := action.NewAttestationPush(&action.AttestationPushOpts{
 				ActionsOpts: actionOpts, KeyPath: pkPath, CLIVersion: info.Version, CLIDigest: info.Digest,
 			})
+			if err != nil {
+				return fmt.Errorf("failed to load action: %w", err)
+			}
 
 			annotations, err := extractAnnotations(annotationsFlag)
 			if err != nil {

--- a/app/cli/cmd/attestation_push.go
+++ b/app/cli/cmd/attestation_push.go
@@ -73,7 +73,7 @@ func newAttestationPushCmd() *cobra.Command {
 				return err
 			}
 
-			res, err := a.Run(annotations)
+			res, err := a.Run("", annotations)
 			if err != nil {
 				if errors.Is(err, action.ErrAttestationNotInitialized) {
 					return err

--- a/app/cli/cmd/attestation_reset.go
+++ b/app/cli/cmd/attestation_reset.go
@@ -41,7 +41,10 @@ func newAttestationResetCmd() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			a := action.NewAttestationReset(actionOpts)
+			a, err := action.NewAttestationReset(actionOpts)
+			if err != nil {
+				return fmt.Errorf("failed to load action: %w", err)
+			}
 
 			if err := a.Run(trigger, reason); err != nil {
 				return newGracefulError(err)

--- a/app/cli/cmd/attestation_reset.go
+++ b/app/cli/cmd/attestation_reset.go
@@ -46,7 +46,7 @@ func newAttestationResetCmd() *cobra.Command {
 				return fmt.Errorf("failed to load action: %w", err)
 			}
 
-			if err := a.Run(trigger, reason); err != nil {
+			if err := a.Run("", trigger, reason); err != nil {
 				return newGracefulError(err)
 			}
 

--- a/app/cli/cmd/attestation_status.go
+++ b/app/cli/cmd/attestation_status.go
@@ -43,7 +43,7 @@ func newAttestationStatusCmd() *cobra.Command {
 				return fmt.Errorf("failed to load action: %w", err)
 			}
 
-			res, err := a.Run()
+			res, err := a.Run("")
 			if err != nil {
 				return err
 			}

--- a/app/cli/cmd/attestation_status.go
+++ b/app/cli/cmd/attestation_status.go
@@ -34,11 +34,14 @@ func newAttestationStatusCmd() *cobra.Command {
 		Use:   "status",
 		Short: "check the status of the current attestation process",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			a := action.NewAttestationStatus(
+			a, err := action.NewAttestationStatus(
 				&action.AttestationStatusOpts{
 					ActionsOpts: actionOpts,
 				},
 			)
+			if err != nil {
+				return fmt.Errorf("failed to load action: %w", err)
+			}
 
 			res, err := a.Run()
 			if err != nil {

--- a/app/cli/internal/action/action.go
+++ b/app/cli/internal/action/action.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/chainloop-dev/chainloop/internal/attestation/crafter"
-	"github.com/chainloop-dev/chainloop/internal/attestation/crafter/statemanager/local"
+	"github.com/chainloop-dev/chainloop/internal/attestation/crafter/statemanager/filesystem"
 	"github.com/rs/zerolog"
 	"google.golang.org/grpc"
 )
@@ -40,7 +40,7 @@ func toTimePtr(t time.Time) *time.Time {
 // TODO: We'll enable the ability to load a crafter that relies on a remote state manager
 func newCrafter(_ *grpc.ClientConn, logger *zerolog.Logger) (*crafter.Crafter, error) {
 	statePath := filepath.Join(os.TempDir(), "chainloop-attestation.tmp.json")
-	localStateManager, err := local.New(statePath)
+	localStateManager, err := filesystem.New(statePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create local state manager: %w", err)
 	}

--- a/app/cli/internal/action/action.go
+++ b/app/cli/internal/action/action.go
@@ -16,8 +16,13 @@
 package action
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 
+	"github.com/chainloop-dev/chainloop/internal/attestation/crafter"
+	"github.com/chainloop-dev/chainloop/internal/attestation/crafter/statemanager/local"
 	"github.com/rs/zerolog"
 	"google.golang.org/grpc"
 )
@@ -29,4 +34,16 @@ type ActionsOpts struct {
 
 func toTimePtr(t time.Time) *time.Time {
 	return &t
+}
+
+// load a crafter with local state manager
+// TODO: We'll enable the ability to load a crafter that relies on a remote state manager
+func newCrafter(_ *grpc.ClientConn, logger *zerolog.Logger) (*crafter.Crafter, error) {
+	statePath := filepath.Join(os.TempDir(), "chainloop-attestation.tmp.json")
+	localStateManager, err := local.New(statePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create local state manager: %w", err)
+	}
+
+	return crafter.NewCrafter(localStateManager, crafter.WithLogger(logger))
 }

--- a/app/cli/internal/action/attestation_add.go
+++ b/app/cli/internal/action/attestation_add.go
@@ -41,15 +41,18 @@ type AttestationAdd struct {
 	connectionInsecure bool
 }
 
-func NewAttestationAdd(cfg *AttestationAddOpts) *AttestationAdd {
+func NewAttestationAdd(cfg *AttestationAddOpts) (*AttestationAdd, error) {
+	c, err := newCrafter(cfg.CPConnection, &cfg.Logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load crafter: %w", err)
+	}
+
 	return &AttestationAdd{
-		ActionsOpts: cfg.ActionsOpts,
-		c: crafter.NewCrafter(
-			crafter.WithLogger(&cfg.Logger),
-		),
+		ActionsOpts:        cfg.ActionsOpts,
+		c:                  c,
 		casURI:             cfg.CASURI,
 		connectionInsecure: cfg.ConnectionInsecure,
-	}
+	}, nil
 }
 
 var ErrAttestationNotInitialized = errors.New("attestation not yet initialized")

--- a/app/cli/internal/action/attestation_add.go
+++ b/app/cli/internal/action/attestation_add.go
@@ -101,7 +101,7 @@ func (action *AttestationAdd) Run(attestationID, materialName, materialValue str
 		casBackend.Uploader = casclient.New(artifactCASConn, casclient.WithLogger(action.Logger))
 	}
 
-	if err := action.c.AddMaterial(materialName, materialValue, casBackend, annotations, attestationID); err != nil {
+	if err := action.c.AddMaterial(attestationID, materialName, materialValue, casBackend, annotations); err != nil {
 		return fmt.Errorf("adding material: %w", err)
 	}
 

--- a/app/cli/internal/action/attestation_add.go
+++ b/app/cli/internal/action/attestation_add.go
@@ -57,12 +57,12 @@ func NewAttestationAdd(cfg *AttestationAddOpts) (*AttestationAdd, error) {
 
 var ErrAttestationNotInitialized = errors.New("attestation not yet initialized")
 
-func (action *AttestationAdd) Run(k, v string, annotations map[string]string) error {
-	if initialized := action.c.AlreadyInitialized(); !initialized {
+func (action *AttestationAdd) Run(attestationID, materialName, materialValue string, annotations map[string]string) error {
+	if initialized := action.c.AlreadyInitialized(attestationID); !initialized {
 		return ErrAttestationNotInitialized
 	}
 
-	if err := action.c.LoadCraftingState(); err != nil {
+	if err := action.c.LoadCraftingState(attestationID); err != nil {
 		action.Logger.Err(err).Msg("loading existing attestation")
 		return err
 	}
@@ -101,7 +101,7 @@ func (action *AttestationAdd) Run(k, v string, annotations map[string]string) er
 		casBackend.Uploader = casclient.New(artifactCASConn, casclient.WithLogger(action.Logger))
 	}
 
-	if err := action.c.AddMaterial(k, v, casBackend, annotations); err != nil {
+	if err := action.c.AddMaterial(materialName, materialValue, casBackend, annotations, attestationID); err != nil {
 		return fmt.Errorf("adding material: %w", err)
 	}
 

--- a/app/cli/internal/action/attestation_init.go
+++ b/app/cli/internal/action/attestation_init.go
@@ -119,8 +119,8 @@ func (action *AttestationInit) Run(contractRevision int) error {
 	// with the workflowRunId that comes from the control plane
 	initOpts := &crafter.InitOpts{
 		WfInfo: workflowMeta, SchemaV1: contractVersion.GetV1(),
-		DryRun:  action.dryRun,
-		StateID: attestationID,
+		DryRun:        action.dryRun,
+		AttestationID: attestationID,
 	}
 
 	if err := action.c.Init(initOpts); err != nil {

--- a/app/cli/internal/action/attestation_init.go
+++ b/app/cli/internal/action/attestation_init.go
@@ -48,13 +48,18 @@ func (e ErrRunnerContextNotFound) Error() string {
 	return fmt.Sprintf("The contract expects the attestation to be crafted in a runner of type %q but couldn't be detected", e.RunnerType)
 }
 
-func NewAttestationInit(cfg *AttestationInitOpts) *AttestationInit {
+func NewAttestationInit(cfg *AttestationInitOpts) (*AttestationInit, error) {
+	c, err := newCrafter(cfg.CPConnection, &cfg.Logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load crafter: %w", err)
+	}
+
 	return &AttestationInit{
 		ActionsOpts: cfg.ActionsOpts,
 		override:    cfg.Override,
-		c:           crafter.NewCrafter(crafter.WithLogger(&cfg.Logger)),
+		c:           c,
 		dryRun:      cfg.DryRun,
-	}
+	}, nil
 }
 
 func (action *AttestationInit) Run(contractRevision int) error {

--- a/app/cli/internal/action/attestation_push.go
+++ b/app/cli/internal/action/attestation_push.go
@@ -60,12 +60,12 @@ func NewAttestationPush(cfg *AttestationPushOpts) (*AttestationPush, error) {
 	}, nil
 }
 
-func (action *AttestationPush) Run(runtimeAnnotations map[string]string) (*AttestationResult, error) {
-	if initialized := action.c.AlreadyInitialized(); !initialized {
+func (action *AttestationPush) Run(attestationID string, runtimeAnnotations map[string]string) (*AttestationResult, error) {
+	if initialized := action.c.AlreadyInitialized(attestationID); !initialized {
 		return nil, ErrAttestationNotInitialized
 	}
 
-	if err := action.c.LoadCraftingState(); err != nil {
+	if err := action.c.LoadCraftingState(attestationID); err != nil {
 		action.Logger.Err(err).Msg("loading existing attestation")
 		return nil, err
 	}
@@ -133,7 +133,7 @@ func (action *AttestationPush) Run(runtimeAnnotations map[string]string) (*Attes
 	if action.c.CraftingState.DryRun {
 		action.Logger.Info().Msg("dry-run completed, push skipped")
 		// We are done, remove the existing att state
-		if err := action.c.Reset(); err != nil {
+		if err := action.c.Reset(attestationID); err != nil {
 			return nil, err
 		}
 
@@ -148,7 +148,7 @@ func (action *AttestationPush) Run(runtimeAnnotations map[string]string) (*Attes
 	action.Logger.Info().Msg("push completed")
 
 	// We are done, remove the existing att state
-	if err := action.c.Reset(); err != nil {
+	if err := action.c.Reset(attestationID); err != nil {
 		return nil, err
 	}
 

--- a/app/cli/internal/action/attestation_push.go
+++ b/app/cli/internal/action/attestation_push.go
@@ -45,14 +45,19 @@ type AttestationPush struct {
 	keyPath, cliVersion, cliDigest string
 }
 
-func NewAttestationPush(cfg *AttestationPushOpts) *AttestationPush {
+func NewAttestationPush(cfg *AttestationPushOpts) (*AttestationPush, error) {
+	c, err := newCrafter(cfg.CPConnection, &cfg.Logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load crafter: %w", err)
+	}
+
 	return &AttestationPush{
 		ActionsOpts: cfg.ActionsOpts,
-		c:           crafter.NewCrafter(crafter.WithLogger(&cfg.Logger)),
+		c:           c,
 		keyPath:     cfg.KeyPath,
 		cliVersion:  cfg.CLIVersion,
 		cliDigest:   cfg.CLIDigest,
-	}
+	}, nil
 }
 
 func (action *AttestationPush) Run(runtimeAnnotations map[string]string) (*AttestationResult, error) {

--- a/app/cli/internal/action/attestation_reset.go
+++ b/app/cli/internal/action/attestation_reset.go
@@ -45,12 +45,12 @@ func NewAttestationReset(opts *ActionsOpts) (*AttestationReset, error) {
 	return &AttestationReset{ActionsOpts: opts, c: c}, nil
 }
 
-func (action *AttestationReset) Run(trigger, reason string) error {
-	if initialized := action.c.AlreadyInitialized(); !initialized {
+func (action *AttestationReset) Run(attestationID, trigger, reason string) error {
+	if initialized := action.c.AlreadyInitialized(attestationID); !initialized {
 		return ErrAttestationNotInitialized
 	}
 
-	if err := action.c.LoadCraftingState(); err != nil {
+	if err := action.c.LoadCraftingState(attestationID); err != nil {
 		action.Logger.Err(err).Msg("loading existing attestation")
 		return err
 	}
@@ -70,7 +70,7 @@ func (action *AttestationReset) Run(trigger, reason string) error {
 		}
 	}
 
-	return action.c.Reset()
+	return action.c.Reset(attestationID)
 }
 
 func parseTrigger(in string) pb.AttestationServiceCancelRequest_TriggerType {

--- a/app/cli/internal/action/attestation_reset.go
+++ b/app/cli/internal/action/attestation_reset.go
@@ -17,6 +17,7 @@ package action
 
 import (
 	"context"
+	"fmt"
 
 	pb "github.com/chainloop-dev/chainloop/app/controlplane/api/controlplane/v1"
 	"github.com/chainloop-dev/chainloop/internal/attestation/crafter"
@@ -35,11 +36,13 @@ type AttestationReset struct {
 	c *crafter.Crafter
 }
 
-func NewAttestationReset(opts *ActionsOpts) *AttestationReset {
-	return &AttestationReset{
-		ActionsOpts: opts,
-		c:           crafter.NewCrafter(crafter.WithLogger(&opts.Logger)),
+func NewAttestationReset(opts *ActionsOpts) (*AttestationReset, error) {
+	c, err := newCrafter(opts.CPConnection, &opts.Logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load crafter: %w", err)
 	}
+
+	return &AttestationReset{ActionsOpts: opts, c: c}, nil
 }
 
 func (action *AttestationReset) Run(trigger, reason string) error {

--- a/app/cli/internal/action/attestation_status.go
+++ b/app/cli/internal/action/attestation_status.go
@@ -66,14 +66,14 @@ func NewAttestationStatus(cfg *AttestationStatusOpts) (*AttestationStatus, error
 	return &AttestationStatus{ActionsOpts: cfg.ActionsOpts, c: c}, nil
 }
 
-func (action *AttestationStatus) Run() (*AttestationStatusResult, error) {
+func (action *AttestationStatus) Run(attestationID string) (*AttestationStatusResult, error) {
 	c := action.c
 
-	if initialized := c.AlreadyInitialized(); !initialized {
+	if initialized := c.AlreadyInitialized(attestationID); !initialized {
 		return nil, ErrAttestationNotInitialized
 	}
 
-	if err := c.LoadCraftingState(); err != nil {
+	if err := c.LoadCraftingState(attestationID); err != nil {
 		action.Logger.Err(err).Msg("loading existing attestation")
 		return nil, err
 	}

--- a/app/cli/internal/action/attestation_status.go
+++ b/app/cli/internal/action/attestation_status.go
@@ -57,11 +57,13 @@ type AttestationStatusResultMaterial struct {
 	Set, IsOutput, Required bool
 }
 
-func NewAttestationStatus(cfg *AttestationStatusOpts) *AttestationStatus {
-	return &AttestationStatus{
-		ActionsOpts: cfg.ActionsOpts,
-		c:           crafter.NewCrafter(crafter.WithLogger(&cfg.Logger)),
+func NewAttestationStatus(cfg *AttestationStatusOpts) (*AttestationStatus, error) {
+	c, err := newCrafter(cfg.CPConnection, &cfg.Logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load crafter: %w", err)
 	}
+
+	return &AttestationStatus{ActionsOpts: cfg.ActionsOpts, c: c}, nil
 }
 
 func (action *AttestationStatus) Run() (*AttestationStatusResult, error) {

--- a/internal/attestation/crafter/crafter.go
+++ b/internal/attestation/crafter/crafter.go
@@ -39,11 +39,17 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+// StateManager is an interface for managing the state of the crafting process
 type StateManager interface {
+	// Check if the state is already initialized
 	Initialized() (bool, error)
+	// Write the state to the manager backend
 	Write(*api.CraftingState) error
+	// Read the state from the manager backend
 	Read(*api.CraftingState) error
+	// Reset/Delete the state
 	Reset() error
+	// Info returns a string representation of the state manager
 	Info() string
 }
 
@@ -58,13 +64,6 @@ type Crafter struct {
 var ErrAttestationStateNotLoaded = errors.New("crafting state not loaded")
 
 type NewOpt func(c *Crafter)
-
-// where to store the attestation state file
-// func WithStatePath(path string) NewOpt {
-// 	return func(c *Crafter) {
-// 		c.statePath = path
-// 	}
-// }
 
 func WithLogger(l *zerolog.Logger) NewOpt {
 	return func(c *Crafter) {

--- a/internal/attestation/crafter/crafter.go
+++ b/internal/attestation/crafter/crafter.go
@@ -49,8 +49,8 @@ type StateManager interface {
 	Read(*api.CraftingState) error
 	// Reset/Delete the state
 	Reset() error
-	// Info returns a string representation of the state manager
-	Info() string
+	// Atring returns a string representation of the state manager
+	String() string
 }
 
 type Crafter struct {
@@ -196,7 +196,7 @@ func (c *Crafter) initCraftingStateFile(schema *schemaapi.CraftingSchema, wf *ap
 		return fmt.Errorf("failed to persist crafting state: %w", err)
 	}
 
-	c.logger.Debug().Str("path", c.stateManager.Info()).Msg("created state file")
+	c.logger.Debug().Str("state", c.stateManager.String()).Msg("created state file")
 
 	return c.LoadCraftingState()
 }
@@ -207,7 +207,7 @@ func (c *Crafter) Reset() error {
 }
 
 func (c *Crafter) LoadCraftingState() error {
-	c.logger.Debug().Str("path", c.stateManager.Info()).Msg("loading state")
+	c.logger.Debug().Str("state", c.stateManager.String()).Msg("loading state")
 
 	c.CraftingState = &api.CraftingState{}
 
@@ -222,7 +222,7 @@ func (c *Crafter) LoadCraftingState() error {
 	}
 
 	c.Runner = NewRunner(runnerType)
-	c.logger.Debug().Str("path", c.stateManager.Info()).Msg("loaded state")
+	c.logger.Debug().Str("state", c.stateManager.String()).Msg("loaded state")
 
 	return nil
 }

--- a/internal/attestation/crafter/crafter_test.go
+++ b/internal/attestation/crafter/crafter_test.go
@@ -162,7 +162,7 @@ func newInitializedCrafter(t *testing.T, contractPath string, wfMeta *v1.Workflo
 		return nil, err
 	}
 
-	if err = c.Init(&crafter.InitOpts{SchemaV1: contract, WfInfo: wfMeta, DryRun: dryRun}); err != nil {
+	if err = c.Init(&crafter.InitOpts{SchemaV1: contract, WfInfo: wfMeta, DryRun: dryRun, AttestationID: ""}); err != nil {
 		return nil, err
 	}
 

--- a/internal/attestation/crafter/crafter_test.go
+++ b/internal/attestation/crafter/crafter_test.go
@@ -315,7 +315,7 @@ func (s *crafterSuite) TestResolveEnvVars() {
 			c, err := newInitializedCrafter(s.T(), contract, &v1.WorkflowMetadata{}, false, "")
 			require.NoError(s.T(), err)
 
-			err = c.ResolveEnvVars()
+			err = c.ResolveEnvVars("")
 
 			if tc.expectedError != "" {
 				s.Error(err)
@@ -349,14 +349,14 @@ func (s *crafterSuite) TestAlreadyInitialized() {
 		// TODO: replace by a mock
 		c, err := crafter.NewCrafter(testingStateManager(t, statePath))
 		require.NoError(s.T(), err)
-		s.True(c.AlreadyInitialized())
+		s.True(c.AlreadyInitialized(""))
 	})
 
 	s.T().Run("non existing", func(t *testing.T) {
 		statePath := fmt.Sprintf("%s/attestation.json", t.TempDir())
 		c, err := crafter.NewCrafter(testingStateManager(t, statePath))
 		require.NoError(s.T(), err)
-		s.False(c.AlreadyInitialized())
+		s.False(c.AlreadyInitialized(""))
 	})
 }
 

--- a/internal/attestation/crafter/statemanager/filesystem/filesystem.go
+++ b/internal/attestation/crafter/statemanager/filesystem/filesystem.go
@@ -29,6 +29,9 @@ type Filesystem struct {
 	statePath string
 }
 
+// Filesystem crafter does not require passing a stateID as it only supports a single state file
+// This also allow us to not to require users to provide a stateID when using the filesystem crafter
+// and keep the current UX
 func New(statePath string) (*Filesystem, error) {
 	if statePath == "" {
 		return nil, fmt.Errorf("state path cannot be empty")
@@ -37,11 +40,11 @@ func New(statePath string) (*Filesystem, error) {
 	return &Filesystem{statePath}, nil
 }
 
-func (l *Filesystem) String() string {
+func (l *Filesystem) Info(_ string) string {
 	return fmt.Sprintf("file://%s", l.statePath)
 }
 
-func (l *Filesystem) Initialized() (bool, error) {
+func (l *Filesystem) Initialized(_ string) (bool, error) {
 	if file, err := os.Stat(l.statePath); err != nil && !os.IsNotExist(err) {
 		return false, fmt.Errorf("failed to check state file: %w", err)
 	} else if file != nil {
@@ -51,7 +54,7 @@ func (l *Filesystem) Initialized() (bool, error) {
 	return false, nil
 }
 
-func (l *Filesystem) Write(state *v1.CraftingState) error {
+func (l *Filesystem) Write(_ string, state *v1.CraftingState) error {
 	if state == nil {
 		return fmt.Errorf("state cannot be nil")
 	}
@@ -77,7 +80,7 @@ func (l *Filesystem) Write(state *v1.CraftingState) error {
 	return nil
 }
 
-func (l *Filesystem) Read(state *v1.CraftingState) error {
+func (l *Filesystem) Read(_ string, state *v1.CraftingState) error {
 	if state == nil {
 		return fmt.Errorf("state cannot be nil")
 	}
@@ -102,7 +105,7 @@ func (l *Filesystem) Read(state *v1.CraftingState) error {
 	return nil
 }
 
-func (l *Filesystem) Reset() error {
+func (l *Filesystem) Reset(_ string) error {
 	if err := os.Remove(l.statePath); err != nil && os.IsNotExist(err) {
 		return &statemanager.ErrNotFound{Path: l.statePath}
 	} else if err != nil {

--- a/internal/attestation/crafter/statemanager/filesystem/filesystem.go
+++ b/internal/attestation/crafter/statemanager/filesystem/filesystem.go
@@ -37,8 +37,8 @@ func New(statePath string) (*Filesystem, error) {
 	return &Filesystem{statePath}, nil
 }
 
-func (l *Filesystem) Info() string {
-	return l.statePath
+func (l *Filesystem) String() string {
+	return fmt.Sprintf("file://%s", l.statePath)
 }
 
 func (l *Filesystem) Initialized() (bool, error) {

--- a/internal/attestation/crafter/statemanager/filesystem/filesystem_test.go
+++ b/internal/attestation/crafter/statemanager/filesystem/filesystem_test.go
@@ -146,7 +146,7 @@ func (s *testSuite) TestReset() {
 }
 func (s *testSuite) TestString() {
 	fs, _ := New("state.json")
-	s.Equal("state.json", fs.String())
+	s.Equal("file://state.json", fs.String())
 }
 
 func (s *testSuite) TestInitialized() {

--- a/internal/attestation/crafter/statemanager/filesystem/filesystem_test.go
+++ b/internal/attestation/crafter/statemanager/filesystem/filesystem_test.go
@@ -79,7 +79,7 @@ func (s *testSuite) TestWrite() {
 			sm, err := New(s.statePath)
 			require.NoError(s.T(), err)
 
-			err = sm.Write(tc.state)
+			err = sm.Write("", tc.state)
 			if tc.wantErr {
 				s.Error(err)
 				return
@@ -87,7 +87,7 @@ func (s *testSuite) TestWrite() {
 
 			s.NoError(err)
 			got := &v1.CraftingState{}
-			err = sm.Read(got)
+			err = sm.Read("", got)
 			s.NoError(err)
 			s.Equal(tc.state, got)
 			s.True(tc.state.DryRun)
@@ -99,14 +99,14 @@ func (s *testSuite) TestRead() {
 	s.T().Run("empty input state", func(t *testing.T) {
 		sm, err := New(s.statePath)
 		require.NoError(t, err)
-		err = sm.Read(nil)
+		err = sm.Read("", nil)
 		s.Error(err)
 	})
 
 	s.T().Run("no state found in path return NotFound error", func(t *testing.T) {
 		sm, err := New(s.statePath)
 		require.NoError(t, err)
-		err = sm.Read(&v1.CraftingState{})
+		err = sm.Read("", &v1.CraftingState{})
 		s.Error(err)
 		want := &statemanager.ErrNotFound{}
 		s.ErrorAs(err, &want)
@@ -116,7 +116,7 @@ func (s *testSuite) TestRead() {
 		sm, err := New("testdata/state.json")
 		require.NoError(t, err)
 		got := &v1.CraftingState{}
-		err = sm.Read(got)
+		err = sm.Read("", got)
 		require.NoError(s.T(), err)
 
 		if ok := proto.Equal(s.exampleState, got); !ok {
@@ -129,7 +129,7 @@ func (s *testSuite) TestReset() {
 	s.T().Run("no state found in path return NotFound error", func(t *testing.T) {
 		sm, err := New(s.statePath)
 		require.NoError(t, err)
-		err = sm.Reset()
+		err = sm.Reset("")
 		s.Error(err)
 		want := &statemanager.ErrNotFound{}
 		s.ErrorAs(err, &want)
@@ -140,20 +140,20 @@ func (s *testSuite) TestReset() {
 		require.NoError(s.T(), err)
 		sm, err := New(s.statePath)
 		require.NoError(t, err)
-		err = sm.Reset()
+		err = sm.Reset("")
 		s.NoError(err)
 	})
 }
-func (s *testSuite) TestString() {
+func (s *testSuite) TestInfo() {
 	fs, _ := New("state.json")
-	s.Equal("file://state.json", fs.String())
+	s.Equal("file://state.json", fs.Info(""))
 }
 
 func (s *testSuite) TestInitialized() {
 	s.T().Run("non existing", func(t *testing.T) {
 		fs, err := New(s.statePath)
 		require.NoError(s.T(), err)
-		ok, err := fs.Initialized()
+		ok, err := fs.Initialized("")
 		require.NoError(s.T(), err)
 		s.False(ok)
 	})
@@ -163,7 +163,7 @@ func (s *testSuite) TestInitialized() {
 		require.NoError(s.T(), err)
 		fs, err := New(s.statePath)
 		require.NoError(s.T(), err)
-		ok, err := fs.Initialized()
+		ok, err := fs.Initialized("")
 		require.NoError(s.T(), err)
 		s.True(ok)
 	})

--- a/internal/attestation/crafter/statemanager/filesystem/filesystem_test.go
+++ b/internal/attestation/crafter/statemanager/filesystem/filesystem_test.go
@@ -144,9 +144,9 @@ func (s *testSuite) TestReset() {
 		s.NoError(err)
 	})
 }
-func (s *testSuite) TestInfo() {
+func (s *testSuite) TestString() {
 	fs, _ := New("state.json")
-	s.Equal("state.json", fs.Info())
+	s.Equal("state.json", fs.String())
 }
 
 func (s *testSuite) TestInitialized() {

--- a/internal/attestation/crafter/statemanager/filesystem/filesystem_test.go
+++ b/internal/attestation/crafter/statemanager/filesystem/filesystem_test.go
@@ -1,0 +1,187 @@
+//
+// Copyright 2024 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filesystem
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	v1 "github.com/chainloop-dev/chainloop/app/cli/api/attestation/v1"
+	"github.com/chainloop-dev/chainloop/internal/attestation/crafter/statemanager"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/protobuf/proto"
+)
+
+func (s *testSuite) TestNew() {
+	testCases := []struct {
+		name      string
+		statePath string
+		wantErr   bool
+	}{
+		{
+			name:      "empty state path",
+			statePath: "",
+			wantErr:   true,
+		},
+		{
+			name:      "valid state path",
+			statePath: "state.json",
+			wantErr:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			_, err := New(tc.statePath)
+			if tc.wantErr {
+				s.Error(err)
+			} else {
+				s.NoError(err)
+			}
+		})
+	}
+}
+
+func (s *testSuite) TestWrite() {
+	testCases := []struct {
+		name    string
+		state   *v1.CraftingState
+		wantErr bool
+	}{
+		{
+			name:    "empty state",
+			wantErr: true,
+		},
+		{
+			name:    "valid state",
+			state:   s.exampleState,
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			sm, err := New(s.statePath)
+			require.NoError(s.T(), err)
+
+			err = sm.Write(tc.state)
+			if tc.wantErr {
+				s.Error(err)
+				return
+			}
+
+			s.NoError(err)
+			got := &v1.CraftingState{}
+			err = sm.Read(got)
+			s.NoError(err)
+			s.Equal(tc.state, got)
+			s.True(tc.state.DryRun)
+		})
+	}
+}
+
+func (s *testSuite) TestRead() {
+	s.T().Run("empty input state", func(t *testing.T) {
+		sm, err := New(s.statePath)
+		require.NoError(t, err)
+		err = sm.Read(nil)
+		s.Error(err)
+	})
+
+	s.T().Run("no state found in path return NotFound error", func(t *testing.T) {
+		sm, err := New(s.statePath)
+		require.NoError(t, err)
+		err = sm.Read(&v1.CraftingState{})
+		s.Error(err)
+		want := &statemanager.ErrNotFound{}
+		s.ErrorAs(err, &want)
+	})
+
+	s.T().Run("we can read the state", func(t *testing.T) {
+		sm, err := New("testdata/state.json")
+		require.NoError(t, err)
+		got := &v1.CraftingState{}
+		err = sm.Read(got)
+		require.NoError(s.T(), err)
+
+		if ok := proto.Equal(s.exampleState, got); !ok {
+			s.Fail(fmt.Sprintf("These two protobuf messages are not equal:\nexpected: %v\nactual:  %v", s.exampleState, got))
+		}
+	})
+}
+
+func (s *testSuite) TestReset() {
+	s.T().Run("no state found in path return NotFound error", func(t *testing.T) {
+		sm, err := New(s.statePath)
+		require.NoError(t, err)
+		err = sm.Reset()
+		s.Error(err)
+		want := &statemanager.ErrNotFound{}
+		s.ErrorAs(err, &want)
+	})
+
+	s.T().Run("if state exists it can remove it", func(t *testing.T) {
+		_, err := os.Create(s.statePath)
+		require.NoError(s.T(), err)
+		sm, err := New(s.statePath)
+		require.NoError(t, err)
+		err = sm.Reset()
+		s.NoError(err)
+	})
+}
+func (s *testSuite) TestInfo() {
+	fs, _ := New("state.json")
+	s.Equal("state.json", fs.Info())
+}
+
+func (s *testSuite) TestInitialized() {
+	s.T().Run("non existing", func(t *testing.T) {
+		fs, err := New(s.statePath)
+		require.NoError(s.T(), err)
+		ok, err := fs.Initialized()
+		require.NoError(s.T(), err)
+		s.False(ok)
+	})
+
+	s.T().Run("already initialized", func(t *testing.T) {
+		_, err := os.Create(s.statePath)
+		require.NoError(s.T(), err)
+		fs, err := New(s.statePath)
+		require.NoError(s.T(), err)
+		ok, err := fs.Initialized()
+		require.NoError(s.T(), err)
+		s.True(ok)
+	})
+}
+
+type testSuite struct {
+	suite.Suite
+	statePath    string
+	exampleState *v1.CraftingState
+}
+
+func (s *testSuite) SetupTest() {
+	s.statePath = fmt.Sprintf("%s/attestation.json", s.T().TempDir())
+	s.exampleState = &v1.CraftingState{DryRun: true, Attestation: &v1.Attestation{
+		Annotations: map[string]string{"foo": "bar"},
+	}}
+}
+
+func TestSuite(t *testing.T) {
+	suite.Run(t, new(testSuite))
+}

--- a/internal/attestation/crafter/statemanager/filesystem/testdata/state.json
+++ b/internal/attestation/crafter/statemanager/filesystem/testdata/state.json
@@ -1,0 +1,8 @@
+{
+  "attestation": {
+    "annotations": {
+      "foo": "bar"
+    }
+  },
+  "dryRun": true
+}

--- a/internal/attestation/crafter/statemanager/local/local.go
+++ b/internal/attestation/crafter/statemanager/local/local.go
@@ -1,0 +1,96 @@
+//
+// Copyright 2024 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package local
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	v1 "github.com/chainloop-dev/chainloop/app/cli/api/attestation/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+type Local struct {
+	statePath string
+}
+
+func New(statePath string) (*Local, error) {
+	if statePath == "" {
+		return nil, fmt.Errorf("state path cannot be empty")
+	}
+
+	return &Local{statePath}, nil
+}
+
+func (l *Local) Info() string {
+	return l.statePath
+}
+
+func (l *Local) Initialized() (bool, error) {
+	if file, err := os.Stat(l.statePath); err != nil {
+		return false, fmt.Errorf("failed to check state file: %w", err)
+	} else if file != nil {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (l *Local) Write(state *v1.CraftingState) error {
+	marshaler := protojson.MarshalOptions{Indent: "  "}
+	raw, err := marshaler.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("failed to marshal state: %w", err)
+	}
+
+	// Create empty file
+	file, err := os.Create(l.statePath)
+	if err != nil {
+		return fmt.Errorf("failed to create state file: %w", err)
+	}
+	defer file.Close()
+
+	_, err = file.Write(raw)
+	if err != nil {
+		return fmt.Errorf("failed to write state file: %w", err)
+	}
+
+	return nil
+}
+
+func (l *Local) Read(state *v1.CraftingState) error {
+	file, err := os.Open(l.statePath)
+	if err != nil {
+		return fmt.Errorf("failed to open state file: %w", err)
+	}
+	defer file.Close()
+
+	stateRaw, err := io.ReadAll(file)
+	if err != nil {
+		return err
+	}
+
+	if err := protojson.Unmarshal(stateRaw, state); err != nil {
+		return fmt.Errorf("failed to unmarshal state: %w", err)
+	}
+
+	return nil
+}
+
+func (l *Local) Reset() error {
+	return os.Remove(l.statePath)
+}

--- a/internal/attestation/crafter/statemanager/statemanager.go
+++ b/internal/attestation/crafter/statemanager/statemanager.go
@@ -1,0 +1,29 @@
+//
+// Copyright 2024 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statemanager
+
+import (
+	"fmt"
+)
+
+// ErrNotFound error
+type ErrNotFound struct {
+	Path string
+}
+
+func (e *ErrNotFound) Error() string {
+	return fmt.Sprintf("state not found: %s", e.Path)
+}


### PR DESCRIPTION
Modularizes the code that we have today that stores state in the filesystem behind a common interface.

This will allow us to easily implement remote state support.

refs https://github.com/chainloop-dev/chainloop/issues/494