### PR TITLE
feat(attestations): handle authentication combinations

### DIFF
--- a/app/cli/internal/action/attestation_init.go
+++ b/app/cli/internal/action/attestation_init.go
@@ -122,7 +122,8 @@ func (action *AttestationInit) Run(ctx context.Context, contractRevision int, wo
 				Runner:           discoveredRunner.ID(),
 				JobUrl:           discoveredRunner.RunURI(),
 				ContractRevision: int32(contractRevision),
-				WorkflowName:     workflow.GetName(),
+				// send the workflow name explicitly provided by the user to detect that functional case
+				WorkflowName: workflowName,
 			},
 		)
 		if err != nil {

--- a/app/controlplane/internal/usercontext/apitoken_middleware.go
+++ b/app/controlplane/internal/usercontext/apitoken_middleware.go
@@ -165,7 +165,7 @@ func setRobotAccountFromAPIToken(ctx context.Context, apiTokenUC *biz.APITokenUs
 		return nil, errors.New("API token revoked")
 	}
 
-	ctx = withRobotAccount(ctx, &RobotAccount{OrgID: token.OrganizationID.String()})
+	ctx = withRobotAccount(ctx, &RobotAccount{OrgID: token.OrganizationID.String(), ProviderKey: attjwtmiddleware.APITokenProviderKey})
 
 	return ctx, nil
 }

--- a/app/controlplane/internal/usercontext/robotaccount_middleware.go
+++ b/app/controlplane/internal/usercontext/robotaccount_middleware.go
@@ -27,7 +27,7 @@ import (
 )
 
 type RobotAccount struct {
-	ID, WorkflowID, OrgID string
+	ID, WorkflowID, OrgID, ProviderKey string
 }
 
 func withRobotAccount(ctx context.Context, acc *RobotAccount) context.Context {
@@ -112,7 +112,9 @@ func WithAttestationContextFromRobotAccount(robotAccountUseCase *biz.RobotAccoun
 			}
 
 			// Set the robot account in the context
-			ctx = withRobotAccount(ctx, &RobotAccount{ID: account.ID.String(), WorkflowID: workflowID, OrgID: orgID})
+			ctx = withRobotAccount(ctx, &RobotAccount{
+				ID: account.ID.String(), WorkflowID: workflowID, OrgID: orgID, ProviderKey: authInfo.ProviderKey,
+			})
 
 			return handler(ctx, req)
 		}


### PR DESCRIPTION
This code improves the user feedback by returning an error when the user is using a robot-account-based attestation and a workflow-name at the same time.

I do it by refactoring a little bit the code to explicitly check the kind of authentication is received and handle both cases. Note that I required to do a change in the CLI too so send the `name` only if only the user provided it.

API token auth missing name

```
go run main.go --insecure att init --replace                         
ERR rpc error: code = InvalidArgument desc = when using an API Token, workflow name is required as parameter
```

using ROBOT account with name

```
go run main.go --insecure att init --replace --workflow-name fo
ERR rpc error: code = InvalidArgument desc = workflow name is not compatible with robot-account based attestations
```