### PR TITLE
feat(policies): Add attestation as new resource type and workflow create permission

### DIFF
--- a/app/controlplane/internal/authz/authz.go
+++ b/app/controlplane/internal/authz/authz.go
@@ -147,9 +147,6 @@ var rolesMap = map[Role][]*Policy{
 		PolicyWorkflowRead,
 		// Organization
 		PolicyOrganizationRead,
-		// Attestation
-		PolicyAttestationRead,
-		PolicyAttestationList,
 	},
 	RoleAdmin: {
 		// We do a manual check in the artifact upload endpoint

--- a/app/controlplane/internal/authz/authz.go
+++ b/app/controlplane/internal/authz/authz.go
@@ -57,6 +57,7 @@ const (
 	ResourceWorkflow              = "workflow"
 	UserMembership                = "membership_user"
 	Organization                  = "organization"
+	ResourceAttestation           = "attestation"
 
 	// We have for now three roles, viewer, admin and owner
 	// The owner of an org
@@ -102,10 +103,15 @@ var (
 	PolicyWorkflowRunList = &Policy{ResourceWorkflowRun, ActionList}
 	PolicyWorkflowRunRead = &Policy{ResourceWorkflowRun, ActionRead}
 	// Workflow
-	PolicyWorkflowList = &Policy{ResourceWorkflow, ActionList}
-	PolicyWorkflowRead = &Policy{ResourceWorkflow, ActionRead}
+	PolicyWorkflowCreate = &Policy{ResourceWorkflow, ActionCreate}
+	PolicyWorkflowList   = &Policy{ResourceWorkflow, ActionList}
+	PolicyWorkflowRead   = &Policy{ResourceWorkflow, ActionRead}
 	// User Membership
 	PolicyOrganizationRead = &Policy{Organization, ActionRead}
+	// Attestation
+	PolicyAttestationCreate = &Policy{ResourceAttestation, ActionCreate}
+	PolicyAttestationRead   = &Policy{ResourceAttestation, ActionRead}
+	PolicyAttestationList   = &Policy{ResourceAttestation, ActionList}
 )
 
 // List of policies for each role
@@ -141,6 +147,9 @@ var rolesMap = map[Role][]*Policy{
 		PolicyWorkflowRead,
 		// Organization
 		PolicyOrganizationRead,
+		// Attestation
+		PolicyAttestationRead,
+		PolicyAttestationList,
 	},
 	RoleAdmin: {
 		// We do a manual check in the artifact upload endpoint


### PR DESCRIPTION
This PR adds a new resource type `attestation` with three new permissions for: `create, read and list`. Additionally it create a new permissions for `workflow` resource, `create`.

The addition to the default policy list for API Tokens and to the server URL mapping will come in a different PR.

Refs #752 