### PR TITLE
chore(api): handle context.Canceled error

### DIFF
--- a/app/controlplane/internal/service/attestationstate.go
+++ b/app/controlplane/internal/service/attestationstate.go
@@ -49,7 +49,7 @@ func (s *AttestationStateService) Initialized(ctx context.Context, req *cpAPI.At
 
 	initialized, err := s.uc.Initialized(ctx, robotAccount.WorkflowID, req.WorkflowRunId)
 	if err != nil {
-		return nil, handleUseCaseErr("state", err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	return &cpAPI.AttestationStateServiceInitializedResponse{
@@ -70,7 +70,7 @@ func (s *AttestationStateService) Save(ctx context.Context, req *cpAPI.Attestati
 	}
 
 	if err := s.uc.Save(ctx, robotAccount.WorkflowID, req.WorkflowRunId, req.AttestationState, encryptionPassphrase); err != nil {
-		return nil, handleUseCaseErr("state", err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	return &cpAPI.AttestationStateServiceSaveResponse{}, nil
@@ -89,7 +89,7 @@ func (s *AttestationStateService) Read(ctx context.Context, req *cpAPI.Attestati
 
 	state, err := s.uc.Read(ctx, robotAccount.WorkflowID, req.WorkflowRunId, encryptionPassphrase)
 	if err != nil {
-		return nil, handleUseCaseErr("state", err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	return &cpAPI.AttestationStateServiceReadResponse{
@@ -106,7 +106,7 @@ func (s *AttestationStateService) Reset(ctx context.Context, req *cpAPI.Attestat
 	}
 
 	if err := s.uc.Reset(ctx, robotAccount.WorkflowID, req.WorkflowRunId); err != nil {
-		return nil, handleUseCaseErr("state", err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	return &cpAPI.AttestationStateServiceResetResponse{}, nil

--- a/app/controlplane/internal/service/casredirect.go
+++ b/app/controlplane/internal/service/casredirect.go
@@ -28,7 +28,6 @@ import (
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/conf"
 	"github.com/chainloop-dev/chainloop/internal/oauth"
 	casJWT "github.com/chainloop-dev/chainloop/internal/robotaccount/cas"
-	sl "github.com/chainloop-dev/chainloop/internal/servicelogger"
 	kerrors "github.com/go-kratos/kratos/v2/errors"
 	khttp "github.com/go-kratos/kratos/v2/transport/http"
 )
@@ -95,7 +94,7 @@ func (s *CASRedirectService) GetDownloadURL(ctx context.Context, req *pb.GetDown
 			return nil, kerrors.BadRequest("invalid", err.Error())
 		}
 
-		return nil, sl.LogAndMaskErr(err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	backend := mapping.CASBackend
@@ -108,7 +107,7 @@ func (s *CASRedirectService) GetDownloadURL(ctx context.Context, req *pb.GetDown
 	// Create an URL to download the artifact from the CAS backend
 	downloadBase, err := url.Parse(s.casServerConf.GetDownloadUrl())
 	if err != nil {
-		return nil, sl.LogAndMaskErr(err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	// 1 - append the digest /download/[digest]
@@ -119,7 +118,7 @@ func (s *CASRedirectService) GetDownloadURL(ctx context.Context, req *pb.GetDown
 		ref := &biz.CASCredsOpts{BackendType: string(backend.Provider), SecretPath: backend.SecretName, Role: casJWT.Downloader}
 		t, err := s.casCredsUseCase.GenerateTemporaryCredentials(ref)
 		if err != nil {
-			return nil, sl.LogAndMaskErr(err, s.log)
+			return nil, handleUseCaseErr(err, s.log)
 		}
 
 		q := downloadURL.Query()

--- a/app/controlplane/internal/service/context.go
+++ b/app/controlplane/internal/service/context.go
@@ -20,7 +20,6 @@ import (
 
 	pb "github.com/chainloop-dev/chainloop/app/controlplane/api/controlplane/v1"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz"
-	sl "github.com/chainloop-dev/chainloop/internal/servicelogger"
 	errors "github.com/go-kratos/kratos/v2/errors"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -72,7 +71,7 @@ func (s *ContextService) Current(ctx context.Context, _ *pb.ContextServiceCurren
 	// Add cas backend
 	backend, err := s.uc.FindDefaultBackend(ctx, currentOrg.ID)
 	if err != nil && !biz.IsNotFound(err) {
-		return nil, sl.LogAndMaskErr(err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	if backend != nil {
@@ -83,7 +82,7 @@ func (s *ContextService) Current(ctx context.Context, _ *pb.ContextServiceCurren
 	if currentUser != nil {
 		m, err := s.userUC.CurrentMembership(ctx, currentUser.ID)
 		if err != nil {
-			return nil, handleUseCaseErr("membership", err, s.log)
+			return nil, handleUseCaseErr(err, s.log)
 		}
 
 		if m != nil {

--- a/app/controlplane/internal/service/organization.go
+++ b/app/controlplane/internal/service/organization.go
@@ -49,11 +49,11 @@ func (s *OrganizationService) Create(ctx context.Context, req *pb.OrganizationSe
 	// Create an organization with an associated inline CAS backend
 	org, err := s.orgUC.Create(ctx, req.Name, biz.WithCreateInlineBackend())
 	if err != nil {
-		return nil, handleUseCaseErr("organization", err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	if _, err := s.membershipUC.Create(ctx, org.ID, currentUser.ID, biz.WithMembershipRole(authz.RoleOwner)); err != nil {
-		return nil, handleUseCaseErr("organization", err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	return &pb.OrganizationServiceCreateResponse{Result: bizOrgToPb(org)}, nil
@@ -67,7 +67,7 @@ func (s *OrganizationService) Update(ctx context.Context, req *pb.OrganizationSe
 
 	org, err := s.orgUC.Update(ctx, currentUser.ID, req.Id, req.Name)
 	if err != nil {
-		return nil, handleUseCaseErr("organization", err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	return &pb.OrganizationServiceUpdateResponse{Result: bizOrgToPb(org)}, nil
@@ -81,7 +81,7 @@ func (s *OrganizationService) ListMemberships(ctx context.Context, _ *pb.Organiz
 
 	memberships, err := s.membershipUC.ByOrg(ctx, currentOrg.ID)
 	if err != nil {
-		return nil, handleUseCaseErr("organization", err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	result := make([]*pb.OrgMembershipItem, 0, len(memberships))
@@ -104,7 +104,7 @@ func (s *OrganizationService) DeleteMembership(ctx context.Context, req *pb.Orga
 	}
 
 	if err := s.membershipUC.DeleteOther(ctx, currentOrg.ID, currentUser.ID, req.MembershipId); err != nil {
-		return nil, handleUseCaseErr("organization", err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	return &pb.OrganizationServiceDeleteMembershipResponse{}, nil
@@ -123,7 +123,7 @@ func (s *OrganizationService) UpdateMembership(ctx context.Context, req *pb.Orga
 
 	m, err := s.membershipUC.UpdateRole(ctx, currentOrg.ID, currentUser.ID, req.MembershipId, pbRoleToBiz(req.Role))
 	if err != nil {
-		return nil, handleUseCaseErr("membership", err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	return &pb.OrganizationServiceUpdateMembershipResponse{Result: bizMembershipToPb(m)}, nil

--- a/app/controlplane/internal/service/orginvitation.go
+++ b/app/controlplane/internal/service/orginvitation.go
@@ -51,7 +51,7 @@ func (s *OrgInvitationService) Create(ctx context.Context, req *pb.OrgInvitation
 	// Validations and rbac checks are done in the biz layer
 	i, err := s.useCase.Create(ctx, org.ID, user.ID, req.ReceiverEmail, biz.WithInvitationRole(pbRoleToBiz(req.Role)))
 	if err != nil {
-		return nil, handleUseCaseErr("invitation", err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	return &pb.OrgInvitationServiceCreateResponse{Result: bizInvitationToPB(i)}, nil
@@ -64,7 +64,7 @@ func (s *OrgInvitationService) Revoke(ctx context.Context, req *pb.OrgInvitation
 	}
 
 	if err := s.useCase.Revoke(ctx, org.ID, req.Id); err != nil {
-		return nil, handleUseCaseErr("invitation", err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	return &pb.OrgInvitationServiceRevokeResponse{}, nil
@@ -78,7 +78,7 @@ func (s *OrgInvitationService) ListSent(ctx context.Context, _ *pb.OrgInvitation
 
 	invitations, err := s.useCase.ListByOrg(ctx, org.ID)
 	if err != nil {
-		return nil, handleUseCaseErr("invitation", err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	res := []*pb.OrgInvitationItem{}

--- a/app/controlplane/internal/service/orgmetric.go
+++ b/app/controlplane/internal/service/orgmetric.go
@@ -20,7 +20,6 @@ import (
 
 	pb "github.com/chainloop-dev/chainloop/app/controlplane/api/controlplane/v1"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz"
-	sl "github.com/chainloop-dev/chainloop/internal/servicelogger"
 )
 
 type OrgMetricsService struct {
@@ -47,17 +46,17 @@ func (s *OrgMetricsService) Totals(ctx context.Context, req *pb.OrgMetricsServic
 	// TODO: Merge it to a single request
 	totals, err := s.uc.RunsTotal(ctx, currentOrg.ID, *req.TimeWindow.ToDuration())
 	if err != nil {
-		return nil, sl.LogAndMaskErr(err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	totalsByStatus, err := s.uc.RunsTotalByStatus(ctx, currentOrg.ID, *req.TimeWindow.ToDuration())
 	if err != nil {
-		return nil, sl.LogAndMaskErr(err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	totalsByRunnerType, err := s.uc.RunsTotalByRunnerType(ctx, currentOrg.ID, *req.TimeWindow.ToDuration())
 	if err != nil {
-		return nil, sl.LogAndMaskErr(err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	return &pb.OrgMetricsServiceTotalsResponse{Result: &pb.OrgMetricsServiceTotalsResponse_Result{
@@ -75,7 +74,7 @@ func (s *OrgMetricsService) TopWorkflowsByRunsCount(ctx context.Context, req *pb
 
 	res, err := s.uc.TopWorkflowsByRunsCount(ctx, currentOrg.ID, int(req.GetNumWorkflows()), *req.TimeWindow.ToDuration())
 	if err != nil {
-		return nil, sl.LogAndMaskErr(err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	var result = []*pb.TopWorkflowsByRunsCountResponse_TotalByStatus{}
@@ -97,7 +96,7 @@ func (s *OrgMetricsService) DailyRunsCount(ctx context.Context, req *pb.DailyRun
 
 	metricsByDay, err := s.uc.DailyRunsCount(ctx, org.ID, req.WorkflowId, *req.TimeWindow.ToDuration())
 	if err != nil {
-		return nil, handleUseCaseErr("metrics", err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	var res = make([]*pb.DailyRunsCountResponse_TotalByDay, 0, len(metricsByDay))

--- a/app/controlplane/internal/service/referrer.go
+++ b/app/controlplane/internal/service/referrer.go
@@ -65,7 +65,7 @@ func (s *ReferrerService) DiscoverPrivate(ctx context.Context, req *pb.ReferrerS
 		referrer, err = s.referrerUC.GetFromRoot(ctx, req.GetDigest(), req.GetKind(), []uuid.UUID{orgUUID})
 	}
 	if err != nil {
-		return nil, handleUseCaseErr("referrer discovery", err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	return &pb.ReferrerServiceDiscoverPrivateResponse{
@@ -76,7 +76,7 @@ func (s *ReferrerService) DiscoverPrivate(ctx context.Context, req *pb.ReferrerS
 func (s *ReferrerService) DiscoverPublicShared(ctx context.Context, req *pb.DiscoverPublicSharedRequest) (*pb.DiscoverPublicSharedResponse, error) {
 	res, err := s.referrerUC.GetFromRootInPublicSharedIndex(ctx, req.GetDigest(), req.GetKind())
 	if err != nil {
-		return nil, handleUseCaseErr("referrer discovery", err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	return &pb.DiscoverPublicSharedResponse{

--- a/app/controlplane/internal/service/robotaccount.go
+++ b/app/controlplane/internal/service/robotaccount.go
@@ -20,7 +20,6 @@ import (
 
 	pb "github.com/chainloop-dev/chainloop/app/controlplane/api/controlplane/v1"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz"
-	sl "github.com/chainloop-dev/chainloop/internal/servicelogger"
 	"github.com/go-kratos/kratos/v2/errors"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -49,7 +48,7 @@ func (s *RobotAccountService) Create(ctx context.Context, req *pb.RobotAccountSe
 	if err != nil && biz.IsNotFound(err) {
 		return nil, errors.NotFound("not found", err.Error())
 	} else if err != nil {
-		return nil, sl.LogAndMaskErr(err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	return &pb.RobotAccountServiceCreateResponse{
@@ -69,7 +68,7 @@ func (s *RobotAccountService) List(ctx context.Context, req *pb.RobotAccountServ
 	if err != nil && biz.IsNotFound(err) {
 		return nil, errors.NotFound("not found", err.Error())
 	} else if err != nil {
-		return nil, sl.LogAndMaskErr(err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	result := make([]*pb.RobotAccountServiceListResponse_RobotAccountItem, 0, len(robotAccounts))
@@ -97,7 +96,7 @@ func (s *RobotAccountService) Revoke(ctx context.Context, req *pb.RobotAccountSe
 	}
 
 	if err := s.robotAccountUseCase.Revoke(ctx, currentOrg.ID, req.Id); err != nil {
-		return nil, sl.LogAndMaskErr(err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	return &pb.RobotAccountServiceRevokeResponse{}, nil

--- a/app/controlplane/internal/service/user.go
+++ b/app/controlplane/internal/service/user.go
@@ -23,7 +23,6 @@ import (
 	pb "github.com/chainloop-dev/chainloop/app/controlplane/api/controlplane/v1"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/authz"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/biz"
-	sl "github.com/chainloop-dev/chainloop/internal/servicelogger"
 	errors "github.com/go-kratos/kratos/v2/errors"
 )
 
@@ -53,7 +52,7 @@ func (s *UserService) ListMemberships(ctx context.Context, _ *pb.UserServiceList
 	if err != nil && biz.IsNotFound(err) {
 		return nil, errors.NotFound("not found", err.Error())
 	} else if err != nil {
-		return nil, sl.LogAndMaskErr(err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	result := make([]*pb.OrgMembershipItem, 0, len(memberships))
@@ -74,7 +73,7 @@ func (s *UserService) SetCurrentMembership(ctx context.Context, req *pb.SetCurre
 	if err != nil && biz.IsNotFound(err) {
 		return nil, errors.NotFound("not found", err.Error())
 	} else if err != nil {
-		return nil, sl.LogAndMaskErr(err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	return &pb.SetCurrentMembershipResponse{Result: bizMembershipToPb(m)}, nil
@@ -90,7 +89,7 @@ func (s *UserService) DeleteMembership(ctx context.Context, req *pb.DeleteMember
 	if err != nil && biz.IsNotFound(err) {
 		return nil, errors.NotFound("not found", err.Error())
 	} else if err != nil {
-		return nil, sl.LogAndMaskErr(err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	return &pb.DeleteMembershipResponse{}, nil

--- a/app/controlplane/internal/service/workflow.go
+++ b/app/controlplane/internal/service/workflow.go
@@ -55,7 +55,7 @@ func (s *WorkflowService) Create(ctx context.Context, req *pb.WorkflowServiceCre
 
 	p, err := s.useCase.Create(ctx, createOpts)
 	if err != nil {
-		return nil, handleUseCaseErr("workflow", err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	workflow := bizWorkflowToPb(p)
@@ -82,7 +82,7 @@ func (s *WorkflowService) Update(ctx context.Context, req *pb.WorkflowServiceUpd
 
 	p, err := s.useCase.Update(ctx, currentOrg.ID, req.Id, updateOpts)
 	if err != nil {
-		return nil, handleUseCaseErr("workflow", err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	workflow := bizWorkflowToPb(p)
@@ -101,7 +101,7 @@ func (s *WorkflowService) List(ctx context.Context, _ *pb.WorkflowServiceListReq
 
 	workflows, err := s.useCase.List(ctx, currentOrg.ID)
 	if err != nil {
-		return nil, handleUseCaseErr("workflow", err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	result := make([]*pb.WorkflowItem, 0, len(workflows))
@@ -119,7 +119,7 @@ func (s *WorkflowService) Delete(ctx context.Context, req *pb.WorkflowServiceDel
 	}
 
 	if err := s.useCase.Delete(ctx, currentOrg.ID, req.Id); err != nil {
-		return nil, handleUseCaseErr("workflow", err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	return &pb.WorkflowServiceDeleteResponse{}, nil
@@ -133,7 +133,7 @@ func (s *WorkflowService) View(ctx context.Context, req *pb.WorkflowServiceViewR
 
 	wf, err := s.useCase.FindByIDInOrg(ctx, currentOrg.ID, req.Id)
 	if err != nil {
-		return nil, handleUseCaseErr("workflow", err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	return &pb.WorkflowServiceViewResponse{Result: bizWorkflowToPb(wf)}, nil

--- a/app/controlplane/internal/service/workflowcontract.go
+++ b/app/controlplane/internal/service/workflowcontract.go
@@ -46,7 +46,7 @@ func (s *WorkflowContractService) List(ctx context.Context, _ *pb.WorkflowContra
 
 	contracts, err := s.contractUseCase.List(ctx, currentOrg.ID)
 	if err != nil {
-		return nil, handleUseCaseErr("contract", err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	result := make([]*pb.WorkflowContractItem, 0, len(contracts))
@@ -65,7 +65,7 @@ func (s *WorkflowContractService) Describe(ctx context.Context, req *pb.Workflow
 
 	contractWithVersion, err := s.contractUseCase.Describe(ctx, currentOrg.ID, req.GetId(), int(req.GetRevision()))
 	if err != nil {
-		return nil, handleUseCaseErr("contract", err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	} else if contractWithVersion == nil {
 		return nil, errors.NotFound("not found", "contract not found")
 	}
@@ -90,7 +90,7 @@ func (s *WorkflowContractService) Create(ctx context.Context, req *pb.WorkflowCo
 		Name:  req.Name, Description: req.Description,
 		Schema: req.GetV1()})
 	if err != nil {
-		return nil, handleUseCaseErr("contract", err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	return &pb.WorkflowContractServiceCreateResponse{Result: bizWorkFlowContractToPb(schema)}, nil
@@ -109,7 +109,7 @@ func (s *WorkflowContractService) Update(ctx context.Context, req *pb.WorkflowCo
 			Description: req.Description,
 		})
 	if err != nil {
-		return nil, handleUseCaseErr("contract", err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	result := &pb.WorkflowContractServiceUpdateResponse_Result{
@@ -127,7 +127,7 @@ func (s *WorkflowContractService) Delete(ctx context.Context, req *pb.WorkflowCo
 	}
 
 	if err := s.contractUseCase.Delete(ctx, currentOrg.ID, req.Id); err != nil {
-		return nil, handleUseCaseErr("contract", err, s.log)
+		return nil, handleUseCaseErr(err, s.log)
 	}
 
 	return &pb.WorkflowContractServiceDeleteResponse{}, nil


### PR DESCRIPTION
Gracefully handle context.Canceled error. This patch also makes sure all the error in the API are properly handled. NOTE: this will be moved to a middleware later on.

Closes #627