### PR TITLE
feat(workflows-chainloop): Consolidates robot accounts into API token

### DIFF
--- a/.github/workflows/build_and_package.yaml
+++ b/.github/workflows/build_and_package.yaml
@@ -23,8 +23,8 @@ jobs:
       packages: write # to push container images
       pull-requests: write
     env:
-      CHAINLOOP_VERSION: 0.89.0
-      CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT }}
+      CHAINLOOP_VERSION: 0.90.1
+      CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
       CONTAINER_IMAGE_CP: ghcr.io/chainloop-dev/chainloop/control-plane:${{ github.ref_name }}
       CONTAINER_IMAGE_CAS: ghcr.io/chainloop-dev/chainloop/artifact-cas:${{ github.ref_name }}
       GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,8 +21,8 @@ jobs:
       contents: read
       security-events: write
     env:
-      CHAINLOOP_VERSION: 0.86.0
-      CHAINLOOP_ROBOT_ACCOUNT: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT_CODEQL }}
+      CHAINLOOP_VERSION: 0.90.1
+      CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -11,11 +11,12 @@ concurrency: "deploy-to-prod"
 jobs:
   chainloop_init:
     name: Chainloop Init
-    uses: chainloop-dev/labs/.github/workflows/chainloop_init.yml@f055bc60d670593b6d1646c45dd2e3e091bf6743
+    uses: chainloop-dev/labs/.github/workflows/chainloop_init.yml@dfc395be86c9254f42de204584a032d5c1f99706
     secrets:
-      api_token: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT_DOCS_RELEASE }}
+      api_token: ${{ secrets.CHAINLOOP_TOKEN }}
     with:
-      chainloop_labs_branch: f055bc60d670593b6d1646c45dd2e3e091bf6743
+      chainloop_labs_branch: dfc395be86c9254f42de204584a032d5c1f99706
+      workflow_name: "chainloop-docs-release"
 
   deploy_docs:
     name: Deploy Documentation
@@ -82,13 +83,14 @@ jobs:
 
   chainloop_push:
     name: Chainloop Push
-    uses: chainloop-dev/labs/.github/workflows/chainloop_push.yml@f055bc60d670593b6d1646c45dd2e3e091bf6743
+    uses: chainloop-dev/labs/.github/workflows/chainloop_push.yml@dfc395be86c9254f42de204584a032d5c1f99706
     needs:
       - deploy_docs
     secrets:
-      api_token: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT_DOCS_RELEASE }}
+      api_token: ${{ secrets.CHAINLOOP_TOKEN }}
       signing_key: ${{ secrets.COSIGN_KEY }}
       signing_key_password: ${{ secrets.COSIGN_PASSWORD }}
     with:
       attestation_name: "docs"
-      chainloop_labs_branch: f055bc60d670593b6d1646c45dd2e3e091bf6743
+      chainloop_labs_branch: dfc395be86c9254f42de204584a032d5c1f99706
+      workflow_name: "chainloop-docs-release"

--- a/.github/workflows/package_chart.yaml
+++ b/.github/workflows/package_chart.yaml
@@ -22,7 +22,7 @@ jobs:
       project: "chainloop"
       workflow_name: "chainloop-vault-helm-package"
     secrets:
-      api_token: ${{ secrets.CHAINLOOP_API_TOKEN }}
+      api_token: ${{ secrets.CHAINLOOP_TOKEN }}
 
   package:
     name: Package and push Helm Chart
@@ -31,8 +31,8 @@ jobs:
     permissions:
       packages: write
     env:
-      CHAINLOOP_VERSION: 0.88.0
-      CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_API_TOKEN }}
+      CHAINLOOP_VERSION: 0.90.1
+      CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
       CHAINLOOP_WORKFLOW_NAME: ${{ needs.onboard_workflow.outputs.workflow_name }}
     steps:
       - name: Install Chainloop

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
       project: "chainloop"
       workflow_name: "chainloop-vault-release"
     secrets:
-      api_token: ${{ secrets.CHAINLOOP_API_TOKEN }}
+      api_token: ${{ secrets.CHAINLOOP_TOKEN }}
 
   release:
     name: Record release from GitHub
@@ -26,8 +26,8 @@ jobs:
     permissions:
       packages: write
     env:
-      CHAINLOOP_VERSION: 0.89.0
-      CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_API_TOKEN }}
+      CHAINLOOP_VERSION: 0.90.1
+      CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
       CHAINLOOP_WORKFLOW_NAME: ${{ needs.onboard_workflow.outputs.workflow_name }}
       GH_TOKEN: ${{ github.token }}
     steps:

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -20,11 +20,12 @@ permissions: read-all
 jobs:
   chainloop_init:
     name: Chainloop Init
-    uses: chainloop-dev/labs/.github/workflows/chainloop_init.yml@54b18c97630a84a134c3fc93489d86c533d5a440
+    uses: chainloop-dev/labs/.github/workflows/chainloop_init.yml@dfc395be86c9254f42de204584a032d5c1f99706
     secrets:
-      api_token: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT_SCORECARDS }}
+      api_token: ${{ secrets.CHAINLOOP_TOKEN }}
     with:
-      chainloop_labs_branch: 54b18c97630a84a134c3fc93489d86c533d5a440
+      chainloop_labs_branch: dfc395be86c9254f42de204584a032d5c1f99706
+      workflow_name: "chainloop-vault-scorecards"
 
   analysis:
     name: Scorecard analysis
@@ -84,13 +85,14 @@ jobs:
 
   chainloop_push:
     name: Chainloop Push
-    uses: chainloop-dev/labs/.github/workflows/chainloop_push.yml@54b18c97630a84a134c3fc93489d86c533d5a440
+    uses: chainloop-dev/labs/.github/workflows/chainloop_push.yml@dfc395be86c9254f42de204584a032d5c1f99706
     needs:
       - analysis
     secrets:
-      api_token: ${{ secrets.CHAINLOOP_ROBOT_ACCOUNT_SCORECARDS }}
+      api_token: ${{ secrets.CHAINLOOP_TOKEN }}
       signing_key: ${{ secrets.COSIGN_KEY }}
       signing_key_password: ${{ secrets.COSIGN_PASSWORD }}
     with:
       attestation_name: "scorecards"
-      chainloop_labs_branch: 54b18c97630a84a134c3fc93489d86c533d5a440
+      chainloop_labs_branch: dfc395be86c9254f42de204584a032d5c1f99706
+      workflow_name: "chainloop-vault-scorecards"

--- a/.github/workflows/sync_contracts.yml
+++ b/.github/workflows/sync_contracts.yml
@@ -19,4 +19,4 @@ jobs:
     name: Chainloop Contract Sync
     uses: chainloop-dev/labs/.github/workflows/chainloop_contract_sync.yml@0d6e9ca1190aecc9048729de0cce8e96f314e2bb
     secrets:
-      api_token: ${{ secrets.CHAINLOOP_API_TOKEN }}
+      api_token: ${{ secrets.CHAINLOOP_TOKEN }}


### PR DESCRIPTION
This patch drops support for Chainloop Robot Accounts in favor of API Tokens by using the env variable `CHAINLOOP_TOKEN`. It additionally performs the following changes:

- Bump version of Chainloop CLI to ensure latest compatibility
- Bump reusable workflows to their latest version available on Chainloop's labs
