### PR TITLE
fix(chainloop): add missing policy

### DIFF
--- a/app/controlplane/internal/authz/authz.go
+++ b/app/controlplane/internal/authz/authz.go
@@ -101,8 +101,10 @@ var (
 	PolicyWorkflowRunList = &Policy{ResourceWorkflowRun, ActionList}
 	PolicyWorkflowRunRead = &Policy{ResourceWorkflowRun, ActionRead}
 	// Workflow
-	PolicyWorkflowList = &Policy{ResourceWorkflow, ActionList}
-	PolicyWorkflowRead = &Policy{ResourceWorkflow, ActionRead}
+	PolicyWorkflowList   = &Policy{ResourceWorkflow, ActionList}
+	PolicyWorkflowRead   = &Policy{ResourceWorkflow, ActionRead}
+	PolicyWorkflowCreate = &Policy{ResourceWorkflow, ActionCreate}
+
 	// User Membership
 	PolicyOrganizationRead = &Policy{Organization, ActionRead}
 )


### PR DESCRIPTION
Restore a policy that was wronly removed in a previous merge.

refs #761 