### PR TITLE
feat(cli): Allow to pass --output flag to artifact download

### DIFF
--- a/app/cli/cmd/artifact_download.go
+++ b/app/cli/cmd/artifact_download.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 The Chainloop Authors.
+// Copyright 2024 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import (
 )
 
 func newArtifactDownloadCmd() *cobra.Command {
-	var digest, downloadPath string
+	var digest, downloadPath, outputFile string
 	var artifactCASConn *grpc.ClientConn
 
 	cmd := &cobra.Command{
@@ -45,9 +45,10 @@ func newArtifactDownloadCmd() *cobra.Command {
 			opts := &action.ArtifactDownloadOpts{
 				ActionsOpts:      actionOpts,
 				ArtifactsCASConn: artifactCASConn,
+				Stdout:           cmd.OutOrStdout(),
 			}
 
-			return action.NewArtifactDownload(opts).Run(downloadPath, digest)
+			return action.NewArtifactDownload(opts).Run(downloadPath, outputFile, digest)
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
 			if artifactCASConn != nil {
@@ -62,6 +63,7 @@ func newArtifactDownloadCmd() *cobra.Command {
 	err := cmd.MarkFlagRequired("digest")
 	cobra.CheckErr(err)
 	cmd.Flags().StringVar(&downloadPath, "path", "", "download path, default to current directory")
+	cmd.Flags().StringVar(&outputFile, "output", "", "The `file` to write a single asset to (use \"-\" to write to standard output")
 
 	return cmd
 }

--- a/app/cli/cmd/artifact_download.go
+++ b/app/cli/cmd/artifact_download.go
@@ -16,6 +16,8 @@
 package cmd
 
 import (
+	"errors"
+
 	"github.com/chainloop-dev/chainloop/app/cli/internal/action"
 	pb "github.com/chainloop-dev/chainloop/app/controlplane/api/controlplane/v1"
 	"github.com/spf13/cobra"
@@ -31,6 +33,10 @@ func newArtifactDownloadCmd() *cobra.Command {
 		Short: "download an artifact",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			var err error
+
+			if err := validateFlags(downloadPath, outputFile); err != nil {
+				return err
+			}
 
 			// Retrieve temporary credentials for uploading
 			artifactCASConn, err = wrappedArtifactConn(actionOpts.CPConnection,
@@ -66,4 +72,13 @@ func newArtifactDownloadCmd() *cobra.Command {
 	cmd.Flags().StringVar(&outputFile, "output", "", "The `file` to write a single asset to (use \"-\" to write to standard output")
 
 	return cmd
+}
+
+// validateFlags checks if the flags are valid
+func validateFlags(downloadPath, outputFile string) error {
+	if downloadPath != "" && outputFile != "" {
+		return errors.New("cannot specify both --path and --output flags at the same time")
+	}
+
+	return nil
 }

--- a/app/cli/internal/action/artifact_download.go
+++ b/app/cli/internal/action/artifact_download.go
@@ -61,6 +61,10 @@ func (a *ArtifactDownload) Run(downloadPath, outputFile, digest string) error {
 		return fmt.Errorf("artifact with digest %s not found", h)
 	}
 
+	if downloadPath != "" && outputFile != "" {
+		return errors.New("both downloadPath and outputFile cannot be set at the same time")
+	}
+
 	if downloadPath == "" {
 		downloadPath, err = os.Getwd()
 		if err != nil {

--- a/app/cli/internal/action/artifact_download.go
+++ b/app/cli/internal/action/artifact_download.go
@@ -35,18 +35,20 @@ import (
 type ArtifactDownload struct {
 	*ActionsOpts
 	artifactsCASConn *grpc.ClientConn
+	stdout           io.Writer
 }
 
 type ArtifactDownloadOpts struct {
 	*ActionsOpts
 	ArtifactsCASConn *grpc.ClientConn
+	Stdout           io.Writer
 }
 
 func NewArtifactDownload(opts *ArtifactDownloadOpts) *ArtifactDownload {
-	return &ArtifactDownload{opts.ActionsOpts, opts.ArtifactsCASConn}
+	return &ArtifactDownload{opts.ActionsOpts, opts.ArtifactsCASConn, opts.Stdout}
 }
 
-func (a *ArtifactDownload) Run(downloadPath, digest string) error {
+func (a *ArtifactDownload) Run(downloadPath, outputFile, digest string) error {
 	h, err := crv1.NewHash(digest)
 	if err != nil {
 		return fmt.Errorf("invalid digest: %w", err)
@@ -60,25 +62,35 @@ func (a *ArtifactDownload) Run(downloadPath, digest string) error {
 	}
 
 	if downloadPath == "" {
-		var err error
 		downloadPath, err = os.Getwd()
 		if err != nil {
 			return fmt.Errorf("getting current dir: %w", err)
 		}
 	}
 
-	downloadPath = path.Join(downloadPath, info.Filename)
-	f, err := os.Create(downloadPath)
-	if err != nil {
-		return fmt.Errorf("creating destination file: %w", err)
+	// Determine output destination
+	outputPath := path.Join(downloadPath, info.Filename)
+	if outputFile != "" && outputFile != "-" {
+		outputPath = path.Join(downloadPath, outputFile)
 	}
-	defer f.Close()
+
+	// Open output file
+	var f io.Writer
+	if outputFile == "-" {
+		f = a.stdout
+	} else {
+		f, err = os.Create(outputPath)
+		if err != nil {
+			return fmt.Errorf("creating destination file: %w", err)
+		}
+		defer f.(*os.File).Close()
+
+		a.Logger.Info().Str("name", outputFile).Str("to", outputPath).Msg("downloading file")
+	}
 
 	// Calculate the checksum as we write it to a file
 	hash := sha256.New()
 	w := io.MultiWriter(f, hash)
-
-	a.Logger.Info().Str("name", info.Filename).Str("to", downloadPath).Msg("downloading file")
 
 	// render progress bar
 	go renderOperationStatus(ctx, client.ProgressStatus, info.Size)
@@ -108,6 +120,8 @@ func renderOperationStatus(ctx context.Context, progressChan casclient.ProgressS
 	pw.Style().Visibility.ETA = true
 	pw.Style().Visibility.Speed = true
 	pw.SetUpdateFrequency(progress.DefaultUpdateFrequency)
+	// Render to stderr to avoid interfering with the output if the flag --output is set to "-"
+	pw.SetOutputWriter(os.Stderr)
 
 	var tracker *progress.Tracker
 	go pw.Render()

--- a/app/cli/internal/action/artifact_download.go
+++ b/app/cli/internal/action/artifact_download.go
@@ -71,7 +71,7 @@ func (a *ArtifactDownload) Run(downloadPath, outputFile, digest string) error {
 	// Determine output destination
 	outputPath := path.Join(downloadPath, info.Filename)
 	if outputFile != "" && outputFile != "-" {
-		outputPath = path.Join(downloadPath, outputFile)
+		outputPath = outputFile
 	}
 
 	// Open output file


### PR DESCRIPTION
This PR allows the user to pass a `--output` to `artifact download` command to specify the output.

This work in different modes:
- Passing an actual filename to to the flag to override the custom name:
```bash
$ chainloop artifact download --digest sha256:a614bb8b24252994a821476bdac82bba822461468b092c196e68a3db297bc6bd --path /tmp/artifacts --output myfile.txt

INF API token provided to the command line
INF downloading file name=myfile.txt to=/tmp/artifacts/myfile.txt
99.96% [#################.] [2.80KB in 224.154ms; 12.49KB/s] ...
 ... done! [2.80KB in 251ms; 11.13KB/s]

$ ls -l /tmp/artifacts
total 8
-rw-r--r--  1 javirln  wheel  2800 Apr 29 17:30 myfile.txt
```

- Sending the output to a pipe:
```bash
$ chainloop artifact download --digest sha256:a614bb8b24252994a821476bdac82bba822461468b092c196e68a3db297bc6bd --output - | jq '.'
INF API token provided to the command line
99.96% [#################.] [2.80KB in 208.439ms; 13.43KB/s] ...
 ... done! [2.80KB in 251ms; 11.16KB/s]
{
  "payloadType": "application/vnd.in-toto+json",
  "payload": "eyJfdHlwZ....
}
```

- Using the default filename:
```bash
$ chainloop artifact download --digest sha256:a614bb8b24252994a821476bdac82bba822461468b092c196e68a3db297bc6bd
INF API token provided to the command line
INF downloading file name= to=/tmp/artifacts/attestation-2ff0f163-3b9f-48d9-91d3-7b766a458fc1.json
99.96% [#################.] [2.80KB in 37.387ms; 74.86KB/s] ...
 ... done! [2.80KB in 251ms; 11.14KB/s]
```
Closes #492 