### PR TITLE
refactor(cli): Consolidates API Token and Robot Account into Token on attestations

### DIFF
--- a/app/cli/cmd/attestation.go
+++ b/app/cli/cmd/attestation.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	robotAccount              string
+	attAPIToken               string
 	useAttestationRemoteState bool
 	GracefulExit              bool
 	// attestationID is the unique identifier of the in-progress attestation
@@ -34,7 +34,6 @@ var (
 
 // Legacy env variable
 const robotAccountEnvVarName = "CHAINLOOP_ROBOT_ACCOUNT"
-const tokenEnvVarName = "CHAINLOOP_TOKEN"
 
 func newAttestationCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -56,19 +55,23 @@ func newAttestationCmd() *cobra.Command {
 				return cmd.MarkFlagRequired("attestation-id")
 			}
 
+			if os.Getenv(tokenEnvVarName) != "" && os.Getenv(robotAccountEnvVarName) != "" {
+				return fmt.Errorf("both %s and %s env variables cannot be set at the same time", tokenEnvVarName, robotAccountEnvVarName)
+			}
+
 			return nil
 		},
 	}
 
-	cmd.PersistentFlags().StringVarP(&robotAccount, "token", "t", "", fmt.Sprintf("auth token. NOTE: You can also use the env variable %s", tokenEnvVarName))
+	cmd.PersistentFlags().StringVarP(&attAPIToken, "token", "t", "", fmt.Sprintf("auth token. NOTE: You can also use the env variable %s", tokenEnvVarName))
 	// We do not use viper in this case because we do not want this token to be saved in the config file
 	// Instead we load the env variable manually
-	if robotAccount == "" {
+	if attAPIToken == "" {
 		// Check first the new env variable
-		robotAccount = os.Getenv(tokenEnvVarName)
+		attAPIToken = os.Getenv(tokenEnvVarName)
 		// If it stills not set, use the legacy one for some time
-		if robotAccount == "" {
-			robotAccount = os.Getenv(robotAccountEnvVarName)
+		if attAPIToken == "" {
+			attAPIToken = os.Getenv(robotAccountEnvVarName)
 		}
 	}
 

--- a/app/cli/cmd/attestation.go
+++ b/app/cli/cmd/attestation.go
@@ -32,7 +32,9 @@ var (
 	attestationID string
 )
 
+// Legacy env variable
 const robotAccountEnvVarName = "CHAINLOOP_ROBOT_ACCOUNT"
+const tokenEnvVarName = "CHAINLOOP_TOKEN"
 
 func newAttestationCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -58,11 +60,16 @@ func newAttestationCmd() *cobra.Command {
 		},
 	}
 
-	cmd.PersistentFlags().StringVarP(&robotAccount, "token", "t", "", fmt.Sprintf("robot account token. NOTE: You can also use the env variable %s", robotAccountEnvVarName))
+	cmd.PersistentFlags().StringVarP(&robotAccount, "token", "t", "", fmt.Sprintf("auth token. NOTE: You can also use the env variable %s", tokenEnvVarName))
 	// We do not use viper in this case because we do not want this token to be saved in the config file
 	// Instead we load the env variable manually
 	if robotAccount == "" {
-		robotAccount = os.Getenv(robotAccountEnvVarName)
+		// Check first the new env variable
+		robotAccount = os.Getenv(tokenEnvVarName)
+		// If it stills not set, use the legacy one for some time
+		if robotAccount == "" {
+			robotAccount = os.Getenv(robotAccountEnvVarName)
+		}
 	}
 
 	cmd.PersistentFlags().BoolVar(&GracefulExit, "graceful-exit", false, "exit 0 in case of error. NOTE: this flag will be removed once Chainloop reaches 1.0")

--- a/app/cli/cmd/errors.go
+++ b/app/cli/cmd/errors.go
@@ -36,4 +36,4 @@ func newGracefulError(err error) error {
 
 var ErrAttestationNotInitialized = errors.New("attestation not yet initialized, execute the init command first")
 var ErrAttestationAlreadyExist = errors.New("attestation already initialized, to override it use the --replace flag`")
-var ErrRobotAccountRequired = errors.New("robot account token required, please provide it via the pre-defined env variable or command flag")
+var ErrAttestationTokenRequired = errors.New("token required, please provide it via the pre-defined env variable or command flag")

--- a/app/cli/cmd/root.go
+++ b/app/cli/cmd/root.go
@@ -195,10 +195,8 @@ func loadControlplaneAuthToken(cmd *cobra.Command) (string, error) {
 	// If the CMD uses a robot account instead of the regular auth token we override it
 	// TODO: the attestation CLI should get split from this one
 	if _, ok := cmd.Annotations[useWorkflowRobotAccount]; ok {
-		if attAPIToken != "" {
-			logger.Debug().Msg("loaded token from robot account")
-		} else {
-			return "", newGracefulError(ErrRobotAccountRequired)
+		if attAPIToken == "" {
+			return "", newGracefulError(ErrAttestationTokenRequired)
 		}
 
 		return attAPIToken, nil

--- a/app/cli/cmd/root.go
+++ b/app/cli/cmd/root.go
@@ -46,7 +46,7 @@ const (
 	useWorkflowRobotAccount = "withWorkflowRobotAccount"
 	appName                 = "chainloop"
 	//nolint:gosec
-	apiTokenEnvVarName = "CHAINLOOP_API_TOKEN"
+	tokenEnvVarName = "CHAINLOOP_TOKEN"
 )
 
 func NewRootCmd(l zerolog.Logger) *cobra.Command {
@@ -104,11 +104,11 @@ func NewRootCmd(l zerolog.Logger) *cobra.Command {
 	rootCmd.PersistentFlags().StringVarP(&flagOutputFormat, "output", "o", "table", "Output format, valid options are json and table")
 
 	// Override the oauth authentication requirement for the CLI by providing an API token
-	rootCmd.PersistentFlags().StringVarP(&apiToken, "token", "t", "", fmt.Sprintf("API token. NOTE: Alternatively use the env variable %s", apiTokenEnvVarName))
+	rootCmd.PersistentFlags().StringVarP(&apiToken, "token", "t", "", fmt.Sprintf("API token. NOTE: Alternatively use the env variable %s", tokenEnvVarName))
 	// We do not use viper in this case because we do not want this token to be saved in the config file
 	// Instead we load the env variable manually
 	if apiToken == "" {
-		apiToken = os.Getenv(apiTokenEnvVarName)
+		apiToken = os.Getenv(tokenEnvVarName)
 	}
 
 	rootCmd.AddCommand(newWorkflowCmd(), newAuthCmd(), NewVersionCmd(),
@@ -195,13 +195,13 @@ func loadControlplaneAuthToken(cmd *cobra.Command) (string, error) {
 	// If the CMD uses a robot account instead of the regular auth token we override it
 	// TODO: the attestation CLI should get split from this one
 	if _, ok := cmd.Annotations[useWorkflowRobotAccount]; ok {
-		if robotAccount != "" {
+		if attAPIToken != "" {
 			logger.Debug().Msg("loaded token from robot account")
 		} else {
 			return "", newGracefulError(ErrRobotAccountRequired)
 		}
 
-		return robotAccount, nil
+		return attAPIToken, nil
 	}
 
 	// override if token is passed as a flag/env variable

--- a/docs/docs/getting-started/attestation-crafting.md
+++ b/docs/docs/getting-started/attestation-crafting.md
@@ -64,19 +64,19 @@ To create an attestation two things are required, the Chainloop crafting tool an
 
 The crafting tool is currently bundled within Chainloop command line tool. To install it just follow the [installation](installation) instructions.
 
-The robot account was created during the [previous step](./workflow-definition#robot-account-creation) and it's required during all the stages of the crafting process. It can be provided via the `--token` flag or the `$CHAINLOOP_ROBOT_ACCOUNT` environment variable.
+The robot account was created during the [previous step](./workflow-definition#robot-account-creation) and it's required during all the stages of the crafting process. It can be provided via the `--token` flag or the `$CHAINLOOP_TOKEN` environment variable.
 
 ### Initialization
 
 ```bash
-$ export CHAINLOOP_ROBOT_ACCOUNT=deadbeef
+$ export CHAINLOOP_TOKEN=deadbeef
 ```
 
 #### Options
 
 `chainloop attestation init` supports the following options
 
-- `--token` robot account provided by the SecOps team. Alternatively, you can set the `CHAINLOOP_ROBOT_ACCOUNT` environment variable.
+- `--token` auth token provided by the SecOps team. Alternatively, you can set the `CHAINLOOP_TOKEN` environment variable.
 - `--revision` of the contract (default: `latest`)
 - `--dry-run`; do not store the attestation in the Control plane, and do not fail if the runner context or required env variables can not be resolved. Useful for development (default: `false`)
 

--- a/docs/docs/reference/operator/api-tokens.mdx
+++ b/docs/docs/reference/operator/api-tokens.mdx
@@ -39,7 +39,7 @@ Available Commands:
   revoke      revoke API token
 ```
 
-and then they can be used by the CLI by either setting `CHAINLOOP_API_TOKEN` environment variable or by using the `--token` flag, for example
+and then they can be used by the CLI by either setting `CHAINLOOP_TOKEN` environment variable or by using the `--token` flag, for example
 
 ```
 chainloop workflow list --token <your-token>


### PR DESCRIPTION
This PR consolidates `CHAINLOOP_API_TOKEN` and `CHAINLOOP_ROBOT_ACCOUNT` into `CHAINLOOP_TOKEN` on attestations commands it is from:

```bash
$ export CHAINLOOP_ROBOT_ACCOUNT=deadbeef
$ chainloop attestation init ...
```
To
```bash
$ export CHAINLOOP_TOKEN=deadbeef
$ chainloop attestation init ...
```
Or
```bash
$ chainloop attestation init --token deadbeaf
```