### PR TITLE
feat(cli): output format to export PAE-encoded payload

### DIFF
--- a/app/cli/cmd/workflow_workflow_run_describe.go
+++ b/app/cli/cmd/workflow_workflow_run_describe.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"time"
 
@@ -26,11 +27,13 @@ import (
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/muesli/reflow/wrap"
+	"github.com/secure-systems-lab/go-securesystemslib/dsse"
 	"github.com/spf13/cobra"
 )
 
 const formatStatement = "statement"
 const formatAttestation = "attestation"
+const formatPayloadPAE = "payload-pae"
 
 func newWorkflowWorkflowRunDescribeCmd() *cobra.Command {
 	var runID, attestationDigest, publicKey string
@@ -58,7 +61,7 @@ func newWorkflowWorkflowRunDescribeCmd() *cobra.Command {
 				return err
 			}
 
-			return encodeAttestationOutput(res)
+			return encodeAttestationOutput(res, os.Stdout)
 		},
 	}
 
@@ -73,7 +76,7 @@ func newWorkflowWorkflowRunDescribeCmd() *cobra.Command {
 	}
 
 	// Override default output flag
-	cmd.InheritedFlags().StringVarP(&flagOutputFormat, "output", "o", "table", "output format, valid options are table, json, attestation or statement")
+	cmd.InheritedFlags().StringVarP(&flagOutputFormat, "output", "o", "table", "output format, valid options are table, json, attestation, statement or payload-pae")
 
 	return cmd
 }
@@ -193,7 +196,7 @@ func predicateV1Table(att *action.WorkflowRunAttestationItem) {
 	}
 }
 
-func encodeAttestationOutput(run *action.WorkflowRunItemFull) error {
+func encodeAttestationOutput(run *action.WorkflowRunItemFull, writer io.Writer) error {
 	// Try to encode as a table or json
 	err := encodeOutput(run, workflowRunDescribeTableOutput)
 	// It was correctly encoded, we are done
@@ -217,7 +220,18 @@ func encodeAttestationOutput(run *action.WorkflowRunItemFull) error {
 		return encodeJSON(run.Attestation.Statement())
 	case formatAttestation:
 		return encodeJSON(run.Attestation.Envelope)
+	case formatPayloadPAE:
+		return describePayload(run, writer)
 	default:
 		return ErrOutputFormatNotImplemented
 	}
+}
+
+func describePayload(run *action.WorkflowRunItemFull, writer io.Writer) error {
+	payload, err := run.Attestation.Envelope.DecodeB64Payload()
+	if err != nil {
+		return fmt.Errorf("could not decode attestation payload: %w", err)
+	}
+	_, err = fmt.Fprint(writer, string(dsse.PAE(run.Attestation.Envelope.PayloadType, payload)))
+	return err
 }

--- a/app/cli/cmd/workflow_workflow_run_describe.go
+++ b/app/cli/cmd/workflow_workflow_run_describe.go
@@ -33,6 +33,9 @@ import (
 
 const formatStatement = "statement"
 const formatAttestation = "attestation"
+
+// outputs the payload in PAE encoding, so that it matches the signature in the attestation,
+// and it's easily verifiable by external tools
 const formatPayloadPAE = "payload-pae"
 
 func newWorkflowWorkflowRunDescribeCmd() *cobra.Command {
@@ -221,13 +224,13 @@ func encodeAttestationOutput(run *action.WorkflowRunItemFull, writer io.Writer) 
 	case formatAttestation:
 		return encodeJSON(run.Attestation.Envelope)
 	case formatPayloadPAE:
-		return describePayload(run, writer)
+		return encodePAE(run, writer)
 	default:
 		return ErrOutputFormatNotImplemented
 	}
 }
 
-func describePayload(run *action.WorkflowRunItemFull, writer io.Writer) error {
+func encodePAE(run *action.WorkflowRunItemFull, writer io.Writer) error {
 	payload, err := run.Attestation.Envelope.DecodeB64Payload()
 	if err != nil {
 		return fmt.Errorf("could not decode attestation payload: %w", err)

--- a/app/cli/cmd/workflow_workflow_run_describe_test.go
+++ b/app/cli/cmd/workflow_workflow_run_describe_test.go
@@ -45,7 +45,6 @@ func (s *workflowRunDescribeSuite) SetupTest() {
 			},
 		},
 	}
-
 }
 
 func (s *workflowRunDescribeSuite) TestOutputTypePayload() {

--- a/app/cli/cmd/workflow_workflow_run_describe_test.go
+++ b/app/cli/cmd/workflow_workflow_run_describe_test.go
@@ -1,0 +1,61 @@
+//
+// Copyright 2024 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/base64"
+	"testing"
+
+	"github.com/chainloop-dev/chainloop/app/cli/internal/action"
+	"github.com/secure-systems-lab/go-securesystemslib/dsse"
+	"github.com/stretchr/testify/suite"
+)
+
+type workflowRunDescribeSuite struct {
+	suite.Suite
+
+	run *action.WorkflowRunItemFull
+}
+
+func TestSuite(t *testing.T) {
+	suite.Run(t, new(workflowRunDescribeSuite))
+}
+
+func (s *workflowRunDescribeSuite) SetupTest() {
+	s.run = &action.WorkflowRunItemFull{
+		Attestation: &action.WorkflowRunAttestationItem{
+			Envelope: &dsse.Envelope{
+				PayloadType: "application/vnd.in-toto+json",
+				Payload:     base64.StdEncoding.EncodeToString([]byte("hello")),
+				Signatures:  nil,
+			},
+		},
+	}
+
+}
+
+func (s *workflowRunDescribeSuite) TestOutputTypePayload() {
+	flagOutputFormat = formatPayloadPAE
+	expected := "DSSEv1 28 application/vnd.in-toto+json 5 hello"
+
+	buf := new(bytes.Buffer)
+	err := encodeAttestationOutput(s.run, buf)
+	s.NoError(err)
+
+	s.Require().NoError(err)
+	s.Equal(expected, buf.String())
+}


### PR DESCRIPTION
This PR implements the `payload-pae` output format to obtain the PAE-encoded payload for easier verification:
```
go run app/cli/main.go --insecure wf run describe --digest sha256:8e0bb3ce5b2aa98fb1aaab2cb9e8ba8015e9802d2a6d0ddb75aa09a96750bc85  --output payload-pae > payload.pae.txt
```
payload.pae.txt would look like:
```
DSSEv1 28 application/vnd.in-toto+json 1414 {"_type":"https://in-toto.io/Statement/v1","subject" ...
```
Then, it can be easily matched against the signature with Cosign:
```
cosign -d verify-blob --signature sig.txt --insecure-ignore-tlog --key cosign.pub payload.pae.txt
```
Closes #968 