### PR TITLE
feat(cli): Workflow run can receive a status flag

### DIFF
--- a/app/cli/cmd/workflow_workflow_run_list.go
+++ b/app/cli/cmd/workflow_workflow_run_list.go
@@ -30,7 +30,7 @@ func newWorkflowWorkflowRunListCmd() *cobra.Command {
 		DefaultLimit: 20,
 	}
 
-	var workflowID string
+	var workflowID, status string
 
 	cmd := &cobra.Command{
 		Use:     "list",
@@ -44,6 +44,7 @@ func newWorkflowWorkflowRunListCmd() *cobra.Command {
 						Limit:      paginationOpts.Limit,
 						NextCursor: paginationOpts.NextCursor,
 					},
+					Status: status,
 				},
 			)
 			if err != nil {
@@ -70,6 +71,7 @@ func newWorkflowWorkflowRunListCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&workflowID, "workflow", "", "workflow ID")
 	cmd.Flags().BoolVar(&full, "full", false, "full report")
+	cmd.Flags().StringVar(&status, "status", "", fmt.Sprintf("filter by workflow run status: %v", action.WorkflowRunStatus))
 	// Add pagination flags
 	paginationOpts.AddFlags(cmd)
 

--- a/app/cli/cmd/workflow_workflow_run_list.go
+++ b/app/cli/cmd/workflow_workflow_run_list.go
@@ -17,6 +17,7 @@ package cmd
 
 import (
 	"fmt"
+	"golang.org/x/exp/maps"
 	"time"
 
 	"github.com/chainloop-dev/chainloop/app/cli/cmd/options"
@@ -71,7 +72,7 @@ func newWorkflowWorkflowRunListCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&workflowID, "workflow", "", "workflow ID")
 	cmd.Flags().BoolVar(&full, "full", false, "full report")
-	cmd.Flags().StringVar(&status, "status", "", fmt.Sprintf("filter by workflow run status: %v", action.WorkflowRunStatus))
+	cmd.Flags().StringVar(&status, "status", "", fmt.Sprintf("filter by workflow run status: %v", maps.Keys(action.WorkflowRunStatus())))
 	// Add pagination flags
 	paginationOpts.AddFlags(cmd)
 

--- a/app/cli/cmd/workflow_workflow_run_list.go
+++ b/app/cli/cmd/workflow_workflow_run_list.go
@@ -23,7 +23,6 @@ import (
 	"github.com/chainloop-dev/chainloop/app/cli/internal/action"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
-	"golang.org/x/exp/maps"
 )
 
 func newWorkflowWorkflowRunListCmd() *cobra.Command {
@@ -72,7 +71,7 @@ func newWorkflowWorkflowRunListCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&workflowID, "workflow", "", "workflow ID")
 	cmd.Flags().BoolVar(&full, "full", false, "full report")
-	cmd.Flags().StringVar(&status, "status", "", fmt.Sprintf("filter by workflow run status: %v", maps.Keys(action.WorkflowRunStatus())))
+	cmd.Flags().StringVar(&status, "status", "", fmt.Sprintf("filter by workflow run status: %v", listAvailableWorkflowStatusFlag()))
 	// Add pagination flags
 	paginationOpts.AddFlags(cmd)
 
@@ -109,4 +108,15 @@ func workflowRunListTableOutput(runs []*action.WorkflowRunItem) error {
 	t.Render()
 
 	return nil
+}
+
+// listAvailableWorkflowStatusFlag returns a list of available workflow status flags
+func listAvailableWorkflowStatusFlag() []string {
+	m := action.WorkflowRunStatus()
+	r := make([]string, 0, len(m))
+	for k := range m {
+		r = append(r, k)
+	}
+
+	return r
 }

--- a/app/cli/cmd/workflow_workflow_run_list.go
+++ b/app/cli/cmd/workflow_workflow_run_list.go
@@ -17,13 +17,13 @@ package cmd
 
 import (
 	"fmt"
-	"golang.org/x/exp/maps"
 	"time"
 
 	"github.com/chainloop-dev/chainloop/app/cli/cmd/options"
 	"github.com/chainloop-dev/chainloop/app/cli/internal/action"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
+	"golang.org/x/exp/maps"
 )
 
 func newWorkflowWorkflowRunListCmd() *cobra.Command {

--- a/app/cli/internal/action/workflow_run_list_test.go
+++ b/app/cli/internal/action/workflow_run_list_test.go
@@ -128,9 +128,6 @@ func (s *workflowRunListSuite) TestTransformWorkflowRunStatus() {
 		s.T().Run(testCase.name, func(_ *testing.T) {
 			result := transformWorkflowRunStatus(testCase.testInput)
 			s.Equal(testCase.expectedOutput, result)
-			if result != testCase.expectedOutput {
-				s.Equal(testCase.expectedOutput, result)
-			}
 		})
 	}
 }

--- a/app/cli/internal/action/workflow_run_list_test.go
+++ b/app/cli/internal/action/workflow_run_list_test.go
@@ -18,6 +18,7 @@ package action
 import (
 	"testing"
 
+	pb "github.com/chainloop-dev/chainloop/app/controlplane/api/controlplane/v1"
 	v1 "github.com/chainloop-dev/chainloop/app/controlplane/api/workflowcontract/v1"
 	"github.com/stretchr/testify/suite"
 )
@@ -88,4 +89,47 @@ func (s *workflowRunListSuite) TestHumanizedRunnerType() {
 
 func TestWorkflowRunlist(t *testing.T) {
 	suite.Run(t, new(workflowRunListSuite))
+}
+
+func TestTransformWorkflowRunStatus(t *testing.T) {
+	testCases := []struct {
+		name           string
+		testInput      string
+		expectedOutput pb.RunStatus
+	}{
+		{
+			name:           "initialized status",
+			testInput:      "INITIALIZED",
+			expectedOutput: pb.RunStatus_RUN_STATUS_INITIALIZED,
+		}, {
+			name:           "succeeded status",
+			testInput:      "SUCCEEDED",
+			expectedOutput: pb.RunStatus_RUN_STATUS_SUCCEEDED,
+		}, {
+			name:           "failed status",
+			testInput:      "FAILED",
+			expectedOutput: pb.RunStatus_RUN_STATUS_FAILED,
+		}, {
+			name:           "expired status",
+			testInput:      "EXPIRED",
+			expectedOutput: pb.RunStatus_RUN_STATUS_EXPIRED,
+		}, {
+			name:           "cancelled status",
+			testInput:      "CANCELLED",
+			expectedOutput: pb.RunStatus_RUN_STATUS_CANCELLED,
+		}, {
+			name:           "unknown status",
+			testInput:      "UNKNOWN",
+			expectedOutput: pb.RunStatus_RUN_STATUS_UNSPECIFIED,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			result := transformWorkflowRunStatus(testCase.testInput)
+			if result != testCase.expectedOutput {
+				t.Errorf("Expected %v, got %v", testCase.expectedOutput, result)
+			}
+		})
+	}
 }

--- a/app/cli/internal/action/workflow_run_list_test.go
+++ b/app/cli/internal/action/workflow_run_list_test.go
@@ -18,7 +18,6 @@ package action
 import (
 	"testing"
 
-	pb "github.com/chainloop-dev/chainloop/app/controlplane/api/controlplane/v1"
 	v1 "github.com/chainloop-dev/chainloop/app/controlplane/api/workflowcontract/v1"
 	"github.com/stretchr/testify/suite"
 )
@@ -80,7 +79,7 @@ func (s *workflowRunListSuite) TestHumanizedRunnerType() {
 	)
 
 	for _, testCase := range testCases {
-		s.T().Run(testCase.name, func(_ *testing.T) {
+		s.Run(testCase.name, func() {
 			result := humanizedRunnerType(testCase.testInput)
 			s.Equal(testCase.expectedOutput, result)
 		})
@@ -89,45 +88,4 @@ func (s *workflowRunListSuite) TestHumanizedRunnerType() {
 
 func TestWorkflowRunlist(t *testing.T) {
 	suite.Run(t, new(workflowRunListSuite))
-}
-
-func (s *workflowRunListSuite) TestTransformWorkflowRunStatus() {
-	testCases := []struct {
-		name           string
-		testInput      string
-		expectedOutput pb.RunStatus
-	}{
-		{
-			name:           "initialized status",
-			testInput:      "INITIALIZED",
-			expectedOutput: pb.RunStatus_RUN_STATUS_INITIALIZED,
-		}, {
-			name:           "succeeded status",
-			testInput:      "SUCCEEDED",
-			expectedOutput: pb.RunStatus_RUN_STATUS_SUCCEEDED,
-		}, {
-			name:           "failed status",
-			testInput:      "FAILED",
-			expectedOutput: pb.RunStatus_RUN_STATUS_FAILED,
-		}, {
-			name:           "expired status",
-			testInput:      "EXPIRED",
-			expectedOutput: pb.RunStatus_RUN_STATUS_EXPIRED,
-		}, {
-			name:           "cancelled status",
-			testInput:      "CANCELLED",
-			expectedOutput: pb.RunStatus_RUN_STATUS_CANCELLED,
-		}, {
-			name:           "unknown status",
-			testInput:      "UNKNOWN",
-			expectedOutput: pb.RunStatus_RUN_STATUS_UNSPECIFIED,
-		},
-	}
-
-	for _, testCase := range testCases {
-		s.T().Run(testCase.name, func(_ *testing.T) {
-			result := transformWorkflowRunStatus(testCase.testInput)
-			s.Equal(testCase.expectedOutput, result)
-		})
-	}
 }

--- a/app/cli/internal/action/workflow_run_list_test.go
+++ b/app/cli/internal/action/workflow_run_list_test.go
@@ -80,7 +80,7 @@ func (s *workflowRunListSuite) TestHumanizedRunnerType() {
 	)
 
 	for _, testCase := range testCases {
-		s.T().Run(testCase.name, func(t *testing.T) {
+		s.T().Run(testCase.name, func(_ *testing.T) {
 			result := humanizedRunnerType(testCase.testInput)
 			s.Equal(testCase.expectedOutput, result)
 		})
@@ -91,7 +91,7 @@ func TestWorkflowRunlist(t *testing.T) {
 	suite.Run(t, new(workflowRunListSuite))
 }
 
-func TestTransformWorkflowRunStatus(t *testing.T) {
+func (s *workflowRunListSuite) TestTransformWorkflowRunStatus() {
 	testCases := []struct {
 		name           string
 		testInput      string
@@ -125,10 +125,11 @@ func TestTransformWorkflowRunStatus(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
+		s.T().Run(testCase.name, func(_ *testing.T) {
 			result := transformWorkflowRunStatus(testCase.testInput)
+			s.Equal(testCase.expectedOutput, result)
 			if result != testCase.expectedOutput {
-				t.Errorf("Expected %v, got %v", testCase.expectedOutput, result)
+				s.Equal(testCase.expectedOutput, result)
 			}
 		})
 	}


### PR DESCRIPTION
Added a status flag with the possible values that are verified on the `actions` package. Passing the flag works as expected:

Ref: #718 

```
$chainloop wf workflow-run ls --status FAILED
┌──────────────────────────────────────┬────────────────────────────────┬───────┬─────────────────────┬────────┐
│ ID                                   │ WORKFLOW                       │ STATE │ CREATED AT          │ RUNNER │
├──────────────────────────────────────┼────────────────────────────────┼───────┼─────────────────────┼────────┤
│ 56220bdc-5e28-4e92-b955-c8ffa25cca6f │ chainloop/chainloop-codeql     │ error │ 29 Apr 24 08:28 UTC │ GitHub │
│ d21220ae-907f-40af-99ac-0d88af1636e7 │ chainloop/chainloop-codeql     │ error │ 29 Apr 24 08:10 UTC │ GitHub │
│ ab3ea91e-f1b9-4a24-ba06-34c3cf8c6bf4 │ chainloop/chainloop-codeql     │ error │ 29 Apr 24 07:49 UTC │ GitHub │
│ 4414888d-0eb2-44cf-b960-38078d995d39 │ chainloop/chainloop-codeql     │ error │ 29 Apr 24 07:42 UTC │ GitHub │
│ ad00cd05-2593-44b7-a81b-eb066297c5dc │ chainloop/chainloop-codeql     │ error │ 29 Apr 24 07:36 UTC │ GitHub │
│ f09ff2ad-18a7-49e9-803a-7d4b91a39980 │ chainloop/chainloop-codeql     │ error │ 29 Apr 24 07:23 UTC │ GitHub │
│ aa6b895b-0e35-42c7-88be-aec8e7d50177 │ chainloop/chainloop-scorecards │ error │ 26 Apr 24 14:33 UTC │ GitHub │
│ e9227628-e892-4f69-a369-038175775bb1 │ chainloop/chainloop-scorecards │ error │ 26 Apr 24 14:30 UTC │ GitHub │
│ 6992087d-3224-4ca0-9056-8d8995f390f8 │ chainloop/chainloop-scorecards │ error │ 26 Apr 24 14:26 UTC │ GitHub │
│ 93d4bdf9-163f-4f25-9f98-5157386700f3 │ chainloop/chainloop-scorecards │ error │ 26 Apr 24 14:20 UTC │ GitHub │
│ 1411b1a3-41fc-4edb-80ea-c98076bba830 │ chainloop/chainloop-scorecards │ error │ 26 Apr 24 14:17 UTC │ GitHub │
│ 344ffb1d-62b6-454b-a0d8-b15cb10d06b8 │ chainloop/chainloop-scorecards │ error │ 26 Apr 24 14:14 UTC │ GitHub │
│ 8f05b1f1-c9ae-4597-9533-438328b54485 │ chainloop/chainloop-scorecards │ error │ 26 Apr 24 14:13 UTC │ GitHub │
│ 70b23075-493a-45f6-b8f2-6af7a474456c │ chainloop/chainloop-scorecards │ error │ 26 Apr 24 14:02 UTC │ GitHub │
│ e87ac523-cc3e-4a07-82f8-c499541ae04b │ chainloop/chainloop-scorecards │ error │ 26 Apr 24 13:59 UTC │ GitHub │
│ bd66e30b-328b-48d5-b1a9-5f6e1c674a63 │ chainloop/chainloop-scorecards │ error │ 26 Apr 24 13:49 UTC │ GitHub │
│ 86db597a-1bfc-419e-8713-0c26d42917c9 │ chainloop/chainloop-scorecards │ error │ 26 Apr 24 13:33 UTC │ GitHub │
│ e5c4a599-f82e-4e39-9cbc-e29bbde6272c │ chainloop/chainloop-scorecards │ error │ 26 Apr 24 12:22 UTC │ GitHub │
│ 04e1fb16-471b-4fff-98c0-bf3dadcf9b52 │ chainloop/chainloop-scorecards │ error │ 26 Apr 24 12:02 UTC │ GitHub │
│ 30851df8-ce8d-4c0f-9dad-8ca65c81a648 │ chainloop/chainloop-scorecards │ error │ 26 Apr 24 11:42 UTC │ GitHub │
└──────────────────────────────────────┴────────────────────────────────┴───────┴─────────────────────┴────────┘
Pagination options 

--next MjAyNC0wNC0yNlQxMTo0MjowMi4wNTE5OTJaLDMwODUxZGY4LWNlOGQtNGMwZi05ZGFkLThjYTY1YzgxYTY0OA==

Process finished with the exit code 0
```

Listing the possible values:
```
$chainloop wf workflow-run ls --help
List workflow runs

Usage:
  chainloop workflow workflow-run list [flags]

Aliases:
  list, ls

Flags:
      --full              full report
  -h, --help              help for list
      --limit int         number of items to show (default 20)
      --next string       cursor to load the next page
      --status string     filter by workflow run status: [FAILED EXPIRED CANCELLED INITIALIZED SUCCEEDED]
      --workflow string   workflow ID

Global Flags:
      --artifact-cas string    URL for the Artifacts Content Addressable Storage (CAS) (default "api.cas.chainloop.dev:443")
  -c, --config string          Path to an existing config file (default is $HOME/.config/chainloop/config.toml)
      --control-plane string   URL for the Control Plane API (default "api.cp.chainloop.dev:443")
      --debug                  Enable debug/verbose logging mode
  -i, --insecure               Skip TLS transport during connection to the control plane
  -o, --output string          Output format, valid options are json and table (default "table")
  -t, --token string           API token. NOTE: Alternatively use the env variable CHAINLOOP_API_TOKEN

Process finished with the exit code 0

```