### PR TITLE
chore(ci): disable dagger linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,27 +53,28 @@ jobs:
           buf_api_token: ${{ secrets.buf_api_token }}
       - uses: bufbuild/buf-lint-action@bd48f53224baaaf0fc55de9a913e7680ca6dbea4 # v1.0.3
 
-  lint-dagger-module:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install Dagger CLI
-        run: |
-          mkdir -p ~/.local/bin
-          cd ~/.local
-          curl -L https://dl.dagger.io/dagger/install.sh | sh
+  # temporarily disabled until we stabilize the module
+  # lint-dagger-module:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Install Dagger CLI
+  #       run: |
+  #         mkdir -p ~/.local/bin
+  #         cd ~/.local
+  #         curl -L https://dl.dagger.io/dagger/install.sh | sh
 
-      - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
-        with:
-          go-version: "1.22.1"
+  #     - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+  #       with:
+  #         go-version: "1.22.1"
 
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+  #     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
-      - name: Initialize module
-        run: |
-          make -C extras/dagger module-init
+  #     - name: Initialize module
+  #       run: |
+  #         make -C extras/dagger module-init
 
-      - name: Lint
-        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
-        with:
-          working-directory: extras/dagger/src
-          version: v1.54
+  #     - name: Lint
+  #       uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
+  #       with:
+  #         working-directory: extras/dagger/src
+  #         version: v1.54

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ lint:
 	make -C ./app/controlplane lint
 	make -C ./app/cli lint
 	make -C ./app/artifact-cas lint
-	make -C ./extras/dagger lint
+	# make -C ./extras/dagger lint
 
 .PHONY: test
 # All tests, both unit and integration


### PR DESCRIPTION
Temporarily disable the Go linter for the dagger module until it gets stabilized 