### PR TITLE
feat(controlplane): unique workflow name and formatted project

### DIFF
--- a/app/controlplane/internal/biz/biz.go
+++ b/app/controlplane/internal/biz/biz.go
@@ -78,7 +78,7 @@ func ValidateIsDNS1123(name string) error {
 	if len(err) > 0 {
 		errMsg := ""
 		for _, e := range err {
-			errMsg += e + "\n"
+			errMsg += fmt.Sprintf("%q: %s\n", name, e)
 		}
 
 		return errors.New(errMsg)

--- a/app/controlplane/internal/biz/casclient_test.go
+++ b/app/controlplane/internal/biz/casclient_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2025 The Chainloop Authors.
+// Copyright 2023 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/app/controlplane/internal/biz/casclient_test.go
+++ b/app/controlplane/internal/biz/casclient_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 The Chainloop Authors.
+// Copyright 2025 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/app/controlplane/internal/biz/casmapping_integration_test.go
+++ b/app/controlplane/internal/biz/casmapping_integration_test.go
@@ -355,7 +355,7 @@ func (s *casMappingIntegrationSuite) SetupTest() {
 	workflow, err := s.Workflow.Create(ctx, &biz.WorkflowCreateOpts{Name: "test-workflow", OrgID: s.org1.ID})
 	assert.NoError(err)
 
-	publicWorkflow, err := s.Workflow.Create(ctx, &biz.WorkflowCreateOpts{Name: "test-workflow", OrgID: s.org1.ID, Public: true})
+	publicWorkflow, err := s.Workflow.Create(ctx, &biz.WorkflowCreateOpts{Name: "test-workflow-public", OrgID: s.org1.ID, Public: true})
 	assert.NoError(err)
 
 	// Robot account

--- a/app/controlplane/internal/biz/workflow.go
+++ b/app/controlplane/internal/biz/workflow.go
@@ -108,6 +108,10 @@ func (uc *WorkflowUseCase) Create(ctx context.Context, opts *WorkflowCreateOpts)
 }
 
 func (uc *WorkflowUseCase) Update(ctx context.Context, orgID, workflowID string, opts *WorkflowUpdateOpts) (*Workflow, error) {
+	if opts == nil {
+		return nil, NewErrValidationStr("no update options provided")
+	}
+
 	orgUUID, err := uuid.Parse(orgID)
 	if err != nil {
 		return nil, NewErrInvalidUUID(err)
@@ -125,7 +129,7 @@ func (uc *WorkflowUseCase) Update(ctx context.Context, orgID, workflowID string,
 		}
 	}
 
-	if opts.Project != nil {
+	if opts.Project != nil && *opts.Project != "" {
 		if err := ValidateIsDNS1123(*opts.Project); err != nil {
 			return nil, NewErrValidation(err)
 		}

--- a/app/controlplane/internal/biz/workflow.go
+++ b/app/controlplane/internal/biz/workflow.go
@@ -98,7 +98,7 @@ func (uc *WorkflowUseCase) Create(ctx context.Context, opts *WorkflowCreateOpts)
 	wf, err := uc.wfRepo.Create(ctx, opts)
 	if err != nil {
 		if errors.Is(err, ErrAlreadyExists) {
-			return nil, NewErrValidationStr("that name is already taken")
+			return nil, NewErrValidationStr("name already taken")
 		}
 
 		return nil, fmt.Errorf("failed to create workflow: %w", err)
@@ -141,7 +141,7 @@ func (uc *WorkflowUseCase) Update(ctx context.Context, orgID, workflowID string,
 	wf, err := uc.wfRepo.Update(ctx, workflowUUID, opts)
 	if err != nil {
 		if errors.Is(err, ErrAlreadyExists) {
-			return nil, NewErrValidationStr("that name is already taken")
+			return nil, NewErrValidationStr("name already taken")
 		}
 
 		return nil, fmt.Errorf("failed to update workflow: %w", err)

--- a/app/controlplane/internal/biz/workflow.go
+++ b/app/controlplane/internal/biz/workflow.go
@@ -91,6 +91,8 @@ func (uc *WorkflowUseCase) Create(ctx context.Context, opts *WorkflowCreateOpts)
 	contract, err := uc.findOrCreateContract(ctx, opts.OrgID, opts.ContractID, opts.Project, opts.Name)
 	if err != nil {
 		return nil, err
+	} else if contract == nil {
+		return nil, NewErrNotFound("contract")
 	}
 
 	// Set the potential new schemaID
@@ -109,7 +111,7 @@ func (uc *WorkflowUseCase) Create(ctx context.Context, opts *WorkflowCreateOpts)
 
 func (uc *WorkflowUseCase) Update(ctx context.Context, orgID, workflowID string, opts *WorkflowUpdateOpts) (*Workflow, error) {
 	if opts == nil {
-		return nil, NewErrValidationStr("no update options provided")
+		return nil, NewErrValidationStr("no updates provided")
 	}
 
 	orgUUID, err := uuid.Parse(orgID)

--- a/app/controlplane/internal/biz/workflowcontract.go
+++ b/app/controlplane/internal/biz/workflowcontract.go
@@ -155,7 +155,7 @@ func (uc *WorkflowContractUseCase) Create(ctx context.Context, opts *WorkflowCon
 
 	if err != nil {
 		if errors.Is(err, ErrAlreadyExists) {
-			return nil, NewErrValidationStr("that name is already taken")
+			return nil, NewErrValidationStr("name already taken")
 		}
 
 		return nil, fmt.Errorf("failed to create contract: %w", err)
@@ -189,7 +189,7 @@ func (uc *WorkflowContractUseCase) createWithUniqueName(ctx context.Context, opt
 		return c, nil
 	}
 
-	return nil, NewErrValidationStr("that name is already taken")
+	return nil, NewErrValidationStr("name already taken")
 }
 
 func (uc *WorkflowContractUseCase) Describe(ctx context.Context, orgID, contractID string, revision int) (*WorkflowContractWithVersion, error) {
@@ -247,7 +247,7 @@ func (uc *WorkflowContractUseCase) Update(ctx context.Context, orgID, contractID
 	c, err := uc.repo.Update(ctx, opts)
 	if err != nil {
 		if errors.Is(err, ErrAlreadyExists) {
-			return nil, NewErrValidationStr("that name is already taken")
+			return nil, NewErrValidationStr("name already taken")
 		}
 
 		return nil, fmt.Errorf("failed to update contract: %w", err)

--- a/app/controlplane/internal/data/ent/migrate/migrations/20240312141340.sql
+++ b/app/controlplane/internal/data/ent/migrate/migrations/20240312141340.sql
@@ -1,0 +1,47 @@
+-- Update existing data in "workflows" table
+-- Make the name and project RFC 1123 compliant
+UPDATE workflows
+SET name = regexp_replace(
+             lower(name), 
+             '[^a-z0-9-]', 
+             '-', 
+             'g'
+         );
+
+-- and project
+UPDATE workflows
+SET project = regexp_replace(
+             lower(name), 
+             '[^a-z0-9-]', 
+             '-', 
+             'g'
+         );
+
+-- Append suffixes to duplicates
+WITH numbered_names AS (
+    SELECT 
+        id,
+        name,
+        ROW_NUMBER() OVER (PARTITION BY name ORDER BY id) AS rn
+    FROM workflows
+)
+UPDATE workflows AS o
+SET name = CONCAT(o.name, '-', nn.rn - 1)
+FROM numbered_names AS nn
+WHERE o.id = nn.id AND nn.rn > 1;
+
+
+WITH numbered_projects AS (
+    SELECT 
+        id,
+        project,
+        ROW_NUMBER() OVER (PARTITION BY name ORDER BY id) AS rn
+    FROM workflows
+)
+UPDATE workflows AS o
+SET name = CONCAT(o.project, '-', np.rn - 1)
+FROM numbered_projects AS np
+WHERE o.id = np.id AND np.rn > 1;
+
+-- Create index "workflow_name_organization_id" to table: "workflows"
+CREATE UNIQUE INDEX "workflow_name_organization_id" ON "workflows" ("name", "organization_id");

--- a/app/controlplane/internal/data/ent/migrate/migrations/atlas.sum
+++ b/app/controlplane/internal/data/ent/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:r7SX8nurXdCWaClBBw+6Z2fU5Kbbh+c3KXRI/xn+Icw=
+h1:LpC3mlITc6Fy6Eg+4mWTf9aeNukj568zl8GuXKN+1hs=
 20230706165452_init-schema.sql h1:VvqbNFEQnCvUVyj2iDYVQQxDM0+sSXqocpt/5H64k8M=
 20230710111950-cas-backend.sql h1:A8iBuSzZIEbdsv9ipBtscZQuaBp3V5/VMw7eZH6GX+g=
 20230712094107-cas-backends-workflow-runs.sql h1:a5rzxpVGyd56nLRSsKrmCFc9sebg65RWzLghKHh5xvI=
@@ -26,3 +26,4 @@ h1:r7SX8nurXdCWaClBBw+6Z2fU5Kbbh+c3KXRI/xn+Icw=
 20240303073902.sql h1:vTC9GmUjsyYzOmsEkLcVLvu+h5iJAohQnGFl+OoQLHQ=
 20240303145130.sql h1:IY21A96Cq7wrNXkLWqhwNGXWcJVxUG7v6PorhOxMvao=
 20240312102059.sql h1:nHApYqyVHcdHHivQFDw+AzPTVa4Gn3NHqmZnxVeZsoA=
+20240312141340.sql h1:QDVfhXAD0//TikLmOWM6hdXiEGeahrjm1xeyHlYu9f8=

--- a/app/controlplane/internal/data/ent/migrate/schema.go
+++ b/app/controlplane/internal/data/ent/migrate/schema.go
@@ -326,6 +326,13 @@ var (
 				OnDelete:   schema.NoAction,
 			},
 		},
+		Indexes: []*schema.Index{
+			{
+				Name:    "workflow_name_organization_id",
+				Unique:  true,
+				Columns: []*schema.Column{WorkflowsColumns[1], WorkflowsColumns[9]},
+			},
+		},
 	}
 	// WorkflowContractsColumns holds the columns for the "workflow_contracts" table.
 	WorkflowContractsColumns = []*schema.Column{

--- a/app/controlplane/internal/data/ent/schema/workflow.go
+++ b/app/controlplane/internal/data/ent/schema/workflow.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 The Chainloop Authors.
+// Copyright 2024 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import (
 	"entgo.io/ent/dialect/entsql"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
+	"entgo.io/ent/schema/index"
 	"github.com/google/uuid"
 )
 
@@ -64,5 +65,12 @@ func (Workflow) Edges() []ent.Edge {
 
 		// M2M. referrer can be part of multiple workflows
 		edge.From("referrers", Referrer.Type).Ref("workflows"),
+	}
+}
+
+func (Workflow) Indexes() []ent.Index {
+	return []ent.Index{
+		// names are unique within an organization
+		index.Fields("name").Edges("organization").Unique(),
 	}
 }

--- a/app/controlplane/internal/data/workflow.go
+++ b/app/controlplane/internal/data/workflow.go
@@ -63,7 +63,11 @@ func (r *WorkflowRepo) Create(ctx context.Context, opts *biz.WorkflowCreateOpts)
 		SetDescription(opts.Description).
 		Save(ctx)
 	if err != nil {
-		return nil, err
+		if ent.IsConstraintError(err) {
+			return nil, biz.ErrAlreadyExists
+		}
+
+		return nil, fmt.Errorf("failed to create workflow: %w", err)
 	}
 
 	// Reload the object to include the relations
@@ -88,7 +92,12 @@ func (r *WorkflowRepo) Update(ctx context.Context, id uuid.UUID, opts *biz.Workf
 	}
 
 	wf, err := req.Save(ctx)
+
 	if err != nil {
+		if ent.IsConstraintError(err) {
+			return nil, biz.ErrAlreadyExists
+		}
+
 		return nil, fmt.Errorf("failed to update workflow: %w", err)
 	}
 


### PR DESCRIPTION
Similarly to #601 but applied to workflows, it

- Makes both workflow names and project RFC 1123 compliant
- Make sure that the workflow name is unique at the organization level
- migrates the existing workflow names and projects to meet 1

Closes #602 