### PR TITLE
feat(docs-deploy): Bump version of chainloop action to perform checkout before init

### DIFF
--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -11,11 +11,11 @@ concurrency: "deploy-to-prod"
 jobs:
   chainloop_init:
     name: Chainloop Init
-    uses: chainloop-dev/labs/.github/workflows/chainloop_init.yml@7f4de29435dc009326587051f507d2cd8c77d28b
+    uses: chainloop-dev/labs/.github/workflows/chainloop_init.yml@d0298b552d20d018e4ec39a28661d225bab40057
     secrets:
       api_token: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT_DOCS_RELEASE }}
     with:
-      chainloop_labs_branch: 7f4de29435dc009326587051f507d2cd8c77d28b
+      chainloop_labs_branch: d0298b552d20d018e4ec39a28661d225bab40057
 
   deploy_docs:
     name: Deploy Documentation
@@ -80,7 +80,7 @@ jobs:
 
   chainloop_push:
     name: Chainloop Push
-    uses: chainloop-dev/labs/.github/workflows/chainloop_push.yml@7f4de29435dc009326587051f507d2cd8c77d28b
+    uses: chainloop-dev/labs/.github/workflows/chainloop_push.yml@d0298b552d20d018e4ec39a28661d225bab40057
     needs:
       - deploy_docs
     secrets:
@@ -89,4 +89,4 @@ jobs:
       signing_key_password: ${{ secrets.COSIGN_PASSWORD }}
     with:
       attestation_name: "docs"
-      chainloop_labs_branch: 7f4de29435dc009326587051f507d2cd8c77d28b
+      chainloop_labs_branch: d0298b552d20d018e4ec39a28661d225bab40057


### PR DESCRIPTION
This PR leverages the changes introduced in https://github.com/chainloop-dev/labs/pull/6 so all needed git repository information is being retrieved before the attestation init is being done.

Closes #705 