### PR TITLE
feat(sync-contract): Change pointer of env variable to use CHAINLOOP API TOKEN

### DIFF
--- a/.github/workflows/sync_contracts.yml
+++ b/.github/workflows/sync_contracts.yml
@@ -19,4 +19,4 @@ jobs:
     name: Chainloop Contract Sync
     uses: chainloop-dev/labs/.github/workflows/chainloop_contract_sync.yml@0d6e9ca1190aecc9048729de0cce8e96f314e2bb
     secrets:
-      api_token: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT_SYNC_CONTRACTS }}
+      api_token: ${{ secrets.CHAINLOOP_API_TOKEN }}


### PR DESCRIPTION
This patch changes the pointer to the environment variable to use a `CHAINLOOP API TOKEN`.

Old token will be removed once this PR is merged.

Refs #785 