### PR TITLE
build images with username

### DIFF
--- a/app/artifact-cas/Dockerfile.goreleaser
+++ b/app/artifact-cas/Dockerfile.goreleaser
@@ -5,4 +5,6 @@ FROM scratch
 COPY ./artifact-cas /
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
+USER 1001
+
 ENTRYPOINT [ "/artifact-cas", "--conf", "/data/conf"]

--- a/app/cli/Dockerfile.goreleaser
+++ b/app/cli/Dockerfile.goreleaser
@@ -5,4 +5,6 @@ FROM scratch
 COPY ./chainloop /
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
+USER 1001
+
 ENTRYPOINT [ "./chainloop"]

--- a/app/controlplane/Dockerfile.goreleaser
+++ b/app/controlplane/Dockerfile.goreleaser
@@ -14,4 +14,6 @@ COPY ./chainloop-plugin-smtp /plugins/
 # tmp is required for the plugins to run
 COPY --from=builder /tmp /tmp
 
+USER 1001
+
 ENTRYPOINT [ "/control-plane", "--conf", "/data/conf"]

--- a/app/controlplane/Dockerfile.migrations
+++ b/app/controlplane/Dockerfile.migrations
@@ -3,3 +3,5 @@
 FROM arigaio/atlas@sha256:37b8b163719e2f9baf5c97099e8d0772bc1bd84f392e402afcc3e565d11e074f
 
 COPY app/controlplane/pkg/data/ent/migrate/migrations /migrations
+
+USER 1001


### PR DESCRIPTION
builds all our container images indicating a non-root user `1001`

Next, we can release these images and give them a try in our helm chart, which will probably require some changes to pick the right usercontext

refs #936 