### PR TITLE
chore(cli): make attestation cmds context aware

### DIFF
--- a/app/cli/cmd/attestation_add.go
+++ b/app/cli/cmd/attestation_add.go
@@ -55,7 +55,7 @@ func newAttestationAddCmd() *cobra.Command {
 				return err
 			}
 
-			if err := a.Run("", name, value, annotations); err != nil {
+			if err := a.Run(cmd.Context(), "", name, value, annotations); err != nil {
 				if errors.Is(err, action.ErrAttestationNotInitialized) {
 					return err
 				}

--- a/app/cli/cmd/attestation_init.go
+++ b/app/cli/cmd/attestation_init.go
@@ -48,7 +48,7 @@ func newAttestationInitCmd() *cobra.Command {
 			}
 
 			// Initialize it
-			err = a.Run(contractRevision)
+			err = a.Run(cmd.Context(), contractRevision)
 			if err != nil {
 				if errors.Is(err, action.ErrAttestationAlreadyExist) {
 					return err
@@ -67,7 +67,7 @@ func newAttestationInitCmd() *cobra.Command {
 				return newGracefulError(err)
 			}
 
-			res, err := statusAction.Run("")
+			res, err := statusAction.Run(cmd.Context(), "")
 			if err != nil {
 				return newGracefulError(err)
 			}

--- a/app/cli/cmd/attestation_push.go
+++ b/app/cli/cmd/attestation_push.go
@@ -73,7 +73,7 @@ func newAttestationPushCmd() *cobra.Command {
 				return err
 			}
 
-			res, err := a.Run("", annotations)
+			res, err := a.Run(cmd.Context(), "", annotations)
 			if err != nil {
 				if errors.Is(err, action.ErrAttestationNotInitialized) {
 					return err

--- a/app/cli/cmd/attestation_reset.go
+++ b/app/cli/cmd/attestation_reset.go
@@ -46,7 +46,7 @@ func newAttestationResetCmd() *cobra.Command {
 				return fmt.Errorf("failed to load action: %w", err)
 			}
 
-			if err := a.Run("", trigger, reason); err != nil {
+			if err := a.Run(cmd.Context(), "", trigger, reason); err != nil {
 				return newGracefulError(err)
 			}
 

--- a/app/cli/cmd/attestation_status.go
+++ b/app/cli/cmd/attestation_status.go
@@ -43,7 +43,7 @@ func newAttestationStatusCmd() *cobra.Command {
 				return fmt.Errorf("failed to load action: %w", err)
 			}
 
-			res, err := a.Run("")
+			res, err := a.Run(cmd.Context(), "")
 			if err != nil {
 				return err
 			}

--- a/app/cli/internal/action/attestation_init.go
+++ b/app/cli/internal/action/attestation_init.go
@@ -61,11 +61,10 @@ func NewAttestationInit(cfg *AttestationInitOpts) (*AttestationInit, error) {
 	}, nil
 }
 
-func (action *AttestationInit) Run(contractRevision int) error {
+func (action *AttestationInit) Run(ctx context.Context, contractRevision int) error {
 	action.Logger.Debug().Msg("Retrieving attestation definition")
 	client := pb.NewAttestationServiceClient(action.ActionsOpts.CPConnection)
 	// get information of the workflow
-	ctx := context.Background()
 	resp, err := client.GetContract(ctx, &pb.AttestationServiceGetContractRequest{ContractRevision: int32(contractRevision)})
 	if err != nil {
 		return err
@@ -123,17 +122,17 @@ func (action *AttestationInit) Run(contractRevision int) error {
 		AttestationID: attestationID,
 	}
 
-	if err := action.c.Init(initOpts); err != nil {
+	if err := action.c.Init(ctx, initOpts); err != nil {
 		return err
 	}
 
 	// Load the env variables both the system populated and the user predefined ones
-	if err := action.c.ResolveEnvVars(attestationID); err != nil {
+	if err := action.c.ResolveEnvVars(ctx, attestationID); err != nil {
 		if action.dryRun {
 			return nil
 		}
 
-		_ = action.c.Reset(attestationID)
+		_ = action.c.Reset(ctx, attestationID)
 		return err
 	}
 

--- a/app/cli/internal/action/attestation_reset.go
+++ b/app/cli/internal/action/attestation_reset.go
@@ -45,12 +45,12 @@ func NewAttestationReset(opts *ActionsOpts) (*AttestationReset, error) {
 	return &AttestationReset{ActionsOpts: opts, c: c}, nil
 }
 
-func (action *AttestationReset) Run(attestationID, trigger, reason string) error {
-	if initialized := action.c.AlreadyInitialized(attestationID); !initialized {
+func (action *AttestationReset) Run(ctx context.Context, attestationID, trigger, reason string) error {
+	if initialized := action.c.AlreadyInitialized(ctx, attestationID); !initialized {
 		return ErrAttestationNotInitialized
 	}
 
-	if err := action.c.LoadCraftingState(attestationID); err != nil {
+	if err := action.c.LoadCraftingState(ctx, attestationID); err != nil {
 		action.Logger.Err(err).Msg("loading existing attestation")
 		return err
 	}
@@ -70,7 +70,7 @@ func (action *AttestationReset) Run(attestationID, trigger, reason string) error
 		}
 	}
 
-	return action.c.Reset(attestationID)
+	return action.c.Reset(ctx, attestationID)
 }
 
 func parseTrigger(in string) pb.AttestationServiceCancelRequest_TriggerType {

--- a/app/cli/internal/action/attestation_status.go
+++ b/app/cli/internal/action/attestation_status.go
@@ -16,6 +16,7 @@
 package action
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -66,14 +67,14 @@ func NewAttestationStatus(cfg *AttestationStatusOpts) (*AttestationStatus, error
 	return &AttestationStatus{ActionsOpts: cfg.ActionsOpts, c: c}, nil
 }
 
-func (action *AttestationStatus) Run(attestationID string) (*AttestationStatusResult, error) {
+func (action *AttestationStatus) Run(ctx context.Context, attestationID string) (*AttestationStatusResult, error) {
 	c := action.c
 
-	if initialized := c.AlreadyInitialized(attestationID); !initialized {
+	if initialized := c.AlreadyInitialized(ctx, attestationID); !initialized {
 		return nil, ErrAttestationNotInitialized
 	}
 
-	if err := c.LoadCraftingState(attestationID); err != nil {
+	if err := c.LoadCraftingState(ctx, attestationID); err != nil {
 		action.Logger.Err(err).Msg("loading existing attestation")
 		return nil, err
 	}

--- a/internal/attestation/crafter/crafter_test.go
+++ b/internal/attestation/crafter/crafter_test.go
@@ -16,6 +16,7 @@
 package crafter_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -162,7 +163,7 @@ func newInitializedCrafter(t *testing.T, contractPath string, wfMeta *v1.Workflo
 		return nil, err
 	}
 
-	if err = c.Init(&crafter.InitOpts{SchemaV1: contract, WfInfo: wfMeta, DryRun: dryRun, AttestationID: ""}); err != nil {
+	if err = c.Init(context.Background(), &crafter.InitOpts{SchemaV1: contract, WfInfo: wfMeta, DryRun: dryRun, AttestationID: ""}); err != nil {
 		return nil, err
 	}
 
@@ -315,7 +316,7 @@ func (s *crafterSuite) TestResolveEnvVars() {
 			c, err := newInitializedCrafter(s.T(), contract, &v1.WorkflowMetadata{}, false, "")
 			require.NoError(s.T(), err)
 
-			err = c.ResolveEnvVars("")
+			err = c.ResolveEnvVars(context.Background(), "")
 
 			if tc.expectedError != "" {
 				s.Error(err)
@@ -349,14 +350,14 @@ func (s *crafterSuite) TestAlreadyInitialized() {
 		// TODO: replace by a mock
 		c, err := crafter.NewCrafter(testingStateManager(t, statePath))
 		require.NoError(s.T(), err)
-		s.True(c.AlreadyInitialized(""))
+		s.True(c.AlreadyInitialized(context.Background(), ""))
 	})
 
 	s.T().Run("non existing", func(t *testing.T) {
 		statePath := fmt.Sprintf("%s/attestation.json", t.TempDir())
 		c, err := crafter.NewCrafter(testingStateManager(t, statePath))
 		require.NoError(s.T(), err)
-		s.False(c.AlreadyInitialized(""))
+		s.False(c.AlreadyInitialized(context.Background(), ""))
 	})
 }
 

--- a/internal/attestation/crafter/statemanager/filesystem/filesystem.go
+++ b/internal/attestation/crafter/statemanager/filesystem/filesystem.go
@@ -41,7 +41,7 @@ func New(statePath string) (*Filesystem, error) {
 	return &Filesystem{statePath}, nil
 }
 
-func (l *Filesystem) Info(ctx context.Context, _ string) string {
+func (l *Filesystem) Info(_ context.Context, _ string) string {
 	return fmt.Sprintf("file://%s", l.statePath)
 }
 

--- a/internal/attestation/crafter/statemanager/filesystem/filesystem.go
+++ b/internal/attestation/crafter/statemanager/filesystem/filesystem.go
@@ -16,6 +16,7 @@
 package filesystem
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -40,11 +41,11 @@ func New(statePath string) (*Filesystem, error) {
 	return &Filesystem{statePath}, nil
 }
 
-func (l *Filesystem) Info(_ string) string {
+func (l *Filesystem) Info(ctx context.Context, _ string) string {
 	return fmt.Sprintf("file://%s", l.statePath)
 }
 
-func (l *Filesystem) Initialized(_ string) (bool, error) {
+func (l *Filesystem) Initialized(_ context.Context, _ string) (bool, error) {
 	if file, err := os.Stat(l.statePath); err != nil && !os.IsNotExist(err) {
 		return false, fmt.Errorf("failed to check state file: %w", err)
 	} else if file != nil {
@@ -54,7 +55,7 @@ func (l *Filesystem) Initialized(_ string) (bool, error) {
 	return false, nil
 }
 
-func (l *Filesystem) Write(_ string, state *v1.CraftingState) error {
+func (l *Filesystem) Write(_ context.Context, _ string, state *v1.CraftingState) error {
 	if state == nil {
 		return fmt.Errorf("state cannot be nil")
 	}
@@ -80,7 +81,7 @@ func (l *Filesystem) Write(_ string, state *v1.CraftingState) error {
 	return nil
 }
 
-func (l *Filesystem) Read(_ string, state *v1.CraftingState) error {
+func (l *Filesystem) Read(_ context.Context, _ string, state *v1.CraftingState) error {
 	if state == nil {
 		return fmt.Errorf("state cannot be nil")
 	}
@@ -105,7 +106,7 @@ func (l *Filesystem) Read(_ string, state *v1.CraftingState) error {
 	return nil
 }
 
-func (l *Filesystem) Reset(_ string) error {
+func (l *Filesystem) Reset(_ context.Context, _ string) error {
 	if err := os.Remove(l.statePath); err != nil && os.IsNotExist(err) {
 		return &statemanager.ErrNotFound{Path: l.statePath}
 	} else if err != nil {

--- a/internal/attestation/crafter/statemanager/filesystem/filesystem_test.go
+++ b/internal/attestation/crafter/statemanager/filesystem/filesystem_test.go
@@ -16,6 +16,7 @@
 package filesystem
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -79,7 +80,7 @@ func (s *testSuite) TestWrite() {
 			sm, err := New(s.statePath)
 			require.NoError(s.T(), err)
 
-			err = sm.Write("", tc.state)
+			err = sm.Write(context.Background(), "", tc.state)
 			if tc.wantErr {
 				s.Error(err)
 				return
@@ -87,7 +88,7 @@ func (s *testSuite) TestWrite() {
 
 			s.NoError(err)
 			got := &v1.CraftingState{}
-			err = sm.Read("", got)
+			err = sm.Read(context.Background(), "", got)
 			s.NoError(err)
 			s.Equal(tc.state, got)
 			s.True(tc.state.DryRun)
@@ -99,14 +100,14 @@ func (s *testSuite) TestRead() {
 	s.T().Run("empty input state", func(t *testing.T) {
 		sm, err := New(s.statePath)
 		require.NoError(t, err)
-		err = sm.Read("", nil)
+		err = sm.Read(context.Background(), "", nil)
 		s.Error(err)
 	})
 
 	s.T().Run("no state found in path return NotFound error", func(t *testing.T) {
 		sm, err := New(s.statePath)
 		require.NoError(t, err)
-		err = sm.Read("", &v1.CraftingState{})
+		err = sm.Read(context.Background(), "", &v1.CraftingState{})
 		s.Error(err)
 		want := &statemanager.ErrNotFound{}
 		s.ErrorAs(err, &want)
@@ -116,7 +117,7 @@ func (s *testSuite) TestRead() {
 		sm, err := New("testdata/state.json")
 		require.NoError(t, err)
 		got := &v1.CraftingState{}
-		err = sm.Read("", got)
+		err = sm.Read(context.Background(), "", got)
 		require.NoError(s.T(), err)
 
 		if ok := proto.Equal(s.exampleState, got); !ok {
@@ -129,7 +130,7 @@ func (s *testSuite) TestReset() {
 	s.T().Run("no state found in path return NotFound error", func(t *testing.T) {
 		sm, err := New(s.statePath)
 		require.NoError(t, err)
-		err = sm.Reset("")
+		err = sm.Reset(context.Background(), "")
 		s.Error(err)
 		want := &statemanager.ErrNotFound{}
 		s.ErrorAs(err, &want)
@@ -140,20 +141,20 @@ func (s *testSuite) TestReset() {
 		require.NoError(s.T(), err)
 		sm, err := New(s.statePath)
 		require.NoError(t, err)
-		err = sm.Reset("")
+		err = sm.Reset(context.Background(), "")
 		s.NoError(err)
 	})
 }
 func (s *testSuite) TestInfo() {
 	fs, _ := New("state.json")
-	s.Equal("file://state.json", fs.Info(""))
+	s.Equal("file://state.json", fs.Info(context.Background(), ""))
 }
 
 func (s *testSuite) TestInitialized() {
 	s.T().Run("non existing", func(t *testing.T) {
 		fs, err := New(s.statePath)
 		require.NoError(s.T(), err)
-		ok, err := fs.Initialized("")
+		ok, err := fs.Initialized(context.Background(), "")
 		require.NoError(s.T(), err)
 		s.False(ok)
 	})
@@ -163,7 +164,7 @@ func (s *testSuite) TestInitialized() {
 		require.NoError(s.T(), err)
 		fs, err := New(s.statePath)
 		require.NoError(s.T(), err)
-		ok, err := fs.Initialized("")
+		ok, err := fs.Initialized(context.Background(), "")
 		require.NoError(s.T(), err)
 		s.True(ok)
 	})


### PR DESCRIPTION
Makes the client-side attestation process context aware. This will fit well with the new remote state API #494 