### PR TITLE
feat(ci): Update release pipeline to include all architecture binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -106,7 +106,7 @@ jobs:
           # Binaries x86_64
           # TODO: add the rest of binaries
           # NOTE that we are not making the attestation fail if the material is not found. We will fail on "att push"
-          echo -n '${{ steps.release.outputs.artifacts }}' | jq -r '.[] | select(.type=="Binary" and .goos=="linux" and .goarch=="amd64") | { "name": "\(.extra.ID)-\(.goos)-\(.goarch)", "path":"\(.path)"} | @base64' | while read i; do
+          echo -n '${{ steps.release.outputs.artifacts }}' | jq -r '.[] | select(.type=="Binary" and .goos=="linux") | { "name": "\(.extra.ID)-\(.goos)-\(.goarch)", "path":"\(.path)"} | @base64' | while read i; do
               BINARY_NAME=$(echo "${i}" | base64 --decode | jq -r ${1} .name)
               BINARY_PATH=$(echo "${i}" | base64 --decode | jq -r ${1} .path)
               chainloop attestation add --name ${BINARY_NAME} --value ${BINARY_PATH} || true


### PR DESCRIPTION
This PR removes the constraint of only parsing amd64 binaries and instead, look for both arm64 and amd64 to comply with the new contract version introduced https://github.com/chainloop-dev/chainloop/pull/741

Locally tested:
`$ cat 'goreleaser.json' | jq -r '.[] | select(.type=="Binary" and .goos=="linux") | { "name": "\(.extra.ID)-\(.goos)-\(.goarch)", "path":"\(.path)"} '`
```json
{
  "name": "artifact-cas-linux-amd64",
  "path": "dist/artifact-cas_linux_amd64_v1/artifact-cas"
}
{
  "name": "control-plane-linux-amd64",
  "path": "dist/control-plane_linux_amd64_v1/control-plane"
}
{
  "name": "chainloop-plugin-discord-webhook-linux-amd64",
  "path": "dist/chainloop-plugin-discord-webhook_linux_amd64_v1/chainloop-plugin-discord-webhook"
}
{
  "name": "chainloop-plugin-smtp-linux-amd64",
  "path": "dist/chainloop-plugin-smtp_linux_amd64_v1/chainloop-plugin-smtp"
}
{
  "name": "chainloop-plugin-dependency-track-linux-amd64",
  "path": "dist/chainloop-plugin-dependency-track_linux_amd64_v1/chainloop-plugin-dependency-track"
}
{
  "name": "cli-linux-amd64",
  "path": "dist/cli_linux_amd64_v1/chainloop"
}
{
  "name": "cli-linux-arm64",
  "path": "dist/cli_linux_arm64/chainloop"
}
```