### PR TITLE
feat(action): Create new action to consume GitHub releases

### DIFF
--- a/.github/workflows/github_release.yaml
+++ b/.github/workflows/github_release.yaml
@@ -54,15 +54,6 @@ jobs:
           gh release download $tag -A tar.gz -D /tmp
           chainloop attestation add --value "/tmp/chainloop-$version.tar.gz"
 
-          # Include control-plane image
-          chainloop attestation add --value "ghcr.io/chainloop-dev/chainloop/control-plane:$tag"
-
-          # Include cas image
-          chainloop attestation add --value "ghcr.io/chainloop-dev/chainloop/artifact-cas:$tag"
-
-          # Include cli image
-          chainloop attestation add --value "ghcr.io/chainloop-dev/chainloop/cli:$tag"
-
       - name: Finish and Record Attestation
         if: ${{ success() }}
         run: |

--- a/.github/workflows/github_release.yaml
+++ b/.github/workflows/github_release.yaml
@@ -1,0 +1,83 @@
+name: GitHub Release Attestation
+
+on:
+  release:
+
+permissions:
+  contents: read
+
+jobs:
+  # This reusable workflow inspects if the given workflow_name exists on Chainloop. If the Workflow does not exist
+  # it will create one with an empty contract ready for operators to be filled. Otherwise, if found, it will just
+  # be ignored and the process will continue. For this to work it's using a pre-created API Token
+  onboard_workflow:
+    name: Onboard Chainloop Workflow
+    uses: chainloop-dev/labs/.github/workflows/chainloop_onboard.yml@4173e015dbd5dc2a8802555c268da63d57bbe576
+    with:
+      project: "chainloop"
+      workflow_name: "chainloop-github-release"
+    secrets:
+      api_token: ${{ secrets.CHAINLOOP_API_TOKEN }}
+
+  release:
+    name: Record release from GitHub
+    runs-on: ubuntu-latest
+    needs: onboard_workflow
+    permissions:
+      packages: write
+    env:
+      CHAINLOOP_VERSION: 0.89.0
+      CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_API_TOKEN }}
+      CHAINLOOP_WORKFLOW_NAME: ${{ needs.onboard_workflow.outputs.workflow_name }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Install Chainloop
+        run: |
+          curl -sfL https://raw.githubusercontent.com/chainloop-dev/chainloop/01ad13af08950b7bfbc83569bea207aeb4e1a285/docs/static/install.sh | bash -s -- --version v${{ env.CHAINLOOP_VERSION }}
+
+      - name: Initialize Attestation
+        run: |
+          chainloop attestation init --workflow-name ${CHAINLOOP_WORKFLOW_NAME}
+
+      - name: Attest all assets
+        run: |
+          tag=$(echo -n ${{github.ref}} | cut -d / -f3)
+          gh release download $tag -D /tmp/github-release
+          for entry in $(ls /tmp/github-release); do
+            chainloop attestation add --value "/tmp/github-release/$entry"
+          done
+          
+          # Include source code
+          version=$(echo -n $tag | sed 's/v//g')
+          gh release download $tag -A tar.gz -D /tmp
+          chainloop attestation add --value "/tmp/chainloop-$version.tar.gz"
+
+          # Include control-plane image
+          chainloop attestation add --value "ghcr.io/chainloop-dev/chainloop/control-plane:$tag"
+
+          # Include cas image
+          chainloop attestation add --value "ghcr.io/chainloop-dev/chainloop/artifact-cas:$tag"
+
+          # Include cli image
+          chainloop attestation add --value "ghcr.io/chainloop-dev/chainloop/cli:$tag"
+
+      - name: Finish and Record Attestation
+        if: ${{ success() }}
+        run: |
+          chainloop attestation status --full
+          chainloop attestation push --key env://CHAINLOOP_SIGNING_KEY
+        env:
+          CHAINLOOP_SIGNING_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+          CHAINLOOP_SIGNING_KEY: ${{ secrets.COSIGN_KEY }}
+
+      - name: Mark attestation as failed
+        if: ${{ failure() }}
+        run: |
+          chainloop attestation reset
+
+      - name: Mark attestation as cancelled
+        if: ${{ cancelled() }}
+        run: |
+          chainloop attestation reset --trigger cancellation

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: GitHub Release Attestation
+name: Release
 
 on:
   release:
@@ -15,7 +15,7 @@ jobs:
     uses: chainloop-dev/labs/.github/workflows/chainloop_onboard.yml@4173e015dbd5dc2a8802555c268da63d57bbe576
     with:
       project: "chainloop"
-      workflow_name: "chainloop-github-release"
+      workflow_name: "chainloop-vault-release"
     secrets:
       api_token: ${{ secrets.CHAINLOOP_API_TOKEN }}
 


### PR DESCRIPTION
This patch uses changes introduced in https://github.com/chainloop-dev/chainloop/pull/820 to auto discover materials based on the GitHub releases' assets.

Changes:
- Uses the workflow chainloop-vault-release
- Rename the file from `github_release` to `release`
- Attests everything included on the GitHub Release

Refs #785 