### PR TITLE
refactor(materials): Add custom types for different CSAF profiles

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	github.com/invopop/jsonschema v0.7.0
 	github.com/jackc/pgx/v5 v5.5.4
 	github.com/muesli/reflow v0.3.0
-	github.com/openvex/go-vex v0.2.5
+	github.com/openvex/go-vex v0.2.6-0.20240506020847-46399d425c68
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	google.golang.org/genproto/googleapis/api v0.0.0-20240401170217-c3f982113cda
 	google.golang.org/genproto/googleapis/bytestream v0.0.0-20240318140521-94a12d6c2237
@@ -135,7 +135,7 @@ require (
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481 // indirect
 	github.com/oklog/run v1.1.0 // indirect
-	github.com/package-url/packageurl-go v0.1.1 // indirect
+	github.com/package-url/packageurl-go v0.1.2 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/xattr v0.4.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1126,8 +1126,6 @@ github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFSt
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
-github.com/openvex/go-vex v0.2.5 h1:41utdp2rHgAGCsG+UbjmfMG5CWQxs15nGqir1eRgSrQ=
-github.com/openvex/go-vex v0.2.5/go.mod h1:j+oadBxSUELkrKh4NfNb+BPo77U3q7gdKME88IO/0Wo=
 github.com/openvex/go-vex v0.2.6-0.20240506020847-46399d425c68 h1:jeJVHaHnxL274I8rs7Gl4JStaIqPziFcMbaXMevgaHw=
 github.com/openvex/go-vex v0.2.6-0.20240506020847-46399d425c68/go.mod h1:Dy5jfIe2cXiV80fCRdteTgx4vxmVgJMfuJsJ3BKtjks=
 github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5/go.mod h1:/wsWhb9smxSfWAKL3wpBW7V8scJMt8N8gnaMCS9E/cA=
@@ -1136,8 +1134,6 @@ github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/owenrumney/go-sarif v1.1.1 h1:QNObu6YX1igyFKhdzd7vgzmw7XsWN3/6NMGuDzBgXmE=
 github.com/owenrumney/go-sarif v1.1.1/go.mod h1:dNDiPlF04ESR/6fHlPyq7gHKmrM0sHUvAGjsoh8ZH0U=
-github.com/package-url/packageurl-go v0.1.1 h1:KTRE0bK3sKbFKAk3yy63DpeskU7Cvs/x/Da5l+RtzyU=
-github.com/package-url/packageurl-go v0.1.1/go.mod h1:uQd4a7Rh3ZsVg5j0lNyAfyxIeGde9yrlhjF78GzeW0c=
 github.com/package-url/packageurl-go v0.1.2 h1:0H2DQt6DHd/NeRlVwW4EZ4oEI6Bn40XlNPRqegcxuo4=
 github.com/package-url/packageurl-go v0.1.2/go.mod h1:uQd4a7Rh3ZsVg5j0lNyAfyxIeGde9yrlhjF78GzeW0c=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=

--- a/go.sum
+++ b/go.sum
@@ -1128,6 +1128,8 @@ github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/openvex/go-vex v0.2.5 h1:41utdp2rHgAGCsG+UbjmfMG5CWQxs15nGqir1eRgSrQ=
 github.com/openvex/go-vex v0.2.5/go.mod h1:j+oadBxSUELkrKh4NfNb+BPo77U3q7gdKME88IO/0Wo=
+github.com/openvex/go-vex v0.2.6-0.20240506020847-46399d425c68 h1:jeJVHaHnxL274I8rs7Gl4JStaIqPziFcMbaXMevgaHw=
+github.com/openvex/go-vex v0.2.6-0.20240506020847-46399d425c68/go.mod h1:Dy5jfIe2cXiV80fCRdteTgx4vxmVgJMfuJsJ3BKtjks=
 github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5/go.mod h1:/wsWhb9smxSfWAKL3wpBW7V8scJMt8N8gnaMCS9E/cA=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
@@ -1136,6 +1138,8 @@ github.com/owenrumney/go-sarif v1.1.1 h1:QNObu6YX1igyFKhdzd7vgzmw7XsWN3/6NMGuDzB
 github.com/owenrumney/go-sarif v1.1.1/go.mod h1:dNDiPlF04ESR/6fHlPyq7gHKmrM0sHUvAGjsoh8ZH0U=
 github.com/package-url/packageurl-go v0.1.1 h1:KTRE0bK3sKbFKAk3yy63DpeskU7Cvs/x/Da5l+RtzyU=
 github.com/package-url/packageurl-go v0.1.1/go.mod h1:uQd4a7Rh3ZsVg5j0lNyAfyxIeGde9yrlhjF78GzeW0c=
+github.com/package-url/packageurl-go v0.1.2 h1:0H2DQt6DHd/NeRlVwW4EZ4oEI6Bn40XlNPRqegcxuo4=
+github.com/package-url/packageurl-go v0.1.2/go.mod h1:uQd4a7Rh3ZsVg5j0lNyAfyxIeGde9yrlhjF78GzeW0c=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/internal/attestation/crafter/materials/csaf.go
+++ b/internal/attestation/crafter/materials/csaf.go
@@ -1,0 +1,152 @@
+//
+// Copyright 2024 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package materials
+
+import (
+	"fmt"
+
+	"github.com/openvex/go-vex/pkg/csaf"
+)
+
+// CSAFValidator is an interface for validating CSAF documents
+type CSAFValidator interface {
+	ValidateDocument() error
+}
+
+// Common structs missing on "github.com/openvex/go-vex/pkg/csaf" implementation
+
+type RevisionHistoryItem struct {
+	Date    string `json:"date"`
+	Number  int    `json:"string"`
+	Summary string `json:"summary"`
+}
+
+type Tracking struct {
+	csaf.Tracking
+	RevisionHistory []RevisionHistoryItem `json:"revision_history"`
+	Status          string                `json:"status"`
+	Version         string                `json:"version"`
+}
+
+type CSAFDocument struct {
+	csaf.CSAF
+	Document struct {
+		csaf.DocumentMetadata
+		Tracking    Tracking    `json:"tracking"`
+		Category    string      `json:"category"`
+		CsafVersion string      `json:"csaf_version"`
+		Notes       []csaf.Note `json:"notes"`
+	} `json:"document"`
+}
+
+func (c *CSAFDocument) validateBaseDocument() error {
+	// Validate required fields
+	requiredFields := []string{
+		c.Document.Category,
+		c.Document.CsafVersion,
+		c.Document.Publisher.Category,
+		c.Document.Publisher.Name,
+		c.Document.Publisher.Namespace,
+		c.Document.Title,
+		c.Document.Tracking.CurrentReleaseDate.String(),
+		c.Document.Tracking.ID,
+		c.Document.Tracking.InitialReleaseDate.String(),
+		c.Document.Tracking.Status,
+		c.Document.Tracking.Version,
+	}
+
+	for _, field := range requiredFields {
+		if field == "" {
+			return fmt.Errorf("required field is empty: %v", field)
+		}
+	}
+
+	return nil
+}
+
+// SecurityIncidentResponse represents a CSAF document of type SecurityIncidentResponse
+type SecurityIncidentResponse struct {
+	CSAFDocument
+}
+
+// ValidateDocument validates the SecurityIncidentResponse document
+func (s *SecurityIncidentResponse) ValidateDocument() error {
+	return s.validateSecurityIncidentResponse()
+}
+
+// ValidateSecurityIncidentResponse validates the SecurityIncidentResponse document
+func (s *SecurityIncidentResponse) validateSecurityIncidentResponse() error {
+	if err := s.validateBaseDocument(); err != nil {
+		return err
+	}
+
+	if len(s.Document.Notes) == 0 {
+		return fmt.Errorf("notes are empty")
+	}
+
+	if len(s.Document.References) == 0 {
+		return fmt.Errorf("references are empty")
+	}
+
+	return nil
+}
+
+// InformationalAdvisory represents a CSAF document of type InformationalAdvisory
+type InformationalAdvisory struct {
+	SecurityIncidentResponse
+}
+
+// ValidateDocument validates the InformationalAdvisory document
+func (s *InformationalAdvisory) ValidateDocument() error {
+	return s.validateSecurityIncidentResponse()
+}
+
+// SecurityAdvisory represents a CSAF document of type SecurityAdvisory
+type SecurityAdvisory struct {
+	CSAFDocument
+}
+
+// ValidateDocument validates the SecurityAdvisory document
+func (s *SecurityAdvisory) ValidateDocument() error {
+	return s.validateSecurityAdvisory()
+}
+
+// ValidateSecurityAdvisory validates the SecurityAdvisory document
+func (s *SecurityAdvisory) validateSecurityAdvisory() error {
+	if err := s.validateBaseDocument(); err != nil {
+		return err
+	}
+
+	if len(s.ProductTree.ListProducts()) == 0 {
+		return fmt.Errorf("notes are empty")
+	}
+
+	if len(s.Vulnerabilities) == 0 {
+		return fmt.Errorf("references are empty")
+	}
+
+	return nil
+}
+
+// Vex represents a CSAF document of type VEX
+type Vex struct {
+	SecurityAdvisory
+}
+
+// ValidateDocument validates the Vex document
+func (s *Vex) ValidateDocument() error {
+	return s.validateSecurityAdvisory()
+}

--- a/internal/attestation/crafter/materials/csafvex_test.go
+++ b/internal/attestation/crafter/materials/csafvex_test.go
@@ -78,7 +78,7 @@ func TestCSAFVEXCraft(t *testing.T) {
 		{
 			name:     "invalid path",
 			filePath: "./testdata/non-existing.json",
-			wantErr:  "unexpected material type",
+			wantErr:  "csaf: failed to open document",
 		},
 		{
 			name:     "invalid artifact type",


### PR DESCRIPTION
This PR introduces a refactor that extracts the different CSAF profiles with _partial_ validations from the specification found here: https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#4-profiles

The implementation does not attempt to add a validation library but rather some basic validations to the common CSAF document.

Refers #635 