### PR TITLE
fix(attestation): do not load cas-backend on dry-mode

### DIFF
--- a/app/cli/internal/action/attestation_add.go
+++ b/app/cli/internal/action/attestation_add.go
@@ -78,41 +78,45 @@ func (action *AttestationAdd) Run(ctx context.Context, attestationID, materialNa
 		return err
 	}
 
-	// Get upload creds and CASbackend for the current attestation and set up CAS client
-	client := pb.NewAttestationServiceClient(action.CPConnection)
-	creds, err := client.GetUploadCreds(ctx,
-		&pb.AttestationServiceGetUploadCredsRequest{
-			WorkflowRunId: action.c.CraftingState.GetAttestation().GetWorkflow().GetWorkflowRunId(),
-		},
-	)
-	if err != nil {
-		return err
-	}
-
-	b := creds.GetResult().GetBackend()
-	if b == nil {
-		return fmt.Errorf("no backend found in upload creds")
+	// Default to inline CASBackend and override if we are not in dry-run mode
+	casBackend := &casclient.CASBackend{
+		Name: "not-set",
 	}
 
 	// Define CASbackend information based on the API response
-	casBackend := &casclient.CASBackend{
-		Name:    b.Provider,
-		MaxSize: b.GetLimits().MaxBytes,
-	}
-
-	// Some CASBackends will actually upload information to the CAS server
-	// in such case we need to set up a connection
-	if !b.IsInline && creds.Result.Token != "" {
-		artifactCASConn, err := grpcconn.New(action.casURI, creds.Result.Token, action.connectionInsecure)
+	if !action.c.CraftingState.GetDryRun() {
+		// Get upload creds and CASbackend for the current attestation and set up CAS client
+		client := pb.NewAttestationServiceClient(action.CPConnection)
+		creds, err := client.GetUploadCreds(ctx,
+			&pb.AttestationServiceGetUploadCredsRequest{
+				WorkflowRunId: action.c.CraftingState.GetAttestation().GetWorkflow().GetWorkflowRunId(),
+			},
+		)
 		if err != nil {
 			return err
 		}
-		defer artifactCASConn.Close()
+		b := creds.GetResult().GetBackend()
+		if b == nil {
+			return fmt.Errorf("no backend found in upload creds")
+		}
+		casBackend.Name = b.Provider
+		casBackend.MaxSize = b.GetLimits().MaxBytes
+		// Some CASBackends will actually upload information to the CAS server
+		// in such case we need to set up a connection
+		if !b.IsInline && creds.Result.Token != "" {
+			artifactCASConn, err := grpcconn.New(action.casURI, creds.Result.Token, action.connectionInsecure)
+			if err != nil {
+				return err
+			}
+			defer artifactCASConn.Close()
 
-		casBackend.Uploader = casclient.New(artifactCASConn, casclient.WithLogger(action.Logger))
+			casBackend.Uploader = casclient.New(artifactCASConn, casclient.WithLogger(action.Logger))
+		}
 	}
+
 	// Add material to the attestation crafting state based on if the material is contract free or not.
 	// By default, try to detect the material kind automatically
+	var err error
 	switch {
 	case materialName == "" && materialType == "":
 		var kind schemaapi.CraftingSchema_Material_MaterialType


### PR DESCRIPTION
When running an attestation in dry-mode, we should not upload files either and hence we do not need to ask for the cas-backend information to the server.

This PR makes sure that the controlplane `GetUploadCreds` is only called if regular attestation mode is engaged.

fixes #926 