### PR TITLE
fix(ci): Use chainloop action on scorecard pipeline

### DIFF
--- a/.chainloop.yml
+++ b/.chainloop.yml
@@ -7,3 +7,7 @@ docs:
     path: reports/sbom.spdx.json
   - name: built-site
     path: reports/build.tar.gz
+
+scorecards:
+  - name: sarif-results
+    path: metadata/results.sarif

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -4,16 +4,15 @@
 
 name: Scorecard supply-chain security
 on:
-  pull_request:
-#  # For Branch-Protection check. Only the default branch is supported. See
-#  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
-#  branch_protection_rule:
-#  # To guarantee Maintained check is occasionally updated. See
-#  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
-#  schedule:
-#    - cron: "20 7 * * 2"
-#  push:
-#    branches: ["main"]
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: "20 7 * * 2"
+  push:
+    branches: ["main"]
 
 # Declare default permissions as read only.
 permissions: read-all

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -4,23 +4,34 @@
 
 name: Scorecard supply-chain security
 on:
-  # For Branch-Protection check. Only the default branch is supported. See
-  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
-  branch_protection_rule:
-  # To guarantee Maintained check is occasionally updated. See
-  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
-  schedule:
-    - cron: "20 7 * * 2"
-  push:
-    branches: ["main"]
+  pull_request:
+#  # For Branch-Protection check. Only the default branch is supported. See
+#  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+#  branch_protection_rule:
+#  # To guarantee Maintained check is occasionally updated. See
+#  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+#  schedule:
+#    - cron: "20 7 * * 2"
+#  push:
+#    branches: ["main"]
 
 # Declare default permissions as read only.
 permissions: read-all
 
 jobs:
+  chainloop_init:
+    name: Chainloop Init
+    uses: chainloop-dev/labs/.github/workflows/chainloop_init.yml@54b18c97630a84a134c3fc93489d86c533d5a440
+    secrets:
+      api_token: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT_SCORECARDS }}
+    with:
+      chainloop_labs_branch: 54b18c97630a84a134c3fc93489d86c533d5a440
+
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    needs:
+      - chainloop_init
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
@@ -30,23 +41,10 @@ jobs:
       actions: read
 
     steps:
-      - name: Install Chainloop
-        run: |
-          curl -sfL https://raw.githubusercontent.com/chainloop-dev/chainloop/01ad13af08950b7bfbc83569bea207aeb4e1a285/docs/static/install.sh | bash -s -- --version v${{ env.CHAINLOOP_VERSION }}
-        env:
-          CHAINLOOP_VERSION: 0.83.0
-          CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT_SCORECARDS }}
-
       - name: "Checkout code"
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           persist-credentials: false
-
-      - name: Initialize Attestation
-        run: |
-          chainloop attestation init
-        env:
-          CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT_SCORECARDS }}
 
       - name: "Run analysis"
         uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
@@ -68,18 +66,14 @@ jobs:
           #     of the value entered here.
           publish_results: true
 
-      - name: Add Attestation (Sarif results)
-        run: |
-          chainloop attestation add --name sarif-results --value results.sarif
-        env:
-          CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT_SCORECARDS }}
-
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v3.1.3
         with:
-          name: SARIF file
+          # When downloading if not name is set the artifact name will be "artifact"
+          # We need to specify the name to download it later
+          name: metadata
           path: results.sarif
           retention-days: 5
 
@@ -89,26 +83,15 @@ jobs:
         with:
           sarif_file: results.sarif
 
-      - name: Finish and Record Attestation
-        if: ${{ success() }}
-        run: |
-          chainloop attestation status --full
-          chainloop attestation push --key env://CHAINLOOP_SIGNING_KEY
-        env:
-          CHAINLOOP_SIGNING_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
-          CHAINLOOP_SIGNING_KEY: ${{ secrets.COSIGN_KEY }}
-          CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT_SCORECARDS }}
-
-      - name: Mark attestation as failed
-        if: ${{ failure() }}
-        run: |
-          chainloop attestation reset
-        env:
-          CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT_SCORECARDS }}
-
-      - name: Mark attestation as cancelled
-        if: ${{ cancelled() }}
-        run: |
-          chainloop attestation reset --trigger cancellation
-        env:
-          CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT_SCORECARDS }}
+  chainloop_push:
+    name: Chainloop Push
+    uses: chainloop-dev/labs/.github/workflows/chainloop_push.yml@54b18c97630a84a134c3fc93489d86c533d5a440
+    needs:
+      - analysis
+    secrets:
+      api_token: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT_SCORECARDS }}
+      signing_key: ${{ secrets.COSIGN_KEY }}
+      signing_key_password: ${{ secrets.COSIGN_PASSWORD }}
+    with:
+      attestation_name: "scorecards"
+      chainloop_labs_branch: 54b18c97630a84a134c3fc93489d86c533d5a440


### PR DESCRIPTION
Leverages the use of chainloop action rather the manual steps so it complies with ossf/scorecard constraints.