### PR TITLE
docs: remove hardcoded CLI version

### DIFF
--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -29,7 +29,8 @@ curl -sfL https://docs.chainloop.dev/install.sh | bash -s
 you can retrieve a specific version with
 
 ```bash
-curl -sfL https://docs.chainloop.dev/install.sh | bash -s -- --version v0.1.2
+# You can find all the available versions at https://github.com/chainloop-dev/chainloop/releases
+curl -sfL https://docs.chainloop.dev/install.sh | bash -s -- --version vx.x.x
 ```
 
 and customize the install path (default to /usr/local/bin)


### PR DESCRIPTION
The version shown in the instructions is very old and can confused people. It's best to not to show the version but indicate how to find it.

refs #792 