### PR TITLE
fix(makefile): fixes atlas installation by using its own install script

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -5,7 +5,9 @@ VERSION=$(shell git describe --tags --always)
 init: init-api-tools
 	go install github.com/google/wire/cmd/wire@latest
 	go install github.com/vektra/mockery/v2@v2.20.0
-	go install ariga.io/atlas/cmd/atlas@v0.12.0
+	# using binary release for atlas, since ent schema handler is not included
+	# in the community version anymore https://github.com/ariga/atlas/issues/2388#issuecomment-1864287189
+	curl -sSf https://atlasgo.sh | sh -s -- -y
 
 # initialize API tooling
 .PHONY: init-api-tools


### PR DESCRIPTION
While working in #687, we noticed that atlas releases have been changed recently, forcing users to download them from their release server. `go install` doesn't work anymore, since it won't include some code that it's indeed included in the binary release, for example, the `ent://` schema handler. 

More information can be found in this issue https://github.com/ariga/atlas/issues/2388, explaining why `atlas` binary cannot be built from source anymore.

Also note that this install script performs a `sudo` command to install `atlas` in `/usr/local/bin`. I haven't found a workaround for it, so from now on, running `make init` will require escalating privileges to copy the files.

fixes #687 