### PR TITLE
feat(deployment): support custom CAs

### DIFF
--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -7,7 +7,7 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.61.0
+version: 1.61.1
 # Do not update appVersion, this is handled automatically by the release process
 appVersion: v0.91.6
 

--- a/deployment/chainloop/README.md
+++ b/deployment/chainloop/README.md
@@ -399,6 +399,22 @@ controlplane:
       keyPass: "REDACTED"  
 ```
 
+### Insert custom Certificate Authorities (CAs)
+
+In some scenarios, you might want to add custom Certificate Authorities to the Chainloop deployment. Like in the instance where your OIDC provider uses a self-signed certificate. To do so, add the PEM-encoded CA certificate to the `customCAs` list in your `values.yaml` file like in the example below.
+
+```yaml
+  customCAs:
+    - |-
+      -----BEGIN CERTIFICATE-----
+      MIIFmDCCA4CgAwIBAgIQU9C87nMpOIFKYpfvOHFHFDANBgkqhkiG9w0BAQsFADBm
+      BhMCVVMxMzAxBgNVBAoTKihTVEFHSU5HKSBJbnRlcm5ldCBTZWN1cml0eSBSZXNl
+      REDACTED
+      5CunuvCXmEQJHo7kGcViT7sETn6Jz9KOhvYcXkJ7po6d93A/jy4GKPIPnsKKNEmR
+      7DiA+/9Qdp9RBWJpTS9i/mDnJg1xvo8Xz49mrrgfmcAXTCJqXi24NatI3Oc=
+      -----END CERTIFICATE-----
+```
+
 ### Send exceptions to Sentry
 
 You can configure different sentry projects for both the controlplane and the artifact CAS
@@ -568,6 +584,7 @@ chainloop config save \
 | `controlplane.keylessSigning.fileCA.cert`                    | The PEM-encoded certificate of the file based CA         | `""`         |
 | `controlplane.keylessSigning.fileCA.key`                     | The PEM-encoded private key of the file based CA         | `""`         |
 | `controlplane.keylessSigning.fileCA.keyPass`                 | The secret key pass                                      | `""`         |
+| `controlplane.customCAs`                                     | List of custom CA certificates content                   | `[]`         |
 
 ### Artifact Content Addressable (CAS) API
 

--- a/deployment/chainloop/templates/controlplane/customcas.secret.yaml
+++ b/deployment/chainloop/templates/controlplane/customcas.secret.yaml
@@ -1,0 +1,18 @@
+{{- /*
+Copyright Chainloop, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- $customCAs := .Values.controlplane.customCAs }}
+{{- if (not (empty $customCAs)) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "chainloop.controlplane.fullname" . }}-custom-cas
+  labels:
+    {{- include "chainloop.controlplane.labels" . | nindent 4 }}
+data: 
+  {{- range $index, $pem := $customCAs }}
+  custom-{{ $index }}.crt: {{ $pem | b64enc | quote }}
+  {{- end -}}
+{{- end -}}

--- a/deployment/chainloop/templates/controlplane/deployment.yaml
+++ b/deployment/chainloop/templates/controlplane/deployment.yaml
@@ -91,6 +91,13 @@ spec:
             - name: gcp-secretmanager-serviceaccountkey
               mountPath: /gcp-secrets
             {{- end }}
+            {{- if (not (empty .Values.controlplane.customCAs)) }}
+            - name: custom-cas
+              # NOTE: /etc/ssl/certs already contains the system CA certs
+              # Let's use another known path https://go.dev/src/crypto/x509/root_linux.go
+              mountPath: /etc/pki/tls/certs
+              readOnly: true
+            {{- end }}
       volumes:
         - name: config
           projected:
@@ -99,6 +106,13 @@ spec:
                 name: {{ include "chainloop.controlplane.fullname" . }}
             - configMap:
                name: {{ include "chainloop.controlplane.fullname" . }}
+        {{- if (not (empty .Values.controlplane.customCAs)) }}
+        - name: custom-cas
+          projected:
+            sources:
+            - secret:
+               name: {{ include "chainloop.controlplane.fullname" . }}-custom-cas
+        {{- end }}
         # required for the plugins to store the socket files
         - name: tmp
           emptyDir: {}

--- a/deployment/chainloop/values.yaml
+++ b/deployment/chainloop/values.yaml
@@ -475,6 +475,10 @@ controlplane:
       key: ""
       keyPass: ""
 
+  ## Inject custom CA certificates to the controlplane container
+  ## @param controlplane.customCAs List of custom CA certificates content
+  customCAs: []
+
 ## @section Artifact Content Addressable (CAS) API
 ##################################
 #         Artifacts CAS          #


### PR DESCRIPTION
Add support to providing custom CAs available during TLS verification by the application HTTP clients.

Example of applying this change and adding a custom CA

- Will create a secret
- Will mount it in a default system path understood by golang's crypto library https://go.dev/src/crypto/x509/root_linux.go

I've tested it locally pointing my OIDC server to an nginx with a TLS certificate provided by the [staging certificate](https://letsencrypt.org/docs/staging-environment/) from let's encrypt. 

Closes https://github.com/chainloop-dev/chainloop/issues/956

```diff
 ---
+# Source: chainloop/templates/controlplane/customcas.secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chainloop-2-controlplane-custom-cas
+  labels:
+    app.kubernetes.io/name: chainloop
+    helm.sh/chart: chainloop-1.61.0
+    app.kubernetes.io/instance: chainloop-2
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "v0.91.6"
+    app.kubernetes.io/part-of: chainloop
+    app.kubernetes.io/component: controlplane
+data:
+  custom-0.crt: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZtRENDQTRDZ0F3SUJBZ0lRVTlDODduTXBPSUZLWXBmdk9IRkhGREFOQmdrcWhraUc5dzBCQVFzRkFEQm0KTVFzd0NRWURWUVFHRXdKVlV6RXpNREVHQTFVRUNoTXFLRk5VUVVkSlRrY3BJRWx1ZEdWeWJtVjBJRk5sWTNWeQphWFI1SUZKbGMyVmhjbU5vSUVkeWIzVndNU0l3SUFZRFZRUURFeGtvVTFSQlIwbE9SeWtnVUhKbGRHVnVaQ0JRClpXRnlJRmd4TUI0WERURTFNRFl3TkRFeE1EUXpPRm9YRFRNMU1EWXdOREV4TURRek9Gb3daakVMTUFrR0ExVUUKQmhNQ1ZWTXhNekF4QmdOVkJBb1RLaWhUVkVGSFNVNUhLU0JKYm5SbGNtNWxkQ0JUWldOMWNtbDBlU0JTWlhObApZWEpqYUNCSGNtOTFjREVpTUNBR0ExVUVBeE1aS0ZOVVFVZEpUa2NwSUZCeVpYUmxibVFnVUdWaGNpQllNVENDCkFpSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnSVBBRENDQWdvQ2dnSUJBTGJhZ0VkRFRhMVFnR0JXU1lreU1oc2MKWlhFTk9CYVZSVE1YMWhjZUpFTmdzTDBNYTQ5RDNNaWxJNEtTMzhtdGttZEY2Y1BXbkwrK2ZnZWhUMEZiUkhaZwpqT0VyOFVBTjRqSDZvbWpyYlREKytWWm5lVHNNVmFHYW1RbURkRmw1ZzFnWWFpZ2trbXg4T2lDTzY4YTRRWGc0CndTeW42aURpcEtQOHV0c0UreDFFMjhTQTc1SE9ZcXBkcms0SEd4dVVMdmxyMDN3WkdUSWYvb1J0Mi9jK2RZbUQKb2FKaGdlK0dPckxBRVFCeU83KzgrdnpPd3BOQVBFeDZMVytjckVFWjdlQlhpaDZWUDE5c1RHeTN5ZnFLNXRQdApUZFhYQ09RTUtBcCtnQ2ovVkJ5aG1JciswaU5EQzU0MGd0dlYzMDNXcGNid25ra0xZQzBGdDJjWVV5SHRrc3RPCmZSY1JPK0syY1pvem9Td1ZQeUI4L0o5UnBjUkszamduWDlsdWpmd0EvcEFiUDBKMlVQUUZ4bVdGUlFuRmphcTYKcmtxYk5FQmdMeStrRkwxTkVzUmJ2RmJLclJpNWJZeTJsTm1zMk5KUFp2ZE5RYlQvMmRCWkttSnF4SGt4Q3VPUQpGamhKUU5lTytOam0xWjFpQVRTLzNydHMyeVpscVhLc3hRVXpONnZOYkQ4S25YUk1FZU9YVVl2YlY0bHFmQ2Y4Cm1TMTRXRWJTaU15ODdHQjVTOXVjU1YxWFVybFRHNVVHY01TWk9CY0VVcGlzUlBFbVFXVU9UV0lvRFE1Rk9pYS8KR0krS2k1MjNyMnJ1RW1ibUczN0VCU0JYZHhJZG5kcXJqeStRVkFtQ2VieUR4OWVWRUdPSXBuMjZiVzVMS2VydQptSnhhL0NGQmFLaTRiUnZtZEpSTEFnTUJBQUdqUWpCQU1BNEdBMVVkRHdFQi93UUVBd0lCQmpBUEJnTlZIUk1CCkFmOEVCVEFEQVFIL01CMEdBMVVkRGdRV0JCUzE4Mlh5L3JBS2toLzdQSDN6UktDc1l5WERGREFOQmdrcWhraUcKOXcwQkFRc0ZBQU9DQWdFQW5jRFpOeXREYnJyVmU2OFVUNnB5MWxmRjJoNlRtMnA4cm80Mmk4N1dXeVAyTEs4WQpuTEhDMGh2TmZXZVdtalpRWUJRZkdDNWM3YVFSZXphayt0SExkbXJOS0hrbjVrbis5RTlMQ2pDYUVzeUlJbjJqCnFkSGxBa2VwdS9DM0tuTnRWeDV0VzA3ZTVidklqSlNjd2tDRGJQM2FrV1FpeFBwUkZBc25QK1VMeDdrMGFPMXgKcUFlYUFoUTJyZ28xRjU4aGNmbGdxS1RYbnBQTTAyaW50VmZpVlZrWDVHWHBKaks1RW9RdExjZXlHT3JreGxNLwpzVFBxNFVybnlwbXNxU2FnV1YzSGNVbFl0RGluYytudWtGazZlUjRYa3pYQmJ3S2FqbDBZanp0ZnJDSUhPbjVRCkNKTDZURVJWRGJNL2FBUGx5OGtKMXNXR0x1dnZXWXpNWWdMekR1bC8vclVGMTBnRU1XYVhWWlY1MUtwUzlEWS8KNUN1bnV2Q1htRVFKSG83a0djVmlUN3NFVG42Sno5S09odlljWGtKN3BvNmQ5M0Evank0R0tQSVBuc0tLTkVtUgp4VXVYWTR4UmRoNDV0TUpuTFRVRGRDOUZJVTBmbFRlTzkvdk5wVkE4T1BVMWkxNHZDeitNVThLWDFiVjNHWG0vCmZ4bEI3VkJCalg5djVvVWVwMG8vajY4Ui9pRGxDT000VlZmUmE4Z1g2VDJGVTdmTmRhdHZHcm83dVF6SXZXb2YKZ045V1V3Q2JFTUJ5L1loQlNyWHljS0E4Y3JnR2czeDFtSXNvcG44OEpLd21NQmE2OG9TN0VITTl3N0M0eTcxTQo3RGlBKy85UWRwOVJCV0pwVFM5aS9tRG5KZzF4dm84WHo0OW1ycmdmbWNBWFRDSnFYaTI0TmF0STNPYz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ=="
+---
 # Source: chainloop/templates/controlplane/jwt_cas_private_key.secret.yaml
 apiVersion: v1
 kind: Secret
@@ -1430,7 +1446,7 @@
     metadata:
       annotations:
         checksum/config: daa5fd5324f11e1802d549215a36da1e567627536c8a0658af8a13ac8ec2146d
-        checksum/secret-config: 88fdc4664ce52cc1b4928c92a4903e96ce7462dffc3fe6c6ed41164540a079aa
+        checksum/secret-config: 49be03a7a7d243ca88ad971ac5958ada0b40ce3596251eff6eb8a3ae936f6bc3
         checksum/cas-private-key: 7bc159cd8a76c55ccef7fa39b7780459d289d515eade0115b574cc1c2aa27555
         kubectl.kubernetes.io/default-container: controlplane
       labels:
@@ -1492,6 +1508,11 @@
               mountPath: /tmp
             - name: jwt-cas-private-key
               mountPath: /secrets
+            - name: custom-cas
+              # NOTE: /etc/ssl/certs already contains the system CA certs
+              # Let's use another known path https://go.dev/src/crypto/x509/root_linux.go
+              mountPath: /etc/pki/tls/certs
+              readOnly: true
       volumes:
         - name: config
           projected:
@@ -1500,6 +1521,11 @@
                 name: chainloop-2-controlplane
             - configMap:
                name: chainloop-2-controlplane
+        - name: custom-cas
+          projected:
+            sources:
+            - secret:
+               name: chainloop-2-controlplane-custom-cas
         # required for the plugins to store the socket files
         - name: tmp
           emptyDir: {}

```