### PR TITLE
feat(apitoken): Adds workflow run list policy to default apitoken policies

### DIFF
--- a/app/controlplane/internal/biz/apitoken.go
+++ b/app/controlplane/internal/biz/apitoken.go
@@ -73,7 +73,7 @@ func NewAPITokenUseCase(apiTokenRepo APITokenRepo, conf *conf.Auth, authzE *auth
 		enforcer:     authzE,
 		DefaultAuthzPolicies: []*authz.Policy{
 			// Add permissions to workflow run
-			authz.PolicyWorkflowRunList, authz.PolicyWorkflowRunRead,
+			authz.PolicyWorkflowRunList, authz.PolicyWorkflowRunmimissRead,
 			// Add permissions to workflow contract management
 			authz.PolicyWorkflowContractList, authz.PolicyWorkflowContractRead, authz.PolicyWorkflowContractUpdate,
 			// to download artifacts and list referrers

--- a/app/controlplane/internal/biz/apitoken.go
+++ b/app/controlplane/internal/biz/apitoken.go
@@ -72,6 +72,8 @@ func NewAPITokenUseCase(apiTokenRepo APITokenRepo, conf *conf.Auth, authzE *auth
 		logger:       servicelogger.ScopedHelper(logger, "biz/APITokenUseCase"),
 		enforcer:     authzE,
 		DefaultAuthzPolicies: []*authz.Policy{
+			// Add permissions to workflow run
+			authz.PolicyWorkflowRunList,
 			// Add permissions to workflow contract management
 			authz.PolicyWorkflowContractList, authz.PolicyWorkflowContractRead, authz.PolicyWorkflowContractUpdate,
 			// to download artifacts and list referrers

--- a/app/controlplane/internal/biz/apitoken.go
+++ b/app/controlplane/internal/biz/apitoken.go
@@ -73,7 +73,7 @@ func NewAPITokenUseCase(apiTokenRepo APITokenRepo, conf *conf.Auth, authzE *auth
 		enforcer:     authzE,
 		DefaultAuthzPolicies: []*authz.Policy{
 			// Add permissions to workflow run
-			authz.PolicyWorkflowRunList,
+			authz.PolicyWorkflowRunList, authz.PolicyWorkflowRunRead,
 			// Add permissions to workflow contract management
 			authz.PolicyWorkflowContractList, authz.PolicyWorkflowContractRead, authz.PolicyWorkflowContractUpdate,
 			// to download artifacts and list referrers

--- a/app/controlplane/internal/biz/apitoken.go
+++ b/app/controlplane/internal/biz/apitoken.go
@@ -73,7 +73,7 @@ func NewAPITokenUseCase(apiTokenRepo APITokenRepo, conf *conf.Auth, authzE *auth
 		enforcer:     authzE,
 		DefaultAuthzPolicies: []*authz.Policy{
 			// Add permissions to workflow run
-			authz.PolicyWorkflowRunList, authz.PolicyWorkflowRunmimissRead,
+			authz.PolicyWorkflowRunList, authz.PolicyWorkflowRunRead,
 			// Add permissions to workflow contract management
 			authz.PolicyWorkflowContractList, authz.PolicyWorkflowContractRead, authz.PolicyWorkflowContractUpdate,
 			// to download artifacts and list referrers


### PR DESCRIPTION
This PR adds to the list of available policies of an apitoken the listing of `WorkflowRuns`.

Tests are covering the case where the apitoken should have all default tokens when created.

Closes #717 