### PR TITLE
feat(attestation): explicit OCI credentials support

### DIFF
--- a/app/cli/internal/action/action.go
+++ b/app/cli/internal/action/action.go
@@ -40,7 +40,7 @@ func toTimePtr(t time.Time) *time.Time {
 }
 
 // load a crafter with either local or remote state
-func newCrafter(enableRemoteState bool, conn *grpc.ClientConn, logger *zerolog.Logger) (*crafter.Crafter, error) {
+func newCrafter(enableRemoteState bool, conn *grpc.ClientConn, opts ...crafter.NewOpt) (*crafter.Crafter, error) {
 	var stateManager crafter.StateManager
 	var err error
 
@@ -55,5 +55,5 @@ func newCrafter(enableRemoteState bool, conn *grpc.ClientConn, logger *zerolog.L
 		return nil, fmt.Errorf("failed to create state manager: %w", err)
 	}
 
-	return crafter.NewCrafter(stateManager, crafter.WithLogger(logger))
+	return crafter.NewCrafter(stateManager, opts...)
 }

--- a/app/cli/internal/action/attestation_init.go
+++ b/app/cli/internal/action/attestation_init.go
@@ -53,7 +53,7 @@ func (e ErrRunnerContextNotFound) Error() string {
 }
 
 func NewAttestationInit(cfg *AttestationInitOpts) (*AttestationInit, error) {
-	c, err := newCrafter(cfg.UseAttestationRemoteState, cfg.CPConnection, &cfg.Logger)
+	c, err := newCrafter(cfg.UseAttestationRemoteState, cfg.CPConnection, crafter.WithLogger(&cfg.Logger))
 	if err != nil {
 		return nil, fmt.Errorf("failed to load crafter: %w", err)
 	}

--- a/app/cli/internal/action/attestation_push.go
+++ b/app/cli/internal/action/attestation_push.go
@@ -46,7 +46,7 @@ type AttestationPush struct {
 }
 
 func NewAttestationPush(cfg *AttestationPushOpts) (*AttestationPush, error) {
-	c, err := newCrafter(cfg.UseAttestationRemoteState, cfg.CPConnection, &cfg.Logger)
+	c, err := newCrafter(cfg.UseAttestationRemoteState, cfg.CPConnection, crafter.WithLogger(&cfg.Logger))
 	if err != nil {
 		return nil, fmt.Errorf("failed to load crafter: %w", err)
 	}

--- a/app/cli/internal/action/attestation_reset.go
+++ b/app/cli/internal/action/attestation_reset.go
@@ -36,13 +36,13 @@ type AttestationReset struct {
 	c *crafter.Crafter
 }
 
-func NewAttestationReset(opts *ActionsOpts) (*AttestationReset, error) {
-	c, err := newCrafter(opts.UseAttestationRemoteState, opts.CPConnection, &opts.Logger)
+func NewAttestationReset(cfg *ActionsOpts) (*AttestationReset, error) {
+	c, err := newCrafter(cfg.UseAttestationRemoteState, cfg.CPConnection, crafter.WithLogger(&cfg.Logger))
 	if err != nil {
 		return nil, fmt.Errorf("failed to load crafter: %w", err)
 	}
 
-	return &AttestationReset{ActionsOpts: opts, c: c}, nil
+	return &AttestationReset{ActionsOpts: cfg, c: c}, nil
 }
 
 func (action *AttestationReset) Run(ctx context.Context, attestationID, trigger, reason string) error {

--- a/app/cli/internal/action/attestation_status.go
+++ b/app/cli/internal/action/attestation_status.go
@@ -60,7 +60,7 @@ type AttestationStatusResultMaterial struct {
 }
 
 func NewAttestationStatus(cfg *AttestationStatusOpts) (*AttestationStatus, error) {
-	c, err := newCrafter(cfg.UseAttestationRemoteState, cfg.CPConnection, &cfg.Logger)
+	c, err := newCrafter(cfg.UseAttestationRemoteState, cfg.CPConnection, crafter.WithLogger(&cfg.Logger))
 	if err != nil {
 		return nil, fmt.Errorf("failed to load crafter: %w", err)
 	}

--- a/extras/dagger/main.go
+++ b/extras/dagger/main.go
@@ -55,7 +55,6 @@ func (m *Chainloop) AttestationStatus(ctx context.Context, attestationID string)
 // The file type is required for materials of kind ARTIFACT that are uploaded to the CAS
 func (m *Chainloop) AttestationAdd(
 	ctx context.Context,
-	attestationID string,
 	// material name
 	name string,
 	// path to the file to be added
@@ -64,27 +63,12 @@ func (m *Chainloop) AttestationAdd(
 	// raw value to be added
 	// +optional
 	value string,
-	// Container Registry Credentials for Container image-based materials
-	// i.e docker.io, ghcr.io, etc
-	// +optional
-	registry string,
-	// +optional
-	registryUsername string,
-	// +optional
-	registrySecret *Secret,
-) (string, error) {
-	// Validate that either the path or the raw value is provided
+	attestationID string) (string, error) {
 	if value != "" && path != nil {
 		return "", fmt.Errorf("only one of material path or value can be provided")
 	}
 
 	c := m.cliImage()
-	// If the registry credentials are provided, we need to mount them to the container
-	// These credentials are used to resolve materials of type CONTAINER_IMAGE
-	if registry != "" {
-		c = c.WithRegistryAuth(registry, registryUsername, registrySecret)
-	}
-
 	// if the value is provided in a file we need to upload it to the container
 	if path != nil {
 		fileName, err := path.Name(ctx)
@@ -144,7 +128,7 @@ func (m *Chainloop) AttestationReset(ctx context.Context,
 
 func (m *Chainloop) cliImage() *Container {
 	return dag.Container().
-		From("bitnami/minideb").
+		From(clImage).
 		WithSecretVariable("CHAINLOOP_ROBOT_ACCOUNT", m.Token).
 		WithEnvVariable("CACHEBUSTER", time.Now().String())
 }

--- a/internal/attestation/crafter/materials/materials.go
+++ b/internal/attestation/crafter/materials/materials.go
@@ -27,6 +27,7 @@ import (
 	schemaapi "github.com/chainloop-dev/chainloop/app/controlplane/api/workflowcontract/v1"
 	api "github.com/chainloop-dev/chainloop/internal/attestation/crafter/api/attestation/v1"
 	"github.com/chainloop-dev/chainloop/internal/casclient"
+	"github.com/google/go-containerregistry/pkg/authn"
 	cr_v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/rs/zerolog"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -135,7 +136,7 @@ type Craftable interface {
 	Craft(ctx context.Context, value string) (*api.Attestation_Material, error)
 }
 
-func Craft(ctx context.Context, materialSchema *schemaapi.CraftingSchema_Material, value string, casBackend *casclient.CASBackend, logger *zerolog.Logger) (*api.Attestation_Material, error) {
+func Craft(ctx context.Context, materialSchema *schemaapi.CraftingSchema_Material, value string, casBackend *casclient.CASBackend, ociAuth authn.Keychain, logger *zerolog.Logger) (*api.Attestation_Material, error) {
 	var crafter Craftable
 	var err error
 
@@ -147,7 +148,7 @@ func Craft(ctx context.Context, materialSchema *schemaapi.CraftingSchema_Materia
 	case schemaapi.CraftingSchema_Material_STRING:
 		crafter, err = NewStringCrafter(materialSchema)
 	case schemaapi.CraftingSchema_Material_CONTAINER_IMAGE:
-		crafter, err = NewOCIImageCrafter(materialSchema, logger)
+		crafter, err = NewOCIImageCrafter(materialSchema, ociAuth, logger)
 	case schemaapi.CraftingSchema_Material_ARTIFACT:
 		crafter, err = NewArtifactCrafter(materialSchema, casBackend, logger)
 	case schemaapi.CraftingSchema_Material_SBOM_CYCLONEDX_JSON:

--- a/internal/attestation/crafter/materials/materials_test.go
+++ b/internal/attestation/crafter/materials/materials_test.go
@@ -40,7 +40,7 @@ func TestCraft(t *testing.T) {
 		},
 	}
 
-	got, err := materials.Craft(context.TODO(), schema, "test-value", nil, nil)
+	got, err := materials.Craft(context.TODO(), schema, "test-value", nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(contractAPI.CraftingSchema_Material_STRING, got.MaterialType)
 	assert.False(got.UploadedToCas)

--- a/internal/attestation/crafter/materials/oci_image.go
+++ b/internal/attestation/crafter/materials/oci_image.go
@@ -29,15 +29,16 @@ import (
 
 type OCIImageCrafter struct {
 	*crafterCommon
+	keychain authn.Keychain
 }
 
-func NewOCIImageCrafter(schema *schemaapi.CraftingSchema_Material, l *zerolog.Logger) (*OCIImageCrafter, error) {
+func NewOCIImageCrafter(schema *schemaapi.CraftingSchema_Material, ociAuth authn.Keychain, l *zerolog.Logger) (*OCIImageCrafter, error) {
 	if schema.Type != schemaapi.CraftingSchema_Material_CONTAINER_IMAGE {
 		return nil, fmt.Errorf("material type is not container image")
 	}
 
 	craftCommon := &crafterCommon{logger: l, input: schema}
-	return &OCIImageCrafter{craftCommon}, nil
+	return &OCIImageCrafter{craftCommon, ociAuth}, nil
 }
 
 func (i *OCIImageCrafter) Craft(_ context.Context, imageRef string) (*api.Attestation_Material, error) {
@@ -48,7 +49,7 @@ func (i *OCIImageCrafter) Craft(_ context.Context, imageRef string) (*api.Attest
 		return nil, err
 	}
 
-	descriptor, err := remote.Get(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	descriptor, err := remote.Get(ref, remote.WithAuthFromKeychain(i.keychain))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/ociauth/auth.go
+++ b/internal/ociauth/auth.go
@@ -29,6 +29,18 @@ type Credentials struct {
 	username, password, server string
 }
 
+// Get and validate OCI credentials by providing a registry URL (no path)
+func NewCredentialsFromRegistry(repoURI, username, password string) (authn.Keychain, error) {
+	reg, err := name.NewRegistry(repoURI)
+	if err != nil {
+		return nil, fmt.Errorf("invalid registry server URI: %w", err)
+	}
+
+	c := &Credentials{username, password, reg.RegistryStr()}
+	return validateOCICredentials(c)
+}
+
+// Get and validate OCI credentials by providing a repository URL
 func NewCredentials(repoURI, username, password string) (authn.Keychain, error) {
 	repo, err := name.NewRepository(repoURI)
 	if err != nil {


### PR DESCRIPTION
This patch adds support to providing OCI credentials via command-line flags or env variables, that will be used to authenticate during `CONTAINER_IMAGE` attestations.

Before, `chain loop att add` was loading the default docker credentials stored in `~/.docker/config,` and although this is still the default behavior, now, optionally, the credentials can be explicitly set.

This is important because of our push to support stateless, encapsulated, attestation processes #501 

This is also a requirement to fix #511 
