### PR TITLE
fix(cli): show digest in stdout in att push command

### DIFF
--- a/app/cli/cmd/attestation_push.go
+++ b/app/cli/cmd/attestation_push.go
@@ -93,7 +93,7 @@ func newAttestationPushCmd() *cobra.Command {
 			}
 
 			if res.Digest != "" {
-				logger.Info().Msgf("Attestation Digest: %s", res.Digest)
+				fmt.Printf("Attestation Digest: %s", res.Digest)
 			}
 
 			return nil


### PR DESCRIPTION
Show digest in stdout instead of stderr, so that command output doesn't break.

Fixes #805 