### PR TITLE
chore(ci): bump chainloop CLI version

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
       contents: read
       security-events: write
     env:
-      CHAINLOOP_VERSION: 0.83.0
+      CHAINLOOP_VERSION: 0.86.0
       CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT_CODEQL }}
 
     strategy:

--- a/.github/workflows/package_chart.yaml
+++ b/.github/workflows/package_chart.yaml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       packages: write
     env:
-      CHAINLOOP_VERSION: 0.83.0 # Min version that includes HELM_CHART material type
+      CHAINLOOP_VERSION: 0.86.0
       CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT_CHART_PACKAGE }}
     steps:
       - name: Install Chainloop

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
       packages: write # to push container images
       pull-requests: write
     env:
-      CHAINLOOP_VERSION: 0.81.1
+      CHAINLOOP_VERSION: 0.86.0
       CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT }}
       CONTAINER_IMAGE_CP: ghcr.io/chainloop-dev/chainloop/control-plane:${{ github.ref_name }}
       CONTAINER_IMAGE_CAS: ghcr.io/chainloop-dev/chainloop/artifact-cas:${{ github.ref_name }}

--- a/docs/docs/getting-started/attestation-crafting.md
+++ b/docs/docs/getting-started/attestation-crafting.md
@@ -237,7 +237,7 @@ jobs:
     env:
       # highlight-start
       # Version of Chainloop to install
-      CHAINLOOP_VERSION: 0.15.0
+      CHAINLOOP_VERSION: 0.86.0
       # Export robot-account env variable
       # Used by the CLI to authenticate with the control plane
       CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_WF_RELEASE }}

--- a/docs/examples/ci-workflows/github.yaml
+++ b/docs/examples/ci-workflows/github.yaml
@@ -13,7 +13,7 @@ jobs:
   release:
     env:
       # Version of Chainloop to install
-      CHAINLOOP_VERSION: 0.15.0
+      CHAINLOOP_VERSION: 0.86.0
       # Export robot-account env variable
       CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_WF_RELEASE }}
     name: "Release binary and container images"

--- a/extras/dagger/main.go
+++ b/extras/dagger/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	chainloopVersion = "v0.81.1"
+	chainloopVersion = "v0.86.0"
 )
 
 type Chainloop struct{}


### PR DESCRIPTION
Bump the version of Chainloop used in our pipelines and in the dagger module.

The latest version of our CLI has support for recording container images tags 