### PR TITLE
fix(allowlist): run in most of the routes

### DIFF
--- a/app/controlplane/internal/usercontext/allowlist_middleware.go
+++ b/app/controlplane/internal/usercontext/allowlist_middleware.go
@@ -68,6 +68,7 @@ func CheckUserInAllowList(allowList *conf.Auth_AllowList) middleware.Middleware 
 
 func selectedRoute(ctx context.Context, selectedRoutes []string) bool {
 	if info, ok := transport.FromServerContext(ctx); ok {
+		fmt.Println("info.Operation(): ", info.Operation())
 		for _, route := range selectedRoutes {
 			if info.Operation() == route {
 				return true

--- a/app/controlplane/internal/usercontext/allowlist_middleware.go
+++ b/app/controlplane/internal/usercontext/allowlist_middleware.go
@@ -68,7 +68,6 @@ func CheckUserInAllowList(allowList *conf.Auth_AllowList) middleware.Middleware 
 
 func selectedRoute(ctx context.Context, selectedRoutes []string) bool {
 	if info, ok := transport.FromServerContext(ctx); ok {
-		fmt.Println("info.Operation(): ", info.Operation())
 		for _, route := range selectedRoutes {
 			if info.Operation() == route {
 				return true


### PR DESCRIPTION
AllowList middleware was not working on orgCreate endpoint since it was skipped in the parent selector.

This PR makes sure the allowList middleware uses it's on selector that's just limited to login and delete account