### PR TITLE
fix(cli): sanitize remote url

### DIFF
--- a/internal/attestation/crafter/crafter_unit_test.go
+++ b/internal/attestation/crafter/crafter_unit_test.go
@@ -34,6 +34,49 @@ type crafterUnitSuite struct {
 	suite.Suite
 }
 
+func (s *crafterUnitSuite) TestSanitizeRemoteURI() {
+	testCases := []struct {
+		name    string
+		uri     string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "ssh",
+			uri:  "git@cyberdyne.com:skynet.git",
+			want: "git@cyberdyne.com:skynet.git",
+		},
+		{
+			name: "https",
+			uri:  "https://cyberdyne.com/skynet.git",
+			want: "https://cyberdyne.com/skynet.git",
+		},
+		{
+			name: "https with user",
+			uri:  "https://demo-user:pass@cyberdyne.com/skynet.git",
+			want: "https://cyberdyne.com/skynet.git",
+		},
+		{
+			name:    "invalid uri",
+			uri:     "https://demo-user@pass:cyberdyne.com/skynet.git",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			got, err := sanitizeRemoteURL(tc.uri)
+			if tc.wantErr {
+				s.Error(err)
+				return
+			}
+
+			require.NoError(s.T(), err)
+			s.Equal(tc.want, got)
+		})
+	}
+}
+
 func (s *crafterUnitSuite) TestGitRepoHead() {
 	initRepo := func(withCommit bool) func(string) (*HeadCommit, error) {
 		return func(repoPath string) (*HeadCommit, error) {


### PR DESCRIPTION
In some cases, like the case of Gitlab, the CI will inject a remote with some temporary credentials to pull from the private repositories. This meant that the attestations had those temporary credentials in it as part of the `git.head` object in the attestation.

This patch updates the attestation cli to make sure the URI is sanitized before being ingested. 