### PR TITLE
feat(docs): update youtube video links to use privacy mode

### DIFF
--- a/docs/docs/getting-started/attestation-crafting.md
+++ b/docs/docs/getting-started/attestation-crafting.md
@@ -6,7 +6,7 @@ title: Attestation Crafting
 <iframe
   width="100%"
   height="500"
-  src="https://www.youtube.com/embed/Q_0dlBqKtIU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+  src="https://www.youtube-nocookie.com/embed/Q_0dlBqKtIU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 ## Introduction
 

--- a/docs/docs/guides/dagger/README.md
+++ b/docs/docs/guides/dagger/README.md
@@ -9,7 +9,7 @@ title: Use Dagger With Chainloop
 Daggerized version of [Chainloop](https://docs.chainloop.dev) that can be used to attest and collect pieces of evidence from your [Dagger](https://dagger.io/) pipelines.
 
 <iframe width="100%" height="500"
-    src="https://www.youtube.com/embed/s-ZtU8PvNmk"
+    src="https://www.youtube-nocookie.com/embed/s-ZtU8PvNmk"
     frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen>
 </iframe>
 

--- a/docs/docs/guides/dependency-track/dependency-track.mdx
+++ b/docs/docs/guides/dependency-track/dependency-track.mdx
@@ -27,7 +27,7 @@ See the integration in action in the following video
 <iframe
   width="100%"
   height="500"
-  src="https://www.youtube.com/embed/S1110n4C9gY"
+  src="https://www.youtube-nocookie.com/embed/S1110n4C9gY"
   title="YouTube video player"
   frameborder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"

--- a/docs/docs/guides/guac/guac.mdx
+++ b/docs/docs/guides/guac/guac.mdx
@@ -20,7 +20,7 @@ to a cloud storage bucket. From there, [GUAC can be configured](./#configure-gua
 <iframe
   width="100%"
   height="500"
-  src="https://www.youtube.com/embed/XEeMeyC9ZJs"
+  src="https://www.youtube-nocookie.com/embed/XEeMeyC9ZJs"
   title="YouTube video player"
   frameborder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"

--- a/docs/docs/how-does-it-work/how-does-it-work.mdx
+++ b/docs/docs/how-does-it-work/how-does-it-work.mdx
@@ -59,7 +59,7 @@ See an example on how to integrate Chainloop with an existing GitHub action in t
 <iframe
   width="100%"
   height="415"
-  src="https://www.youtube.com/embed/iBTVpjNaE6M"
+  src="https://www.youtube-nocookie.com/embed/iBTVpjNaE6M"
   title="Chainloop demo"
   frameborder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"

--- a/docs/docs/intro/intro.mdx
+++ b/docs/docs/intro/intro.mdx
@@ -103,7 +103,7 @@ Even worse, if you detect an issue during auditing or because of a new security 
 <iframe
   width="100%"
   height="415"
-  src="https://www.youtube.com/embed/GfSR2ZkZ3as"
+  src="https://www.youtube-nocookie.com/embed/GfSR2ZkZ3as"
   title="Chainloop introduction"
   frameborder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -144,7 +144,7 @@ title: Use Dagger With Chainloop
 ${content.replaceAll(
   "## Prerequisites",
   `<iframe width="100%" height="500"
-    src="https://www.youtube.com/embed/s-ZtU8PvNmk"
+    src="https://www.youtube-nocookie.com/embed/s-ZtU8PvNmk"
     frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen>
 </iframe>
 


### PR DESCRIPTION
This patch add `nocookie` to youtube links, this way we want to prevent youtube from using cookies for advertising and gathering information about the user in our docs page.
