### PR TITLE
fix(cli): do not double render the envelope on attestation push

### DIFF
--- a/app/cli/internal/action/attestation_push.go
+++ b/app/cli/internal/action/attestation_push.go
@@ -16,7 +16,6 @@
 package action
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -38,7 +37,7 @@ type AttestationPushOpts struct {
 
 type AttestationResult struct {
 	Digest   string                   `json:"digest"`
-	Envelope string                   `json:"envelope"`
+	Envelope *dsse.Envelope           `json:"envelope"`
 	Status   *AttestationStatusResult `json:"status"`
 }
 
@@ -144,14 +143,7 @@ func (action *AttestationPush) Run(ctx context.Context, attestationID string, ru
 		return nil, err
 	}
 
-	var rawEnvelope bytes.Buffer
-	encoder := json.NewEncoder(&rawEnvelope)
-	encoder.SetIndent("", "   ")
-	if err := encoder.Encode(envelope); err != nil {
-		return nil, fmt.Errorf("failed to encode output: %w", err)
-	}
-
-	attestationResult := &AttestationResult{Envelope: rawEnvelope.String(), Status: attestationStatus}
+	attestationResult := &AttestationResult{Envelope: envelope, Status: attestationStatus}
 
 	action.Logger.Debug().Msg("render completed")
 	if action.c.CraftingState.DryRun {


### PR DESCRIPTION
Fixes a rendering output issue from the CLI that was causing problems when dumping the output to a variable.

It's been fixed by removing some manual rendering we used to do about the payload and instead leverage the native rendering of the json marshaller. The reason this was different in the past is because the default output was a formatted json output, now it's not the case anymore.

```
go run main.go att init --name test --replace                                  
INF Attestation initialized! now you can check its status or add materials to it
┌───────────────────┬──────────────────────────────────────┐
│ Initialized At    │ 06 Jun 24 09:44 UTC                  │
├───────────────────┼──────────────────────────────────────┤
│ Attestation ID    │ 27c34933-3e64-4ad2-b12a-42d202e6b737 │
│ Name              │ test                                 │
│ Team              │                                      │
│ Project           │ bar                                  │
│ Contract Revision │ 1                                    │
└───────────────────┴──────────────────────────────────────┘
```  

```
r=$(go run main.go att push -o json)                                                
INF push completed
```

```
echo $r | jq .digest
"sha256:051f64e49f6f7cfac4063eedaada78ad2e8f720b173c6b2948de50d0fac8507a"
```
```
echo $r | jq .envelope
{
  "payloadType": "application/vnd.in-toto+json",
  "payload": "eyJfdHlwZSI6Imh0dHBzOi8vaW4tdG90by5pby9TdGF0ZW1lbnQvdjEiLCAic3ViamVjdCI6W3sibmFtZSI6ImNoYWlubG9vcC53b3JrZmxvdy50ZXN0IiwgImRpZ2VzdCI6eyJzaGEyNTYiOiI2YWQzMmYwYjY
1NjM1ZWMxYzBlNGE0MTE2YzNiZDFmNjViZDk4MGE5MjU1MzA0Y2UwYTQyOTMxMjFiYjY2ZjJkIn19LCB7Im5hbWUiOiJnaXQuaGVhZCIsICJkaWdlc3QiOnsic2hhMSI6ImJhOTQ5ZGZjNmM1YTc2MmI4MzA2ZjE5ZDJkNWQ0OWFk
NmU3MjI1MzgifSwgImFubm90YXRpb25zIjp7ImF1dGhvci5lbWFpbCI6Im1pZ3VlbEBjaGFpbmxvb3AuZGV2IiwgImF1dGhvci5uYW1lIjoiTWlndWVsIE1hcnRpbmV6IFRyaXZpbm8iLCAiZGF0ZSI6IjIwMjQtMDYtMDZUMDk6N
DM6NDZaIiwgIm1lc3NhZ2UiOiJmaXgoY2xpKTogZG8gbm90IGRvdWJsZSByZW5kZXIgdGhlIGVudmVsb3BlIG9uIGF0dGVzdGF0aW9uIHB1c2hcblxuU2lnbmVkLW9mZi1ieTogTWlndWVsIE1hcnRpbmV6IFRyaXZpbm8gPG1pZ3
VlbEBjaGFpbmxvb3AuZGV2PlxuIiwgInJlbW90ZXMiOlt7Im5hbWUiOiJvcmlnaW4iLCAidXJsIjoiZ2l0QGdpdGh1Yi5jb206bWlnbWFydHJpL2NoYWlubG9vcC5naXQifSwgeyJuYW1lIjoidXBzdHJlYW0iLCAidXJsIjoiZ2l
0QGdpdGh1Yi5jb206Y2hhaW5sb29wLWRldi9jaGFpbmxvb3AuZ2l0In0sIHsibmFtZSI6InRlc3QtdG9rZW4iLCAidXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL2NoYWlubG9vcC1kZXYvY2hhaW5sb29wLmdpdCJ9XX19XSwgInBy
ZWRpY2F0ZVR5cGUiOiJjaGFpbmxvb3AuZGV2L2F0dGVzdGF0aW9uL3YwLjIiLCAicHJlZGljYXRlIjp7ImJ1aWxkVHlwZSI6ImNoYWlubG9vcC5kZXYvd29ya2Zsb3dydW4vdjAuMSIsICJidWlsZGVyIjp7ImlkIjoiY2hhaW5sb
29wLmRldi9jbGkvZGV2QHNoYTI1NjpjNDMyMGFiZGU4ZjE4YTZjN2Q0NmUzOTk5ZDAxOTBmMTkxMmVhZTFiYWJiN2ExNzAwNWY3ZDNlOGEwZmQ3NjZkIn0sICJtZXRhZGF0YSI6eyJmaW5pc2hlZEF0IjoiMjAyNC0wNi0wNlQwOT
o0NDozNS4wNjMwOTE1ODFaIiwgImluaXRpYWxpemVkQXQiOiIyMDI0LTA2LTA2VDA5OjQ0OjI3LjY1MzMxNjYxOFoiLCAibmFtZSI6InRlc3QiLCAib3JnYW5pemF0aW9uIjoibWlndWVsLXRlc3QiLCAicHJvamVjdCI6ImJhciI
sICJ0ZWFtIjoiIiwgIndvcmtmbG93SUQiOiJlODRiYjRmZS0xOTNiLTRjY2QtYmZmOS01Njk5NjQyYmUzZTAiLCAid29ya2Zsb3dSdW5JRCI6IjI3YzM0OTMzLTNlNjQtNGFkMi1iMTJhLTQyZDIwMmU2YjczNyJ9LCAicnVubmVy
VHlwZSI6IlJVTk5FUl9UWVBFX1VOU1BFQ0lGSUVEIn19",
  "signatures": [
    {
      "keyid": "",
      "sig": "MEQCIBT/uL8g3cBrtp0Aj1jheU1ArLw+NJoWmgy3qTrQ0I+kAiBUHkNfq1r/J2u6CP0wO5ZIv6Al1kq6vcmEK9JlYzU/fg=="
    }
  ]
}
```
