### PR TITLE
docs: document API tokens

### DIFF
--- a/docs/docs/reference/operator/api-tokens.mdx
+++ b/docs/docs/reference/operator/api-tokens.mdx
@@ -1,0 +1,46 @@
+---
+title: Controlplane API Tokens
+---
+
+The Chainloop CLI is used to interact with the Chainloop Control Plane supports two authentication methods.
+
+### User Authentication
+
+- Meant for interactive use
+- Associated with an user account
+- Valid for 24 hours
+
+They can be obtained by running the `chainloop auth login` command.
+
+### API tokens
+
+Alternatively, you can create Service Accounts (API Tokens) that
+
+- Are meant for non-interactive use, i.e automation
+- Are associated with a organization
+- Have a customizable expiry time that can be manually revoked
+- supports ACL for fine-grained access control (SOON)
+
+You can operate on your organization API tokens using the `chainloop organization api-token` command.
+
+```sh
+$ chainloop organization api-token -h
+Manage API tokens to authenticate with the Chainloop API.
+
+Usage:
+  chainloop organization api-token [command]
+
+Aliases:
+  api-token, token
+
+Available Commands:
+  create      Create an API token
+  list        List API tokens in this organization
+  revoke      revoke API token
+```
+
+and then they can be used by the CLI by either setting `CHAINLOOP_API_TOKEN` environment variable or by using the `--token` flag, for example
+
+```
+chainloop workflow list --token <your-token>
+```


### PR DESCRIPTION
Document API tokens in the operator reference section 

![image](https://github.com/chainloop-dev/chainloop/assets/24523/6c89ddd0-c09c-4355-ab0b-360a531046ea)
