### PR TITLE
feat(package): attest container images in helm package gh action

### DIFF
--- a/.github/workflows/package_chart.yaml
+++ b/.github/workflows/package_chart.yaml
@@ -35,9 +35,6 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
 
-      - name: Install yq
-        uses: frenck/action-setup-yq@v1
-
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Initialize Attestation

--- a/.github/workflows/package_chart.yaml
+++ b/.github/workflows/package_chart.yaml
@@ -35,6 +35,9 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
 
+      - name: Install yq
+        uses: frenck/action-setup-yq@v1
+
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Initialize Attestation
@@ -46,7 +49,16 @@ jobs:
 
       - name: Add Attestation (Helm Chart)
         run: |
+          export PACKAGED_VERSION=$(cat ./deployment/chainloop/Chart.yaml | yq .appVersion)
+          export CONTAINER_CP=$(cat deployment/chainloop/values.yaml | yq .controlplane.image.repository)
+          export CONTAINER_CAS=$(cat deployment/chainloop/values.yaml | yq .cas.image.repository)
+
+          # Attest Chart
           chainloop attestation add --name helm-chart --value chainloop*.tgz
+          # Attest Control plane image
+          chainloop attestation add --name control-plane-image --value "${CONTAINER_CP}:${PACKAGED_VERSION}"
+          # Attest CAS image
+          chainloop attestation add --name artifact-cas-image --value "${CONTAINER_CAS}:${PACKAGED_VERSION}"
 
       - name: Push Chart
         run: |


### PR DESCRIPTION
This PR adds the container images present in the chart tor the Chainloop attestation, during the package phase. This way, Chainloop will add the proper references to the Release phase in the Trust Hub, providing a full end to end view of the release->package->deployment proocess.

Package contract has been updated accordingly.