### PR TITLE
fix(controlplane): handle org update duplicates

### DIFF
--- a/app/controlplane/internal/biz/organization.go
+++ b/app/controlplane/internal/biz/organization.go
@@ -157,6 +157,10 @@ func (uc *OrganizationUseCase) Update(ctx context.Context, userID, orgID string,
 	// Perform the update
 	org, err := uc.orgRepo.Update(ctx, orgUUID, name)
 	if err != nil {
+		if errors.Is(err, ErrAlreadyExists) {
+			return nil, NewErrValidationStr("an organization with that name already exists")
+		}
+
 		return nil, fmt.Errorf("failed to update organization: %w", err)
 	} else if org == nil {
 		return nil, NewErrNotFound("organization")

--- a/app/controlplane/internal/data/organization.go
+++ b/app/controlplane/internal/data/organization.go
@@ -70,7 +70,9 @@ func (r *OrganizationRepo) Update(ctx context.Context, id uuid.UUID, name *strin
 	}
 
 	org, err := req.Save(ctx)
-	if err != nil {
+	if err != nil && ent.IsConstraintError(err) {
+		return nil, biz.ErrAlreadyExists
+	} else if err != nil {
 		return nil, fmt.Errorf("failed to update organization: %w", err)
 	}
 


### PR DESCRIPTION
When updating an org, instead of returning a generic error, now the API returns a validation error if there is an org with the same name to the one we're trying to set

Closes #528 