### PR TITLE
fix: do not fail telemetry on containers

### DIFF
--- a/app/cli/internal/telemetry/posthog/posthog.go
+++ b/app/cli/internal/telemetry/posthog/posthog.go
@@ -86,7 +86,7 @@ func (p *Tracker) TrackEvent(_ context.Context, eventName string, id string, tag
 	// - The machine ID is available and different from the userID.
 	// - The userID is different from the default one.
 	// An alias can help to track the same user across different devices even when it was not logged in.
-	if (tags["machine_id"] != "" && tags["machine_id"] != id) || id != telemetry.UnrecognisedUserID {
+	if (tags["machine_id"] != "" && tags["machine_id"] != id) && id != telemetry.UnrecognisedUserID {
 		if err := p.client.Enqueue(posthog.Alias{
 			DistinctId: id,
 			Alias:      tags["machine_id"],

--- a/extras/dagger/main.go
+++ b/extras/dagger/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	chainloopVersion = "v0.89.0"
+	chainloopVersion = "v0.88.1"
 )
 
 type Chainloop struct{}

--- a/extras/dagger/main.go
+++ b/extras/dagger/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	chainloopVersion = "v0.88.1"
+	chainloopVersion = "v0.89.0"
 )
 
 type Chainloop struct{}


### PR DESCRIPTION
The issue with Dagger pipelines was that there was a bug in the condition when machine_id was nil. 

machineID can not be set in a dagger pipeline since it's run in a scratch container

```
failed to get machine ID: machineid: machineid: open /etc/machine-id: no such file or directory
```

note, this will not be taken into effect until we do a new release AND update the dagger module to use the updated container image