### PR TITLE
feat(api-tokens): Allow API tokens to operate with attestations

### DIFF
--- a/app/controlplane/internal/authz/authz.go
+++ b/app/controlplane/internal/authz/authz.go
@@ -192,6 +192,12 @@ var ServerOperationsMap = map[string][]*Policy{
 	"/controlplane.v1.WorkflowContractService/Update":   {PolicyWorkflowContractUpdate},
 	// Get current information about an organization
 	"/controlplane.v1.ContextService/Current": {PolicyOrganizationRead},
+	// Attestations
+	"/controlplane.v1.AttestationService/GetContract":    {PolicyAttestationRead},
+	"/controlplane.v1.AttestationService/Init":           {PolicyAttestationCreate},
+	"/controlplane.v1.AttestationService/Store":          {PolicyAttestationCreate},
+	"/controlplane.v1.AttestationService/GetUploadCreds": {PolicyAttestationRead},
+	"/controlplane.v1.AttestationService/Cancel":         {PolicyAttestationCreate},
 	// Listing, create or selecting an organization does not have any required permissions,
 	// since all the permissions here are in the context of an organization
 	// Create new organization

--- a/app/controlplane/internal/authz/middleware/middleware_test.go
+++ b/app/controlplane/internal/authz/middleware/middleware_test.go
@@ -125,6 +125,27 @@ func TestWithAuthMiddleware(t *testing.T) {
 			operationName:  "/controlplane.v1.WorkflowContractService/List",
 			hasPermissions: true,
 		},
+		{
+			name:           "api token has permissions to perform an attestation",
+			hasToken:       true,
+			operationName:  "/controlplane.v1.AttestationService/Init",
+			hasPermissions: true,
+		},
+		{
+			name:           "same for owner with attestations",
+			hasUser:        true,
+			userRole:       "role:org:owner",
+			operationName:  "/controlplane.v1.AttestationService/Init",
+			hasPermissions: false,
+		},
+		{
+			name:           "but no for a viewer with attestations",
+			hasUser:        true,
+			userRole:       "role:org:viewer",
+			operationName:  "/controlplane.v1.AttestationService/Init",
+			hasPermissions: false,
+			wantErr:        true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/app/controlplane/internal/biz/apitoken.go
+++ b/app/controlplane/internal/biz/apitoken.go
@@ -79,6 +79,8 @@ func NewAPITokenUseCase(apiTokenRepo APITokenRepo, conf *conf.Auth, authzE *auth
 			// to download artifacts and list referrers
 			authz.PolicyArtifactDownload, authz.PolicyReferrerRead,
 			authz.PolicyOrganizationRead,
+			// Add permissions to attestation management
+			authz.PolicyAttestationList, authz.PolicyAttestationCreate, authz.PolicyAttestationRead,
 		},
 	}
 


### PR DESCRIPTION
This PR adds default policies regarding attestation: `read, create and list` to API tokens and protects the endpoints related to attestations with the attestation policies.

Creating a new api token now successfully adds the new policies to the DB:
```
api-token:194b692d-787a-4bb1-93bd-57965a0374a1,  workflow_run,read
api-token:194b692d-787a-4bb1-93bd-57965a0374a1,  workflow_contract,read
api-token:194b692d-787a-4bb1-93bd-57965a0374a1,  cas_artifact,read
api-token:194b692d-787a-4bb1-93bd-57965a0374a1,  organization,read
api-token:194b692d-787a-4bb1-93bd-57965a0374a1,  workflow_run,list
api-token:194b692d-787a-4bb1-93bd-57965a0374a1,  workflow_contract,list
api-token:194b692d-787a-4bb1-93bd-57965a0374a1,  workflow_contract,update
api-token:194b692d-787a-4bb1-93bd-57965a0374a1,  referrer,read
api-token:194b692d-787a-4bb1-93bd-57965a0374a1,  attestation,list
api-token:194b692d-787a-4bb1-93bd-57965a0374a1,  attestation,read
api-token:194b692d-787a-4bb1-93bd-57965a0374a1,  attestation,create
```

Refs #752 