### PR TITLE
feat(cli): automatically discover runner context

### DIFF
--- a/internal/attestation/crafter/crafter.go
+++ b/internal/attestation/crafter/crafter.go
@@ -383,9 +383,9 @@ func (c *Crafter) ResolveEnvVars(ctx context.Context, attestationID string) erro
 	}
 
 	// Runner specific environment variables
-	c.logger.Debug().Str("runnerType", c.Runner.String()).Msg("loading runner specific env variables")
+	c.logger.Debug().Str("runnerType", c.Runner.ID().String()).Msg("loading runner specific env variables")
 	if !c.Runner.CheckEnv() {
-		errorStr := fmt.Sprintf("couldn't detect the environment %q. Is the crafting process happening in the target env?", c.Runner.String())
+		errorStr := fmt.Sprintf("couldn't detect the environment %q. Is the crafting process happening in the target env?", c.Runner.ID().String())
 		return fmt.Errorf("%s - %w", errorStr, ErrRunnerContextNotFound)
 	}
 
@@ -394,7 +394,7 @@ func (c *Crafter) ResolveEnvVars(ctx context.Context, attestationID string) erro
 	for index, envVarDef := range c.Runner.ListEnvVars() {
 		varNames[index] = envVarDef.Name
 	}
-	c.logger.Debug().Str("runnerType", c.Runner.String()).Strs("variables", varNames).Msg("list of env variables to automatically extract")
+	c.logger.Debug().Str("runnerType", c.Runner.ID().String()).Strs("variables", varNames).Msg("list of env variables to automatically extract")
 
 	outputEnvVars, errors := c.Runner.ResolveEnvVars()
 	if len(errors) > 0 {

--- a/internal/attestation/crafter/runner.go
+++ b/internal/attestation/crafter/runner.go
@@ -86,7 +86,7 @@ func discoverRunner(logger zerolog.Logger) SupportedRunner {
 			detectedStr = append(detectedStr, d.ID().String())
 		}
 
-		logger.Info().Strs("detected", detectedStr).Msg("multiple runners detected, incongruent environment")
+		logger.Warn().Strs("detected", detectedStr).Msg("multiple runners detected, incongruent environment")
 		return runners.NewGeneric()
 	}
 

--- a/internal/attestation/crafter/runners/azurepipeline.go
+++ b/internal/attestation/crafter/runners/azurepipeline.go
@@ -19,6 +19,8 @@ import (
 	neturl "net/url"
 	"os"
 	"path"
+
+	schemaapi "github.com/chainloop-dev/chainloop/app/controlplane/api/workflowcontract/v1"
 )
 
 type AzurePipeline struct{}
@@ -27,6 +29,10 @@ const AzurePipelineID = "azure-pipeline"
 
 func NewAzurePipeline() *AzurePipeline {
 	return &AzurePipeline{}
+}
+
+func (r *AzurePipeline) ID() schemaapi.CraftingSchema_Runner_RunnerType {
+	return schemaapi.CraftingSchema_Runner_AZURE_PIPELINE
 }
 
 // Figure out if we are in a Azure Pipeline job or not

--- a/internal/attestation/crafter/runners/azurepipeline.go
+++ b/internal/attestation/crafter/runners/azurepipeline.go
@@ -25,8 +25,6 @@ import (
 
 type AzurePipeline struct{}
 
-const AzurePipelineID = "azure-pipeline"
-
 func NewAzurePipeline() *AzurePipeline {
 	return &AzurePipeline{}
 }
@@ -59,10 +57,6 @@ func (r *AzurePipeline) ListEnvVars() []*EnvVarDefinition {
 		{"AGENT_VERSION", false},
 		{"TF_BUILD", false},
 	}
-}
-
-func (r *AzurePipeline) String() string {
-	return AzurePipelineID
 }
 
 func (r *AzurePipeline) RunURI() (url string) {

--- a/internal/attestation/crafter/runners/azurepipeline_test.go
+++ b/internal/attestation/crafter/runners/azurepipeline_test.go
@@ -115,7 +115,7 @@ func (s *azurePipelineSuite) TestRunURI() {
 }
 
 func (s *azurePipelineSuite) TestRunnerName() {
-	s.Equal("azure-pipeline", s.runner.String())
+	s.Equal("AZURE_PIPELINE", s.runner.ID().String())
 }
 
 // Run before each test

--- a/internal/attestation/crafter/runners/circleci_build.go
+++ b/internal/attestation/crafter/runners/circleci_build.go
@@ -15,7 +15,11 @@
 
 package runners
 
-import "os"
+import (
+	"os"
+
+	schemaapi "github.com/chainloop-dev/chainloop/app/controlplane/api/workflowcontract/v1"
+)
 
 type CircleCIBuild struct{}
 
@@ -23,6 +27,10 @@ const CircleCIBuildID = "circleci-build"
 
 func NewCircleCIBuild() *CircleCIBuild {
 	return &CircleCIBuild{}
+}
+
+func (r *CircleCIBuild) ID() schemaapi.CraftingSchema_Runner_RunnerType {
+	return schemaapi.CraftingSchema_Runner_CIRCLECI_BUILD
 }
 
 func (r *CircleCIBuild) CheckEnv() bool {

--- a/internal/attestation/crafter/runners/circleci_build.go
+++ b/internal/attestation/crafter/runners/circleci_build.go
@@ -23,8 +23,6 @@ import (
 
 type CircleCIBuild struct{}
 
-const CircleCIBuildID = "circleci-build"
-
 func NewCircleCIBuild() *CircleCIBuild {
 	return &CircleCIBuild{}
 }
@@ -56,10 +54,6 @@ func (r *CircleCIBuild) ListEnvVars() []*EnvVarDefinition {
 		{"CIRCLE_NODE_TOTAL", false},
 		{"CIRCLE_NODE_INDEX", false},
 	}
-}
-
-func (r *CircleCIBuild) String() string {
-	return JenkinsJobID
 }
 
 func (r *CircleCIBuild) RunURI() string {

--- a/internal/attestation/crafter/runners/circleci_build_test.go
+++ b/internal/attestation/crafter/runners/circleci_build_test.go
@@ -108,7 +108,7 @@ func (s *circleCIBuildSuite) TestRunURI() {
 }
 
 func (s *circleCIBuildSuite) TestRunnerName() {
-	s.Equal("jenkins-job", s.runner.String())
+	s.Equal("CIRCLECI_BUILD", s.runner.ID().String())
 }
 
 // Run before each test

--- a/internal/attestation/crafter/runners/daggerpipeline.go
+++ b/internal/attestation/crafter/runners/daggerpipeline.go
@@ -15,7 +15,11 @@
 
 package runners
 
-import "os"
+import (
+	"os"
+
+	schemaapi "github.com/chainloop-dev/chainloop/app/controlplane/api/workflowcontract/v1"
+)
 
 type DaggerPipeline struct{}
 
@@ -23,6 +27,10 @@ const DaggerPipelineID = "dagger-pipeline"
 
 func NewDaggerPipeline() *DaggerPipeline {
 	return &DaggerPipeline{}
+}
+
+func (r *DaggerPipeline) ID() schemaapi.CraftingSchema_Runner_RunnerType {
+	return schemaapi.CraftingSchema_Runner_DAGGER_PIPELINE
 }
 
 func (r *DaggerPipeline) CheckEnv() bool {

--- a/internal/attestation/crafter/runners/daggerpipeline.go
+++ b/internal/attestation/crafter/runners/daggerpipeline.go
@@ -23,8 +23,6 @@ import (
 
 type DaggerPipeline struct{}
 
-const DaggerPipelineID = "dagger-pipeline"
-
 func NewDaggerPipeline() *DaggerPipeline {
 	return &DaggerPipeline{}
 }
@@ -48,10 +46,6 @@ func (r *DaggerPipeline) ListEnvVars() []*EnvVarDefinition {
 		// Version of the Chainloop Client
 		{"CHAINLOOP_DAGGER_CLIENT", false},
 	}
-}
-
-func (r *DaggerPipeline) String() string {
-	return DaggerPipelineID
 }
 
 // TODO: figure out an URL and or more useful information

--- a/internal/attestation/crafter/runners/daggerpipeline_test.go
+++ b/internal/attestation/crafter/runners/daggerpipeline_test.go
@@ -76,7 +76,7 @@ func (s *daggerPipelineSuite) TestRunURI() {
 }
 
 func (s *daggerPipelineSuite) TestRunnerName() {
-	s.Equal("dagger-pipeline", s.runner.String())
+	s.Equal("DAGGER_PIPELINE", s.runner.ID().String())
 }
 
 // Run before each test

--- a/internal/attestation/crafter/runners/generic.go
+++ b/internal/attestation/crafter/runners/generic.go
@@ -19,8 +19,6 @@ import schemaapi "github.com/chainloop-dev/chainloop/app/controlplane/api/workfl
 
 type Generic struct{}
 
-const GenericID = "generic"
-
 func NewGeneric() *Generic {
 	return &Generic{}
 }
@@ -37,10 +35,6 @@ func (r *Generic) CheckEnv() bool {
 // automatically inject environment variables into the attestation.
 func (r *Generic) ListEnvVars() []*EnvVarDefinition {
 	return []*EnvVarDefinition{}
-}
-
-func (r *Generic) String() string {
-	return GenericID
 }
 
 func (r *Generic) RunURI() string {

--- a/internal/attestation/crafter/runners/generic.go
+++ b/internal/attestation/crafter/runners/generic.go
@@ -15,12 +15,18 @@
 
 package runners
 
+import schemaapi "github.com/chainloop-dev/chainloop/app/controlplane/api/workflowcontract/v1"
+
 type Generic struct{}
 
 const GenericID = "generic"
 
 func NewGeneric() *Generic {
 	return &Generic{}
+}
+
+func (r *Generic) ID() schemaapi.CraftingSchema_Runner_RunnerType {
+	return schemaapi.CraftingSchema_Runner_RUNNER_TYPE_UNSPECIFIED
 }
 
 func (r *Generic) CheckEnv() bool {

--- a/internal/attestation/crafter/runners/generic_test.go
+++ b/internal/attestation/crafter/runners/generic_test.go
@@ -45,7 +45,7 @@ func (s *genericSuite) TestRunURI() {
 }
 
 func (s *genericSuite) TestRunnerName() {
-	s.Equal("generic", s.runner.String())
+	s.Equal("RUNNER_TYPE_UNSPECIFIED", s.runner.ID().String())
 }
 
 // Run before each test

--- a/internal/attestation/crafter/runners/githubaction.go
+++ b/internal/attestation/crafter/runners/githubaction.go
@@ -18,6 +18,8 @@ package runners
 import (
 	"fmt"
 	"os"
+
+	schemaapi "github.com/chainloop-dev/chainloop/app/controlplane/api/workflowcontract/v1"
 )
 
 const GitHubActionID = "github-action"
@@ -26,6 +28,10 @@ type GitHubAction struct{}
 
 func NewGithubAction() *GitHubAction {
 	return &GitHubAction{}
+}
+
+func (r *GitHubAction) ID() schemaapi.CraftingSchema_Runner_RunnerType {
+	return schemaapi.CraftingSchema_Runner_GITHUB_ACTION
 }
 
 // Figure out if we are in a Github Action job or not

--- a/internal/attestation/crafter/runners/githubaction.go
+++ b/internal/attestation/crafter/runners/githubaction.go
@@ -22,8 +22,6 @@ import (
 	schemaapi "github.com/chainloop-dev/chainloop/app/controlplane/api/workflowcontract/v1"
 )
 
-const GitHubActionID = "github-action"
-
 type GitHubAction struct{}
 
 func NewGithubAction() *GitHubAction {
@@ -56,10 +54,6 @@ func (r *GitHubAction) ListEnvVars() []*EnvVarDefinition {
 		{"RUNNER_NAME", false},
 		{"RUNNER_OS", false},
 	}
-}
-
-func (r *GitHubAction) String() string {
-	return GitHubActionID
 }
 
 func (r *GitHubAction) RunURI() (url string) {

--- a/internal/attestation/crafter/runners/githubaction_test.go
+++ b/internal/attestation/crafter/runners/githubaction_test.go
@@ -112,7 +112,7 @@ func (s *githubActionSuite) TestRunURI() {
 }
 
 func (s *githubActionSuite) TestRunnerName() {
-	s.Equal("github-action", s.runner.String())
+	s.Equal("GITHUB_ACTION", s.runner.ID().String())
 }
 
 // Run before each test

--- a/internal/attestation/crafter/runners/gitlabpipeline.go
+++ b/internal/attestation/crafter/runners/gitlabpipeline.go
@@ -23,8 +23,6 @@ import (
 
 type GitlabPipeline struct{}
 
-const GitlabPipelineID = "gitlab-pipeline"
-
 func NewGitlabPipeline() *GitlabPipeline {
 	return &GitlabPipeline{}
 }
@@ -56,10 +54,6 @@ func (r *GitlabPipeline) ListEnvVars() []*EnvVarDefinition {
 		{"CI_RUNNER_DESCRIPTION", false},
 		{"CI_COMMIT_REF_NAME", false},
 	}
-}
-
-func (r *GitlabPipeline) String() string {
-	return GitlabPipelineID
 }
 
 func (r *GitlabPipeline) RunURI() (url string) {

--- a/internal/attestation/crafter/runners/gitlabpipeline.go
+++ b/internal/attestation/crafter/runners/gitlabpipeline.go
@@ -17,6 +17,8 @@ package runners
 
 import (
 	"os"
+
+	schemaapi "github.com/chainloop-dev/chainloop/app/controlplane/api/workflowcontract/v1"
 )
 
 type GitlabPipeline struct{}
@@ -25,6 +27,10 @@ const GitlabPipelineID = "gitlab-pipeline"
 
 func NewGitlabPipeline() *GitlabPipeline {
 	return &GitlabPipeline{}
+}
+
+func (r *GitlabPipeline) ID() schemaapi.CraftingSchema_Runner_RunnerType {
+	return schemaapi.CraftingSchema_Runner_GITLAB_PIPELINE
 }
 
 // Figure out if we are in a Github Action job or not

--- a/internal/attestation/crafter/runners/gitlabpipeline_test.go
+++ b/internal/attestation/crafter/runners/gitlabpipeline_test.go
@@ -112,7 +112,7 @@ func (s *gitlabPipelineSuite) TestRunURI() {
 }
 
 func (s *gitlabPipelineSuite) TestRunnerName() {
-	s.Equal("gitlab-pipeline", s.runner.String())
+	s.Equal("GITLAB_PIPELINE", s.runner.ID().String())
 }
 
 // Run before each test

--- a/internal/attestation/crafter/runners/jenkinsjob.go
+++ b/internal/attestation/crafter/runners/jenkinsjob.go
@@ -23,8 +23,6 @@ import (
 
 type JenkinsJob struct{}
 
-const JenkinsJobID = "jenkins-job"
-
 func NewJenkinsJob() *JenkinsJob {
 	return &JenkinsJob{}
 }
@@ -60,10 +58,6 @@ func (r *JenkinsJob) ListEnvVars() []*EnvVarDefinition {
 		{"AGENT_WORKDIR", false},
 		{"NODE_NAME", false},
 	}
-}
-
-func (r *JenkinsJob) String() string {
-	return JenkinsJobID
 }
 
 func (r *JenkinsJob) RunURI() string {

--- a/internal/attestation/crafter/runners/jenkinsjob.go
+++ b/internal/attestation/crafter/runners/jenkinsjob.go
@@ -15,7 +15,11 @@
 
 package runners
 
-import "os"
+import (
+	"os"
+
+	schemaapi "github.com/chainloop-dev/chainloop/app/controlplane/api/workflowcontract/v1"
+)
 
 type JenkinsJob struct{}
 
@@ -23,6 +27,10 @@ const JenkinsJobID = "jenkins-job"
 
 func NewJenkinsJob() *JenkinsJob {
 	return &JenkinsJob{}
+}
+
+func (r *JenkinsJob) ID() schemaapi.CraftingSchema_Runner_RunnerType {
+	return schemaapi.CraftingSchema_Runner_JENKINS_JOB
 }
 
 // Checks whether we are within a Jenkins job

--- a/internal/attestation/crafter/runners/jenkinsjob_test.go
+++ b/internal/attestation/crafter/runners/jenkinsjob_test.go
@@ -106,7 +106,7 @@ func (s *jenkinsJobSuite) TestRunURI() {
 }
 
 func (s *jenkinsJobSuite) TestRunnerName() {
-	s.Equal("jenkins-job", s.runner.String())
+	s.Equal("JENKINS_JOB", s.runner.ID().String())
 }
 
 // Run before each test


### PR DESCRIPTION
Decouple the detection from the enforcement of runner types.

Now that the CLI will

- detect the runner type
- check that's the expected one, if listed in the contract
- load the required information associated with that runner context.


Closes #515 