### PR TITLE
fix(remoteattestations): Allow API tokens to work with remote state

### DIFF
--- a/app/controlplane/cmd/wire_gen.go
+++ b/app/controlplane/cmd/wire_gen.go
@@ -163,7 +163,13 @@ func wireApp(bootstrap *conf.Bootstrap, readerWriter credentials.ReaderWriter, l
 		cleanup()
 		return nil, nil, err
 	}
-	attestationStateService := service.NewAttestationStateService(attestationStateUseCase, v2...)
+	newAttestationStateServiceOpt := &service.NewAttestationStateServiceOpt{
+		AttestationStateUseCase: attestationStateUseCase,
+		WorkflowUseCase:         workflowUseCase,
+		WorkflowRunUseCase:      workflowRunUseCase,
+		Opts:                    v2,
+	}
+	attestationStateService := service.NewAttestationStateService(newAttestationStateServiceOpt)
 	userService := service.NewUserService(membershipUseCase, organizationUseCase, v2...)
 	validator, err := newProtoValidator()
 	if err != nil {

--- a/app/controlplane/internal/service/attestationstate.go
+++ b/app/controlplane/internal/service/attestationstate.go
@@ -167,7 +167,7 @@ func encryptionPassphrase(ctx context.Context) (string, error) {
 	return hex.EncodeToString(hash[:]), nil
 }
 
-// Cascade-based way of retrieving the workflow from the robot-account, the workflow_name or the run_ID
+// Cascade-based way of retrieving the workflow from the robot-account or the run_ID
 func (s *AttestationStateService) findWorkflowFromTokenOrRunID(ctx context.Context, orgID string, workflowID, runID string) (*biz.Workflow, error) {
 	if orgID == "" {
 		return nil, biz.NewErrValidationStr("orgID must be provided")

--- a/app/controlplane/internal/service/service.go
+++ b/app/controlplane/internal/service/service.go
@@ -50,6 +50,7 @@ var ProviderSet = wire.NewSet(
 	NewSigningService,
 	wire.Struct(new(NewWorkflowRunServiceOpts), "*"),
 	wire.Struct(new(NewAttestationServiceOpts), "*"),
+	wire.Struct(new(NewAttestationStateServiceOpt), "*"),
 )
 
 func requireCurrentUser(ctx context.Context) (*usercontext.User, error) {


### PR DESCRIPTION
This patch fixes the attestation state service by inspecting the workflowRunID from the requests and comparing them with the `orgID`.

This issue was preventing the use of `--remote-state` flag on the `attestation` command. Tests performed locally:

Attestation init passing the `workflow-name` because we are using an API token
```bash
$ chainloop --insecure attestation init --replace --workflow-name wf-test --remote-state
WRN API contacted in insecure mode
INF Attestation initialized! now you can check its status or add materials to it
┌───────────────────┬──────────────────────────────────────┐
│ Initialized At    │ 03 Jun 24 17:50 UTC                  │
├───────────────────┼──────────────────────────────────────┤
│ Attestation ID    │ 311ccbf5-9dc9-4bc0-ab78-e55c9f4521a3 │
│ Name              │ wf-test                              │
│ Team              │ founding                             │
│ Project           │ core                                 │
│ Contract Revision │ 5                                    │
└───────────────────┴──────────────────────────────────────┘
┌──────────────────────┐
│ Materials            │
├───────────┬──────────┤
│ Name      │ one-file │
│ Type      │ ARTIFACT │
│ Set       │ No       │
│ Required  │ Yes      │
│ Is output │ Yes      │
└───────────┴──────────┘
```

Adding materials to the attestation by passing the `attestation-id`
```bash
$ chainloop --insecure attestation add --remote-state --attestation-id 311ccbf5-9dc9-4bc0-ab78-e55c9f4521a3 --name one-file --value SECURITY.md
WRN API contacted in insecure mode
INF material added to attestation
```

Attestation push
```bash
$ chainloop --insecure attestation push --remote-state --attestation-id 311ccbf5-9dc9-4bc0-ab78-e55c9f4521a3 --key cosign.key
WRN API contacted in insecure mode
Enter password for private key:
INF push completed
┌───────────────────┬──────────────────────────────────────┐
│ Initialized At    │ 03 Jun 24 17:50 UTC                  │
├───────────────────┼──────────────────────────────────────┤
│ Attestation ID    │ 311ccbf5-9dc9-4bc0-ab78-e55c9f4521a3 │
│ Name              │ wf-test                              │
│ Team              │ founding                             │
│ Project           │ core                                 │
│ Contract Revision │ 5                                    │
└───────────────────┴──────────────────────────────────────┘
┌─────────────────────────────────────────────────────────────────────────────────────┐
│ Materials                                                                           │
├───────────┬─────────────────────────────────────────────────────────────────────────┤
│ Name      │ one-file                                                                │
│ Type      │ ARTIFACT                                                                │
│ Set       │ Yes                                                                     │
│ Required  │ Yes                                                                     │
│ Is output │ Yes                                                                     │
│ Value     │ SECURITY.md                                                             │
│ Digest    │ sha256:bd03143bd1201f6dfacb8dd9f4cda76a56974e0a38c117c64204a5c0ebaf20c4 │
└───────────┴─────────────────────────────────────────────────────────────────────────┘
Attestation Digest: sha256:35506ccc0628695e8cd115d97ad5c58f3203501213126e3a1baed1d9c6892b4a%
```

From another attestation, let's try the reset:
```bash
$ chainloop --insecure attestation reset --remote-state --attestation-id 8531c617-eae8-42a3-a54e-9b4b6b4267ea
WRN API contacted in insecure mode
INF Attestation canceled
```

Checking the status of an attestation:
```bash
$ chainloop --insecure attestation init --replace --workflow-name wf-test --remote-state
WRN API contacted in insecure mode
INF Attestation initialized! now you can check its status or add materials to it
┌───────────────────┬──────────────────────────────────────┐
│ Initialized At    │ 03 Jun 24 17:54 UTC                  │
├───────────────────┼──────────────────────────────────────┤
│ Attestation ID    │ ae98015f-46c4-4dc3-8376-98642030c99c │
│ Name              │ wf-test                              │
│ Team              │ founding                             │
│ Project           │ core                                 │
│ Contract Revision │ 5                                    │
└───────────────────┴──────────────────────────────────────┘
┌──────────────────────┐
│ Materials            │
├───────────┬──────────┤
│ Name      │ one-file │
│ Type      │ ARTIFACT │
│ Set       │ No       │
│ Required  │ Yes      │
│ Is output │ Yes      │
└───────────┴──────────┘

$ chainloop --insecure attestation status --remote-state --attestation-id ae98015f-46c4-4dc3-8376-98642030c99c
WRN API contacted in insecure mode
┌───────────────────┬──────────────────────────────────────┐
│ Initialized At    │ 03 Jun 24 17:54 UTC                  │
├───────────────────┼──────────────────────────────────────┤
│ Attestation ID    │ ae98015f-46c4-4dc3-8376-98642030c99c │
│ Name              │ wf-test                              │
│ Team              │ founding                             │
│ Project           │ core                                 │
│ Contract Revision │ 5                                    │
└───────────────────┴──────────────────────────────────────┘
┌──────────────────────┐
│ Materials            │
├───────────┬──────────┤
│ Name      │ one-file │
│ Type      │ ARTIFACT │
│ Set       │ No       │
│ Required  │ Yes      │
│ Is output │ Yes      │
└───────────┴──────────┘
```

Full flow using now a robot account:
```bash
$ chainloop --insecure wf create --name demo-team --project founding --project core
WRN API contacted in insecure mode
INF API token provided to the command line
┌──────────────────────────────────────┬───────────┬─────────┬─────────────────────┬────────┬─────────────────┐
│ ID                                   │ NAME      │ PROJECT │ CREATED AT          │ RUNNER │ LAST RUN STATUS │
├──────────────────────────────────────┼───────────┼─────────┼─────────────────────┼────────┼─────────────────┤
│ 5c86ffa0-5d94-4238-b612-7fdadda2cb71 │ demo-team │ core    │ 03 Jun 24 17:55 UTC │        │                 │
└──────────────────────────────────────┴───────────┴─────────┴─────────────────────┴────────┴─────────────────┘

This is an automatically generated Robot Account Token (ID: 9ec599b3-6277-4e4d-bff6-7fa5e02796e5). Save the following token since it will not printed again:

THE-ROBOT-ACCOUNT-TOKEN

$ export CHAINLOOP_TOKEN=THE-ROBOT-ACCOUNT-TOKEN

$ chainloop --insecure attestation init --replace --remote-state
WRN API contacted in insecure mode
INF Attestation initialized! now you can check its status or add materials to it
┌───────────────────┬──────────────────────────────────────┐
│ Initialized At    │ 03 Jun 24 17:56 UTC                  │
├───────────────────┼──────────────────────────────────────┤
│ Attestation ID    │ 0a5fffd1-5289-404c-8c1a-6175478ef0a5 │
│ Name              │ demo-team                            │
│ Team              │                                      │
│ Project           │ core                                 │
│ Contract Revision │ 1                                    │
└───────────────────┴──────────────────────────────────────┘
$ chainloop --insecure attestation status --remote-state --attestation-id 0a5fffd1-5289-404c-8c1a-6175478ef0a5
WRN API contacted in insecure mode
┌───────────────────┬──────────────────────────────────────┐
│ Initialized At    │ 03 Jun 24 17:56 UTC                  │
├───────────────────┼──────────────────────────────────────┤
│ Attestation ID    │ 0a5fffd1-5289-404c-8c1a-6175478ef0a5 │
│ Name              │ demo-team                            │
│ Team              │                                      │
│ Project           │ core                                 │
│ Contract Revision │ 1                                    │
└───────────────────┴──────────────────────────────────────┘
$ chainloop --insecure attestation add --value SECURITY.md --remote-state --attestation-id 0a5fffd1-5289-404c-8c1a-6175478ef0a5
WRN API contacted in insecure mode
INF material kind detected kind=ARTIFACT
INF material added to attestation
$ chainloop --insecure attestation push --remote-state --attestation-id 0a5fffd1-5289-404c-8c1a-6175478ef0a5 --key cosign.key
WRN API contacted in insecure mode
Enter password for private key:
INF push completed
┌───────────────────┬──────────────────────────────────────┐
│ Initialized At    │ 03 Jun 24 17:56 UTC                  │
├───────────────────┼──────────────────────────────────────┤
│ Attestation ID    │ 0a5fffd1-5289-404c-8c1a-6175478ef0a5 │
│ Name              │ demo-team                            │
│ Team              │                                      │
│ Project           │ core                                 │
│ Contract Revision │ 1                                    │
└───────────────────┴──────────────────────────────────────┘
┌────────────────────────────────────────────────────────────────────────────────────┐
│ Materials                                                                          │
├──────────┬─────────────────────────────────────────────────────────────────────────┤
│ Name     │ material-1717437401712017000                                            │
│ Type     │ ARTIFACT                                                                │
│ Set      │ Yes                                                                     │
│ Required │ No                                                                      │
│ Value    │ SECURITY.md                                                             │
│ Digest   │ sha256:bd03143bd1201f6dfacb8dd9f4cda76a56974e0a38c117c64204a5c0ebaf20c4 │
└──────────┴─────────────────────────────────────────────────────────────────────────┘
Attestation Digest: sha256:854726bd8c24f0f0241f4bcc24535f562ed9698707524f06cf6c5590aa52bc7d
```

Closes #873 