### PR TITLE
fix(ci): Only run contract sync on changes in contracts path

### DIFF
--- a/.github/workflows/sync_contracts.yml
+++ b/.github/workflows/sync_contracts.yml
@@ -6,6 +6,8 @@ name: Sync Chainloop Workflow contracts
 on:
   push:
     branches: [ "main" ]
+  paths:
+    - '.github/workflows/contracts/**'
   schedule:
     - cron: "0 0 * * *" # daily at midnight
 


### PR DESCRIPTION
This PR makes the sync of chainloop contracts to only run when changes are on `.github/workflows/contracts`.