### PR TITLE
feat(dagger): support explicit OCI credentials

### DIFF
--- a/extras/dagger/README.md
+++ b/extras/dagger/README.md
@@ -58,7 +58,7 @@ dagger call -m github.com/chainloop-dev/chainloop/extras/dagger \
   --value ghcr.io/chainloop-dev/chainloop/control-plane
 ```
 
-In some cases, you might be providing a private container image as a piece of evidence. In the case, you'll also need to provide the container registry credentials.
+In some cases, you might be providing a private container image as a piece of evidence. In this case, you'll also need to provide the container registry credentials.
 
 ```sh
 # Or one with a raw value such as a container image reference

--- a/extras/dagger/README.md
+++ b/extras/dagger/README.md
@@ -55,7 +55,21 @@ dagger call -m github.com/chainloop-dev/chainloop/extras/dagger \
   --token env:CHAINLOOP_TOKEN attestation-add \
   --attestation-id $ATTESTATION_ID \
   --name my-container-image \
-  --value ghcr.io/chainloop-dev/chainloop
+  --value ghcr.io/chainloop-dev/chainloop/control-plane
+```
+
+In some cases, you might be providing a container image as a piece of evidence. In the case of being a private image, you'll also need to provide the container registry credentials.
+
+```sh
+# Or one with a raw value such as a container image reference
+dagger call -m github.com/chainloop-dev/chainloop/extras/dagger \
+  --token env:CHAINLOOP_TOKEN attestation-add \
+  --attestation-id $ATTESTATION_ID \
+  --name my-container-image \
+  --value ghcr.io/chainloop-dev/chainloop/control-plane
+  --registry ghcr.io \
+  --registry-username my-username \
+  --registry-password MY_PAT_TOKEN
 ```
 
 ### Sign and push ([docs](https://docs.chainloop.dev/getting-started/attestation-crafting#encode-sign-and-push-attestation))

--- a/extras/dagger/README.md
+++ b/extras/dagger/README.md
@@ -58,7 +58,7 @@ dagger call -m github.com/chainloop-dev/chainloop/extras/dagger \
   --value ghcr.io/chainloop-dev/chainloop/control-plane
 ```
 
-In some cases, you might be providing a container image as a piece of evidence. In the case of being a private image, you'll also need to provide the container registry credentials.
+In some cases, you might be providing a private container image as a piece of evidence. In the case, you'll also need to provide the container registry credentials.
 
 ```sh
 # Or one with a raw value such as a container image reference

--- a/extras/dagger/main.go
+++ b/extras/dagger/main.go
@@ -86,7 +86,7 @@ func (m *Chainloop) AttestationAdd(
 	// +optional
 	registryUsername string,
 	// +optional
-	registrySecret *Secret,
+	registryPassword *Secret,
 ) (string, error) {
 	// Validate that either the path or the raw value is provided
 	if value != "" && path != nil {
@@ -98,7 +98,7 @@ func (m *Chainloop) AttestationAdd(
 	if registry != "" {
 		c = c.WithEnvVariable("CHAINLOOP_REGISTRY_SERVER", registry).
 			WithEnvVariable("CHAINLOOP_REGISTRY_USERNAME", registryUsername).
-			WithSecretVariable("CHAINLOOP_REGISTRY_PASSWORD", registrySecret)
+			WithSecretVariable("CHAINLOOP_REGISTRY_PASSWORD", registryPassword)
 	}
 
 	// if the value is provided in a file we need to upload it to the container

--- a/extras/dagger/main.go
+++ b/extras/dagger/main.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-const chainloopVersion = "v0.60.0"
+const chainloopVersion = "v0.65.0"
 
 type Chainloop struct {
 	Token *Secret

--- a/extras/dagger/main.go
+++ b/extras/dagger/main.go
@@ -70,6 +70,7 @@ func (m *Chainloop) AttestationStatus(ctx context.Context, attestationID string)
 // The file type is required for materials of kind ARTIFACT that are uploaded to the CAS
 func (m *Chainloop) AttestationAdd(
 	ctx context.Context,
+	attestationID string,
 	// material name
 	name string,
 	// path to the file to be added
@@ -78,12 +79,28 @@ func (m *Chainloop) AttestationAdd(
 	// raw value to be added
 	// +optional
 	value string,
-	attestationID string) (string, error) {
+	// Container Registry Credentials for Container image-based materials
+	// i.e docker.io, ghcr.io, etc
+	// +optional
+	registry string,
+	// +optional
+	registryUsername string,
+	// +optional
+	registrySecret *Secret,
+) (string, error) {
+	// Validate that either the path or the raw value is provided
 	if value != "" && path != nil {
 		return "", fmt.Errorf("only one of material path or value can be provided")
 	}
 
 	c := m.cliImage()
+	// These OCI credentials are used to resolve materials of type CONTAINER_IMAGE
+	if registry != "" {
+		c = c.WithEnvVariable("CHAINLOOP_REGISTRY_SERVER", registry).
+			WithEnvVariable("CHAINLOOP_REGISTRY_USERNAME", registryUsername).
+			WithSecretVariable("CHAINLOOP_REGISTRY_PASSWORD", registrySecret)
+	}
+
 	// if the value is provided in a file we need to upload it to the container
 	if path != nil {
 		fileName, err := path.Name(ctx)


### PR DESCRIPTION
Adds support to explicit OCI credentials during material addition. It leverages the changes performed here https://github.com/chainloop-dev/chainloop/pull/513

NOTE: This change should be held until a new release of the CLI is pushed

Closes #511 