### PR TITLE
feat(dagger): Allow auto discovery of materials

### DIFF
--- a/extras/dagger/README.md
+++ b/extras/dagger/README.md
@@ -124,6 +124,16 @@ dagger call -m github.com/chainloop-dev/chainloop \
   add-raw-evidence --name my-container-image --value ghcr.io/chainloop-dev/chainloop/control-plane
 ```
 
+If you're attesting materials that don't belong to the target contract, you can allow Chainloop to figure out its type and if discovered, it will be added to the attestation.
+In order to do that, don't pass the `--name`, just provide the path to the file.
+
+```sh
+# Provide a material only through its path
+dagger call -m github.com/chainloop-dev/chainloop \
+  resume --token env:CHAINLOOP_TOKEN --attestation-id $ATTESTATION_ID \
+  add-file-evidence --path ./path/to/sbom.json
+```
+
 In some cases, you might be providing a private container image as a piece of evidence. In this case, you'll also need to preload the container registry credentials.
 
 ```sh

--- a/extras/dagger/main.go
+++ b/extras/dagger/main.go
@@ -170,7 +170,7 @@ func (att *Attestation) AddRawEvidence(
 		"--value", value,
 	}
 
-	if name == "" {
+	if name != "" {
 		args = append(args,
 			"--name", name,
 		)
@@ -208,7 +208,7 @@ func (att *Attestation) AddFileEvidence(
 		"--value", mountPath,
 	}
 
-	if name == "" {
+	if name != "" {
 		args = append(args,
 			"--name", name,
 		)


### PR DESCRIPTION
This patch allows Dagger users to not pass `--name` when attesting materials and can leave that work to Chainloop to figure out the material kind even if the material does not belong to the target contract.

Example adding a generic artifact without `--name`:
```bash
$ dagger call -m . init --token env:CHAINLOOP_TOKEN --workflow-name dagger-wf add-file-evidence --path ./CONTRIBUTING.md push --key file:./cosign.key --passphrase env:COSIGN_PASSWORD

┌───────────────────┬──────────────────────────────────────┐
│ Initialized At    │ 05 Jun 24 06:31 UTC                  │
├───────────────────┼──────────────────────────────────────┤
│ Attestation ID    │ f6ca9154-4c0b-48ac-9387-ae83cc194692 │
│ Name              │ dagger-wf                            │
│ Team              │ founding                             │
│ Project           │ core                                 │
│ Contract Revision │ 5                                    │
└───────────────────┴──────────────────────────────────────┘
┌────────────────────────────────────────────────────────────────────────────────────┐
│ Materials                                                                          │
├──────────┬─────────────────────────────────────────────────────────────────────────┤
│ Name     │ material-1717569069684728253                                            │
│ Type     │ ARTIFACT                                                                │
│ Set      │ Yes                                                                     │
│ Required │ No                                                                      │
│ Value    │ CONTRIBUTING.md                                                         │
│ Digest   │ sha256:8ad74d448581170e408bc4f5cb797548b7d5ea9e1ddff81dc0a7cb8672daeb6a │
└──────────┴─────────────────────────────────────────────────────────────────────────┘
┌───────────────────────────────────┐
│ Runner context                    │
├─────────────────────────┬─────────┤
│ CHAINLOOP_DAGGER_CLIENT │ v0.90.1 │
└─────────────────────────┴─────────┘
Attestation Digest: sha256:25f38cf8efbf09f3101682cd14ffd39bccb4e455e5098650c48ef96220ab19f1
```

Example with auto discovery on `SARIF` type:
```bash
$ dagger call -m . init --token env:CHAINLOOP_TOKEN --workflow-name dagger-wf add-file-evidence --path ./internal/attestation/crafter/materials/testdata/report.sarif push --key file:./cosign.key --passphrase env:COSIGN_PASSWORD
┌───────────────────┬──────────────────────────────────────┐
│ Initialized At    │ 05 Jun 24 06:32 UTC                  │
├───────────────────┼──────────────────────────────────────┤
│ Attestation ID    │ a4e0c5ac-3391-4c91-8be4-7cbc7f75dd0f │
│ Name              │ dagger-wf                            │
│ Team              │ founding                             │
│ Project           │ core                                 │
│ Contract Revision │ 5                                    │
└───────────────────┴──────────────────────────────────────┘
┌────────────────────────────────────────────────────────────────────────────────────┐
│ Materials                                                                          │
├──────────┬─────────────────────────────────────────────────────────────────────────┤
│ Name     │ material-1717569174820089427                                            │
│ Type     │ SARIF                                                                   │
│ Set      │ Yes                                                                     │
│ Required │ No                                                                      │
│ Value    │ report.sarif                                                            │
│ Digest   │ sha256:c4a63494f9289dd9fd44f841efb4f5b52765c2de6332f2d86e5f6c0340b40a95 │
└──────────┴─────────────────────────────────────────────────────────────────────────┘
┌───────────────────────────────────┐
│ Runner context                    │
├─────────────────────────┬─────────┤
│ CHAINLOOP_DAGGER_CLIENT │ v0.90.1 │
└─────────────────────────┴─────────┘
Attestation Digest: sha256:b701f70cac2600e5abec38bc1c3239c759a815de740e83ddf3ae3d8f5b3d5be5
```

Refs #846 