### PR TITLE
feat(posthog): Add Telemetry client Posthog

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,6 +75,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
           COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          POSTHOG_ENDPOINT: ${{ secrets.POSTHOG_ENDPOINT }}
 
       - uses: anchore/sbom-action@c6aed38a4323b393d05372c58a74c39ae8386d02 # v0.15.6
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,6 +28,8 @@ builds:
     ldflags:
       - "{{ .Env.COMMON_LDFLAGS }}"
       - -X github.com/chainloop-dev/chainloop/app/cli/cmd.Version={{ .Version }}
+      - -X github.com/chainloop-dev/chainloop/app/cli/cmd.posthogAPIKey={{ .Env.POSTHOG_API_KEY }}
+      - -X github.com/chainloop-dev/chainloop/app/cli/cmd.posthogEndpoint={{ .Env.POSTHOG_ENDPOINT }}
     targets:
       - darwin_amd64
       - darwin_arm64

--- a/app/cli/Makefile
+++ b/app/cli/Makefile
@@ -3,7 +3,11 @@ VERSION=$(shell git describe --tags --always)
 .PHONY: build
 # build
 build:
-	mkdir -p bin/ && go build -ldflags "-X github.com/chainloop-dev/chainloop/app/cli/cmd.Version=$(VERSION)" -o ./bin/chainloop ./main.go
+	mkdir -p bin/ && go build -ldflags \
+    		  "-X github.com/chainloop-dev/chainloop/app/cli/cmd.Version=$(VERSION) \
+    		  -X github.com/chainloop-dev/chainloop/app/cli/cmd.posthogAPIKey=${POSTHOG_API_KEY} \
+    		  -X github.com/chainloop-dev/chainloop/app/cli/cmd.posthogEndpoint=${POSTHOG_ENDPOINT}" \
+    		  -o ./bin/chainloop ./main.go
 
 .PHONY: test
 # test

--- a/app/cli/cmd/root_test.go
+++ b/app/cli/cmd/root_test.go
@@ -25,38 +25,68 @@ func TestParseToken(t *testing.T) {
 	tests := []struct {
 		name  string
 		token string
-		want  ParsedToken
+		want  *parsedToken
 	}{
 		{
 			name:  "robot account",
-			token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiI5M2QwMjI3NS04NTNjLTRhZDYtOWQ2MC04ZjU2MmIxMjNmZDIiLCJ3b3JrZmxvd19pZCI6IjM1ZTZkOGIwLWE0OGYtNDFmYS05YmU3LWQ1OTM5YjJkZGUyNiIsImlzcyI6ImNwLmNoYWlubG9vcCIsImF1ZCI6WyJhdHRlc3RhdGlvbnMuY2hhaW5sb29wIl0sImp0aSI6IjQ4YWVhMWNiLTk5MGUtNDM2OS1hOTFhLTczNTIzNzk1NjhiNSJ9.aYPAPK-AauJpxRGEapV2ejwxhyhmFej6S79Ni-xJ4Q0",
-			want: ParsedToken{
-				Type: "robot-account",
+			token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJkZGRiODIwMS1lYWI2LTRlNjEtOTIwMS1mMTJiNDdjMDE4OTIiLCJ3b3JrZmxvd19pZCI6ImY0NmIzMDc5LTMwOGYtNGIwNC1hYjYwLTY3NDNmOGUzMGQzMyIsImlzcyI6ImNwLmNoYWlubG9vcCIsImF1ZCI6WyJhdHRlc3RhdGlvbnMuY2hhaW5sb29wIl0sImp0aSI6IjkzODI5NDE1LTA1ODYtNDFkYS05NTJkLTkyYTRjNDk1ZWEyMCJ9.3Af2C62PiODbEknhv47j0LHLuAgWLqvTrfmIzFjwPCM",
+			want: &parsedToken{
+				id:        "93829415-0586-41da-952d-92a4c495ea20",
+				tokenType: "robot-account",
+				orgID:     "dddb8201-eab6-4e61-9201-f12b47c01892",
 			},
 		},
 		{
 			name:  "user account",
 			token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiYmMwYjIxOTktY2E4NS00MmFiLWE4NTctMDQyZTljMTA5ZDQzIiwiaXNzIjoiY3AuY2hhaW5sb29wIiwiYXVkIjpbInVzZXItYXV0aC5jaGFpbmxvb3AiXSwiZXhwIjoxNzE1OTM1MjUwfQ.ounYshGtagtYQsVIzNeE0ztVYRXrmjFSpdmaTF4QvyY",
-			want: ParsedToken{
-				ID:   "bc0b2199-ca85-42ab-a857-042e9c109d43",
-				Type: "user",
+			want: &parsedToken{
+				id:        "bc0b2199-ca85-42ab-a857-042e9c109d43",
+				tokenType: "user",
 			},
 		},
 		{
 			name:  "api token",
-			token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJjcC5jaGFpbmxvb3AiLCJhdWQiOlsiYXBpLXRva2VuLWF1dGguY2hhaW5sb29wIl0sImp0aSI6IjE0NTQ5MzUwLTFjNGItNDdlYi05NDZkLWY2MjJhZWYyMDk0MyJ9.BPzuNxSwx10h22fJ3ocAOEIjsq9OOlk9p8fSoCwqSmM",
-			want: ParsedToken{
-				Type: "api-token",
+			token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJkZGRiODIwMS1lYWI2LTRlNjEtOTIwMS1mMTJiNDdjMDE4OTIiLCJpc3MiOiJjcC5jaGFpbmxvb3AiLCJhdWQiOlsiYXBpLXRva2VuLWF1dGguY2hhaW5sb29wIl0sImp0aSI6IjRiMGYwZGQ0LTQ1MzgtNDI2OS05MmE5LWFiNWIwZmNlMDI1OCJ9.yMgsoe4CcqYoNp0xtrvvSGj1Y74HeqxoxS5sw8pdnQ8",
+			want: &parsedToken{
+				id:        "4b0f0dd4-4538-4269-92a9-ab5b0fce0258",
+				tokenType: "api-token",
+				orgID:     "dddb8201-eab6-4e61-9201-f12b47c01892",
 			},
+		},
+		{
+			name:  "old api token (without orgID)",
+			token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJjcC5jaGFpbmxvb3AiLCJhdWQiOlsiYXBpLXRva2VuLWF1dGguY2hhaW5sb29wIl0sImp0aSI6ImQ0ZTBlZTVlLTk3MTMtNDFkMi05ZmVhLTBiZGIxNDAzMzA4MSJ9.IOd3JIHPwfo9ihU20kvRwLIQJcQtTvp-ajlGqlCD4Es",
+			want: &parsedToken{
+				id:        "d4e0ee5e-9713-41d2-9fea-0bdb14033081",
+				tokenType: "api-token",
+			},
+		},
+		{
+			name:  "old robot account",
+			token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiI5M2QwMjI3NS04NTNjLTRhZDYtOWQ2MC04ZjU2MmIxMjNmZDIiLCJ3b3JrZmxvd19pZCI6IjM1ZTZkOGIwLWE0OGYtNDFmYS05YmU3LWQ1OTM5YjJkZGUyNiIsImlzcyI6ImNwLmNoYWlubG9vcCIsImF1ZCI6WyJhdHRlc3RhdGlvbnMuY2hhaW5sb29wIl0sImp0aSI6ImUxZDUzOGQxLWI2MWQtNGY4MC1iZWQzLWM3MGE1NzRlOWI2NiJ9.81WltZtOno26oNydJ-YtHRwAIEmD2B4RgChhsS4yYVk",
+			want: &parsedToken{
+				id:        "e1d538d1-b61d-4f80-bed3-c70a574e9b66",
+				tokenType: "robot-account",
+				orgID:     "93d02275-853c-4ad6-9d60-8f562b123fd2",
+			},
+		},
+		{
+			name:  "totally random token",
+			token: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE3MTYxOTE2ODQsImV4cCI6MTc0NzcyNzY4NCwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJFbWFpbCI6Impyb2NrZXRAZXhhbXBsZS5jb20iLCJSb2xlIjpbIk1hbmFnZXIiLCJQcm9qZWN0IEFkbWluaXN0cmF0b3IiXX0.5UnBivwkQCG4qWgi-gWkJ-Dsd7-A9G_EVEvswODc7Kk",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := parseToken(tt.token)
 			assert.NoError(t, err)
+			if tt.want == nil {
+				assert.Nil(t, got)
+				return
+			}
 
-			assert.Equal(t, tt.want.ID, got.ID)
-			assert.Equal(t, tt.want.Type, got.Type)
+			assert.Equal(t, tt.want.id, got.id)
+			assert.Equal(t, tt.want.tokenType, got.tokenType)
+			assert.Equal(t, tt.want.orgID, got.orgID)
 		})
 	}
 }

--- a/app/cli/main.go
+++ b/app/cli/main.go
@@ -31,6 +31,7 @@ func main() {
 	logger := zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr, FormatTimestamp: func(interface{}) string { return "" }})
 	rootCmd := cmd.NewRootCmd(logger)
 
+	// Run the command
 	if err := rootCmd.Execute(); err != nil {
 		msg, exitCode := errorInfo(err, logger)
 		logger.Error().Msg(msg)

--- a/docs/docs/reference/operator/cli-telemetry.mdx
+++ b/docs/docs/reference/operator/cli-telemetry.mdx
@@ -1,0 +1,33 @@
+---
+title: CLI Telemetry
+---
+
+By default, the Chainloop CLI sends telemetry data to chainloop.dev. This helps us enhance Chainloop by gaining insights into its usage.
+Telemetry is optional and can be turned off at any time. If you can keep telemetry enabled, we appreciate it! This will assist us in better understanding Chainloop's usage and improving your experience.
+
+## What data is collected?
+The following information is included in telemetry:
+
+- Chainloop CLI version
+- System information (OS, ARCH)
+- CI/CD environment (if detected)
+- Platform hashed URL
+- Command run
+- Anonymous device ID
+- Internal User ID and organization ID (if logged in)
+
+## Can Chainloop telemetry be deactivated?
+
+Chainloop implements the Console [Do Not Track (DNT) standard](https://consoledonottrack.com). As a result, you can deactivate the telemetry by setting the environment variable DO_NOT_TRACK=1 before running the Chainloop CLI.
+
+
+## What do we use to collect telemetry data?
+
+We use [PostHog](https://posthog.com/). PostHog is an open-source product analytics platform that allows us to collect and analyze telemetry data.
+We did it in such a way that anyone can set up their own PostHog instance and use it to collect telemetry. To do so
+compile Chainloop CLI from its source code and set up the following linker flags to the Golang compiler:
+
+```sh
+-X github.com/chainloop-dev/chainloop/app/cli/cmd.posthogAPIKey=$POSTHOG_API_KEY
+-X github.com/chainloop-dev/chainloop/app/cli/cmd.posthogEndpoint=$POSTHOG_ENDPOINT
+```


### PR DESCRIPTION
This PR creates a new implementation of a Tracker client based on Posthog.

Users can deactivate telemetry by setting the env variable `DO_NOT_TRACK=1`, it follows the convention at: https://consoledonottrack.com/

Information being tracked:
- System information (OS, ARCH)
- Command ran
- CI Runner information if detected
- CLI version
- Hashed Control Plane URL
- Anonymous device ID
- User and Organization if logged in

Refs: #780 