### PR TITLE
fix(CLI): fix correct failure reason in table view

### DIFF
--- a/app/cli/cmd/workflow_workflow_run_describe.go
+++ b/app/cli/cmd/workflow_workflow_run_describe.go
@@ -100,7 +100,7 @@ func workflowRunDescribeTableOutput(run *action.WorkflowRunItemFull) error {
 	}
 	gt.AppendRow(table.Row{"State", wr.State})
 	if wr.Reason != "" {
-		gt.AppendRow(table.Row{"Failure Reason", wr.State})
+		gt.AppendRow(table.Row{"Failure Reason", wr.Reason})
 	}
 	gt.AppendRow(table.Row{"Runner Link", wr.RunURL})
 


### PR DESCRIPTION
This is a simple PR to fix the failure reason value shown in the table view.
```
✗ go run app/cli/main.go --insecure wf run describe --id 6f88410e-77d0-4dc3-90f3-add091381f8b
WRN API contacted in insecure mode
┌───────────────────────────────────────────────────────┐
│ Workflow                                              │
├────────────────┬──────────────────────────────────────┤
│ ID             │ 5fba63eb-e410-4546-baf2-99702b3bc0f0 │
│ Name           │ new-workflow                         │
│ Team           │                                      │
│ Project        │ my-project                           │
├────────────────┼──────────────────────────────────────┤
│ Workflow Run   │                                      │
├────────────────┼──────────────────────────────────────┤
│ ID             │ 6f88410e-77d0-4dc3-90f3-add091381f8b │
│ Initialized At │ 16 May 24 12:28 UTC                  │
│ Finished At    │ 16 May 24 12:28 UTC                  │
│ State          │ canceled                             │
│ Failure Reason │ my reason                            │
│ Runner Link    │                                      │
└────────────────┴──────────────────────────────────────┘
WRN there was an issue retrieving the attestation
```
Fixes #636 