### PR TITLE
chore(docs): remove gtag preset option

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -200,9 +200,6 @@ ${content
       "classic",
       /** @type {import('@docusaurus/preset-classic').Options} */
       ({
-        gtag: {
-          trackingID: "G-G4XVJP8LEP",
-        },
         docs: {
           sidebarPath: require.resolve("./sidebars.js"),
           sidebarCollapsed: false,


### PR DESCRIPTION
This is a cleanup of gtag leftovers as the posthog exchanges its functionality