### PR TITLE
fix: make migrations work in openshift

### DIFF
--- a/app/controlplane/Dockerfile.migrations
+++ b/app/controlplane/Dockerfile.migrations
@@ -1,7 +1,14 @@
 # Container image built by go-releaser that's used to run migrations against the database during deployment
 # See https://atlasgo.io/guides/deploying/image
-FROM arigaio/atlas@sha256:5c459e8c134bb3d6d4f0346bbe6aa32ab23b7726286c4f23e7d831557574ed0d
+FROM arigaio/atlas as base
 
+FROM scratch
+# Update permissions to make it readable by the user
+# Otherwise the permissions are 001 which is not compatible with openshift in the default configuration
+# https://github.com/chainloop-dev/chainloop/issues/922
+COPY --from=base --chmod=555 /atlas /
 COPY app/controlplane/pkg/data/ent/migrate/migrations /migrations
 
 USER 1001
+
+ENTRYPOINT ["/atlas"]

--- a/app/controlplane/Dockerfile.migrations
+++ b/app/controlplane/Dockerfile.migrations
@@ -1,6 +1,6 @@
 # Container image built by go-releaser that's used to run migrations against the database during deployment
 # See https://atlasgo.io/guides/deploying/image
-FROM arigaio/atlas as base
+FROM arigaio/atlas@sha256:5c459e8c134bb3d6d4f0346bbe6aa32ab23b7726286c4f23e7d831557574ed0d as base
 
 FROM scratch
 # Update permissions to make it readable by the user


### PR DESCRIPTION
Fixes the permissions of the `atlas` binary. Before it was 001 which didn't work in openshift by default. Now it has a regular read only permission across the board.

Tested in openshift 4.15

Fixes #922 

cc/ @hanygirgis