### PR TITLE
fix(docs-release) Fixed docs release and chainloop integration

### DIFF
--- a/.chainloop.yml
+++ b/.chainloop.yml
@@ -1,0 +1,9 @@
+# Experimental feature used by Chainloop labs shared workflow https://github.com/chainloop-dev/labs
+# It maps the material names with location in disk so they get automatically attested
+docs:
+  - name: sbom-cdx
+    path: reports/sbom.cyclonedx.json
+  - name: sbom-spdx
+    path: reports/sbom.spdx.json
+  - name: built-site
+    path: reports/build.tar.gz

--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -13,7 +13,7 @@ jobs:
     name: Chainloop Init
     uses: chainloop-dev/labs/.github/workflows/chainloop_init.yml@7f4de29435dc009326587051f507d2cd8c77d28b
     secrets:
-      api_token: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT }}
+      api_token: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT_DOCS_RELEASE }}
     with:
       chainloop_labs_branch: 7f4de29435dc009326587051f507d2cd8c77d28b
 


### PR DESCRIPTION
Fix the GitHub workflow for deploying the Chainloop documentation. There was a missing .chainloop.yml file and the robot account token used during the Chainloop init stage was incorrect. Please note that we use a remote-state approach and that the chainloop init and push actions occur in separate jobs.