### PR TITLE
fix(attestation): push on dry-run

### DIFF
--- a/app/cli/cmd/attestation_init.go
+++ b/app/cli/cmd/attestation_init.go
@@ -81,6 +81,10 @@ func newAttestationInitCmd() *cobra.Command {
 				return newGracefulError(err)
 			}
 
+			if res.DryRun {
+				logger.Info().Msg("The attestation is being crafted in dry-run mode. It will not get stored once rendered")
+			}
+
 			return encodeOutput(res, simpleStatusTable)
 		},
 	}

--- a/app/cli/cmd/attestation_status.go
+++ b/app/cli/cmd/attestation_status.go
@@ -106,11 +106,7 @@ func attestationStatusTableOutput(status *action.AttestationStatusResult, full b
 		return err
 	}
 
-	if err := envVarsTable(status, full); err != nil {
-		return err
-	}
-
-	return nil
+	return envVarsTable(status, full)
 }
 
 func envVarsTable(status *action.AttestationStatusResult, full bool) error {

--- a/app/cli/cmd/attestation_status.go
+++ b/app/cli/cmd/attestation_status.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/jedib0t/go-pretty/v6/table"
-	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/muesli/reflow/wrap"
 	"github.com/spf13/cobra"
 
@@ -111,10 +110,6 @@ func attestationStatusTableOutput(status *action.AttestationStatusResult, full b
 		return err
 	}
 
-	if status.DryRun {
-		colors := text.Colors{text.FgHiBlack, text.BgHiYellow}
-		fmt.Println(colors.Sprint("The attestation is being crafted in dry-run mode. It will not get stored once rendered"))
-	}
 	return nil
 }
 

--- a/internal/attestation/crafter/api/attestation/v1/crafting_state_validations.go
+++ b/internal/attestation/crafter/api/attestation/v1/crafting_state_validations.go
@@ -26,14 +26,18 @@ import (
 
 // ValidateComplete makes sure that the crafting state has been completed
 // before it gets passed to the renderer
-func (state *CraftingState) ValidateComplete() error {
+func (state *CraftingState) ValidateComplete(dryRun bool) error {
 	validator, err := protovalidate.New()
 	if err != nil {
 		return fmt.Errorf("could not create validator: %w", err)
 	}
 
-	if err := validator.Validate(state); err != nil {
-		return fmt.Errorf("invalid crafting state: %w", err)
+	// We do not want to validate the schema of the state if we are just doing a dry run
+	// since it's known to not to contain the workflow metadata information
+	if !dryRun {
+		if err := validator.Validate(state); err != nil {
+			return fmt.Errorf("invalid crafting state: %w", err)
+		}
 	}
 
 	// Semantic errors

--- a/internal/attestation/crafter/crafter.go
+++ b/internal/attestation/crafter/crafter.go
@@ -599,7 +599,7 @@ func (c *Crafter) ValidateAttestation() error {
 		return err
 	}
 
-	return c.CraftingState.ValidateComplete()
+	return c.CraftingState.ValidateComplete(c.CraftingState.GetDryRun())
 }
 
 func (c *Crafter) requireStateLoaded() error {


### PR DESCRIPTION
There was a problem while trying to `att push` an attestation that was initialized in `dry-run` mode. The validation error was

```
ERR invalid crafting state: validation error:
 - attestation.workflow.organization: value length must be at least 1 character [string.min_len]
```

This patch skips that schema validation when running in `dry-run` mode since in this mode it's know to not to be fully complete.

refs #796 