### PR TITLE
feat(controlplane): support providing connection string

### DIFF
--- a/internal/oauth/constants.go
+++ b/internal/oauth/constants.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 The Chainloop Authors.
+// Copyright 2024 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package oauth
 const (
 	// URL query params used in the OAuth flow
 	// Shared in a parent module so both clients and servers can use them
-	QueryParamCallback  = "callback"
-	QueryParamLongLived = "long-lived"
+	QueryParamCallback        = "callback"
+	QueryParamLongLived       = "long-lived"
+	QueryParamAuth0Connection = "connection"
 )


### PR DESCRIPTION
Support for providing `connection` string during login that gets forwarded to the upstream oauth2 provider https://auth0.com/docs/api/authentication#login

Closes #562 