### PR TITLE
fix(release-workflow): Add back container images for attestation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,6 +53,15 @@ jobs:
           version=$(echo -n $tag | sed 's/v//g')
           gh release download $tag -A tar.gz -D /tmp
           chainloop attestation add --value "/tmp/chainloop-$version.tar.gz"
+          
+           # Include control-plane image
+           chainloop attestation add --value "ghcr.io/chainloop-dev/chainloop/control-plane:$tag"
+          
+           # Include cas image
+           chainloop attestation add --value "ghcr.io/chainloop-dev/chainloop/artifact-cas:$tag"
+
+           # Include cli image
+           chainloop attestation add --value "ghcr.io/chainloop-dev/chainloop/cli:$tag"
 
       - name: Finish and Record Attestation
         id: attestation-push
@@ -81,6 +90,11 @@ jobs:
           chainloop_release_url="## Chainloop Attestation"$'\n'"[View the attestation of this release](https://app.chainloop.dev/attestation/${{ steps.attestation-push.outputs.attestation_sha }})"
           current_notes=$(gh release view ${{ github.ref }} --json body -q '.body')
           
-          modified_notes="$chainloop_release_url"$'\n\n'"$current_notes"
+          # Only add the attestation link if it doesn't already exist
+          if ! echo "$current_notes" | grep -q "## Chainloop Attestation"; then
+            modified_notes="$chainloop_release_url"$'\n\n'"$current_notes"
+          else
+            modified_notes="$current_notes"
+          fi
           
           gh release edit ${{ github.ref }} -n "$modified_notes"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -90,11 +90,12 @@ jobs:
           chainloop_release_url="## Chainloop Attestation"$'\n'"[View the attestation of this release](https://app.chainloop.dev/attestation/${{ steps.attestation-push.outputs.attestation_sha }})"
           current_notes=$(gh release view ${{ github.ref }} --json body -q '.body')
           
-          # Only add the attestation link if it doesn't already exist
-          if ! echo "$current_notes" | grep -q "## Chainloop Attestation"; then
-            modified_notes="$chainloop_release_url"$'\n\n'"$current_notes"
+          if echo "$current_notes" | grep -q "## Chainloop Attestation"; then
+            # Replace the existing Chainloop Attestation section with the new URL
+            modified_notes=$(echo "$current_notes" | sed -E "s|## Chainloop Attestation[^\n]*\n\[View the attestation of this release\]\(https://app\.chainloop\.dev/attestation/[^\)]*\)|$chainloop_release_url|")
           else
-            modified_notes="$current_notes"
+            # Add the Chainloop Attestation section to the top
+            modified_notes="$chainloop_release_url"$'\n\n'"$current_notes"
           fi
           
           gh release edit ${{ github.ref }} -n "$modified_notes"


### PR DESCRIPTION
This patch adds back the the attestation for all three container images.

It additionally sets a condition to not add the Chainloop Attestation URL if the release notes has it already.