### PR TITLE
feat(workflow-run): Ensure not invalid status is passed to CLI

### DIFF
--- a/app/cli/cmd/workflow_workflow_run_list.go
+++ b/app/cli/cmd/workflow_workflow_run_list.go
@@ -17,6 +17,7 @@ package cmd
 
 import (
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/chainloop-dev/chainloop/app/cli/cmd/options"
@@ -36,6 +37,13 @@ func newWorkflowWorkflowRunListCmd() *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List workflow runs",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if status != "" && !slices.Contains(listAvailableWorkflowStatusFlag(), status) {
+				return fmt.Errorf("invalid status %q, please chose one of: %v", status, listAvailableWorkflowStatusFlag())
+			}
+
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			res, err := action.NewWorkflowRunList(actionOpts).Run(
 				&action.WorkflowRunListOpts{


### PR DESCRIPTION
This patch ensures that if a --status filter flag is passed to `workflow run ls` it receives a valid value.

Tested locally as:
```bash
$ chainloop --insecure  wf run list --status RANDOM --workflow $WORKFLOW_ID -o json
WRN API contacted in insecure mode
INF API token provided to the command line
ERR invalid status "RANDOM", please chose one of: [SUCCEEDED FAILED EXPIRED CANCELLED INITIALIZED]
```
```bash
$ chainloop --insecure  wf run list --status FAILED --workflow $WORKFLOW_ID -o json
WRN API contacted in insecure mode
INF API token provided to the command line
[
   {
      "id": "177a8e15-0075-4ada-a96c-0c4b5447ef44",
      "state": "error",
      "createdAt": "2024-05-16T13:41:52.229947Z",
      "finishedAt": "2024-05-16T13:42:05.9596Z",
      "workflow": {
         "name": "wf-test",
         "id": "ca7b6ac1-0768-4008-92e4-12a7fb7afe77",
         "team": "founding",
         "project": "core",
         "createdAt": "2024-05-15T06:21:00.569712Z",
         "runsCount": 45,
         "public": false
      },
      "runnerType": "Unspecified",
      "contractRevisionUsed": 2,
      "contractRevisionLatest": 2
   },
   {
      "id": "59df8564-e1aa-4b8d-ae45-d2cfd4861dde",
      "state": "error",
      "createdAt": "2024-05-16T13:25:02.145878Z",
      "finishedAt": "2024-05-16T13:25:14.505667Z",
      "workflow": {
         "name": "wf-test",
         "id": "ca7b6ac1-0768-4008-92e4-12a7fb7afe77",
         "team": "founding",
         "project": "core",
         "createdAt": "2024-05-15T06:21:00.569712Z",
         "runsCount": 45,
         "public": false
      },
      "runnerType": "Unspecified",
      "contractRevisionUsed": 2,
      "contractRevisionLatest": 2
   },
   {
      "id": "be8bed30-3367-46f8-9c3d-4b1277b93e0a",
      "state": "error",
      "createdAt": "2024-05-16T13:05:01.092223Z",
      "finishedAt": "2024-05-16T13:05:03.325173Z",
      "workflow": {
         "name": "wf-test",
         "id": "ca7b6ac1-0768-4008-92e4-12a7fb7afe77",
         "team": "founding",
         "project": "core",
         "createdAt": "2024-05-15T06:21:00.569712Z",
         "runsCount": 45,
         "public": false
      },
      "runnerType": "Unspecified",
      "contractRevisionUsed": 1,
      "contractRevisionLatest": 1
   },
...
]
```
```bash
$ chainloop --insecure  wf run list --workflow $WORKFLOW_ID -o json
WRN API contacted in insecure mode
INF API token provided to the command line
[
   {
      "id": "ca15c8c0-9569-4407-b649-839367fec939",
      "state": "initialized",
      "createdAt": "2024-06-03T09:53:20.993595Z",
      "workflow": {
         "name": "wf-test",
         "id": "ca7b6ac1-0768-4008-92e4-12a7fb7afe77",
         "team": "founding",
         "project": "core",
         "createdAt": "2024-05-15T06:21:00.569712Z",
         "runsCount": 45,
         "public": false
      },
      "runnerType": "Unspecified",
      "contractRevisionUsed": 4,
      "contractRevisionLatest": 4
   },
   {
      "id": "be5d7c79-b525-40f9-95f0-a23e1652bbc6",
      "state": "initialized",
      "createdAt": "2024-06-03T09:39:29.784538Z",
      "workflow": {
         "name": "wf-test",
         "id": "ca7b6ac1-0768-4008-92e4-12a7fb7afe77",
         "team": "founding",
         "project": "core",
         "createdAt": "2024-05-15T06:21:00.569712Z",
         "runsCount": 45,
         "public": false
      },
      "runnerType": "Unspecified",
      "contractRevisionUsed": 3,
      "contractRevisionLatest": 3
   },
   {
      "id": "d5e4cf97-f34c-431f-8573-dbf7aeb1a010",
      "state": "success",
      "createdAt": "2024-05-28T15:24:41.003227Z",
      "finishedAt": "2024-05-28T15:25:15.223908Z",
      "workflow": {
         "name": "wf-test",
         "id": "ca7b6ac1-0768-4008-92e4-12a7fb7afe77",
         "team": "founding",
         "project": "core",
         "createdAt": "2024-05-15T06:21:00.569712Z",
         "runsCount": 45,
         "public": false
      },
      "runnerType": "Unspecified",
      "contractRevisionUsed": 3,
      "contractRevisionLatest": 3
   }
...
```
