### PR TITLE
fix(cli): show full output

### DIFF
--- a/app/cli/cmd/attestation_status.go
+++ b/app/cli/cmd/attestation_status.go
@@ -51,7 +51,12 @@ func newAttestationStatusCmd() *cobra.Command {
 				return err
 			}
 
-			return encodeOutput(res, simpleStatusTable)
+			output := simpleStatusTable
+			if full {
+				output = fullStatusTable
+			}
+
+			return encodeOutput(res, output)
 		},
 	}
 


### PR DESCRIPTION
`--full` flag in `chainloop att status` was not working anymore. It was always rendering the table without values

