### PR TITLE
fix(scorecards): Move env variable to individual steps

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -28,14 +28,14 @@ jobs:
       id-token: write
       contents: read
       actions: read
-    env:
-      CHAINLOOP_VERSION: 0.83.0
-      CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT_SCORECARDS }}
 
     steps:
       - name: Install Chainloop
         run: |
           curl -sfL https://raw.githubusercontent.com/chainloop-dev/chainloop/01ad13af08950b7bfbc83569bea207aeb4e1a285/docs/static/install.sh | bash -s -- --version v${{ env.CHAINLOOP_VERSION }}
+        env:
+          CHAINLOOP_VERSION: 0.83.0
+          CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT_SCORECARDS }}
 
       - name: "Checkout code"
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -45,6 +45,8 @@ jobs:
       - name: Initialize Attestation
         run: |
           chainloop attestation init
+        env:
+          CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT_SCORECARDS }}
 
       - name: "Run analysis"
         uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
@@ -69,6 +71,8 @@ jobs:
       - name: Add Attestation (Sarif results)
         run: |
           chainloop attestation add --name sarif-results --value results.sarif
+        env:
+          CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT_SCORECARDS }}
 
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
@@ -93,13 +97,18 @@ jobs:
         env:
           CHAINLOOP_SIGNING_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
           CHAINLOOP_SIGNING_KEY: ${{ secrets.COSIGN_KEY }}
+          CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT_SCORECARDS }}
 
       - name: Mark attestation as failed
         if: ${{ failure() }}
         run: |
           chainloop attestation reset
+        env:
+          CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT_SCORECARDS }}
 
       - name: Mark attestation as cancelled
         if: ${{ cancelled() }}
         run: |
           chainloop attestation reset --trigger cancellation
+        env:
+          CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT_SCORECARDS }}


### PR DESCRIPTION
Scorecard action is complaining about top level env vars in a production workflow, aka: a workflow running on the default branch on the repository.

```bash
2024/04/26 11:42:48 error sending scorecard results to webapp: http response 400, status: 400 Bad Request, error: {"code":400,"message":"workflow verification failed: scorecard job contains env vars, see https://github.com/ossf/scorecard-action#workflow-restrictions for details."}
2024/04/26 11:42:48 retrying in 1s...
2024/04/26 11:42:50 error sending scorecard results to webapp: http response 400, status: 400 Bad Request, error: {"code":400,"message":"workflow verification failed: scorecard job contains env vars, see https://github.com/ossf/scorecard-action#workflow-restrictions for details."}
2024/04/26 11:42:50 retrying in 3s...
2024/04/26 11:42:53 error sending scorecard results to webapp: http response 400, status: 400 Bad Request, error: {"code":400,"message":"workflow verification failed: scorecard job contains env vars, see https://github.com/ossf/scorecard-action#workflow-restrictions for details."}
2024/04/26 11:42:53 retrying in 10s...
2024/04/26 11:43:03 error processing signature: error sending scorecard results to webapp: http response 400, status: 400 Bad Request, error: {"code":400,"message":"workflow verification failed: scorecard job contains env vars, see https://github.com/ossf/scorecard-action#workflow-restrictions for details."}
```

To overrun this, let's move the env to the steps that needs them, removing the top level dependency.

Refers to #706 