### PR TITLE
feat(keyless): add keyless config to deployment template

### DIFF
--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -4,7 +4,7 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.53.0
+version: 1.53.1
 # Do not update appVersion, this is handled automatically by the release process
 appVersion: v0.90.0
 

--- a/deployment/chainloop/README.md
+++ b/deployment/chainloop/README.md
@@ -366,6 +366,20 @@ secretsBackend:
 ```
 
 ### Deploy in keyless mode with file-based CA
+
+*This feature is experimental, as it doesn't still support verification.*
+
+You can enable keyless signing mode by providing a custom Certificate Authority.
+For example, these commands generate a self-signed certificate with an RSA private key of length 4096 and AES256 encryption:
+
+```bash
+> openssl genrsa -aes256 -out ca.key 4096
+...
+> openssl req -new -x509 -sha256 -key ca.key -out ca.crt
+...
+```
+
+Then configure your deployment values with:
 ```yaml
 controlplane:
   keylessSigning:
@@ -379,7 +393,7 @@ controlplane:
       key: |
         -----BEGIN ENCRYPTED PRIVATE KEY-----    
         ...
-      -----END ENCRYPTED PRIVATE KEY-----
+        -----END ENCRYPTED PRIVATE KEY-----
       keyPass: "REDACTED"  
 ```
 

--- a/deployment/chainloop/README.md
+++ b/deployment/chainloop/README.md
@@ -367,7 +367,7 @@ secretsBackend:
 
 ### Deploy in keyless mode with file-based CA
 
-*This feature is experimental, as it doesn't still support verification.*
+*This feature is experimental, as it doesn't yet support verification.*
 
 You can enable keyless signing mode by providing a custom Certificate Authority.
 For example, these commands generate a self-signed certificate with an RSA private key of length 4096 and AES256 encryption:
@@ -379,7 +379,7 @@ For example, these commands generate a self-signed certificate with an RSA priva
 ...
 ```
 
-Then configure your deployment values with:
+Then you can configure your deployment values with:
 ```yaml
 controlplane:
   keylessSigning:

--- a/deployment/chainloop/README.md
+++ b/deployment/chainloop/README.md
@@ -365,6 +365,24 @@ secretsBackend:
 
 ```
 
+### Deploy in keyless mode with file-based CA
+```yaml
+controlplane:
+  keylessSigning:
+    enabled: true
+    backend: fileCA
+    fileCA:
+      cert: |
+        -----BEGIN CERTIFICATE-----
+        ...
+        -----END CERTIFICATE-----
+      key: |
+        -----BEGIN ENCRYPTED PRIVATE KEY-----    
+        ...
+      -----END ENCRYPTED PRIVATE KEY-----
+      keyPass: "REDACTED"  
+```
+
 ### Send exceptions to Sentry
 
 You can configure different sentry projects for both the controlplane and the artifact CAS

--- a/deployment/chainloop/templates/controlplane/config.secret.yaml
+++ b/deployment/chainloop/templates/controlplane/config.secret.yaml
@@ -17,6 +17,16 @@ stringData:
   config.observability.yaml: |
     {{- include "chainloop.sentry" .Values.controlplane.sentry | nindent 4 }}
   {{- end }}
+  {{- if and .Values.controlplane.keylessSigning .Values.controlplane.keylessSigning.enabled }}
+  fileca.secret.yaml: |
+    {{- with .Values.controlplane.keylessSigning.fileCA }}
+    certificate_authority:
+      file_ca:
+        cert_path: "/ca_secrets/file_ca.cert"
+        key_path:  "/ca_secrets/file_ca.key"
+        key_pass: "{{- required "FileCA keyPass is mandatory" .keyPass }}"
+    {{- end }}
+  {{- end }}
   config.secret.yaml: |
     data:
       database:

--- a/deployment/chainloop/templates/controlplane/deployment.yaml
+++ b/deployment/chainloop/templates/controlplane/deployment.yaml
@@ -74,6 +74,10 @@ spec:
               mountPath: /tmp
             - name: jwt-cas-private-key
               mountPath: /secrets
+            {{- if .Values.controlplane.keylessSigning.enabled }}
+            - name: file-ca-cert
+              mountPath: /ca_secrets
+            {{- end }}
             {{- if .Values.controlplane.tlsConfig.secret.name  }}
             - name: server-certs
               mountPath: /data/server-certs
@@ -96,7 +100,7 @@ spec:
         - name: jwt-cas-private-key
           secret:
             secretName: {{ include "chainloop.controlplane.fullname" . }}-jwt-cas
-        {{- if .Values.controlplane.tlsConfig.secret.name  }}
+        {{- if .Values.controlplane.tlsConfig.secret.name }}
         - name: server-certs
           secret:
             secretName: {{ .Values.controlplane.tlsConfig.secret.name  }}
@@ -105,4 +109,9 @@ spec:
         - name: gcp-secretmanager-serviceaccountkey
           secret:
             secretName: {{ include "chainloop.controlplane.fullname" . }}-gcp-secretmanager-serviceaccountkey
+        {{- end }}
+        {{- if .Values.controlplane.keylessSigning.enabled }}
+        - name: file-ca-cert
+          secret:
+            secretName: {{ include "chainloop.controlplane.fullname" . }}-keyless-file-ca
         {{- end }}

--- a/deployment/chainloop/templates/controlplane/file_ca.secret.yaml
+++ b/deployment/chainloop/templates/controlplane/file_ca.secret.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.controlplane.keylessSigning.enabled (eq "fileCA" .Values.controlplane.keylessSigning.backend) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "chainloop.controlplane.fullname" . }}-keyless-file-ca
+  labels:
+    {{- include "chainloop.controlplane.labels" . | nindent 4 }}
+type: Opaque
+data:
+  file_ca.cert: {{ .Values.controlplane.keylessSigning.fileCA.cert | b64enc | quote }}
+  file_ca.key: {{ .Values.controlplane.keylessSigning.fileCA.key | b64enc | quote }}
+{{- end }}

--- a/deployment/chainloop/values.yaml
+++ b/deployment/chainloop/values.yaml
@@ -452,6 +452,26 @@ controlplane:
     dsn: ""
     environment: production
 
+  ## @param controlplane.keylessSigning Configuration for keyless signing using one of the supported providers
+  ## @param controlplane.keylessSigning.enabled Activates or deactivates de feature
+  ## @param controlplane.keylessSigning.backend The backend to use. Currently only "fileCA" is supported
+  ## @param controlplane.keylessSigning.fileCA.cert The PEM-encoded certificate of the file based CA
+  ##       -----BEGIN CERTIFICATE-----
+  ##       ...
+  ##       -----END CERTIFICATE-----
+  ## @param controlplane.keylessSigning.fileCA.key The PEM-encoded private key of the file based CA
+  ##       -----BEGIN RSA PRIVATE KEY-----
+  ##       ...
+  ##       -----END RSA PRIVATE KEY-----
+  ## @param controlplane.keylessSigning.fileCA.keyPass The secret key pass
+  keylessSigning:
+    enabled: false
+    backend: fileCA
+    fileCA:
+      cert: ""
+      key: ""
+      keyPass: ""
+
 ## @section Artifact Content Addressable (CAS) API
 ##################################
 #         Artifacts CAS          #


### PR DESCRIPTION
This PR adds the secrets and configuration to support keyless signing in the K8s deployment.

Before and after applying keyless configuration in values.yaml

```diff
--- before.yaml	2024-06-04 19:01:52
+++ after.yaml	2024-06-04 19:02:02
@@ -129,6 +129,12 @@
   # We store it also as a different key so it can be reused during upgrades by the common.secrets.passwords.manage helper
   generated_jws_hmac_secret: "REDACTED"
 stringData:
+  fileca.secret.yaml: |
+    certificate_authority:
+      file_ca:
+        cert_path: "/ca_secrets/file_ca.cert"
+        key_path:  "/ca_secrets/file_ca.key"
+        key_pass: "REDACTED"
   config.secret.yaml: |
     data:
       database:
@@ -156,6 +162,24 @@
       # Private key used to sign the JWTs meant to be consumed by the CAS
       cas_robot_account_private_key_path: "/secrets/cas.private.key"
 ---
+# Source: chainloop/templates/controlplane/file_ca.secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-chainloop-controlplane-keyless-file-ca
+  labels:
+    app.kubernetes.io/name: chainloop
+    helm.sh/chart: chainloop-1.54.1
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "v0.90.1"
+    app.kubernetes.io/part-of: chainloop
+    app.kubernetes.io/component: controlplane
+type: Opaque
+data:
+  file_ca.cert: "REDACTED"
+  file_ca.key: "REDACTED"
+---
 # Source: chainloop/templates/controlplane/jwt_cas_private_key.secret.yaml
 apiVersion: v1
 kind: Secret
@@ -776,7 +800,7 @@
     metadata:
       annotations:
         checksum/config: 8efedc33a9689b3bc5e07902d1acbe52f02dbe48b9a3c0186d3b281b82ce53db
-        checksum/secret-config: 20313929688b2c1fccc0283e6104a90e9f222f9494fc0cffb4b5b1449deaf23c
+        checksum/secret-config: ab779eb86eecaced7d6350510fdf93b2a88a7242d307f5a517c9d39a6e2e17eb
         checksum/cas-private-key: 83da145aeffe6a714534836f62e2eb177f6dfbfb7fbf257c3548fff320950073
         kubectl.kubernetes.io/default-container: controlplane
       labels:
@@ -838,6 +862,8 @@
               mountPath: /tmp
             - name: jwt-cas-private-key
               mountPath: /secrets
+            - name: file-ca-cert
+              mountPath: /ca_secrets
       volumes:
         - name: config
           projected:
@@ -852,6 +878,9 @@
         - name: jwt-cas-private-key
           secret:
             secretName: test-chainloop-controlplane-jwt-cas
+        - name: file-ca-cert
+          secret:
+            secretName: test-chainloop-controlplane-keyless-file-ca
 ---
 # Source: chainloop/charts/postgresql/templates/primary/statefulset.yaml
 apiVersion: apps/v1
```

Refs #865 
