### PR TITLE
feat(api-tokens): Allow API TOKENs to create robot accounts

### DIFF
--- a/app/controlplane/internal/authz/authz.go
+++ b/app/controlplane/internal/authz/authz.go
@@ -92,7 +92,8 @@ var (
 	// Org Metrics
 	PolicyOrgMetricsRead = &Policy{ResourceOrgMetric, ActionList}
 	// Robot Account
-	PolicyRobotAccountList = &Policy{ResourceRobotAccount, ActionList}
+	PolicyRobotAccountList   = &Policy{ResourceRobotAccount, ActionList}
+	PolicyRobotAccountCreate = &Policy{ResourceRobotAccount, ActionCreate}
 	// Workflow Contract
 	PolicyWorkflowContractList   = &Policy{ResourceWorkflowContract, ActionList}
 	PolicyWorkflowContractRead   = &Policy{ResourceWorkflowContract, ActionRead}
@@ -176,7 +177,8 @@ var ServerOperationsMap = map[string][]*Policy{
 	// Metrics
 	"/controlplane.v1.OrgMetricsService/.*": {PolicyOrgMetricsRead},
 	// Robot Account
-	"/controlplane.v1.RobotAccountService/List": {PolicyRobotAccountList},
+	"/controlplane.v1.RobotAccountService/List":   {PolicyRobotAccountList},
+	"/controlplane.v1.RobotAccountService/Create": {PolicyRobotAccountCreate},
 	// Workflows
 	"/controlplane.v1.WorkflowService/List":   {PolicyWorkflowList},
 	"/controlplane.v1.WorkflowService/View":   {PolicyWorkflowRead},

--- a/app/controlplane/internal/biz/apitoken.go
+++ b/app/controlplane/internal/biz/apitoken.go
@@ -81,6 +81,8 @@ func NewAPITokenUseCase(apiTokenRepo APITokenRepo, conf *conf.Auth, authzE *auth
 			// to download artifacts and list referrers
 			authz.PolicyArtifactDownload, authz.PolicyReferrerRead,
 			authz.PolicyOrganizationRead,
+			// to create robot accounts
+			authz.PolicyRobotAccountCreate,
 		},
 	}
 


### PR DESCRIPTION
This PR allows to invoke `chainloop wf create` without passing the flag `--skip-robot-account-create` when using API tokens to authenticate:
```
✗ go run app/cli/main.go --insecure --token $TOKEN wf create --name my-wf --project my-proj
WRN API contacted in insecure mode
INF API token provided to the command line
┌──────────────────────────────────────┬───────────┬─────────┬─────────────────────┬────────┬─────────────────┐
│ ID                                   │ NAME      │ PROJECT │ CREATED AT          │ RUNNER │ LAST RUN STATUS │
├──────────────────────────────────────┼───────────┼─────────┼─────────────────────┼────────┼─────────────────┤
│ 0c76d9d6-d056-4ca9-84be-fb4d1202af24 │ sdfsdffs2 │ asdfs   │ 16 May 24 14:17 UTC │        │                 │
└──────────────────────────────────────┴───────────┴─────────┴─────────────────────┴────────┴─────────────────┘

This is an automatically generated Robot Account Token (ID: 59091596-30b1-4d52-b37e-a9ee82c805b4). Save the following token since it will not printed again:
```
