### PR TITLE
fix(install.sh): Make install.sh work on Alpine, fixes #587

### DIFF
--- a/docs/static/install.sh
+++ b/docs/static/install.sh
@@ -56,10 +56,11 @@ is_command() {
 # example: check_sha256 "${TMP_DIR}" checksums.txt
 validate_checksums_file() {
   cd "$1"
+  grep "$FILENAME" "$2" > checksum.txt
   if is_command sha256sum; then
-    sha256sum --ignore-missing --quiet --check "$2"
+    sha256sum -c checksum.txt
   elif is_command shasum; then
-    shasum -a 256 --ignore-missing --quiet --check checksums.txt
+    shasum -a 256 -q -c checksum.txt
   else
     fancy_print 1 "We were not able to verify checksums. Commands sha256sum, shasum are not found."
     return 1


### PR DESCRIPTION
The problem was that `sha256sum` on Alpine does not recognize the following options: `--ignore-missing`, `--quiet `. More info in the #587 issue.

```
     sha256sum: unrecognized option '--ignore-missing'
     BusyBox v1.36.1 (2024-05-23 13:45:30 UTC) multi-call binary.

     Usage: sha256sum [-c[sw]] [FILE]...

     Print or check SHA256 checksums

     	-c	Check sums against list in FILEs
     	-s	Don't output anything, status code shows success
     	-w	Warn about improperly formatted checksum lines
```

I have tested this change on OS X, Alpine (chainguard/bash), and Ubuntu (node:latest).
