### PR TITLE
feat(deployment): move init-container connection string

### DIFF
--- a/deployment/chainloop/templates/controlplane/config.secret.yaml
+++ b/deployment/chainloop/templates/controlplane/config.secret.yaml
@@ -14,6 +14,7 @@ type: Opaque
 data:
   # We store it also as a different key so it can be reused during upgrades by the common.secrets.passwords.manage helper
   generated_jws_hmac_secret: {{ $hmacpass }}
+  db_migrate_source: {{include "controlplane.database.atlas_connection_string" . | b64enc | quote }}
 stringData:
   {{- if and .Values.sentry .Values.sentry.enabled }}
     {{- fail "configuring sentry at the top level is no longer supported. Add the configuration to the controlplane section in the values.yaml file" }}

--- a/deployment/chainloop/templates/controlplane/deployment.yaml
+++ b/deployment/chainloop/templates/controlplane/deployment.yaml
@@ -41,9 +41,15 @@ spec:
             - migrate
             - apply
             - --url
-            - "{{include "controlplane.database.atlas_connection_string" . }}"
+            - $(CONNECTION_STRING)
             - --dir
             - file:///migrations
+          env:
+            - name: CONNECTION_STRING
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "chainloop.controlplane.fullname" . }}
+                  key: db_migrate_source
       containers:
         - name: {{ .Chart.Name }}
           securityContext:


### PR DESCRIPTION
Move controlplane init container connection string to a secret instead of loading it from an env var. 

```diff
diff -u /tmp/before.yaml /tmp/after.yaml                                   
--- /tmp/before.yaml    2024-06-15 22:15:13.698002272 +0200
+++ /tmp/after.yaml     2024-06-15 22:17:10.401682053 +0200
@@ -333,7 +333,8 @@
 type: Opaque
 data:
   # We store it also as a different key so it can be reused during upgrades by the common.secrets.passwords.manage helper
-  generated_jws_hmac_secret: "dTRzWGpnQzkwMQ=="
+  generated_jws_hmac_secret: "OFp2dThPc0E5cQ=="
+  db_migrate_source: "cG9zdGdyZXM6Ly9jaGFpbmxvb3A6Y2hhaW5sb29wcHdkQGNoYWlubG9vcC1wb3N0Z3Jlc3FsOjU0MzIvY2hhaW5sb29wLWNwP3NzbG1vZGU9ZGlzYWJsZQ=="
 stringData:
   config.secret.yaml: |
     data:
@@ -357,7 +358,7 @@
       # HMAC key used to sign the JWTs generated by the controlplane
       # The helper returns the base64 quoted value of the secret
       # We need to remove the quotes and then decoding it so it's compatible with the stringData stanza
-      generated_jws_hmac_secret: "u4sXjgC901"
+      generated_jws_hmac_secret: "8Zvu8OsA9q"
 
       # Private key used to sign the JWTs meant to be consumed by the CAS
       cas_robot_account_private_key_path: "/secrets/cas.private.key"
@@ -1430,7 +1431,7 @@
     metadata:
       annotations:
         checksum/config: 8edca7bc7be69d37adac50d08c1c2c06e4c3636e9e0f4344be798522ecdb8fdf
-        checksum/secret-config: 6d7ec9420200cd6907cdca6330dd3c7946b0330d4153c000c5b739b124efb730
+        checksum/secret-config: b7fc9d27411bf4dbd9811184adda4393deb86b2bbb81ec2086a87ddff159ab7d
         checksum/cas-private-key: 01b08a7dabb15fdde13bfe39fca7a7f9e374f5c23ac3ee264910938932e2391f
         kubectl.kubernetes.io/default-container: controlplane
       labels:
@@ -1449,9 +1450,15 @@
             - migrate
             - apply
             - --url
-            - "postgres://chainloop:chainlooppwd@chainloop-postgresql:5432/chainloop-cp?sslmode=disable"
+            - $(CONNECTION_STRING)
             - --dir
             - file:///migrations
+          env:
+            - name: CONNECTION_STRING
+              valueFrom:
+                secretKeyRef:
+                  name: chainloop-controlplane
+                  key: db_migrate_source
```
