### PR TITLE
feat(ci): Adds chainloop to scorecards pipeline

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -28,12 +28,23 @@ jobs:
       id-token: write
       contents: read
       actions: read
+    env:
+      CHAINLOOP_VERSION: 0.83.0
+      CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT_SCORECARDS }}
 
     steps:
+      - name: Install Chainloop
+        run: |
+          curl -sfL https://raw.githubusercontent.com/chainloop-dev/chainloop/01ad13af08950b7bfbc83569bea207aeb4e1a285/docs/static/install.sh | bash -s -- --version v${{ env.CHAINLOOP_VERSION }}
+
       - name: "Checkout code"
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           persist-credentials: false
+
+      - name: Initialize Attestation
+        run: |
+          chainloop attestation init
 
       - name: "Run analysis"
         uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
@@ -55,6 +66,10 @@ jobs:
           #     of the value entered here.
           publish_results: true
 
+      - name: Add Attestation (Sarif results)
+        run: |
+          chainloop attestation add --name sarif-results --value results.sarif
+
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
@@ -69,3 +84,22 @@ jobs:
         uses: github/codeql-action/upload-sarif@6a28655e3dcb49cb0840ea372fd6d17733edd8a4 # v2.21.8
         with:
           sarif_file: results.sarif
+
+      - name: Finish and Record Attestation
+        if: ${{ success() }}
+        run: |
+          chainloop attestation status --full
+          chainloop attestation push --key env://CHAINLOOP_SIGNING_KEY
+        env:
+          CHAINLOOP_SIGNING_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+          CHAINLOOP_SIGNING_KEY: ${{ secrets.COSIGN_KEY }}
+
+      - name: Mark attestation as failed
+        if: ${{ failure() }}
+        run: |
+          chainloop attestation reset
+
+      - name: Mark attestation as cancelled
+        if: ${{ cancelled() }}
+        run: |
+          chainloop attestation reset --trigger cancellation


### PR DESCRIPTION
This PR adds chainloop CLI to scorecards workflows to attest SARIF results.

Closes #706 