### PR TITLE
chore(cli): remove invitation from top-level org cmd

### DIFF
--- a/app/cli/cmd/organization.go
+++ b/app/cli/cmd/organization.go
@@ -33,7 +33,6 @@ func newOrganizationCmd() *cobra.Command {
 		newOrganizationSet(),
 		newOrganizationLeaveCmd(),
 		newOrganizationDescribeCmd(),
-		newOrganizationInvitationCmd(),
 		newOrganizationAPITokenCmd(),
 		newOrganizationMemberCmd(),
 	)


### PR DESCRIPTION
This command is now under `org member` subcommand