### PR TITLE
chore(controlplane): continue invite system org scope

### DIFF
--- a/app/controlplane/api/controlplane/v1/org_invitation.proto
+++ b/app/controlplane/api/controlplane/v1/org_invitation.proto
@@ -28,7 +28,7 @@ service OrgInvitationService {
   rpc Create(OrgInvitationServiceCreateRequest) returns (OrgInvitationServiceCreateResponse);
   // Revoke an invitation.
   rpc Revoke(OrgInvitationServiceRevokeRequest) returns (OrgInvitationServiceRevokeResponse);
-  // List all invitations sent by the current user.
+  // List all invitations in the current org
   rpc ListSent(OrgInvitationServiceListSentRequest) returns (OrgInvitationServiceListSentResponse);
 }
 

--- a/app/controlplane/api/controlplane/v1/org_invitation_grpc.pb.go
+++ b/app/controlplane/api/controlplane/v1/org_invitation_grpc.pb.go
@@ -47,7 +47,7 @@ type OrgInvitationServiceClient interface {
 	Create(ctx context.Context, in *OrgInvitationServiceCreateRequest, opts ...grpc.CallOption) (*OrgInvitationServiceCreateResponse, error)
 	// Revoke an invitation.
 	Revoke(ctx context.Context, in *OrgInvitationServiceRevokeRequest, opts ...grpc.CallOption) (*OrgInvitationServiceRevokeResponse, error)
-	// List all invitations sent by the current user.
+	// List all invitations in the current org
 	ListSent(ctx context.Context, in *OrgInvitationServiceListSentRequest, opts ...grpc.CallOption) (*OrgInvitationServiceListSentResponse, error)
 }
 
@@ -94,7 +94,7 @@ type OrgInvitationServiceServer interface {
 	Create(context.Context, *OrgInvitationServiceCreateRequest) (*OrgInvitationServiceCreateResponse, error)
 	// Revoke an invitation.
 	Revoke(context.Context, *OrgInvitationServiceRevokeRequest) (*OrgInvitationServiceRevokeResponse, error)
-	// List all invitations sent by the current user.
+	// List all invitations in the current org
 	ListSent(context.Context, *OrgInvitationServiceListSentRequest) (*OrgInvitationServiceListSentResponse, error)
 	mustEmbedUnimplementedOrgInvitationServiceServer()
 }

--- a/app/controlplane/api/gen/frontend/controlplane/v1/org_invitation.ts
+++ b/app/controlplane/api/gen/frontend/controlplane/v1/org_invitation.ts
@@ -543,7 +543,7 @@ export interface OrgInvitationService {
     request: DeepPartial<OrgInvitationServiceRevokeRequest>,
     metadata?: grpc.Metadata,
   ): Promise<OrgInvitationServiceRevokeResponse>;
-  /** List all invitations sent by the current user. */
+  /** List all invitations in the current org */
   ListSent(
     request: DeepPartial<OrgInvitationServiceListSentRequest>,
     metadata?: grpc.Metadata,

--- a/app/controlplane/internal/data/orginvitation.go
+++ b/app/controlplane/internal/data/orginvitation.go
@@ -110,10 +110,10 @@ func (r *OrgInvitation) SoftDelete(ctx context.Context, id uuid.UUID) error {
 	return r.data.db.OrgInvitation.UpdateOneID(id).SetDeletedAt(time.Now()).Exec(ctx)
 }
 
-func (r *OrgInvitation) ListBySenderAndOrg(ctx context.Context, userID, orgID uuid.UUID) ([]*biz.OrgInvitation, error) {
-	invite, err := r.query().Where(orginvitation.SenderID(userID), orginvitation.OrganizationID(orgID)).All(ctx)
+func (r *OrgInvitation) ListByOrg(ctx context.Context, orgID uuid.UUID) ([]*biz.OrgInvitation, error) {
+	invite, err := r.query().Where(orginvitation.OrganizationID(orgID)).All(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("error finding invites for user %s: %w", userID.String(), err)
+		return nil, fmt.Errorf("error finding invites for org %s: %w", orgID.String(), err)
 	}
 
 	res := make([]*biz.OrgInvitation, len(invite))

--- a/app/controlplane/internal/service/orginvitation.go
+++ b/app/controlplane/internal/service/orginvitation.go
@@ -58,12 +58,12 @@ func (s *OrgInvitationService) Create(ctx context.Context, req *pb.OrgInvitation
 }
 
 func (s *OrgInvitationService) Revoke(ctx context.Context, req *pb.OrgInvitationServiceRevokeRequest) (*pb.OrgInvitationServiceRevokeResponse, error) {
-	user, err := requireCurrentUser(ctx)
+	org, err := requireCurrentOrg(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := s.useCase.Revoke(ctx, user.ID, req.Id); err != nil {
+	if err := s.useCase.Revoke(ctx, org.ID, req.Id); err != nil {
 		return nil, handleUseCaseErr("invitation", err, s.log)
 	}
 
@@ -71,17 +71,12 @@ func (s *OrgInvitationService) Revoke(ctx context.Context, req *pb.OrgInvitation
 }
 
 func (s *OrgInvitationService) ListSent(ctx context.Context, _ *pb.OrgInvitationServiceListSentRequest) (*pb.OrgInvitationServiceListSentResponse, error) {
-	user, err := requireCurrentUser(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	org, err := requireCurrentOrg(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	invitations, err := s.useCase.ListBySenderAndOrg(ctx, user.ID, org.ID)
+	invitations, err := s.useCase.ListByOrg(ctx, org.ID)
 	if err != nil {
 		return nil, handleUseCaseErr("invitation", err, s.log)
 	}


### PR DESCRIPTION
This is a continuation of #553 but this time applying to `listing` and `revocation`

Now that we are going to have `admin` users in the org, this change will allow us for each admin to be able to see the pending/sent invites in their org, and match it with a list of members in the future.

Refs #535 