### PR TITLE
fix: return empty list of memberships instead of error

### DIFF
--- a/app/controlplane/internal/server/grpc.go
+++ b/app/controlplane/internal/server/grpc.go
@@ -245,9 +245,9 @@ func requireRobotAccountMatcher() selector.MatchFunc {
 
 // Matches all operations that require to have a current organization
 func requireAllButOrganizationOperationsMatcher() selector.MatchFunc {
-	const skipMatcher = "/controlplane.v1.OrganizationService/Create"
+	const skipRegexp = "/controlplane.v1.OrganizationService/Create|/controlplane.v1.UserService/ListMemberships"
 	return func(ctx context.Context, operation string) bool {
-		r := regexp.MustCompile(skipMatcher)
+		r := regexp.MustCompile(skipRegexp)
 		return !r.MatchString(operation)
 	}
 }


### PR DESCRIPTION
```
grpcurl --plaintext -H "authorization: Bearer $TOKEN"  localhost:9000  controlplane.v1.UserService.ListMemberships
{
  
}
```

```
go run main.go --insecure org ls -o json                                                                          
[]
```