### PR TITLE
feat: set new organizations as default

### DIFF
--- a/app/controlplane/internal/service/organization.go
+++ b/app/controlplane/internal/service/organization.go
@@ -52,7 +52,7 @@ func (s *OrganizationService) Create(ctx context.Context, req *pb.OrganizationSe
 		return nil, handleUseCaseErr(err, s.log)
 	}
 
-	if _, err := s.membershipUC.Create(ctx, org.ID, currentUser.ID, biz.WithMembershipRole(authz.RoleOwner)); err != nil {
+	if _, err := s.membershipUC.Create(ctx, org.ID, currentUser.ID, biz.WithMembershipRole(authz.RoleOwner), biz.WithCurrentMembership()); err != nil {
 		return nil, handleUseCaseErr(err, s.log)
 	}
 


### PR DESCRIPTION
During the creation of an org, we now set the membership as current. This is so we can reduce one command when we remove auto-creation of orgs  

```
go run main.go --insecure org ls                          
WRN API contacted in insecure mode
┌──────────────────────────────────────┬─────────────────────────┬─────────┬───────┬─────────────────────┐
│ ORG ID                               │ ORG NAME                │ CURRENT │ ROLE  │ JOINED AT           │
├──────────────────────────────────────┼─────────────────────────┼─────────┼───────┼─────────────────────┤
│ fd6fe7f5-7249-4677-abbe-5a064e4dac84 │ focused-archimedes-8066 │ false   │ owner │ 18 Jun 24 09:03 UTC │
├──────────────────────────────────────┼─────────────────────────┼─────────┼───────┼─────────────────────┤
│ d706f637-cd74-45a7-a402-913769cd182a │ foo                     │ true    │ owner │ 18 Jun 24 09:03 UTC │
└──────────────────────────────────────┴─────────────────────────┴─────────┴───────┴─────────────────────┘
```

```
go run main.go --insecure org create --name now-default   
WRN API contacted in insecure mode
INF Organization "now-default" created!
```

```
go run main.go --insecure org ls                       
WRN API contacted in insecure mode
┌──────────────────────────────────────┬─────────────────────────┬─────────┬───────┬─────────────────────┐
│ ORG ID                               │ ORG NAME                │ CURRENT │ ROLE  │ JOINED AT           │
├──────────────────────────────────────┼─────────────────────────┼─────────┼───────┼─────────────────────┤
│ fd6fe7f5-7249-4677-abbe-5a064e4dac84 │ focused-archimedes-8066 │ false   │ owner │ 18 Jun 24 09:03 UTC │
├──────────────────────────────────────┼─────────────────────────┼─────────┼───────┼─────────────────────┤
│ e267d34d-6814-47ce-bfd5-3131096e269a │ now-default             │ true    │ owner │ 18 Jun 24 09:05 UTC │
├──────────────────────────────────────┼─────────────────────────┼─────────┼───────┼─────────────────────┤
│ d706f637-cd74-45a7-a402-913769cd182a │ foo                     │ false   │ owner │ 18 Jun 24 09:03 UTC │
└──────────────────────────────────────┴─────────────────────────┴─────────┴───────┴─────────────────────┘
```