### PR TITLE
docs: add dagger demo

### DIFF
--- a/docs/docs/guides/dagger/README.md
+++ b/docs/docs/guides/dagger/README.md
@@ -8,7 +8,13 @@ title: Use Dagger With Chainloop
 
 Daggerized version of [Chainloop](https://docs.chainloop.dev) that can be used to attest and collect pieces of evidence from your [Dagger](https://dagger.io/) pipelines.
 
+<iframe width="100%" height="500"
+    src="https://www.youtube.com/embed/s-ZtU8PvNmk"
+    frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen>
+</iframe>
+
 ## Prerequisites
+
 
 - This module requires existing familiarity with Chainloop and its attestation process. Please refer to [this guide](https://docs.chainloop.dev/getting-started/attestation-crafting) to learn more.
 - You need a `token` (aka workflow robot account) [previously generated](https://docs.chainloop.dev/getting-started/workflow-definition#robot-account-creation) by your Chainloop administrator.

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -128,7 +128,16 @@ ${content.replaceAll("./img/fanout.png", "/img/fanout.png")}`,
 title: Use Dagger With Chainloop
 ---
 
-${content}
+${content.replaceAll(
+  "## Prerequisites",
+  `<iframe width="100%" height="500"
+    src="https://www.youtube.com/embed/s-ZtU8PvNmk"
+    frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen>
+</iframe>
+
+## Prerequisites
+`
+)}
  `,
             };
           }


### PR DESCRIPTION
Include the Dagger demo in our guide in the docs.

I've implemented it so it gets injected when you run

```
yarn run docusaurus download-remote-dagger-module
```

![image](https://github.com/chainloop-dev/chainloop/assets/24523/f88fa9bc-e08d-44f3-a8f6-a026981236f3)

refs #501 