### PR TITLE
feat(attestation): Allow the auto discovery of material's kind

### DIFF
--- a/app/cli/cmd/attestation_add.go
+++ b/app/cli/cmd/attestation_add.go
@@ -52,7 +52,10 @@ func newAttestationAddCmd() *cobra.Command {
   chainloop attestation add --name <material-name> --value <material-value>
 
   # Add a material to the attestation that is not defined in the contract but you know the kind
-  chainloop attestation add --kind <material-kind> --value <material-value>`,
+  chainloop attestation add --kind <material-kind> --value <material-value>
+
+  # Add a material to the attestation without specifying the kind enables automatic detection
+  chainloop attestation add --value <material-value>`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if name != "" && kind != "" {
 				return fmt.Errorf("both --name and --kind cannot be set at the same time")

--- a/app/cli/cmd/attestation_add.go
+++ b/app/cli/cmd/attestation_add.go
@@ -54,7 +54,7 @@ func newAttestationAddCmd() *cobra.Command {
   # Add a material to the attestation that is not defined in the contract but you know the kind
   chainloop attestation add --kind <material-kind> --value <material-value>
 
-  # Add a material to the attestation without specifying the kind enables automatic detection
+  # Add a material to the attestation without specifying neither kind nor name enables automatic detection
   chainloop attestation add --value <material-value>`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if name != "" && kind != "" {

--- a/app/cli/cmd/attestation_add.go
+++ b/app/cli/cmd/attestation_add.go
@@ -54,10 +54,7 @@ func newAttestationAddCmd() *cobra.Command {
   # Add a material to the attestation that is not defined in the contract but you know the kind
   chainloop attestation add --kind <material-kind> --value <material-value>`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			switch {
-			case name == "" && kind == "":
-				return fmt.Errorf("either --name or --kind needs to be set")
-			case name != "" && kind != "":
+			if name != "" && kind != "" {
 				return fmt.Errorf("both --name and --kind cannot be set at the same time")
 			}
 

--- a/app/cli/internal/action/attestation_add.go
+++ b/app/cli/internal/action/attestation_add.go
@@ -116,7 +116,7 @@ func (action *AttestationAdd) Run(ctx context.Context, attestationID, materialNa
 	switch {
 	case materialName == "" && materialType == "":
 		var kind schemaapi.CraftingSchema_Material_MaterialType
-		if kind, err = action.c.AddMaterialAutomatic(ctx, attestationID, materialValue, casBackend, annotations); err != nil {
+		if kind, err = action.c.AddMaterialContactFreeAutomatic(ctx, attestationID, materialValue, casBackend, annotations); err != nil {
 			return fmt.Errorf("adding material: %w", err)
 		}
 		action.Logger.Info().Str("kind", kind.String()).Msg("material kind detected")

--- a/app/controlplane/api/workflowcontract/v1/crafting_schema_validations.go
+++ b/app/controlplane/api/workflowcontract/v1/crafting_schema_validations.go
@@ -20,6 +20,25 @@ import (
 	"strings"
 )
 
+// CraftingMaterialInValidationOrder all type of CraftingMaterial that are available for automatic
+// detection. The order of the list is important as it defines the order of the
+// detection process. Normally from most common one to the least common one and weaker validation method.
+var CraftingMaterialInValidationOrder = []CraftingSchema_Material_MaterialType{
+	CraftingSchema_Material_OPENVEX,
+	CraftingSchema_Material_SBOM_CYCLONEDX_JSON,
+	CraftingSchema_Material_SBOM_SPDX_JSON,
+	CraftingSchema_Material_CSAF_VEX,
+	CraftingSchema_Material_CSAF_INFORMATIONAL_ADVISORY,
+	CraftingSchema_Material_CSAF_SECURITY_ADVISORY,
+	CraftingSchema_Material_CSAF_SECURITY_INCIDENT_RESPONSE,
+	CraftingSchema_Material_JUNIT_XML,
+	CraftingSchema_Material_HELM_CHART,
+	CraftingSchema_Material_CONTAINER_IMAGE,
+	CraftingSchema_Material_SARIF,
+	CraftingSchema_Material_ATTESTATION,
+	CraftingSchema_Material_ARTIFACT,
+}
+
 // ListAvailableMaterialKind returns a list of available material kinds
 func ListAvailableMaterialKind() []string {
 	var res []string

--- a/app/controlplane/api/workflowcontract/v1/crafting_schema_validations.go
+++ b/app/controlplane/api/workflowcontract/v1/crafting_schema_validations.go
@@ -37,6 +37,7 @@ var CraftingMaterialInValidationOrder = []CraftingSchema_Material_MaterialType{
 	CraftingSchema_Material_SARIF,
 	CraftingSchema_Material_ATTESTATION,
 	CraftingSchema_Material_ARTIFACT,
+	CraftingSchema_Material_STRING,
 }
 
 // ListAvailableMaterialKind returns a list of available material kinds

--- a/internal/attestation/crafter/crafter.go
+++ b/internal/attestation/crafter/crafter.go
@@ -514,21 +514,26 @@ func (c *Crafter) AddMaterialFromContract(ctx context.Context, attestationID, ke
 	return c.addMaterial(ctx, m, attestationID, value, casBackend, runtimeAnnotations)
 }
 
-// AddMaterialAutomatic adds a material to the crafting state checking the incoming material matches any of the
-// supported types in validation order
-func (c *Crafter) AddMaterialAutomatic(ctx context.Context, attestationID, value string, casBackend *casclient.CASBackend, runtimeAnnotations map[string]string) (schemaapi.CraftingSchema_Material_MaterialType, error) {
+// AddMaterialContactFreeAutomatic adds a material to the crafting state checking the incoming material matches any of the
+// supported types in validation order. If the material is not found it will return an error.
+func (c *Crafter) AddMaterialContactFreeAutomatic(ctx context.Context, attestationID, value string, casBackend *casclient.CASBackend, runtimeAnnotations map[string]string) (schemaapi.CraftingSchema_Material_MaterialType, error) {
 	var kind schemaapi.CraftingSchema_Material_MaterialType
+	var found bool
+
 	// We want to run the material validation in a specific order
 	for _, kind = range schemaapi.CraftingMaterialInValidationOrder {
-		// Skip the ones with weaker validation methods that cannot be automatically detected
-		if kind == schemaapi.CraftingSchema_Material_STRING || kind == schemaapi.CraftingSchema_Material_EVIDENCE {
-			continue
-		}
-
 		if err := c.AddMaterialContractFree(ctx, attestationID, kind.String(), value, casBackend, runtimeAnnotations); err != nil {
+			c.logger.Debug().Err(err).Str("kind", kind.String()).Msg("failed to add material")
 			continue
 		}
+		// If we found a match we break the loop and stop looking
+		found = true
 		break
+	}
+
+	// Return an error if the material could not be added
+	if !found {
+		return kind, fmt.Errorf("failed to add material with attestationID: %s", attestationID)
 	}
 
 	return kind, nil


### PR DESCRIPTION
This patch ease the addition of new materials to an attestation by enabling by default the auto discovery of materials' kind. If the material is not on the contract nor a specific kind is flagged, the CLI will try to match the material with any of the registered kinds.

**Please note this is a best effort.**

Example of usage. Given the following contract:
```bash
$ chainloop --insecure attestation init --replace --workflow-name wf-test
WRN API contacted in insecure mode
INF Attestation initialized! now you can check its status or add materials to it
┌───────────────────┬──────────────────────────────────────┐
│ Initialized At    │ 22 May 24 13:38 UTC                  │
├───────────────────┼──────────────────────────────────────┤
│ Attestation ID    │ 583553ef-d051-4c41-aec4-a4cdd725bf89 │
│ Name              │ wf-test                              │
│ Team              │ founding                             │
│ Project           │ core                                 │
│ Contract Revision │ 3                                    │
└───────────────────┴──────────────────────────────────────┘
┌────────────────────────┐
│ Materials              │
├───────────┬────────────┤
│ Name      │ one-file   │
│ Type      │ ARTIFACT   │
│ Set       │ No         │
│ Required  │ Yes        │
│ Is output │ Yes        │
├───────────┼────────────┤
│ Name      │ other-file │
│ Type      │ EVIDENCE   │
│ Set       │ No         │
│ Required  │ Yes        │
│ Is output │ Yes        │
└───────────┴────────────┘
```
Let's add the compulsory materials:
```bash
$ chainloop --insecure attestation add --value go.mod --name one-file
WRN API contacted in insecure mode
INF material added to attestation

$ chainloop --insecure attestation add --value LICENSE.md --name other-file
WRN API contacted in insecure mode
INF material added to attestation
```
And finally let's try to discover one material without specifying its type:
```bash
$ chainloop --insecure attestation add --value controlplane.cyclonedx.json
WRN API contacted in insecure mode
INF material kind detected kind=SBOM_CYCLONEDX_JSON
INF material added to attestation
```
As a result we can see how it's added to the result:
```bash
$ chainloop --insecure attestation push --key cosign.key
WRN API contacted in insecure mode
Enter password for private key:
INF push completed
┌───────────────────┬──────────────────────────────────────┐
│ Initialized At    │ 22 May 24 13:38 UTC                  │
├───────────────────┼──────────────────────────────────────┤
│ Attestation ID    │ 583553ef-d051-4c41-aec4-a4cdd725bf89 │
│ Name              │ wf-test                              │
│ Team              │ founding                             │
│ Project           │ core                                 │
│ Contract Revision │ 3                                    │
└───────────────────┴──────────────────────────────────────┘
┌─────────────────────────────────────────────────────────────────────────────────────┐
│ Materials                                                                           │
├───────────┬─────────────────────────────────────────────────────────────────────────┤
│ Name      │ one-file                                                                │
│ Type      │ ARTIFACT                                                                │
│ Set       │ Yes                                                                     │
│ Required  │ Yes                                                                     │
│ Is output │ Yes                                                                     │
│ Value     │ go.mod                                                                  │
│ Digest    │ sha256:29773f085c46a33efcb6cdb185f6ec30ce1c4ca708b860708cd055b70488ef4d │
├───────────┼─────────────────────────────────────────────────────────────────────────┤
│ Name      │ other-file                                                              │
│ Type      │ EVIDENCE                                                                │
│ Set       │ Yes                                                                     │
│ Required  │ Yes                                                                     │
│ Is output │ Yes                                                                     │
│ Value     │ LICENSE.md                                                              │
│ Digest    │ sha256:c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4 │
├───────────┼─────────────────────────────────────────────────────────────────────────┤
│ Name      │ material-1716385111238449000                                            │
│ Type      │ SBOM_CYCLONEDX_JSON                                                     │
│ Set       │ Yes                                                                     │
│ Required  │ No                                                                      │
│ Value     │ controlplane.cyclonedx.json                                             │
│ Digest    │ sha256:a6bc29d7a2d8d9f6df12a86ee4c86c58189d77bb6ded9487330c39f46ee00d9a │
└───────────┴─────────────────────────────────────────────────────────────────────────┘
Attestation Digest: sha256:8a0b3a9db0372fdf571dbe85c8a9b5202f473ca97e9dbcdf77c3f9b423ea3b9c
```

Refs #816 #785 