### PR TITLE
fix: allow viewers to change or leave the org

### DIFF
--- a/app/controlplane/internal/authz/authz.go
+++ b/app/controlplane/internal/authz/authz.go
@@ -183,10 +183,14 @@ var ServerOperationsMap = map[string][]*Policy{
 	"/controlplane.v1.ContextService/Current": {PolicyOrganizationRead},
 	// Listing, create or selecting an organization does not have any required permissions,
 	// since all the permissions here are in the context of an organization
-	"/controlplane.v1.OrganizationService/Create":               {},
-	"/controlplane.v1.OrganizationService/SetCurrentMembership": {},
+	// Create new organization
+	"/controlplane.v1.OrganizationService/Create": {},
 	// NOTE: this is about listing my own memberships, not about listing all the memberships in the organization
 	"/controlplane.v1.UserService/ListMemberships": {},
+	// Set the current organization for the current user
+	"/controlplane.v1.UserService/SetCurrentMembership": {},
+	// Leave the organization
+	"/controlplane.v1.UserService/DeleteMembership": {},
 }
 
 type SubjectAPIToken struct {


### PR DESCRIPTION
#559 introduced a regression where did not allow a `viewer` to change organizations.

This patch fixes this plus enables such user role to also `leave` the org 