### PR TITLE
feat(docs): add cookie consent script

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -301,7 +301,7 @@ ${content
         },
       ],
     }),
-  scripts: [],
+  scripts: ["https://app.termly.io/resource-blocker/48c15f14-86c1-4734-bad4-8a627fa691fa?autoBlock=on"],
 };
 
 module.exports = config;


### PR DESCRIPTION
This patch adds the cookie consent script which should display the cookie consent banner at the bottom of the page. `autoBlock=on` should prevent other scripts to load cookies until being accepted
 
<img width="1487" alt="Zrzut ekranu 2024-06-4 o 17 56 33" src="https://github.com/chainloop-dev/chainloop/assets/43812114/6afaaebf-c3a5-4e8a-858e-fabfb04f3b80">
