### PR TITLE
chore(db): update workflow_run revision used

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,14 +38,14 @@ jobs:
 
       # Generate any possible migration from a schema change that way
       # we can detect any migration file that has not been checked in to git
-      # This could happen if the developer ran make generate but didn't run make migration_new
+      # This could happen if the developer ran make generate but didn't run make migration_sync
       - name: Generate migrations
         if: ${{ matrix.app == 'controlplane' }}
         run: |
           wget -q https://release.ariga.io/atlas/atlas-linux-amd64-latest -O /tmp/atlas
           sudo install /tmp/atlas /usr/local/bin/atlas
 
-          make -C app/controlplane migration_new
+          make -C app/controlplane migration_sync
 
       # Check that the generated ent code is up to date
       # see https://entgo.io/docs/ci/

--- a/app/controlplane/Makefile
+++ b/app/controlplane/Makefile
@@ -33,9 +33,9 @@ migration_apply: check-atlas-tool migration_hash
 	atlas migrate status --dir ${local_migrations_dir} --url ${local_db}
 	atlas migrate apply --dir ${local_migrations_dir} --url ${local_db}
 
-.PHONY: migration_update
-# generate updated migration files if needed from the current ent schema
-migration_update: check-atlas-tool migration_hash
+.PHONY: migration_sync
+# sync migration files with the current ent schema
+migration_sync: check-atlas-tool migration_hash
 	atlas migrate diff --dir ${local_migrations_dir} --to "ent://internal/data/ent/schema" --dev-url "docker://postgres/15/test?search_path=public"
 
 .PHONY: migration_new
@@ -66,7 +66,7 @@ lint: check-golangci-lint-tool check-buf-tool
 
 .PHONY: generate
 # generate proto bindings, wire injectors, and ent models
-generate: check-wire-tool api config migration_update
+generate: check-wire-tool api config migration_sync
 	go generate ./...
 
 .PHONY: all

--- a/app/controlplane/Makefile
+++ b/app/controlplane/Makefile
@@ -33,10 +33,15 @@ migration_apply: check-atlas-tool migration_hash
 	atlas migrate status --dir ${local_migrations_dir} --url ${local_db}
 	atlas migrate apply --dir ${local_migrations_dir} --url ${local_db}
 
-.PHONY: migration_new
-# generate new migration if needed from the current ent schema
-migration_new: check-atlas-tool migration_hash
+.PHONY: migration_update
+# generate updated migration files if needed from the current ent schema
+migration_update: check-atlas-tool migration_hash
 	atlas migrate diff --dir ${local_migrations_dir} --to "ent://internal/data/ent/schema" --dev-url "docker://postgres/15/test?search_path=public"
+
+.PHONY: migration_new
+# generate an empty migration file
+migration_new: check-atlas-tool migration_hash
+	atlas migrate new --dir ${local_migrations_dir}
 
 .PHONY: migration_hash
 migration_hash: check-atlas-tool
@@ -61,7 +66,7 @@ lint: check-golangci-lint-tool check-buf-tool
 
 .PHONY: generate
 # generate proto bindings, wire injectors, and ent models
-generate: check-wire-tool api config migration_new
+generate: check-wire-tool api config migration_update
 	go generate ./...
 
 .PHONY: all

--- a/app/controlplane/internal/data/ent/migrate/migrations/20240303145130.sql
+++ b/app/controlplane/internal/data/ent/migrate/migrations/20240303145130.sql
@@ -1,0 +1,7 @@
+-- Updates the contract_revision_used field in workflow_runs to the revision of the contract version used in the run
+-- for existing values in the database if it is not set (0)
+UPDATE workflow_runs
+SET contract_revision_used = wcv.revision
+FROM workflow_contract_versions wcv
+WHERE workflow_runs.contract_revision_used = 0
+AND workflow_runs.workflow_run_contract_version = wcv.id;

--- a/app/controlplane/internal/data/ent/migrate/migrations/atlas.sum
+++ b/app/controlplane/internal/data/ent/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:mf+rCMij2DFHC9ogu8h+ktB0OPUSBAanvHQeIAoPfc4=
+h1:PTn2PGzCqghqtloTCXyt2mqCL53gJMrZ0h7j77qU2H0=
 20230706165452_init-schema.sql h1:VvqbNFEQnCvUVyj2iDYVQQxDM0+sSXqocpt/5H64k8M=
 20230710111950-cas-backend.sql h1:A8iBuSzZIEbdsv9ipBtscZQuaBp3V5/VMw7eZH6GX+g=
 20230712094107-cas-backends-workflow-runs.sql h1:a5rzxpVGyd56nLRSsKrmCFc9sebg65RWzLghKHh5xvI=
@@ -23,3 +23,4 @@ h1:mf+rCMij2DFHC9ogu8h+ktB0OPUSBAanvHQeIAoPfc4=
 20240226145219.sql h1:m90QJxxZjOC7CjMPijxc3vf5pzX1X6Ac9M8Ms0lJ0gQ=
 20240228152445.sql h1:+F9k29PxJCv4CuwoMcnO24y0a+mxqaWsJr2zgI8XDx0=
 20240229202352.sql h1:1oSaJh+gNJ8cc+9AGBizFG4uk6GkHph0R3hsjjz9w4g=
+20240303145130.sql h1:ejcuI4AeWNCNhEkg3+7ButLe2hpIFqmhuPheFXEr6zY=


### PR DESCRIPTION
This patch adds a migration that updates `workflowrun.contract_revision_used` to its contract  `revision`. 

Before

```sql
select "contract_revision_used","contract_revision_latest" from workflow_runs;
 contract_revision_used | contract_revision_latest 
------------------------+--------------------------
                      0 |                        2
                      0 |                        2
                      0 |                        2
                      0 |                        1
                      0 |                        2
                      0 |                        2
                      0 |                        2
                      0 |                        2
                      0 |                        2
                      0 |                        2
                      0 |                        1
                      2 |                        2

```

after

```
--migration ran
UPDATE 11
select "contract_revision_used","contract_revision_latest" from workflow_runs;
 contract_revision_used | contract_revision_latest 
------------------------+--------------------------
                      2 |                        2
                      2 |                        2
                      1 |                        2
                      1 |                        1
                      2 |                        2
                      1 |                        2
                      2 |                        2
                      2 |                        2
                      2 |                        2
                      2 |                        2
                      2 |                        2
                      1 |                        1

```

refs https://github.com/chainloop-dev/frontend/issues/206