### PR TITLE
feat(controlplane): make contract-names unique and DNS1123 compatible

### DIFF
--- a/app/controlplane/internal/biz/biz.go
+++ b/app/controlplane/internal/biz/biz.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 The Chainloop Authors.
+// Copyright 2024 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,12 +17,13 @@ package biz
 
 import (
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"math/big"
 	"strings"
 
 	"github.com/google/wire"
-	"github.com/moby/moby/pkg/namesgenerator"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 // ProviderSet is biz providers.
@@ -53,16 +54,35 @@ var ProviderSet = wire.NewSet(
 
 // generate a DNS1123-valid random name using moby's namesgenerator
 // plus an additional random number
-func generateRandomName() (string, error) {
-	// Create a random name
-	name := namesgenerator.GetRandomName(0)
-	// and append a random number to it
+func generateValidDNS1123WithSuffix(prefix string) (string, error) {
+	// Append a random number to it
 	randomNumber, err := rand.Int(rand.Reader, big.NewInt(10000))
 	if err != nil {
 		return "", fmt.Errorf("failed to generate random number: %w", err)
 	}
 
 	// Replace underscores with dashes to make it compatible with DNS1123
-	name = strings.ReplaceAll(fmt.Sprintf("%s-%d", name, randomNumber), "_", "-")
+	name := strings.ReplaceAll(fmt.Sprintf("%s-%d", prefix, randomNumber), "_", "-")
+
+	if err := ValidateIsDNS1123(name); err != nil {
+		return "", fmt.Errorf("generated name is not DNS1123-valid: %w", err)
+	}
+
 	return name, nil
+}
+
+func ValidateIsDNS1123(name string) error {
+	// The same validation done by Kubernetes for their namespace name
+	// https://github.com/kubernetes/apimachinery/blob/fa98d6eaedb4caccd69fc07d90bbb6a1e551f00f/pkg/api/validation/generic.go#L63
+	err := validation.IsDNS1123Label(name)
+	if len(err) > 0 {
+		errMsg := ""
+		for _, e := range err {
+			errMsg += e + "\n"
+		}
+
+		return errors.New(errMsg)
+	}
+
+	return nil
 }

--- a/app/controlplane/internal/biz/casmapping_integration_test.go
+++ b/app/controlplane/internal/biz/casmapping_integration_test.go
@@ -352,10 +352,10 @@ func (s *casMappingIntegrationSuite) SetupTest() {
 
 	// Create workflowRun in the database
 	// Workflow
-	workflow, err := s.Workflow.Create(ctx, &biz.WorkflowCreateOpts{Name: "test workflow", OrgID: s.org1.ID})
+	workflow, err := s.Workflow.Create(ctx, &biz.WorkflowCreateOpts{Name: "test-workflow", OrgID: s.org1.ID})
 	assert.NoError(err)
 
-	publicWorkflow, err := s.Workflow.Create(ctx, &biz.WorkflowCreateOpts{Name: "test workflow", OrgID: s.org1.ID, Public: true})
+	publicWorkflow, err := s.Workflow.Create(ctx, &biz.WorkflowCreateOpts{Name: "test-workflow", OrgID: s.org1.ID, Public: true})
 	assert.NoError(err)
 
 	// Robot account

--- a/app/controlplane/internal/biz/integration_test.go
+++ b/app/controlplane/internal/biz/integration_test.go
@@ -193,7 +193,7 @@ func (s *testSuite) SetupTest() {
 	assert.NoError(err)
 
 	// Workflow
-	s.workflow, err = s.Workflow.Create(ctx, &biz.WorkflowCreateOpts{Name: "test workflow", OrgID: s.org.ID})
+	s.workflow, err = s.Workflow.Create(ctx, &biz.WorkflowCreateOpts{Name: "test-workflow", OrgID: s.org.ID})
 	assert.NoError(err)
 
 	// Integration configuration

--- a/app/controlplane/internal/biz/organization_integration_test.go
+++ b/app/controlplane/internal/biz/organization_integration_test.go
@@ -248,7 +248,7 @@ func (s *OrgIntegrationTestSuite) SetupTest() {
 	assert.NoError(err)
 
 	// Workflow + contract
-	_, err = s.Workflow.Create(ctx, &biz.WorkflowCreateOpts{Name: "test workflow", OrgID: s.org.ID})
+	_, err = s.Workflow.Create(ctx, &biz.WorkflowCreateOpts{Name: "test-workflow", OrgID: s.org.ID})
 	assert.NoError(err)
 
 	// check integration, OCI repository and workflow and contracts are present in the db

--- a/app/controlplane/internal/biz/organization_test.go
+++ b/app/controlplane/internal/biz/organization_test.go
@@ -49,7 +49,7 @@ func (s *organizationTestSuite) TestCreateWithRandomName() {
 	s.Run("if it runs out of tries, it fails", func() {
 		ctx := context.Background()
 		// the first one fails because it already exists
-		repo.On("Create", ctx, mock.Anything).Times(biz.OrganizationRandomNameMaxTries).Return(nil, biz.ErrAlreadyExists)
+		repo.On("Create", ctx, mock.Anything).Times(biz.RandomNameMaxTries).Return(nil, biz.ErrAlreadyExists)
 		got, err := uc.CreateWithRandomName(ctx)
 		s.Error(err)
 		s.Nil(got)
@@ -78,7 +78,7 @@ func (s *organizationTestSuite) TestValidateOrgName() {
 
 	for _, tc := range testCases {
 		s.T().Run(tc.name, func(t *testing.T) {
-			err := biz.ValidateOrgName(tc.name)
+			err := biz.ValidateIsDNS1123(tc.name)
 			if tc.expectedError {
 				s.Error(err)
 			} else {

--- a/app/controlplane/internal/biz/referrer_integration_test.go
+++ b/app/controlplane/internal/biz/referrer_integration_test.go
@@ -371,7 +371,7 @@ func (s *referrerIntegrationTestSuite) SetupTest() {
 
 	s.workflow1, err = s.Workflow.Create(ctx, &biz.WorkflowCreateOpts{Name: "wf", Team: "team", OrgID: s.org1.ID})
 	require.NoError(s.T(), err)
-	s.workflow2, err = s.Workflow.Create(ctx, &biz.WorkflowCreateOpts{Name: "wf from org 2", Team: "team", OrgID: s.org2.ID})
+	s.workflow2, err = s.Workflow.Create(ctx, &biz.WorkflowCreateOpts{Name: "wf-from-org-2", Team: "team", OrgID: s.org2.ID})
 	require.NoError(s.T(), err)
 
 	// user 1 has access to org 1 and 2

--- a/app/controlplane/internal/biz/workflow.go
+++ b/app/controlplane/internal/biz/workflow.go
@@ -122,7 +122,12 @@ func (uc *WorkflowUseCase) findOrCreateContract(ctx context.Context, orgID, cont
 	}
 
 	// No contractID has been provided so we create a new one
-	contractName := fmt.Sprintf("%s-%s", project, name)
+	contractName := name
+	// Project might be empty
+	if project != "" {
+		contractName = fmt.Sprintf("%s-%s", project, name)
+	}
+
 	return uc.contractUC.Create(ctx, &WorkflowContractCreateOpts{OrgID: orgID, Name: contractName, AddUniquePrefix: true})
 }
 

--- a/app/controlplane/internal/biz/workflow.go
+++ b/app/controlplane/internal/biz/workflow.go
@@ -122,8 +122,8 @@ func (uc *WorkflowUseCase) findOrCreateContract(ctx context.Context, orgID, cont
 	}
 
 	// No contractID has been provided so we create a new one
-	contractName := fmt.Sprintf("%s/%s", project, name)
-	return uc.contractUC.Create(ctx, orgID, contractName, nil)
+	contractName := fmt.Sprintf("%s-%s", project, name)
+	return uc.contractUC.Create(ctx, &WorkflowContractCreateOpts{OrgID: orgID, Name: contractName, AddUniquePrefix: true})
 }
 
 func (uc *WorkflowUseCase) List(ctx context.Context, orgID string) ([]*Workflow, error) {

--- a/app/controlplane/internal/biz/workflow_integration_test.go
+++ b/app/controlplane/internal/biz/workflow_integration_test.go
@@ -59,7 +59,7 @@ func (s *workflowIntegrationTestSuite) TestUpdate() {
 	const (
 		name        = "test-workflow"
 		team        = "test team"
-		project     = "test project"
+		project     = "test-project"
 		description = "test description"
 	)
 

--- a/app/controlplane/internal/biz/workflow_integration_test.go
+++ b/app/controlplane/internal/biz/workflow_integration_test.go
@@ -57,7 +57,7 @@ func (s *workflowIntegrationTestSuite) TestContractLatestAvailable() {
 func (s *workflowIntegrationTestSuite) TestUpdate() {
 	ctx := context.Background()
 	const (
-		name        = "test workflow"
+		name        = "test-workflow"
 		team        = "test team"
 		project     = "test project"
 		description = "test description"

--- a/app/controlplane/internal/biz/workflowcontract.go
+++ b/app/controlplane/internal/biz/workflowcontract.go
@@ -155,7 +155,7 @@ func (uc *WorkflowContractUseCase) Create(ctx context.Context, opts *WorkflowCon
 
 	if err != nil {
 		if errors.Is(err, ErrAlreadyExists) {
-			return nil, NewErrValidationStr("that contract name already exists")
+			return nil, NewErrValidationStr("that name is already taken")
 		}
 
 		return nil, fmt.Errorf("failed to create contract: %w", err)
@@ -189,7 +189,7 @@ func (uc *WorkflowContractUseCase) createWithUniqueName(ctx context.Context, opt
 		return c, nil
 	}
 
-	return nil, NewErrValidationStr("that contract name already exists")
+	return nil, NewErrValidationStr("that name is already taken")
 }
 
 func (uc *WorkflowContractUseCase) Describe(ctx context.Context, orgID, contractID string, revision int) (*WorkflowContractWithVersion, error) {
@@ -247,7 +247,7 @@ func (uc *WorkflowContractUseCase) Update(ctx context.Context, orgID, contractID
 	c, err := uc.repo.Update(ctx, opts)
 	if err != nil {
 		if errors.Is(err, ErrAlreadyExists) {
-			return nil, NewErrValidationStr("that contract name already exists")
+			return nil, NewErrValidationStr("that name is already taken")
 		}
 
 		return nil, fmt.Errorf("failed to update contract: %w", err)

--- a/app/controlplane/internal/biz/workflowcontract_integration_test.go
+++ b/app/controlplane/internal/biz/workflowcontract_integration_test.go
@@ -127,7 +127,7 @@ func (s *workflowContractIntegrationTestSuite) TestCreate() {
 		{
 			name:       "existing contract name",
 			opts:       &biz.WorkflowContractCreateOpts{OrgID: s.org.ID, Name: "name"},
-			wantErrMsg: "already exists",
+			wantErrMsg: "taken",
 		},
 		{
 			name: "can create same name in different org",

--- a/app/controlplane/internal/biz/workflowcontract_integration_test.go
+++ b/app/controlplane/internal/biz/workflowcontract_integration_test.go
@@ -152,7 +152,6 @@ func (s *workflowContractIntegrationTestSuite) TestCreate() {
 			s.NotEmpty(contract.CreatedAt)
 		})
 	}
-
 }
 
 // Run the tests

--- a/app/controlplane/internal/biz/workflowcontract_integration_test.go
+++ b/app/controlplane/internal/biz/workflowcontract_integration_test.go
@@ -1,0 +1,162 @@
+//
+// Copyright 2024 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package biz_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz"
+	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz/testhelpers"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+func (s *workflowContractIntegrationTestSuite) TestUpdate() {
+	ctx := context.Background()
+
+	testCases := []struct {
+		name         string
+		contractName string
+		OrgID, ID    string
+		wantErrMsg   string
+	}{
+		{
+			name:         "non-existing contract",
+			contractName: "non-existing",
+			OrgID:        s.org.ID,
+			ID:           uuid.NewString(),
+			wantErrMsg:   "not found",
+		},
+		{
+			name:         "existing contract invalid name",
+			contractName: "invalid name",
+			OrgID:        s.org.ID,
+			ID:           s.contractOrg1.ID.String(),
+			wantErrMsg:   "RFC 1123",
+		},
+		{
+			name:         "existing contract valid name",
+			contractName: "valid-name",
+			OrgID:        s.org.ID,
+			ID:           s.contractOrg1.ID.String(),
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			contract, err := s.WorkflowContract.Update(ctx, tc.OrgID, tc.ID, tc.contractName, nil)
+			if tc.wantErrMsg != "" {
+				s.ErrorContains(err, tc.wantErrMsg)
+				return
+			}
+
+			require.NoError(s.T(), err)
+			s.Equal(tc.contractName, contract.Contract.Name)
+		})
+	}
+}
+
+func (s *workflowContractIntegrationTestSuite) TestCreate() {
+	ctx := context.Background()
+
+	testCases := []struct {
+		name       string
+		opts       *biz.WorkflowContractCreateOpts
+		wantErrMsg string
+	}{
+		{
+			name:       "org missing",
+			opts:       &biz.WorkflowContractCreateOpts{Name: "name"},
+			wantErrMsg: "required",
+		},
+		{
+			name:       "name missing",
+			opts:       &biz.WorkflowContractCreateOpts{OrgID: s.org.ID},
+			wantErrMsg: "required",
+		},
+		{
+			name:       "invalid name",
+			opts:       &biz.WorkflowContractCreateOpts{OrgID: s.org.ID, Name: "this/not/valid"},
+			wantErrMsg: "RFC 1123",
+		},
+		{
+			name:       "another invalid name",
+			opts:       &biz.WorkflowContractCreateOpts{OrgID: s.org.ID, Name: "this-not Valid"},
+			wantErrMsg: "RFC 1123",
+		},
+		{
+			name: "non-existing contract name",
+			opts: &biz.WorkflowContractCreateOpts{OrgID: s.org.ID, Name: "name"},
+		},
+		{
+			name:       "existing contract name",
+			opts:       &biz.WorkflowContractCreateOpts{OrgID: s.org.ID, Name: "name"},
+			wantErrMsg: "already exists",
+		},
+		{
+			name: "can create same name in different org",
+			opts: &biz.WorkflowContractCreateOpts{OrgID: s.org2.ID, Name: "name"},
+		},
+		{
+			name: "or ask to generate a random name",
+			opts: &biz.WorkflowContractCreateOpts{OrgID: s.org.ID, Name: "name", AddUniquePrefix: true},
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			contract, err := s.WorkflowContract.Create(ctx, tc.opts)
+			if tc.wantErrMsg != "" {
+				s.ErrorContains(err, tc.wantErrMsg)
+				return
+			}
+
+			require.NoError(s.T(), err)
+			s.NotEmpty(contract.ID)
+			s.NotEmpty(contract.CreatedAt)
+		})
+	}
+
+}
+
+// Run the tests
+func TestWorkflowContractUseCase(t *testing.T) {
+	suite.Run(t, new(workflowContractIntegrationTestSuite))
+}
+
+// Utility struct to hold the test suite
+type workflowContractIntegrationTestSuite struct {
+	testhelpers.UseCasesEachTestSuite
+	org, org2 *biz.Organization
+
+	contractOrg1 *biz.WorkflowContract
+}
+
+func (s *workflowContractIntegrationTestSuite) SetupTest() {
+	s.TestingUseCases = testhelpers.NewTestingUseCases(s.T())
+
+	var err error
+	ctx := context.Background()
+	s.org, err = s.Organization.CreateWithRandomName(ctx)
+	s.NoError(err)
+	s.org2, err = s.Organization.CreateWithRandomName(ctx)
+	s.NoError(err)
+
+	s.contractOrg1, err = s.WorkflowContract.Create(ctx, &biz.WorkflowContractCreateOpts{OrgID: s.org.ID, Name: "a-valid-contract"})
+	s.NoError(err)
+}

--- a/app/controlplane/internal/biz/workflowrun_integration_test.go
+++ b/app/controlplane/internal/biz/workflowrun_integration_test.go
@@ -300,64 +300,6 @@ func (s *workflowRunIntegrationTestSuite) TestContractInformation() {
 	})
 }
 
-func (s *workflowRunIntegrationTestSuite) TestUpdate() {
-	testCases := []struct {
-		name         string
-		contractID   string
-		inputName    string
-		inputSchema  *schemav1.CraftingSchema
-		wantError    bool
-		wantRevision int
-	}{
-		{
-			name:       "invalid contract",
-			contractID: uuid.NewString(),
-			wantError:  true,
-		},
-		{
-			name:         "update only name does not bump revision",
-			contractID:   s.contractVersion.Contract.ID.String(),
-			inputName:    "new-name",
-			wantRevision: 1,
-		},
-		{
-			name:         "updating schema bumps revision",
-			contractID:   s.contractVersion.Contract.ID.String(),
-			inputSchema:  &schemav1.CraftingSchema{SchemaVersion: "v123"},
-			wantRevision: 2,
-		},
-		{
-			name:         "updating with same schema DOES NOT bump revision",
-			contractID:   s.contractVersion.Contract.ID.String(),
-			inputSchema:  &schemav1.CraftingSchema{SchemaVersion: "v123"},
-			wantRevision: 2,
-		},
-		{
-			name:         "updating with same schema but different name DOES NOT bump revision either",
-			contractID:   s.contractVersion.Contract.ID.String(),
-			inputSchema:  &schemav1.CraftingSchema{SchemaVersion: "v123"},
-			inputName:    "new-new-name",
-			wantRevision: 2,
-		},
-	}
-
-	for _, tc := range testCases {
-		s.T().Run(tc.name, func(t *testing.T) {
-			contract, err := s.WorkflowContract.Update(context.Background(), s.org.ID, tc.contractID, tc.inputName, tc.inputSchema)
-			if tc.wantError {
-				s.Error(err)
-				return
-			}
-
-			s.NoError(err)
-			s.Equal(tc.wantRevision, contract.Version.Revision)
-			if tc.inputName != "" {
-				s.Equal(tc.inputName, contract.Contract.Name)
-			}
-		})
-	}
-}
-
 // Run the tests
 func TestWorkflowRunUseCase(t *testing.T) {
 	suite.Run(t, new(workflowRunIntegrationTestSuite))

--- a/app/controlplane/internal/biz/workflowrun_integration_test.go
+++ b/app/controlplane/internal/biz/workflowrun_integration_test.go
@@ -390,12 +390,12 @@ func setupWorkflowRunTestData(t *testing.T, suite *testhelpers.TestingUseCases, 
 	assert.NoError(err)
 
 	// Workflow
-	s.workflowOrg1, err = suite.Workflow.Create(ctx, &biz.WorkflowCreateOpts{Name: "test workflow", OrgID: s.org.ID})
+	s.workflowOrg1, err = suite.Workflow.Create(ctx, &biz.WorkflowCreateOpts{Name: "test-workflow", OrgID: s.org.ID})
 	assert.NoError(err)
-	s.workflowOrg2, err = suite.Workflow.Create(ctx, &biz.WorkflowCreateOpts{Name: "test workflow", OrgID: s.org2.ID})
+	s.workflowOrg2, err = suite.Workflow.Create(ctx, &biz.WorkflowCreateOpts{Name: "test-workflow", OrgID: s.org2.ID})
 	assert.NoError(err)
 	// Public workflow
-	s.workflowPublicOrg2, err = suite.Workflow.Create(ctx, &biz.WorkflowCreateOpts{Name: "test public workflow", OrgID: s.org2.ID, Public: true})
+	s.workflowPublicOrg2, err = suite.Workflow.Create(ctx, &biz.WorkflowCreateOpts{Name: "test-public-workflow", OrgID: s.org2.ID, Public: true})
 	assert.NoError(err)
 
 	// Robot account

--- a/app/controlplane/internal/biz/workflowrun_integration_test.go
+++ b/app/controlplane/internal/biz/workflowrun_integration_test.go
@@ -336,7 +336,7 @@ func (s *workflowRunIntegrationTestSuite) TestUpdate() {
 			name:         "updating with same schema but different name DOES NOT bump revision either",
 			contractID:   s.contractVersion.Contract.ID.String(),
 			inputSchema:  &schemav1.CraftingSchema{SchemaVersion: "v123"},
-			inputName:    "new new name",
+			inputName:    "new-new-name",
 			wantRevision: 2,
 		},
 	}

--- a/app/controlplane/internal/biz/workflowrun_integration_test.go
+++ b/app/controlplane/internal/biz/workflowrun_integration_test.go
@@ -317,7 +317,7 @@ func (s *workflowRunIntegrationTestSuite) TestUpdate() {
 		{
 			name:         "update only name does not bump revision",
 			contractID:   s.contractVersion.Contract.ID.String(),
-			inputName:    "new name",
+			inputName:    "new-name",
 			wantRevision: 1,
 		},
 		{

--- a/app/controlplane/internal/data/ent/migrate/migrations/20240312102059.sql
+++ b/app/controlplane/internal/data/ent/migrate/migrations/20240312102059.sql
@@ -1,0 +1,26 @@
+-- Update existing data in "workflow_contracts" table
+-- Make the name RFC 1123 compliant
+UPDATE workflow_contracts
+SET name = regexp_replace(
+             lower(name), 
+             '[^a-z0-9-]', 
+             '-', 
+             'g'
+         );
+
+-- Append suffixes to duplicates
+WITH numbered_names AS (
+    SELECT 
+        id,
+        name,
+        ROW_NUMBER() OVER (PARTITION BY name ORDER BY id) AS rn
+    FROM workflow_contracts
+)
+
+UPDATE workflow_contracts AS o
+SET name = CONCAT(o.name, '-', nn.rn - 1)
+FROM numbered_names AS nn
+WHERE o.id = nn.id AND nn.rn > 1;
+
+-- Create index "workflowcontract_name_organization_workflow_contracts" to table: "workflow_contracts"
+CREATE UNIQUE INDEX "workflowcontract_name_organization_workflow_contracts" ON "workflow_contracts" ("name", "organization_workflow_contracts");

--- a/app/controlplane/internal/data/ent/migrate/migrations/atlas.sum
+++ b/app/controlplane/internal/data/ent/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:aXhZ+yOjz8DHOTQVrsiscPXXB7G2ikqRKOnD8WHfTqA=
+h1:r7SX8nurXdCWaClBBw+6Z2fU5Kbbh+c3KXRI/xn+Icw=
 20230706165452_init-schema.sql h1:VvqbNFEQnCvUVyj2iDYVQQxDM0+sSXqocpt/5H64k8M=
 20230710111950-cas-backend.sql h1:A8iBuSzZIEbdsv9ipBtscZQuaBp3V5/VMw7eZH6GX+g=
 20230712094107-cas-backends-workflow-runs.sql h1:a5rzxpVGyd56nLRSsKrmCFc9sebg65RWzLghKHh5xvI=
@@ -25,3 +25,4 @@ h1:aXhZ+yOjz8DHOTQVrsiscPXXB7G2ikqRKOnD8WHfTqA=
 20240229202352.sql h1:1oSaJh+gNJ8cc+9AGBizFG4uk6GkHph0R3hsjjz9w4g=
 20240303073902.sql h1:vTC9GmUjsyYzOmsEkLcVLvu+h5iJAohQnGFl+OoQLHQ=
 20240303145130.sql h1:IY21A96Cq7wrNXkLWqhwNGXWcJVxUG7v6PorhOxMvao=
+20240312102059.sql h1:nHApYqyVHcdHHivQFDw+AzPTVa4Gn3NHqmZnxVeZsoA=

--- a/app/controlplane/internal/data/ent/migrate/schema.go
+++ b/app/controlplane/internal/data/ent/migrate/schema.go
@@ -348,6 +348,13 @@ var (
 				OnDelete:   schema.Cascade,
 			},
 		},
+		Indexes: []*schema.Index{
+			{
+				Name:    "workflowcontract_name_organization_workflow_contracts",
+				Unique:  true,
+				Columns: []*schema.Column{WorkflowContractsColumns[1], WorkflowContractsColumns[4]},
+			},
+		},
 	}
 	// WorkflowContractVersionsColumns holds the columns for the "workflow_contract_versions" table.
 	WorkflowContractVersionsColumns = []*schema.Column{

--- a/app/controlplane/internal/data/ent/schema/workflowcontract.go
+++ b/app/controlplane/internal/data/ent/schema/workflowcontract.go
@@ -22,6 +22,7 @@ import (
 	"entgo.io/ent/dialect/entsql"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
+	"entgo.io/ent/schema/index"
 	"github.com/google/uuid"
 )
 
@@ -54,5 +55,12 @@ func (WorkflowContract) Edges() []ent.Edge {
 			Unique(),
 		// A contract can be associated to multiple workflows
 		edge.From("workflows", Workflow.Type).Ref("contract"),
+	}
+}
+
+func (WorkflowContract) Indexes() []ent.Index {
+	return []ent.Index{
+		// names are unique within an organization
+		index.Fields("name").Edges("organization").Unique(),
 	}
 }

--- a/app/controlplane/internal/data/workflowcontract.go
+++ b/app/controlplane/internal/data/workflowcontract.go
@@ -266,6 +266,12 @@ func rollback(tx *ent.Tx, err error) error {
 	if rerr := tx.Rollback(); rerr != nil {
 		err = fmt.Errorf("%w: %w", err, rerr)
 	}
+
+	// If the error is a constraint error, we return a more specific error to indicate the client that's a duplicate
+	if ent.IsConstraintError(err) {
+		return biz.ErrAlreadyExists
+	}
+
 	return err
 }
 

--- a/app/controlplane/internal/dispatcher/dispatcher_test.go
+++ b/app/controlplane/internal/dispatcher/dispatcher_test.go
@@ -221,11 +221,11 @@ func (s *dispatcherTestSuite) SetupTest() {
 	assert.NoError(s.T(), err)
 
 	// Workflow
-	s.workflow, err = s.Workflow.Create(ctx, &biz.WorkflowCreateOpts{Name: "test workflow", OrgID: s.org.ID})
+	s.workflow, err = s.Workflow.Create(ctx, &biz.WorkflowCreateOpts{Name: "test-workflow", OrgID: s.org.ID})
 	assert.NoError(s.T(), err)
 
 	// Workflow
-	s.emptyWorkflow, err = s.Workflow.Create(ctx, &biz.WorkflowCreateOpts{Name: "empty workflow", OrgID: s.org.ID})
+	s.emptyWorkflow, err = s.Workflow.Create(ctx, &biz.WorkflowCreateOpts{Name: "empty-workflow", OrgID: s.org.ID})
 	assert.NoError(s.T(), err)
 
 	customImplementation := mockedSDK.NewFanOutPlugin(s.T())


### PR DESCRIPTION
- DB: 
  - requires the workflow contract name to be unique in the context of an organization
  - updates the existing contract entries to be DNS1123 compatible
- biz: 
  - the name must be a valid `DNS1123` value
  - when we auto-create a contract with a name during workflow creation, we make sure it's unique

Closes https://github.com/chainloop-dev/chainloop/issues/600