### PR TITLE
fix(workflow): Replace quoting

### DIFF
--- a/.github/workflows/build_and_package.yaml
+++ b/.github/workflows/build_and_package.yaml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Add Attestation from Goreleaser Output
         run: |
-          jq -r . <<< "${{ steps.release.outputs.artifacts }}" > /tmp/artifacts.json
+          jq -r . <<< '${{ steps.release.outputs.artifacts }}' > /tmp/artifacts.json
           chainloop attestation add --name goreleaser-output --value /tmp/artifacts.json
 
       - name: Finish and Record Attestation


### PR DESCRIPTION
This patch fixes out goreleaser is casted into a file by using `jq`.

Refs #785 