### PR TITLE
feat(dagger): sync method

### DIFF
--- a/extras/dagger/main.go
+++ b/extras/dagger/main.go
@@ -111,6 +111,19 @@ func (att *Attestation) Status(ctx context.Context) (string, error) {
 		Stdout(ctx)
 }
 
+// Sync will force the client to send an actual query to the chainloop control plane
+// This is specially important to be run right after Init
+// for example
+//
+//	att := chainloop.Init(ctx, token, "main")
+//
+//	if err := att.Sync(ctx); err != nil {
+//		return nil, err
+//	}
+func (att *Attestation) Sync(ctx context.Context) error {
+	return nil
+}
+
 // Attach credentials for a container registry.
 // Chainloop will use them to query the registry for container image pieces of evidences
 func (att *Attestation) WithRegistryAuth(


### PR DESCRIPTION
Creates a `Sync` method that forces the execution of the `DAG`. This is important so we can make sure `Init` doesn't wait until push to create an instance of a run in the controlplane for example.

This is a workaround at not being able to do

```
att, err := chainloop.Init(...).Sync(ctx)
```

which is what the Container/File/Directory core primitives can do.

More context here: https://discord.com/channels/707636530424053791/1215428709910188133/1216885885279146074