### PR TITLE
fix(workflows-build-and-package): Add missing workflow-name

### DIFF
--- a/.github/workflows/build_and_package.yaml
+++ b/.github/workflows/build_and_package.yaml
@@ -28,6 +28,7 @@ jobs:
       CONTAINER_IMAGE_CP: ghcr.io/chainloop-dev/chainloop/control-plane:${{ github.ref_name }}
       CONTAINER_IMAGE_CAS: ghcr.io/chainloop-dev/chainloop/artifact-cas:${{ github.ref_name }}
       GH_TOKEN: ${{ github.token }}
+      CHAINLOOP_WORKFLOW_NAME: "chainloop-vault-build-and-package"
     steps:
       - name: Install Cosign
         uses: sigstore/cosign-installer@ef6a6b364bbad08abd36a5f8af60b595d12702f8 # main
@@ -48,7 +49,7 @@ jobs:
 
       - name: Initialize Attestation
         run: |
-          chainloop attestation init
+          chainloop attestation init --workflow-name $CHAINLOOP_WORKFLOW_NAME
 
       - name: Docker login to Github Packages
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0


### PR DESCRIPTION
This patch adds a missing `--workflow-name` on the attestation init on for the `build and package` workflow.

Refs: #891 
