### PR TITLE
feat(ci): Use reusable workflow creation on Helm package

### DIFF
--- a/.github/workflows/package_chart.yaml
+++ b/.github/workflows/package_chart.yaml
@@ -29,7 +29,7 @@ jobs:
     permissions:
       packages: write
     env:
-      CHAINLOOP_VERSION: 0.87.1
+      CHAINLOOP_VERSION: 0.87.2
       CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_API_TOKEN }}
       CHAINLOOP_WORKFLOW_NAME: ${{ needs.onboard_workflow.outputs.workflow_name }}
     steps:

--- a/.github/workflows/package_chart.yaml
+++ b/.github/workflows/package_chart.yaml
@@ -30,7 +30,7 @@ jobs:
       packages: write
     env:
       CHAINLOOP_VERSION: 0.87.1
-      CHAINLOOP_API_TOKEN: ${{ secrets.CHAINLOOP_API_TOKEN }}
+      CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_API_TOKEN }}
       CHAINLOOP_WORKFLOW_NAME: ${{ needs.onboard_workflow.outputs.workflow_name }}
     steps:
       - name: Install Chainloop

--- a/.github/workflows/package_chart.yaml
+++ b/.github/workflows/package_chart.yaml
@@ -1,18 +1,20 @@
 name: Package Helm Chart
 
 on:
-  pull_request:
   # Only push Helm Chart if the deployment templates have changed
-#  push:
-#    branches:
-#      - main
-#    paths:
-#      - deployment/chainloop/**
+  push:
+    branches:
+      - main
+    paths:
+      - deployment/chainloop/**
 
 permissions:
   contents: read
 
 jobs:
+  # This reusable workflow inspects if the given workflow_name exists on Chainloop. If the Workflow does not exist
+  # it will create one with an empty contract ready for operators to be filled. Otherwise, if found, it will just
+  # be ignored and the process will continue. For this to work it's using a pre-created API Token
   onboard_workflow:
     name: Onboard Chainloop Workflow
     uses: chainloop-dev/labs/.github/workflows/chainloop_onboard.yml@4173e015dbd5dc2a8802555c268da63d57bbe576
@@ -37,43 +39,43 @@ jobs:
         run: |
           curl -sfL https://raw.githubusercontent.com/chainloop-dev/chainloop/01ad13af08950b7bfbc83569bea207aeb4e1a285/docs/static/install.sh | bash -s -- --version v${{ env.CHAINLOOP_VERSION }}
 
-#      - name: Docker login to Github Packages
-#        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
-#        with:
-#          registry: ghcr.io
-#          username: ${{ github.actor }}
-#          password: ${{ secrets.GITHUB_TOKEN }}
-#
-#      - name: Install Helm
-#        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
-#
-#      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Docker login to Github Packages
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Helm
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
+
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Initialize Attestation
         run: |
           chainloop attestation init --workflow-name ${CHAINLOOP_WORKFLOW_NAME}
 
-#      - name: Package Chart
-#        run: helm package deployment/chainloop/
-#
-#      - name: Add Attestation (Helm Chart)
-#        run: |
-#          export PACKAGED_VERSION=$(cat ./deployment/chainloop/Chart.yaml | yq .appVersion)
-#          export CONTAINER_CP=$(cat deployment/chainloop/values.yaml | yq .controlplane.image.repository)
-#          export CONTAINER_CAS=$(cat deployment/chainloop/values.yaml | yq .cas.image.repository)
-#
-#          # Attest Chart
-#          chainloop attestation add --name helm-chart --value chainloop*.tgz
-#          # Attest Control plane image
-#          chainloop attestation add --name control-plane-image --value "${CONTAINER_CP}:${PACKAGED_VERSION}"
-#          # Attest CAS image
-#          chainloop attestation add --name artifact-cas-image --value "${CONTAINER_CAS}:${PACKAGED_VERSION}"
-#
-#      - name: Push Chart
-#        run: |
-#          for pkg in chainloop*.tgz; do
-#            helm push ${pkg} oci://ghcr.io/chainloop-dev/charts
-#          done
+      - name: Package Chart
+        run: helm package deployment/chainloop/
+
+      - name: Add Attestation (Helm Chart)
+        run: |
+          export PACKAGED_VERSION=$(cat ./deployment/chainloop/Chart.yaml | yq .appVersion)
+          export CONTAINER_CP=$(cat deployment/chainloop/values.yaml | yq .controlplane.image.repository)
+          export CONTAINER_CAS=$(cat deployment/chainloop/values.yaml | yq .cas.image.repository)
+
+          # Attest Chart
+          chainloop attestation add --name helm-chart --value chainloop*.tgz
+          # Attest Control plane image
+          chainloop attestation add --name control-plane-image --value "${CONTAINER_CP}:${PACKAGED_VERSION}"
+          # Attest CAS image
+          chainloop attestation add --name artifact-cas-image --value "${CONTAINER_CAS}:${PACKAGED_VERSION}"
+
+      - name: Push Chart
+        run: |
+          for pkg in chainloop*.tgz; do
+            helm push ${pkg} oci://ghcr.io/chainloop-dev/charts
+          done
 
       - name: Finish and Record Attestation
         if: ${{ success() }}

--- a/.github/workflows/package_chart.yaml
+++ b/.github/workflows/package_chart.yaml
@@ -1,12 +1,13 @@
 name: Package Helm Chart
 
 on:
+  pull_request:
   # Only push Helm Chart if the deployment templates have changed
-  push:
-    branches:
-      - main
-    paths:
-      - deployment/chainloop/**
+#  push:
+#    branches:
+#      - main
+#    paths:
+#      - deployment/chainloop/**
 
 permissions:
   contents: read
@@ -19,7 +20,7 @@ jobs:
       project: "chainloop"
       workflow_name: "chainloop-vault-helm-package"
     secrets:
-      api_token: ${{ secrets.CHAINLOOP_ONBOARDING_API_TOKEN }}
+      api_token: ${{ secrets.CHAINLOOP_API_TOKEN }}
 
   package:
     name: Package and push Helm Chart
@@ -29,50 +30,50 @@ jobs:
       packages: write
     env:
       CHAINLOOP_VERSION: 0.87.1
-      CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_ONBOARDING_API_TOKEN }}
+      CHAINLOOP_API_TOKEN: ${{ secrets.CHAINLOOP_API_TOKEN }}
       CHAINLOOP_WORKFLOW_NAME: ${{ needs.onboard_workflow.outputs.workflow_name }}
     steps:
       - name: Install Chainloop
         run: |
           curl -sfL https://raw.githubusercontent.com/chainloop-dev/chainloop/01ad13af08950b7bfbc83569bea207aeb4e1a285/docs/static/install.sh | bash -s -- --version v${{ env.CHAINLOOP_VERSION }}
 
-      - name: Docker login to Github Packages
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install Helm
-        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
-
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+#      - name: Docker login to Github Packages
+#        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
+#        with:
+#          registry: ghcr.io
+#          username: ${{ github.actor }}
+#          password: ${{ secrets.GITHUB_TOKEN }}
+#
+#      - name: Install Helm
+#        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
+#
+#      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Initialize Attestation
         run: |
           chainloop attestation init --workflow-name ${CHAINLOOP_WORKFLOW_NAME}
 
-      - name: Package Chart
-        run: helm package deployment/chainloop/
-
-      - name: Add Attestation (Helm Chart)
-        run: |
-          export PACKAGED_VERSION=$(cat ./deployment/chainloop/Chart.yaml | yq .appVersion)
-          export CONTAINER_CP=$(cat deployment/chainloop/values.yaml | yq .controlplane.image.repository)
-          export CONTAINER_CAS=$(cat deployment/chainloop/values.yaml | yq .cas.image.repository)
-
-          # Attest Chart
-          chainloop attestation add --name helm-chart --value chainloop*.tgz
-          # Attest Control plane image
-          chainloop attestation add --name control-plane-image --value "${CONTAINER_CP}:${PACKAGED_VERSION}"
-          # Attest CAS image
-          chainloop attestation add --name artifact-cas-image --value "${CONTAINER_CAS}:${PACKAGED_VERSION}"
-
-      - name: Push Chart
-        run: |
-          for pkg in chainloop*.tgz; do
-            helm push ${pkg} oci://ghcr.io/chainloop-dev/charts
-          done
+#      - name: Package Chart
+#        run: helm package deployment/chainloop/
+#
+#      - name: Add Attestation (Helm Chart)
+#        run: |
+#          export PACKAGED_VERSION=$(cat ./deployment/chainloop/Chart.yaml | yq .appVersion)
+#          export CONTAINER_CP=$(cat deployment/chainloop/values.yaml | yq .controlplane.image.repository)
+#          export CONTAINER_CAS=$(cat deployment/chainloop/values.yaml | yq .cas.image.repository)
+#
+#          # Attest Chart
+#          chainloop attestation add --name helm-chart --value chainloop*.tgz
+#          # Attest Control plane image
+#          chainloop attestation add --name control-plane-image --value "${CONTAINER_CP}:${PACKAGED_VERSION}"
+#          # Attest CAS image
+#          chainloop attestation add --name artifact-cas-image --value "${CONTAINER_CAS}:${PACKAGED_VERSION}"
+#
+#      - name: Push Chart
+#        run: |
+#          for pkg in chainloop*.tgz; do
+#            helm push ${pkg} oci://ghcr.io/chainloop-dev/charts
+#          done
 
       - name: Finish and Record Attestation
         if: ${{ success() }}

--- a/.github/workflows/package_chart.yaml
+++ b/.github/workflows/package_chart.yaml
@@ -12,14 +12,25 @@ permissions:
   contents: read
 
 jobs:
+  onboard_workflow:
+    name: Onboard Chainloop Workflow
+    uses: chainloop-dev/labs/.github/workflows/chainloop_onboard.yml@4173e015dbd5dc2a8802555c268da63d57bbe576
+    with:
+      project: "chainloop"
+      workflow_name: "chainloop-vault-helm-package"
+    secrets:
+      api_token: ${{ secrets.CHAINLOOP_ONBOARDING_API_TOKEN }}
+
   package:
     name: Package and push Helm Chart
     runs-on: ubuntu-latest
+    needs: onboard_workflow
     permissions:
       packages: write
     env:
-      CHAINLOOP_VERSION: 0.86.0
-      CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT_CHART_PACKAGE }}
+      CHAINLOOP_VERSION: 0.87.1
+      CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_ONBOARDING_API_TOKEN }}
+      CHAINLOOP_WORKFLOW_NAME: ${{ needs.onboard_workflow.outputs.workflow_name }}
     steps:
       - name: Install Chainloop
         run: |
@@ -39,7 +50,7 @@ jobs:
 
       - name: Initialize Attestation
         run: |
-          chainloop attestation init
+          chainloop attestation init --workflow-name ${CHAINLOOP_WORKFLOW_NAME}
 
       - name: Package Chart
         run: helm package deployment/chainloop/


### PR DESCRIPTION
This PR leverages the resolvable workflow on Chainloop labs ([link](https://github.com/chainloop-dev/labs/blob/main/.github/workflows/chainloop_onboard.yml)) that onboards a new Workflow created from the context of the GitHub Action, if it does not exist.

Additionally, it uses a global API Token to perform all steps in the attestation process.

Refs https://github.com/chainloop-dev/platform/issues/630