### PR TITLE
feat(dependency-track): support parent ID for autocreate projects (#534)

### DIFF
--- a/app/controlplane/plugins/core/dependency-track/v1/README.md
+++ b/app/controlplane/plugins/core/dependency-track/v1/README.md
@@ -45,6 +45,7 @@ See https://docs.chainloop.dev/guides/dependency-track/
 
 |Field|Type|Required|Description|
 |---|---|---|---|
+|parentID|string|no|ID of parent project to create a new project under|
 |projectID|string|no|The ID of the existing project to send the SBOMs to|
 |projectName|string|no|The name of the project to create and send the SBOMs to|
 
@@ -76,9 +77,19 @@ See https://docs.chainloop.dev/guides/dependency-track/
       "type": "string",
       "minLength": 1,
       "description": "The name of the project to create and send the SBOMs to"
+    },
+    "parentID": {
+      "type": "string",
+      "minLength": 1,
+      "description": "ID of parent project to create a new project under"
     }
   },
   "additionalProperties": false,
-  "type": "object"
+  "type": "object",
+  "dependentRequired": {
+    "parentID": [
+      "projectName"
+    ]
+  }
 }
 ```

--- a/app/controlplane/plugins/core/dependency-track/v1/client/sbom_test.go
+++ b/app/controlplane/plugins/core/dependency-track/v1/client/sbom_test.go
@@ -29,26 +29,30 @@ const hostname = "http://example.com"
 func TestNewSBOMUploader(t *testing.T) {
 	const projectID = "existing-project-id"
 	const projectName = "new project name"
+	const parentID = "parent-existing-project-id"
 	var sbomReader = bytes.NewBuffer(nil)
 
 	tests := []struct {
-		hostname, apiKey, projectID, projectName string
-		sbom                                     io.Reader
-		wantError                                bool
+		hostname, apiKey, projectID, projectName, parentID string
+		sbom                                               io.Reader
+		wantError                                          bool
 	}{
 		// no api key
-		{hostname, "", projectID, projectName, sbomReader, true},
+		{hostname, "", projectID, projectName, parentID, sbomReader, true},
 		// invalid hostname
-		{"invalid-hostname", "apikey", projectID, projectName, sbomReader, true},
+		{"invalid-hostname", "apikey", projectID, projectName, parentID, sbomReader, true},
 		// both projectID and name
-		{hostname, "apikey", projectID, projectName, sbomReader, true},
-		{hostname, "apikey", projectID, "", sbomReader, false},
-		{hostname, "apikey", "", projectName, sbomReader, false},
+		{hostname, "apikey", projectID, projectName, "", sbomReader, true},
+		{hostname, "apikey", projectID, "", "", sbomReader, false},
+		{hostname, "apikey", "", projectName, "", sbomReader, false},
+		// parent ID
+		{hostname, "apikey", projectID, "", parentID, sbomReader, true},
+		{hostname, "apikey", "", projectName, parentID, sbomReader, false},
 	}
 
 	assert := assert.New(t)
 	for _, tc := range tests {
-		got, err := NewSBOMUploader(tc.hostname, tc.apiKey, tc.sbom, tc.projectID, tc.projectName)
+		got, err := NewSBOMUploader(tc.hostname, tc.apiKey, tc.sbom, tc.projectID, tc.projectName, tc.parentID)
 		if tc.wantError {
 			assert.Error(err)
 			continue
@@ -63,6 +67,7 @@ func TestNewSBOMUploader(t *testing.T) {
 			},
 			tc.sbom,
 			tc.projectID, tc.projectName,
+			tc.parentID,
 		}, got)
 	}
 }

--- a/app/controlplane/plugins/core/dependency-track/v1/extension.go
+++ b/app/controlplane/plugins/core/dependency-track/v1/extension.go
@@ -51,6 +51,7 @@ type attachmentRequest struct {
 	ParentID string `json:"parentID,omitempty" jsonschema:"minLength=1,description=ID of parent project to create a new project under"`
 }
 
+// Enforces the requirement that parentID requires the presence of projectName
 // invopop/jsonschema doesn't appear to support dependentRequired through reflection
 func (x attachmentRequest) JSONSchemaExtend(schema *jsonschema.Schema) {
 	schema.DependentRequired = map[string][]string{
@@ -69,7 +70,7 @@ type registrationConfig struct {
 type attachmentConfig struct {
 	ProjectID   string `json:"projectId"`
 	ProjectName string `json:"projectName"`
-	ParentID    string `json:"parentID"`
+	ParentID    string `json:"parentId"`
 }
 
 const description = "Send CycloneDX SBOMs to your Dependency-Track instance"

--- a/app/controlplane/plugins/core/dependency-track/v1/extension.go
+++ b/app/controlplane/plugins/core/dependency-track/v1/extension.go
@@ -27,6 +27,7 @@ import (
 	"github.com/chainloop-dev/chainloop/app/controlplane/plugins/core/dependency-track/v1/client"
 	"github.com/chainloop-dev/chainloop/app/controlplane/plugins/sdk/v1"
 	"github.com/go-kratos/kratos/v2/log"
+	"github.com/invopop/jsonschema"
 )
 
 type DependencyTrack struct {
@@ -46,6 +47,17 @@ type attachmentRequest struct {
 	// Either one or the other
 	ProjectID   string `json:"projectID,omitempty" jsonschema:"oneof_required=projectID,minLength=1,description=The ID of the existing project to send the SBOMs to"`
 	ProjectName string `json:"projectName,omitempty" jsonschema:"oneof_required=projectName,minLength=1,description=The name of the project to create and send the SBOMs to"`
+
+	ParentID string `json:"parentID,omitempty" jsonschema:"minLength=1,description=ID of parent project to create a new project under"`
+}
+
+// invopop/jsonschema doesn't appear to support dependentRequired through reflection
+func (x attachmentRequest) JSONSchemaExtend(schema *jsonschema.Schema) {
+	schema.DependentRequired = map[string][]string{
+		"parentID": {
+			"projectName",
+		},
+	}
 }
 
 // Internal state for both registration and attachment
@@ -57,6 +69,7 @@ type registrationConfig struct {
 type attachmentConfig struct {
 	ProjectID   string `json:"projectId"`
 	ProjectName string `json:"projectName"`
+	ParentID    string `json:"parentID"`
 }
 
 const description = "Send CycloneDX SBOMs to your Dependency-Track instance"
@@ -65,7 +78,7 @@ func New(l log.Logger) (sdk.FanOut, error) {
 	base, err := sdk.NewFanOut(
 		&sdk.NewParams{
 			ID:          "dependency-track",
-			Version:     "1.3",
+			Version:     "1.4",
 			Description: description,
 			Logger:      l,
 			InputSchema: &sdk.InputSchema{
@@ -134,10 +147,10 @@ func (i *DependencyTrack) Attach(ctx context.Context, req *sdk.AttachmentRequest
 		return nil, fmt.Errorf("invalid attachment configuration: %w", err)
 	}
 
-	i.Logger.Infow("msg", "attachment OK", "projectID", request.ProjectID, "projectName", request.ProjectName)
+	i.Logger.Infow("msg", "attachment OK", "projectID", request.ProjectID, "projectName", request.ProjectName, "parentID", request.ParentID)
 
 	// We want to store the project configuration
-	rawConfig, err := sdk.ToConfig(&attachmentConfig{ProjectID: request.ProjectID, ProjectName: request.ProjectName})
+	rawConfig, err := sdk.ToConfig(&attachmentConfig{ProjectID: request.ProjectID, ProjectName: request.ProjectName, ParentID: request.ParentID})
 	if err != nil {
 		return nil, fmt.Errorf("marshalling configuration: %w", err)
 	}
@@ -204,7 +217,8 @@ func doExecute(ctx context.Context, req *sdk.ExecutionRequest, sbom *sdk.Execute
 		req.RegistrationInfo.Credentials.Password,
 		bytes.NewReader(sbom.Content),
 		attachmentConfig.ProjectID,
-		projectName)
+		projectName,
+		attachmentConfig.ParentID)
 	if err != nil {
 		return fmt.Errorf("creating uploader: %w", err)
 	}
@@ -281,7 +295,7 @@ func validateAttachment(ctx context.Context, rc *registrationConfig, ac *attachm
 	}
 
 	// Instantiate an actual client to see if it would work with the current configuration
-	d, err := client.NewSBOMUploader(rc.Domain, credentials.Password, nil, ac.ProjectID, ac.ProjectName)
+	d, err := client.NewSBOMUploader(rc.Domain, credentials.Password, nil, ac.ProjectID, ac.ProjectName, ac.ParentID)
 	if err != nil {
 		return fmt.Errorf("creating uploader: %w", err)
 	}
@@ -311,6 +325,10 @@ func validateAttachmentConfiguration(rc *registrationConfig, ac *attachmentReque
 
 	if ac.ProjectID == "" && ac.ProjectName == "" {
 		return errors.New("project id or name must be provided")
+	}
+
+	if ac.ParentID != "" && ac.ProjectName == "" {
+		return errors.New("project name must be provided to work with parent id")
 	}
 
 	return nil

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -10,7 +10,7 @@ Below you can find the list of currently available integrations. If you can't fi
 
 | ID | Version | Description | Material Requirement |
 | --- | --- | --- | --- |
-| [dependency-track](https://github.com/chainloop-dev/chainloop/blob/main/app/controlplane/plugins/core/dependency-track/v1/README.md) | 1.3 | Send CycloneDX SBOMs to your Dependency-Track instance | SBOM_CYCLONEDX_JSON |
+| [dependency-track](https://github.com/chainloop-dev/chainloop/blob/main/app/controlplane/plugins/core/dependency-track/v1/README.md) | 1.4 | Send CycloneDX SBOMs to your Dependency-Track instance | SBOM_CYCLONEDX_JSON |
 | [discord-webhook](https://github.com/chainloop-dev/chainloop/blob/main/app/controlplane/plugins/core/discord-webhook/v1/README.md) | 1.1 | Send attestations to Discord |  |
 | [guac](https://github.com/chainloop-dev/chainloop/blob/main/app/controlplane/plugins/core/guac/v1/README.md) | 1.0 | Export Attestation and SBOMs metadata to a blob storage backend so guacsec/guac can consume it | SBOM_CYCLONEDX_JSON, SBOM_SPDX_JSON |
 | [slack-webhook](https://github.com/chainloop-dev/chainloop/blob/main/app/controlplane/plugins/core/slack-webhook/v1/README.md) | 1.0 | Send attestations to Slack |  |


### PR DESCRIPTION
For now just supporting parent ID, not name and version. Although I do think it would be useful to support project version as well as parent name and version, this way a workflow could be shared by several projects if the parent name/version could be read from annotations.

No testing for the HTTP submission to dependency-track yet, although I'm not sure the best way to approach that in Go.

closes #544