### PR TITLE
feat(docs): Update documentation to reflect the HELM_CHART material type

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Chainloop supports the collection of the following pieces of evidence types:
 - [OpenVEX](https://github.com/openvex)
 - [SARIF](https://docs.oasis-open.org/sarif/sarif/v2.1.0/)
 - [JUnit](https://www.ibm.com/docs/en/developer-for-zos/14.1?topic=formats-junit-xml-format)
+- [Helm Chart](https://helm.sh/docs/topics/charts/)
 - Generic Artifact Types
 - Key-Value metadata pairs
 

--- a/docs/docs/reference/operator/contract.mdx
+++ b/docs/docs/reference/operator/contract.mdx
@@ -55,6 +55,7 @@ Chainloop supports the collection of the following pieces of evidence types:
 - [OpenVEX](https://github.com/openvex)
 - [SARIF](https://docs.oasis-open.org/sarif/sarif/v2.1.0/)
 - [JUnit](https://www.ibm.com/docs/en/developer-for-zos/14.1?topic=formats-junit-xml-format)
+- [Helm Chart](https://helm.sh/docs/topics/charts/)
 - Generic Artifact Types
 - Key-Value metadata pairs
 


### PR DESCRIPTION
This PR updates the documentation so it states Chainloop now supports HELM_CHART file type as new material.

Refers to #684 