### PR TITLE
feat(posthog): Inject Posthog credentials

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,8 +28,6 @@ builds:
     ldflags:
       - "{{ .Env.COMMON_LDFLAGS }}"
       - -X github.com/chainloop-dev/chainloop/app/cli/cmd.Version={{ .Version }}
-      - -X github.com/chainloop-dev/chainloop/app/cli/cmd.posthogAPIKey={{ .Env.POSTHOG_API_KEY }}
-      - -X github.com/chainloop-dev/chainloop/app/cli/cmd.posthogEndpoint={{ .Env.POSTHOG_ENDPOINT }}
     targets:
       - darwin_amd64
       - darwin_arm64

--- a/app/cli/Makefile
+++ b/app/cli/Makefile
@@ -4,9 +4,7 @@ VERSION=$(shell git describe --tags --always)
 # build
 build:
 	mkdir -p bin/ && go build -ldflags \
-    		  "-X github.com/chainloop-dev/chainloop/app/cli/cmd.Version=$(VERSION) \
-    		  -X github.com/chainloop-dev/chainloop/app/cli/cmd.posthogAPIKey=${POSTHOG_API_KEY} \
-    		  -X github.com/chainloop-dev/chainloop/app/cli/cmd.posthogEndpoint=${POSTHOG_ENDPOINT}" \
+    		  "-X github.com/chainloop-dev/chainloop/app/cli/cmd.Version=$(VERSION)" \
     		  -o ./bin/chainloop ./main.go
 
 .PHONY: test

--- a/app/cli/cmd/root.go
+++ b/app/cli/cmd/root.go
@@ -338,9 +338,12 @@ func parseToken(token string) (*parsedToken, error) {
 }
 
 var (
-	// Posthog API key and endpoint to be injected in the build process
-	posthogAPIKey   = ""
-	posthogEndpoint = ""
+	// Posthog API key and endpoint are not sensitive information it represents Chainloop's Posthog instance.
+	// It can be overridden by the user if they want to use their own instance of Posthog or deactivated by setting
+	// DO_NOT_TRACK=1 more information that can be found at: https://github.com/chainloop-dev/chainloop/blob/main/docs/docs/reference/operator/cli-telemetry.mdx
+	// nolint:gosec
+	posthogAPIKey   = "phc_TWWW19kEiD6sEejlHKWcICQ5Vc06vZUTYia8WdPB0A0"
+	posthogEndpoint = "https://crb.chainloop.dev"
 )
 
 // recordCommand sends the command to the telemetry service


### PR DESCRIPTION
This patch adds public Posthog API key that points to Chainloop instance so it can be included in external builds such as Homebrew.

[Refs: #676](https://github.com/chainloop-dev/platform/issues/676)