### PR TITLE
feat(controlplane): always store the digest of the attestation

### DIFF
--- a/app/controlplane/internal/biz/casmapping_integration_test.go
+++ b/app/controlplane/internal/biz/casmapping_integration_test.go
@@ -32,7 +32,8 @@ import (
 )
 
 const (
-	validDigest       = "sha256:3b0f04c276be095e62f3ac03b9991913c37df1fcd44548e75069adce313aba4d"
+	// This is the digest of the empty envelope
+	validDigest       = "sha256:f845058d865c3d4d491c9019f6afe9c543ad2cd11b31620cc512e341fb03d3d8"
 	validDigest2      = "sha256:2b0f04c276be095e62f3ac03b9991913c37df1fcd44548e75069adce313aba4d"
 	validDigest3      = "sha256:1b0f04c276be095e62f3ac03b9991913c37df1fcd44548e75069adce313aba4d"
 	validDigestPublic = "sha256:8b0f04c276be095e62f3ac03b9991913c37df1fcd44548e75069adce313aba4d"

--- a/app/controlplane/internal/biz/workflowrun_integration_test.go
+++ b/app/controlplane/internal/biz/workflowrun_integration_test.go
@@ -208,13 +208,13 @@ func (s *workflowRunIntegrationTestSuite) TestGetByDigestInOrgOrPublic() {
 		{
 			name:           "can't access workflowRun from other org",
 			orgID:          s.org.ID,
-			digest:         validDigest2,
+			digest:         s.digestAttOrg2,
 			errTypeChecker: biz.IsNotFound,
 		},
 		{
 			name:   "can access workflowRun from other org if public",
 			orgID:  s.org.ID,
-			digest: validDigest3,
+			digest: s.digestAttPublic,
 		},
 	}
 
@@ -306,7 +306,7 @@ type workflowRunTestData struct {
 	runOrg1, runOrg2, runOrg2Public                *biz.WorkflowRun
 	robotAccount                                   *biz.RobotAccount
 	contractVersion                                *biz.WorkflowContractWithVersion
-	digestAtt1                                     string
+	digestAtt1, digestAttOrg2, digestAttPublic     string
 }
 
 // extract this setup to a helper function so it can be used from other test suites
@@ -355,7 +355,7 @@ func setupWorkflowRunTestData(t *testing.T, suite *testhelpers.TestingUseCases, 
 			WorkflowID: s.workflowOrg2.ID.String(), RobotaccountID: s.robotAccount.ID.String(), ContractRevision: s.contractVersion, CASBackendID: s.casBackend.ID,
 		})
 	assert.NoError(err)
-	_, err = suite.WorkflowRun.SaveAttestation(ctx, s.runOrg2.ID.String(), &dsse.Envelope{PayloadType: "test2"})
+	s.digestAttOrg2, err = suite.WorkflowRun.SaveAttestation(ctx, s.runOrg2.ID.String(), &dsse.Envelope{PayloadType: "test2"})
 	assert.NoError(err)
 
 	s.runOrg2Public, err = suite.WorkflowRun.Create(ctx,
@@ -363,7 +363,7 @@ func setupWorkflowRunTestData(t *testing.T, suite *testhelpers.TestingUseCases, 
 			WorkflowID: s.workflowPublicOrg2.ID.String(), RobotaccountID: s.robotAccount.ID.String(), ContractRevision: s.contractVersion, CASBackendID: s.casBackend.ID,
 		})
 	assert.NoError(err)
-	_, err = suite.WorkflowRun.SaveAttestation(ctx, s.runOrg2Public.ID.String(), &dsse.Envelope{PayloadType: "test3"})
+	s.digestAttPublic, err = suite.WorkflowRun.SaveAttestation(ctx, s.runOrg2Public.ID.String(), &dsse.Envelope{PayloadType: "test3"})
 	assert.NoError(err)
 }
 

--- a/app/controlplane/internal/biz/workflowrun_integration_test.go
+++ b/app/controlplane/internal/biz/workflowrun_integration_test.go
@@ -203,7 +203,7 @@ func (s *workflowRunIntegrationTestSuite) TestGetByDigestInOrgOrPublic() {
 		{
 			name:   "existing workflowRun in org1",
 			orgID:  s.org.ID,
-			digest: validDigest,
+			digest: s.digestAtt1,
 		},
 		{
 			name:           "can't access workflowRun from other org",
@@ -306,6 +306,7 @@ type workflowRunTestData struct {
 	runOrg1, runOrg2, runOrg2Public                *biz.WorkflowRun
 	robotAccount                                   *biz.RobotAccount
 	contractVersion                                *biz.WorkflowContractWithVersion
+	digestAtt1                                     string
 }
 
 // extract this setup to a helper function so it can be used from other test suites
@@ -345,7 +346,8 @@ func setupWorkflowRunTestData(t *testing.T, suite *testhelpers.TestingUseCases, 
 			WorkflowID: s.workflowOrg1.ID.String(), RobotaccountID: s.robotAccount.ID.String(), ContractRevision: s.contractVersion, CASBackendID: s.casBackend.ID,
 		})
 	assert.NoError(err)
-	_, err = suite.WorkflowRun.SaveAttestation(ctx, s.runOrg1.ID.String(), &dsse.Envelope{})
+	s.digestAtt1, err = suite.WorkflowRun.SaveAttestation(ctx, s.runOrg1.ID.String(), &dsse.Envelope{PayloadType: "test"})
+
 	assert.NoError(err)
 
 	s.runOrg2, err = suite.WorkflowRun.Create(ctx,
@@ -353,7 +355,7 @@ func setupWorkflowRunTestData(t *testing.T, suite *testhelpers.TestingUseCases, 
 			WorkflowID: s.workflowOrg2.ID.String(), RobotaccountID: s.robotAccount.ID.String(), ContractRevision: s.contractVersion, CASBackendID: s.casBackend.ID,
 		})
 	assert.NoError(err)
-	_, err = suite.WorkflowRun.SaveAttestation(ctx, s.runOrg2.ID.String(), &dsse.Envelope{})
+	_, err = suite.WorkflowRun.SaveAttestation(ctx, s.runOrg2.ID.String(), &dsse.Envelope{PayloadType: "test2"})
 	assert.NoError(err)
 
 	s.runOrg2Public, err = suite.WorkflowRun.Create(ctx,
@@ -361,7 +363,7 @@ func setupWorkflowRunTestData(t *testing.T, suite *testhelpers.TestingUseCases, 
 			WorkflowID: s.workflowPublicOrg2.ID.String(), RobotaccountID: s.robotAccount.ID.String(), ContractRevision: s.contractVersion, CASBackendID: s.casBackend.ID,
 		})
 	assert.NoError(err)
-	_, err = suite.WorkflowRun.SaveAttestation(ctx, s.runOrg2Public.ID.String(), &dsse.Envelope{})
+	_, err = suite.WorkflowRun.SaveAttestation(ctx, s.runOrg2Public.ID.String(), &dsse.Envelope{PayloadType: "test3"})
 	assert.NoError(err)
 }
 


### PR DESCRIPTION
This patch makes sure that the digest of the attestation is always present. Before, only for the attestations that were stored in the CAS that was the case.