### PR TITLE
fix(controlplane): handle not-found contract on update

### DIFF
--- a/app/controlplane/internal/data/workflowcontract.go
+++ b/app/controlplane/internal/data/workflowcontract.go
@@ -167,6 +167,10 @@ func (r *WorkflowContractRepo) Update(ctx context.Context, opts *biz.ContractUpd
 
 	contract, err := contractInOrgTx(ctx, tx, opts.OrgID, opts.ContractID)
 	if err != nil {
+		if ent.IsNotFound(err) {
+			return nil, nil
+		}
+
 		return nil, rollback(tx, err)
 	}
 


### PR DESCRIPTION
Properly return 404 errors when you try to update a contract that doesn't exist. 

This is done by the service/biz layer that will check if the data layer returned any contract object. The previous code didn't do it, that's fixed now.