### PR TITLE
chore(ci): bump cosign version on release process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
       packages: write # to push container images
       pull-requests: write
     env:
-      CHAINLOOP_VERSION: 0.66.0
+      CHAINLOOP_VERSION: 0.80.1
       CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT }}
       CONTAINER_IMAGE_CP: ghcr.io/chainloop-dev/chainloop/control-plane:${{ github.ref_name }}
       CONTAINER_IMAGE_CAS: ghcr.io/chainloop-dev/chainloop/artifact-cas:${{ github.ref_name }}
@@ -31,7 +31,7 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@ef6a6b364bbad08abd36a5f8af60b595d12702f8 # main
         with:
-          cosign-release: "v2.0.2"
+          cosign-release: "v2.2.3"
 
       - name: Install Chainloop
         run: |


### PR DESCRIPTION
cosign <2.2.0 [stopped working](https://twitter.com/projectsigstore/status/1769392922707788070) requiring a version bump 