### PR TITLE
chore(ci): change fetch modality

### DIFF
--- a/.github/workflows/build_and_package.yaml
+++ b/.github/workflows/build_and_package.yaml
@@ -45,8 +45,6 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          fetch-depth: 0
 
       - name: Initialize Attestation
         run: |
@@ -95,7 +93,7 @@ jobs:
       - name: Add Attestation from Goreleaser Output
         run: |
           jq -r . <<< "${{ steps.release.outputs.artifacts }}" > /tmp/artifacts.json
-          chainloop attestation add --name goreleaser-output --value /tmp/artifacts.json 
+          chainloop attestation add --name goreleaser-output --value /tmp/artifacts.json
 
       - name: Finish and Record Attestation
         if: ${{ success() }}

--- a/docs/docs/getting-started/attestation-crafting.md
+++ b/docs/docs/getting-started/attestation-crafting.md
@@ -264,8 +264,6 @@ jobs:
       # highlight-end
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       # highlight-start
       - name: Initialize Attestation

--- a/docs/examples/ci-workflows/github.yaml
+++ b/docs/examples/ci-workflows/github.yaml
@@ -31,8 +31,6 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Initialize Attestation
         run: |


### PR DESCRIPTION
It seems that fetch-depth=0 is the opposite of what I thought it did.

From https://github.com/actions/checkout

> Only a single commit is fetched by default, for the ref/SHA that triggered the workflow. Set fetch-depth: 0 to fetch all history for all branches and tags. Refer [here](https://docs.github.com/actions/using-workflows/events-that-trigger-workflows) to learn which commit $GITHUB_SHA points to for different events.