### PR TITLE
feat(cli): add json output to attestation push

### DIFF
--- a/app/cli/cmd/attestation_push.go
+++ b/app/cli/cmd/attestation_push.go
@@ -82,10 +82,16 @@ func newAttestationPushCmd() *cobra.Command {
 				return newGracefulError(err)
 			}
 
-			if err := encodeJSON(res.Envelope); err != nil {
-				return err
+			// NOTE: we are not moving yet to full table by default
+			// to maintain backward compatibility
+			if flagOutputFormat == formatJSON {
+				return encodeJSON(res)
 			}
 
+			// default to mix of json and text to stdout and stderr by default
+			// kept to maintain backward compatibility
+			// TODO: in the future we'll render either a table or a proper report
+			fmt.Println(res.Envelope)
 			if res.Digest != "" {
 				logger.Info().Msgf("Attestation Digest: %s", res.Digest)
 			}


### PR DESCRIPTION
This patch implements the json output for the att push command. This output includes the envelope in string format and its digest.

note that the default output is kept the same for compatibility reasons.  

default view (not changed)

```
chainloop att push
INF push completed
{
   "payloadType": "application/vnd.in-toto+json",
   "payload": "eyJfdHlwZSI6Imh0dHBzOi8vaW4tdG90by5pby9TdGF0ZW1lbnQvdjEiLCJzdWJqZWN0IjpbeyJuYW1lIjoiY2hhaW5sb29wLndvcmtmbG93LnRlc3QyIiwiZGlnZXN0Ijp7InNoYTI1NiI6ImIzM2MyMmIxYWE2YjQ5YWQzNDVmMDZlZGQyODhiMDdkZDQ0YmM2NTBjMzc2NGZjN2UwYzRhNGJiZDdmZTJhODMifX0seyJuYW1lIjoiZ2l0LmhlYWQiLCJkaWdlc3QiOnsic2hhMSI6IjM1MTBkZDE1YzJiYTRmMWFkMDk0YjVlNTI3ZjNjYTAxNjVhNjk2MDAifSwiYW5ub3RhdGlvbnMiOnsiYXV0aG9yLmVtYWlsIjoibWlndWVsQGNoYWlubG9vcC5kZXYiLCJhdXRob3IubmFtZSI6Ik1pZ3VlbCBNYXJ0aW5leiBUcml2aW5vIiwiZGF0ZSI6IjIwMjQtMDQtMzBUMDY6Mjg6NDZaIiwibWVzc2FnZSI6ImZlYXQoY2xpKTogYWRkIGpzb24gb3V0cHV0IHRvIGF0dGVzdGF0aW9uIHB1c2hcblxuU2lnbmVkLW9mZi1ieTogTWlndWVsIE1hcnRpbmV6IFRyaXZpbm8gPG1pZ3VlbEBjaGFpbmxvb3AuZGV2PlxuIiwicmVtb3RlcyI6W3sibmFtZSI6Im9yaWdpbiIsInVybCI6ImdpdEBnaXRodWIuY29tOm1pZ21hcnRyaS9jaGFpbmxvb3AuZ2l0In0seyJuYW1lIjoidXBzdHJlYW0iLCJ1cmwiOiJnaXRAZ2l0aHViLmNvbTpjaGFpbmxvb3AtZGV2L2NoYWlubG9vcC5naXQifSx7Im5hbWUiOiJ0ZXN0LXRva2VuIiwidXJsIjoiaHR0cHM6Ly9naXRsYWItY2ktdG9rZW46Z2xjYnQtNjVfNVg2dUR6SlZSeDlyU3pnZFdES1pAZ2l0aHViLmNvbS9jaGFpbmxvb3AtZGV2L2NoYWlubG9vcC5naXQifV19fV0sInByZWRpY2F0ZVR5cGUiOiJjaGFpbmxvb3AuZGV2L2F0dGVzdGF0aW9uL3YwLjIiLCJwcmVkaWNhdGUiOnsiYnVpbGRUeXBlIjoiY2hhaW5sb29wLmRldi93b3JrZmxvd3J1bi92MC4xIiwiYnVpbGRlciI6eyJpZCI6ImNoYWlubG9vcC5kZXYvY2xpL2RldkBzaGEyNTY6MmE0ZGE4MGU5Y2IzZDJkZTU5YmVjZTAwNmEwOWZlOGNlN2RiZmJmYWQ3MDQ2MTcyMDIzYzY5N2VjMTc4MDcyMCJ9LCJtZXRhZGF0YSI6eyJmaW5pc2hlZEF0IjoiMjAyNC0wNC0zMFQwNjozMToxOS42Mjk0Mzg2NzZaIiwiaW5pdGlhbGl6ZWRBdCI6IjIwMjQtMDQtMzBUMDY6MzE6MTMuMTg4NDEyOTUyWiIsIm5hbWUiOiJ0ZXN0MiIsIm9yZ2FuaXphdGlvbiI6ImZvbyIsInByb2plY3QiOiJiYXIiLCJ0ZWFtIjoiIiwid29ya2Zsb3dJRCI6IjY1MmRkMmExLTE0NjItNGFhMC05OTVmLTFlMjg2NWFkMjY3NiIsIndvcmtmbG93UnVuSUQiOiJlOTM1ZGQ4ZC0xYzM2LTRjZWUtYmI1MS05MmY0OWQ5YWIxNmQifSwicnVubmVyVHlwZSI6IlJVTk5FUl9UWVBFX1VOU1BFQ0lGSUVEIn19",
   "signatures": [
      {
         "keyid": "",
         "sig": "MEYCIQCeHU0WSYbfu3bVIEbapgLg5Z6cXv+6EEFPUofU7lgzkQIhAPVGq7Tg2j5gZTqX7Kxp/cIt+oM922RA0e3ZQ8gsFRYN"
      }
   ]
}

INF Attestation Digest: sha256:8403a35946fe9f2e81e5265306a5691faf4c24e2b8107da38f9778ef30aa38bf

```

new json output 

```
chainloop att push -o json
INF push completed
{
  "digest": "sha256:2dc17f7c933d20e06b49250a582a3d19bdfbadba9c4e5f3f856af6f261db79d4",
  "envelope": "{\n   \"payloadType\": \"application/vnd.in-toto+json\",\n   \"payload\": \"eyJfdHlwZSI6Imh0dHBzOi8vaW4tdG90by5pby9TdGF0ZW1lbnQvdjEiLCJzdWJqZWN0IjpbeyJuYW1lIjoiY2hhaW5sb29wLndvcmtmbG93LnRlc3QyIiwiZGlnZXN0Ijp7InNoYTI1NiI6IjE1MTAwMzA1OWJmOTRiMTViZTMzNTBiZTc5MGM5MGEyYzE5MzBjOWU0Y2ZkYzQwOTEyYmMxY2UzM2Y3YzFmZGQifX0seyJuYW1lIjoiZ2l0LmhlYWQiLCJkaWdlc3QiOnsic2hhMSI6IjM1MTBkZDE1YzJiYTRmMWFkMDk0YjVlNTI3ZjNjYTAxNjVhNjk2MDAifSwiYW5ub3RhdGlvbnMiOnsiYXV0aG9yLmVtYWlsIjoibWlndWVsQGNoYWlubG9vcC5kZXYiLCJhdXRob3IubmFtZSI6Ik1pZ3VlbCBNYXJ0aW5leiBUcml2aW5vIiwiZGF0ZSI6IjIwMjQtMDQtMzBUMDY6Mjg6NDZaIiwibWVzc2FnZSI6ImZlYXQoY2xpKTogYWRkIGpzb24gb3V0cHV0IHRvIGF0dGVzdGF0aW9uIHB1c2hcblxuU2lnbmVkLW9mZi1ieTogTWlndWVsIE1hcnRpbmV6IFRyaXZpbm8gPG1pZ3VlbEBjaGFpbmxvb3AuZGV2PlxuIiwicmVtb3RlcyI6W3sibmFtZSI6Im9yaWdpbiIsInVybCI6ImdpdEBnaXRodWIuY29tOm1pZ21hcnRyaS9jaGFpbmxvb3AuZ2l0In0seyJuYW1lIjoidXBzdHJlYW0iLCJ1cmwiOiJnaXRAZ2l0aHViLmNvbTpjaGFpbmxvb3AtZGV2L2NoYWlubG9vcC5naXQifSx7Im5hbWUiOiJ0ZXN0LXRva2VuIiwidXJsIjoiaHR0cHM6Ly9naXRsYWItY2ktdG9rZW46Z2xjYnQtNjVfNVg2dUR6SlZSeDlyU3pnZFdES1pAZ2l0aHViLmNvbS9jaGFpbmxvb3AtZGV2L2NoYWlubG9vcC5naXQifV19fV0sInByZWRpY2F0ZVR5cGUiOiJjaGFpbmxvb3AuZGV2L2F0dGVzdGF0aW9uL3YwLjIiLCJwcmVkaWNhdGUiOnsiYnVpbGRUeXBlIjoiY2hhaW5sb29wLmRldi93b3JrZmxvd3J1bi92MC4xIiwiYnVpbGRlciI6eyJpZCI6ImNoYWlubG9vcC5kZXYvY2xpL2RldkBzaGEyNTY6MmE0ZGE4MGU5Y2IzZDJkZTU5YmVjZTAwNmEwOWZlOGNlN2RiZmJmYWQ3MDQ2MTcyMDIzYzY5N2VjMTc4MDcyMCJ9LCJtZXRhZGF0YSI6eyJmaW5pc2hlZEF0IjoiMjAyNC0wNC0zMFQwNjozMjoxOC41NjEwOTA2MzhaIiwiaW5pdGlhbGl6ZWRBdCI6IjIwMjQtMDQtMzBUMDY6MzI6MTEuNjkyOTUyOTk0WiIsIm5hbWUiOiJ0ZXN0MiIsIm9yZ2FuaXphdGlvbiI6ImZvbyIsInByb2plY3QiOiJiYXIiLCJ0ZWFtIjoiIiwid29ya2Zsb3dJRCI6IjY1MmRkMmExLTE0NjItNGFhMC05OTVmLTFlMjg2NWFkMjY3NiIsIndvcmtmbG93UnVuSUQiOiJiYzE2NzhlYy1iMGIzLTQxYWYtYmVhZC1lNzViYzBjNTRiMmMifSwicnVubmVyVHlwZSI6IlJVTk5FUl9UWVBFX1VOU1BFQ0lGSUVEIn19\",\n   \"signatures\": [\n      {\n         \"keyid\": \"\",\n         \"sig\": \"MEUCIDGBc8J4tpGaSyTcdHecnZOa725Tja4tozwtXNr6jSz7AiEA8xOts32aCmDs3TaUTyV8Tiv461gblt+ysfCT2OH9DFU=\"\n      }\n   ]\n}\n"
}
```

Closes #728 