### PR TITLE
feat(docs): Update contracts' examples to include HELM_CHART material

### DIFF
--- a/docs/examples/contracts/helm-chart/contract.yaml
+++ b/docs/examples/contracts/helm-chart/contract.yaml
@@ -1,0 +1,4 @@
+schemaVersion: v1
+materials:
+  - type: HELM_CHART
+    name: helm-chart


### PR DESCRIPTION
This PR adds a new example under the `examples` section named `helm-chart` that highlights an example on how to include the new `HELM_CHART` attestation material on an brand new or existing contract.
