### PR TITLE
fix(attestations): support attestations workflow for API_TOKENS

### DIFF
--- a/app/controlplane/internal/biz/workflowrun.go
+++ b/app/controlplane/internal/biz/workflowrun.go
@@ -313,6 +313,21 @@ func (uc *WorkflowRunUseCase) GetByIDInOrgOrPublic(ctx context.Context, orgID, r
 	return workflowRunInOrgOrPublic(wfrun, orgUUID)
 }
 
+// Returns the workflow run with the provided ID if it belongs to the org
+func (uc *WorkflowRunUseCase) GetByIDInOrg(ctx context.Context, orgID, runID string) (*WorkflowRun, error) {
+	orgUUID, err := uuid.Parse(orgID)
+	if err != nil {
+		return nil, NewErrInvalidUUID(err)
+	}
+
+	runUUID, err := uuid.Parse(runID)
+	if err != nil {
+		return nil, NewErrInvalidUUID(err)
+	}
+
+	return uc.wfRunRepo.FindByIDInOrg(ctx, orgUUID, runUUID)
+}
+
 func (uc *WorkflowRunUseCase) GetByDigestInOrgOrPublic(ctx context.Context, orgID, digest string) (*WorkflowRun, error) {
 	orgUUID, err := uuid.Parse(orgID)
 	if err != nil {

--- a/app/controlplane/internal/data/workflowrun.go
+++ b/app/controlplane/internal/data/workflowrun.go
@@ -102,7 +102,7 @@ func (r *WorkflowRunRepo) FindByIDInOrg(ctx context.Context, orgID, id uuid.UUID
 	if err != nil && !ent.IsNotFound(err) {
 		return nil, err
 	} else if run == nil {
-		return nil, nil
+		return nil, biz.NewErrNotFound("workflow run")
 	}
 
 	return entWrToBizWr(run), nil

--- a/app/controlplane/internal/service/attestation.go
+++ b/app/controlplane/internal/service/attestation.go
@@ -183,14 +183,9 @@ func (s *AttestationService) Store(ctx context.Context, req *cpAPI.AttestationSe
 		return nil, errors.NotFound("not found", "robot account not found")
 	}
 
-	wf, err := s.findWorkflowFromTokenOrNameOrRunID(ctx, robotAccount.OrgID, robotAccount.WorkflowID, "", req.WorkflowRunId)
-	if err != nil {
+	// This will make sure the provided workflowRunID belongs to the org encoded in the robot account
+	if _, err := s.findWorkflowFromTokenOrNameOrRunID(ctx, robotAccount.OrgID, robotAccount.WorkflowID, "", req.WorkflowRunId); err != nil {
 		return nil, handleUseCaseErr(err, s.log)
-	}
-
-	// Check that provided workflowRun belongs to workflow encoded in the robot account
-	if exists, err := s.wrUseCase.ExistsInWorkflow(ctx, wf.ID.String(), req.WorkflowRunId); err != nil || !exists {
-		return nil, errors.NotFound("not found", "workflowRun not found")
 	}
 
 	// Decode the envelope through json encoding but
@@ -291,13 +286,9 @@ func (s *AttestationService) Cancel(ctx context.Context, req *cpAPI.AttestationS
 		return nil, errors.NotFound("not found", "robot account not found")
 	}
 
-	wf, err := s.findWorkflowFromTokenOrNameOrRunID(ctx, robotAccount.OrgID, robotAccount.WorkflowID, "", req.WorkflowRunId)
-	if err != nil {
+	// This will make sure the provided workflowRunID belongs to the org encoded in the robot account
+	if _, err := s.findWorkflowFromTokenOrNameOrRunID(ctx, robotAccount.OrgID, robotAccount.WorkflowID, "", req.WorkflowRunId); err != nil {
 		return nil, handleUseCaseErr(err, s.log)
-	}
-
-	if exists, err := s.wrUseCase.ExistsInWorkflow(ctx, wf.ID.String(), req.WorkflowRunId); err != nil || !exists {
-		return nil, errors.NotFound("not found", "workflowRun not found")
 	}
 
 	var status biz.WorkflowRunStatus


### PR DESCRIPTION
Makes sure to load the workflow from the three possible contexts always scoped for the current organization in the auth.

The three contexts are, 

- the workflow_id in the robot-account
- the workflow_name in the parameter in `init`
- the runID in the rest of the subsequent calls

Closes #783