### PR TITLE
feat: raw token output in CLI

### DIFF
--- a/app/cli/cmd/organization_apitoken_create.go
+++ b/app/cli/cmd/organization_apitoken_create.go
@@ -45,6 +45,11 @@ func newAPITokenCreateCmd() *cobra.Command {
 				return fmt.Errorf("creating API token: %w", err)
 			}
 
+			if flagOutputFormat == "token" {
+				fmt.Print(res.JWT)
+				return nil
+			}
+
 			return encodeOutput([]*action.APITokenItem{res}, apiTokenListTableOutput)
 		},
 	}
@@ -52,6 +57,8 @@ func newAPITokenCreateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&description, "description", "", "API token description")
 	cmd.Flags().DurationVar(&expiresIn, "expiration", 0, "optional API token expiration, in hours i.e 1h, 24h, 178h (week), ...")
 	cmd.Flags().StringVar(&name, "name", "", "token name")
+	// Override default output flag
+	cmd.InheritedFlags().StringVarP(&flagOutputFormat, "output", "o", "table", "output format, valid options are table, json, token")
 	err := cmd.MarkFlagRequired("name")
 	cobra.CheckErr(err)
 


### PR DESCRIPTION
This patch adds an additional output flag value `token` to the `api-token create` command that outputs just the raw API token.

This is useful for automation and one-liner quickstart

```
export CHAINLOOP_TOKEN=$(chainlooop org api-token create --name quickstart -o token)
```

refs #891 