### PR TITLE
feat(discovery): return latest entries

### DIFF
--- a/app/controlplane/internal/biz/referrer_integration_test.go
+++ b/app/controlplane/internal/biz/referrer_integration_test.go
@@ -226,7 +226,7 @@ func (s *referrerIntegrationTestSuite) TestExtractAndPersists() {
 		require.Len(t, got.References, 6)
 
 		for i, want := range []*biz.Referrer{
-			wantReferrerCommit, wantReferrerSBOM, wantReferrerArtifact, wantReferrerOpenVEX, wantReferrerSarif, wantReferrerContainerImage} {
+			wantReferrerArtifact, wantReferrerContainerImage, wantReferrerCommit, wantReferrerOpenVEX, wantReferrerSarif, wantReferrerSBOM} {
 			gotR := got.References[i]
 			s.Equal(want, gotR.Referrer)
 		}
@@ -345,9 +345,9 @@ func (s *referrerIntegrationTestSuite) TestExtractAndPersists() {
 		// it should be referenced by two attestations since it's subject of both
 		require.Len(t, got.References, 2)
 		s.Equal("ATTESTATION", got.References[0].Kind)
-		s.Equal("sha256:c90ccaab0b2cfda9980836aef407f62d747680ea9793ddc6ad2e2d7ab615933d", got.References[0].Digest)
+		s.Equal("sha256:de36d470d792499b1489fc0e6623300fc8822b8f0d2981bb5ec563f8dde723c7", got.References[0].Digest)
 		s.Equal("ATTESTATION", got.References[1].Kind)
-		s.Equal("sha256:de36d470d792499b1489fc0e6623300fc8822b8f0d2981bb5ec563f8dde723c7", got.References[1].Digest)
+		s.Equal("sha256:c90ccaab0b2cfda9980836aef407f62d747680ea9793ddc6ad2e2d7ab615933d", got.References[1].Digest)
 	})
 
 	s.T().Run("if all associated workflows are private, the referrer is private", func(t *testing.T) {

--- a/app/controlplane/internal/biz/referrer_integration_test.go
+++ b/app/controlplane/internal/biz/referrer_integration_test.go
@@ -137,7 +137,7 @@ func (s *referrerIntegrationTestSuite) TestExtractAndPersistsDependentAttestatio
 		s.NoError(err)
 		// It has a commit and an attestation
 		require.Len(s.T(), got.References, 2)
-		s.Equal(wantDependentAtt, got.References[1].Digest)
+		s.Equal(wantDependentAtt, got.References[0].Digest)
 	})
 }
 

--- a/app/controlplane/internal/data/referrer.go
+++ b/app/controlplane/internal/data/referrer.go
@@ -236,7 +236,9 @@ func (r *ReferrerRepo) doGet(ctx context.Context, root *ent.Referrer, allowedOrg
 	// Attach the workflow predicate
 	predicateReferrer = append(predicateReferrer, referrer.HasWorkflowsWith(predicateWF...))
 
-	refs, err := root.QueryReferences().Where(predicateReferrer...).WithWorkflows().Order(referrer.ByDigest()).All(ctx)
+	// sort the references by creation date in descending order
+	// so whenever we add pagination we'll get the latest x references
+	refs, err := root.QueryReferences().Where(predicateReferrer...).WithWorkflows().Order(referrer.ByCreatedAt(), ent.Desc()).All(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query references: %w", err)
 	}


### PR DESCRIPTION
The discovery endpoint now returns the list of references sorted by createdAt in descending order. This sets the stone to add pagination in the future.

```diff
 diff -u /tmp/before.json /tmp/after.json                  
--- /tmp/before.json    2024-05-29 15:55:06.872510711 +0200
+++ /tmp/after.json     2024-05-29 15:54:51.387947393 +0200
@@ -6,11 +6,11 @@
    "createdAt": "2024-05-29T13:53:00.822503Z",
    "references": [
       {
-         "digest": "sha256:8dc72d0b36f95ffd76cddd31205d3c167695eb1f4c9f415ddc6a6c8a32bc7fff",
+         "digest": "sha256:999089a5c4fe4c08c7ab28e8f7cc5a70b89fb1ccb6ec1425d459f055c570fa3e",
          "kind": "ATTESTATION",
          "downloadable": true,
          "public": false,
-         "createdAt": "2024-05-29T13:53:20.398237Z",
+         "createdAt": "2024-05-29T13:53:00.817285Z",
          "references": [],
          "metadata": {
             "name": "tesssss",
@@ -20,11 +20,11 @@
          }
       },
       {
-         "digest": "sha256:999089a5c4fe4c08c7ab28e8f7cc5a70b89fb1ccb6ec1425d459f055c570fa3e",
+         "digest": "sha256:8dc72d0b36f95ffd76cddd31205d3c167695eb1f4c9f415ddc6a6c8a32bc7fff",
          "kind": "ATTESTATION",
          "downloadable": true,
          "public": false,
-         "createdAt": "2024-05-29T13:53:00.817285Z",
+         "createdAt": "2024-05-29T13:53:20.398237Z
```