### PR TITLE
fix(authz): add read permissions in workflow.View

### DIFF
--- a/app/controlplane/internal/authz/authz.go
+++ b/app/controlplane/internal/authz/authz.go
@@ -103,6 +103,7 @@ var (
 	PolicyWorkflowRunRead = &Policy{ResourceWorkflowRun, ActionRead}
 	// Workflow
 	PolicyWorkflowList = &Policy{ResourceWorkflow, ActionList}
+	PolicyWorkflowRead = &Policy{ResourceWorkflow, ActionRead}
 	// User Membership
 	PolicyOrganizationRead = &Policy{Organization, ActionRead}
 )
@@ -137,6 +138,7 @@ var rolesMap = map[Role][]*Policy{
 		PolicyWorkflowRunRead,
 		// Workflow
 		PolicyWorkflowList,
+		PolicyWorkflowRead,
 		// Organization
 		PolicyOrganizationRead,
 	},
@@ -172,6 +174,7 @@ var ServerOperationsMap = map[string][]*Policy{
 	"/controlplane.v1.RobotAccountService/List": {PolicyRobotAccountList},
 	// Workflows
 	"/controlplane.v1.WorkflowService/List": {PolicyWorkflowList},
+	"/controlplane.v1.WorkflowService/View": {PolicyWorkflowRead},
 	// WorkflowRun
 	"/controlplane.v1.WorkflowRunService/List": {PolicyWorkflowRunList},
 	"/controlplane.v1.WorkflowRunService/View": {PolicyWorkflowRunRead},


### PR DESCRIPTION
This patch enables `viewers` to access the new `Workflow.View` API endpoint introduced here #32 

I do not think this patch will require a re-release since we do not use this endpoint yet in the CLI.
 
Before

```
grpcurl --plaintext -H "authorization: Bearer $TOKEN" -d '{"id": "429a9b9e-63cf-44b9-aa8f-27cdd6775e23" }' localhost:9000 controlplane.v1.WorkflowService.View
ERROR:
  Code: PermissionDenied
```


After

```
grpcurl --plaintext -H "authorization: Bearer $TOKEN" -d '{"id": "429a9b9e-63cf-44b9-aa8f-27cdd6775e23" }' localhost:9000 controlplane.v1.WorkflowService.View
ERROR:
  Code: NotFound
```