### PR TITLE
fix: handle posthog nil client

### DIFF
--- a/app/cli/cmd/root.go
+++ b/app/cli/cmd/root.go
@@ -348,6 +348,7 @@ func recordCommand(executedCmd *cobra.Command, authInfo *parsedToken) error {
 	telemetryClient, err := posthog.NewClient(posthogAPIKey, posthogEndpoint)
 	if err != nil {
 		logger.Debug().Err(err).Msgf("creating telemetry client: %v", err)
+		return nil
 	}
 
 	cmdTracker := telemetry.NewCommandTracker(telemetryClient)


### PR DESCRIPTION
Handles a `nil` client when running the build of the code outside of goreleaser.

Refs #809 