### PR TITLE
feat(ci): Attest Chainloop Helm Chart on every release

### DIFF
--- a/.github/workflows/package_chart.yaml
+++ b/.github/workflows/package_chart.yaml
@@ -67,6 +67,7 @@ jobs:
         if: ${{ failure() }}
         run: |
           chainloop attestation reset
+
       - name: Mark attestation as cancelled
         if: ${{ cancelled() }}
         run: |

--- a/.github/workflows/package_chart.yaml
+++ b/.github/workflows/package_chart.yaml
@@ -17,7 +17,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
+    env:
+      CHAINLOOP_VERSION: 0.83.0 # Min version that includes HELM_CHART material type
+      CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT_CHART_PACKAGE }}
     steps:
+      - name: Install Chainloop
+        run: |
+          curl -sfL https://raw.githubusercontent.com/chainloop-dev/chainloop/01ad13af08950b7bfbc83569bea207aeb4e1a285/docs/static/install.sh | bash -s -- --version v${{ env.CHAINLOOP_VERSION }}
+
       - name: Docker login to Github Packages
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
         with:
@@ -30,11 +37,37 @@ jobs:
 
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
+      - name: Initialize Attestation
+        run: |
+          chainloop attestation init
+
       - name: Package Chart
         run: helm package deployment/chainloop/
+
+      - name: Add Attestation (Helm Chart)
+        run: |
+          chainloop attestation add --name helm-chart --value chainloop*.tgz
 
       - name: Push Chart
         run: |
           for pkg in chainloop*.tgz; do
             helm push ${pkg} oci://ghcr.io/chainloop-dev/charts
           done
+
+      - name: Finish and Record Attestation
+        if: ${{ success() }}
+        run: |
+          chainloop attestation status --full
+          chainloop attestation push --key env://CHAINLOOP_SIGNING_KEY
+        env:
+          CHAINLOOP_SIGNING_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+          CHAINLOOP_SIGNING_KEY: ${{ secrets.COSIGN_KEY }}
+
+      - name: Mark attestation as failed
+        if: ${{ failure() }}
+        run: |
+          chainloop attestation reset
+      - name: Mark attestation as cancelled
+        if: ${{ cancelled() }}
+        run: |
+          chainloop attestation reset --trigger cancellation


### PR DESCRIPTION
This PR allows to attest the generated Helm Chart of Chainloop as part of the package process of the Helm Chart.