### PR TITLE
feat(ci): Use reusable workflow for sync contracts

### DIFF
--- a/.github/workflows/sync_contracts.yml
+++ b/.github/workflows/sync_contracts.yml
@@ -13,27 +13,8 @@ on:
 permissions: read-all
 
 jobs:
-  diff:
-    name: Sync Chainloop Workflow contracts
-    runs-on: ubuntu-latest
-    env:
-      CHAINLOOP_VERSION: 0.84.0
-      CHAINLOOP_API_TOKEN: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT_SYNC_CONTRACTS }}
-    steps:
-      - name: Install Chainloop
-        run: |
-          curl -sfL https://raw.githubusercontent.com/chainloop-dev/chainloop/01ad13af08950b7bfbc83569bea207aeb4e1a285/docs/static/install.sh | bash -s -- --version v${{ env.CHAINLOOP_VERSION }}
-
-      - uses: actions/checkout@v4.1.4
-        with:
-          fetch-depth: 0
-
-      - name: Update contracts .github/workflows/contracts on Chainloop
-        run: |
-          for file in $(ls .github/workflows/contracts); do
-              if [[ $file = *.yml || $file = *.yaml ]]; then
-                  contract_name=$(basename $file | cut -d'.' -f1)
-                  echo "Updating contract $contract_name with .github/workflows/contracts/$file"
-                  chainloop wf contract update --name $contract_name --contract .github/workflows/contracts/$file
-              fi
-          done
+  chainloop_contract_sync:
+    name: Chainloop Contract Sync
+    uses: chainloop-dev/labs/.github/workflows/chainloop_contract_sync.yml@888e09a2391d8b0a89758fa222a053e1f058012e
+    secrets:
+      api_token: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT_SYNC_CONTRACTS }}


### PR DESCRIPTION
This PR makes use of the new GitHub workflow for reusable sync of chainloop contracts.