### PR TITLE
feat(docs): Update documenttion for contract-less and auto-discovery

### DIFF
--- a/docs/docs/getting-started/attestation-crafting.md
+++ b/docs/docs/getting-started/attestation-crafting.md
@@ -140,6 +140,10 @@ $ chainloop attestation add --name build-ref --value 80e461e9b385c6986cdb8096c9d
 $ chainloop attestation add --name skynet-sbom --value sbom.cyclonedx.json
 ```
 
+:::tip
+There is also the option of leaving Chainloop CLI to figure out the material type when adding a piece of evidence in an attestation, learn more about auto-discover [here](../reference/attestations.md#auto-discovery-of-pieces-of-evidence).
+:::
+
 ### Inspecting the crafting status
 
 If we check the status of the attestation we'll see that the three required materials have been added

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -70,6 +70,10 @@ This quickstart will guide you through the process of installing the Chainloop C
     chainloop att add --value my-sbom.json
     ```
 
+   :::info
+   The piece of evidence kind were automatically detected, learn more about auto-discover [here](reference/attestations.md).
+   :::
+
     And finally [we sign and push the attestation](/getting-started/attestation-crafting#encode-sign-and-push-attestation) to Chainloop for permanent preservation.
 
     ```bash

--- a/docs/docs/reference/attestations.md
+++ b/docs/docs/reference/attestations.md
@@ -1,0 +1,193 @@
+---
+sidebar_position: 1
+title: Contract-less and auto-discovery of materials
+---
+A Workflow Contract specifies the necessary content that a workflow must include in its attestation. For instance, it might mandate 
+the inclusion of the URI@digest of the generated container image, the container root filesystem used during the build, and the 
+Software Bill of Materials for that container image. These pieces of evidence must be associated with a specific material type. 
+Operators define what must be included in the contracts, and developers need to understand and comply with these requirements.
+
+This has been the case up until now, with the introduction of contract-less materials and auto-discovery, we ease the job of operators 
+and developers when working with attestations.
+
+## Contract-less materials
+Not all pieces of evidences need to to be registered as a material on the contract, you can add as many pieces of evidences as you like by adding 
+its value and a new flag `--kind`, which determines that type of material you’re attesting, example:
+
+```bash
+$ chainloop attestation init --workflow-name wf-test
+INF Attestation initialized! now you can check its status or add materials to it
+┌───────────────────┬──────────────────────────────────────┐
+│ Initialized At    │ 21 May 24 07:23 UTC                  │
+├───────────────────┼──────────────────────────────────────┤
+│ Attestation ID    │ 6e9d2e76-fdc0-4493-a344-4cf44a2b7bf2 │
+│ Name              │ wf-test                              │
+│ Team              │ founding                             │
+│ Project           │ core                                 │
+│ Contract Revision │ 3                                    │
+└───────────────────┴──────────────────────────────────────┘
+┌────────────────────────┐
+│ Materials              │
+├───────────┬────────────┤
+│ Name      │ one-file   │
+│ Type      │ ARTIFACT   │
+│ Set       │ No         │
+│ Required  │ Yes        │
+│ Is output │ Yes        │
+├───────────┼────────────┤
+│ Name      │ other-file │
+│ Type      │ EVIDENCE   │
+│ Set       │ No         │
+│ Required  │ Yes        │
+│ Is output │ Yes        │
+└───────────┴────────────┘
+```
+There are two expected materials of kind `ARTIFACT` and `EVIDENCE`. With the changes we can perform the following:
+
+```bash
+$ chainloop attestation add --value controlplane.cyclonedx.json  --kind SBOM_CYCLONEDX_JSON
+INF material added to attestation
+```
+We are explicitly saying which is the kind (`SBOM_CYCLONEDX_JSON`) we want to apply to material that is not found on the contract. After fulfilling the required materials, 
+the ones stated on the contract, we can perform the attestation as usual:
+
+```bash
+$ chainloop attestation push
+INF push completed
+┌───────────────────┬──────────────────────────────────────┐
+│ Initialized At    │ 21 May 24 06:37 UTC                  │
+├───────────────────┼──────────────────────────────────────┤
+│ Attestation ID    │ 57b8dc22-d84d-40c3-a04c-8948231b3134 │
+│ Name              │ wf-test                              │
+│ Team              │ founding                             │
+│ Project           │ core                                 │
+│ Contract Revision │ 3                                    │
+└───────────────────┴──────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────────────────────────────────┐
+│ Materials                                                                           │
+├───────────┬─────────────────────────────────────────────────────────────────────────┤
+│ Name      │ one-file                                                                │
+│ Type      │ ARTIFACT                                                                │
+│ Set       │ Yes                                                                     │
+│ Required  │ Yes                                                                     │
+│ Is output │ Yes                                                                     │
+│ Value     │ go.mod                                                                  │
+│ Digest    │ sha256:29773f085c46a33efcb6cdb185f6ec30ce1c4ca708b860708cd055b70488ef4d │
+├───────────┼─────────────────────────────────────────────────────────────────────────┤
+│ Name      │ other-file                                                              │
+│ Type      │ EVIDENCE                                                                │
+│ Set       │ Yes                                                                     │
+│ Required  │ Yes                                                                     │
+│ Is output │ Yes                                                                     │
+│ Value     │ LICENSE.md                                                              │
+│ Digest    │ sha256:c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4 │
+├───────────┼─────────────────────────────────────────────────────────────────────────┤
+│ Name      │ material-1716273574284654000                                            │
+│ Type      │ SBOM_CYCLONEDX_JSON                                                     │
+│ Set       │ Yes                                                                     │
+│ Required  │ No                                                                      │
+│ Is output │ Yes                                                                     │
+│ Value     │ controlplane.cyclonedx.json                                             │
+│ Digest    │ sha256:a6bc29d7a2d8d9f6df12a86ee4c86c58189d77bb6ded9487330c39f46ee00d9a │
+└───────────┴─────────────────────────────────────────────────────────────────────────┘
+Attestation Digest: sha256:61832d846b870d01647a384c3df49e3c75fd87f45821c9295d97ab91d5bae198
+```
+
+## Auto-discovery of materials
+In top of contract-less materials, we have introduced auto-discovery. Auto-discovery it’s a way of inspecting the incoming piece of 
+evidence and try to match it with at least of of the available type of [materials](operator/contract.mdx#material-schema) of Chainloop. 
+Please note this is a best effort and the prediction might fail and matching it with the wrong type of material, defaulting in `ARTIFACT`.
+
+In order to let the auto-discovery work, don’t set `--name` nor `--kind`, let the CLI work it our for you.
+
+Example of usage. Given the following contract:
+
+```bash
+$ chainloop attestation init --replace --workflow-name wf-test
+INF Attestation initialized! now you can check its status or add materials to it
+┌───────────────────┬──────────────────────────────────────┐
+│ Initialized At    │ 22 May 24 13:38 UTC                  │
+├───────────────────┼──────────────────────────────────────┤
+│ Attestation ID    │ 583553ef-d051-4c41-aec4-a4cdd725bf89 │
+│ Name              │ wf-test                              │
+│ Team              │ founding                             │
+│ Project           │ core                                 │
+│ Contract Revision │ 3                                    │
+└───────────────────┴──────────────────────────────────────┘
+┌────────────────────────┐
+│ Materials              │
+├───────────┬────────────┤
+│ Name      │ one-file   │
+│ Type      │ ARTIFACT   │
+│ Set       │ No         │
+│ Required  │ Yes        │
+│ Is output │ Yes        │
+├───────────┼────────────┤
+│ Name      │ other-file │
+│ Type      │ EVIDENCE   │
+│ Set       │ No         │
+│ Required  │ Yes        │
+│ Is output │ Yes        │
+└───────────┴────────────┘
+```
+Let's add the required materials:
+
+```bash
+$ chainloop attestation add --value go.mod --name one-file
+INF material added to attestation
+
+$ chainloop attestation add --value LICENSE.md --name other-file
+INF material added to attestation
+```
+And finally let's try to discover one material without specifying its type:
+
+```bash
+$ chainloop attestation add --value controlplane.cyclonedx.json
+INF material kind detected kind=SBOM_CYCLONEDX_JSON
+INF material added to attestation
+```
+As a result we can see how it's added to the result:
+
+```bash
+$ chainloop attestation push
+INF push completed
+┌───────────────────┬──────────────────────────────────────┐
+│ Initialized At    │ 22 May 24 13:38 UTC                  │
+├───────────────────┼──────────────────────────────────────┤
+│ Attestation ID    │ 583553ef-d051-4c41-aec4-a4cdd725bf89 │
+│ Name              │ wf-test                              │
+│ Team              │ founding                             │
+│ Project           │ core                                 │
+│ Contract Revision │ 3                                    │
+└───────────────────┴──────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────────────────────────────────┐
+│ Materials                                                                           │
+├───────────┬─────────────────────────────────────────────────────────────────────────┤
+│ Name      │ one-file                                                                │
+│ Type      │ ARTIFACT                                                                │
+│ Set       │ Yes                                                                     │
+│ Required  │ Yes                                                                     │
+│ Is output │ Yes                                                                     │
+│ Value     │ go.mod                                                                  │
+│ Digest    │ sha256:29773f085c46a33efcb6cdb185f6ec30ce1c4ca708b860708cd055b70488ef4d │
+├───────────┼─────────────────────────────────────────────────────────────────────────┤
+│ Name      │ other-file                                                              │
+│ Type      │ EVIDENCE                                                                │
+│ Set       │ Yes                                                                     │
+│ Required  │ Yes                                                                     │
+│ Is output │ Yes                                                                     │
+│ Value     │ LICENSE.md                                                              │
+│ Digest    │ sha256:c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4 │
+├───────────┼─────────────────────────────────────────────────────────────────────────┤
+│ Name      │ material-1716385111238449000                                            │
+│ Type      │ SBOM_CYCLONEDX_JSON                                                     │
+│ Set       │ Yes                                                                     │
+│ Required  │ No                                                                      │
+│ Value     │ controlplane.cyclonedx.json                                             │
+│ Digest    │ sha256:a6bc29d7a2d8d9f6df12a86ee4c86c58189d77bb6ded9487330c39f46ee00d9a │
+└───────────┴─────────────────────────────────────────────────────────────────────────┘
+Attestation Digest: sha256:8a0b3a9db0372fdf571dbe85c8a9b5202f473ca97e9dbcdf77c3f9b423ea3b9c
+```
+
+## In a nutshell
+Contract-less and auto-discovery and two features that walk hand by hand. They compose a new way of adding pieces of evidences to an existing contract in a frictionless way.

--- a/docs/docs/reference/attestations.md
+++ b/docs/docs/reference/attestations.md
@@ -1,21 +1,17 @@
 ---
 sidebar_position: 1
-title: Contract-less and auto-discovery of materials
+title: Contract-less and auto-discovery of pieces of evidence
 ---
-A Workflow Contract specifies the necessary content that a workflow must include in its attestation. For instance, it might mandate 
-the inclusion of the URI@digest of the generated container image, the container root filesystem used during the build, and the 
-Software Bill of Materials for that container image. These pieces of evidence must be associated with a specific material type. 
-Operators define what must be included in the contracts, and developers need to understand and comply with these requirements.
+A Workflow Contract specifies the necessary content that a workflow must include in its attestation. For instance, it might mandate the inclusion of the URI@digest of the generated container image, the container root filesystem used during the build, and the Software Bill of Materials for that container image. These pieces of evidence must be associated with a specific material type. Operators define what must be included in the [contracts](operator/contract.mdx), and developers need to understand and comply with these requirements.
 
-This has been the case up until now, with the introduction of contract-less materials and auto-discovery, we ease the job of operators 
-and developers when working with attestations.
+This has been the case up until now, with the introduction of contract-less pieces of evidences and auto-discovery, we ease the job of operators and developers when working with attestations.
 
-## Contract-less materials
+## Contract-less pieces of evidence
 Not all pieces of evidences need to to be registered as a material on the contract, you can add as many pieces of evidences as you like by adding 
 its value and a new flag `--kind`, which determines that type of material you’re attesting, example:
 
 ```bash
-$ chainloop attestation init --workflow-name wf-test
+$ chainloop attestation init --name wf-test
 INF Attestation initialized! now you can check its status or add materials to it
 ┌───────────────────┬──────────────────────────────────────┐
 │ Initialized At    │ 21 May 24 07:23 UTC                  │
@@ -93,17 +89,15 @@ INF push completed
 Attestation Digest: sha256:61832d846b870d01647a384c3df49e3c75fd87f45821c9295d97ab91d5bae198
 ```
 
-## Auto-discovery of materials
-In top of contract-less materials, we have introduced auto-discovery. Auto-discovery it’s a way of inspecting the incoming piece of 
-evidence and try to match it with at least of of the available type of [materials](operator/contract.mdx#material-schema) of Chainloop. 
-Please note this is a best effort and the prediction might fail and matching it with the wrong type of material, defaulting in `ARTIFACT`.
+## Auto-discovery of pieces of evidence
+In top of contract-less pieces of evidences, we have introduced auto-discovery. Auto-discovery it’s a way of inspecting the incoming piece of evidence and try to match it with at least of of the available type of [materials](operator/contract.mdx#material-schema) of Chainloop. Please note this is a best effort and the prediction might fail and matching it with the wrong type of material, defaulting in `ARTIFACT`.
 
 In order to let the auto-discovery work, don’t set `--name` nor `--kind`, let the CLI work it our for you.
 
 Example of usage. Given the following contract:
 
 ```bash
-$ chainloop attestation init --replace --workflow-name wf-test
+$ chainloop attestation init --name wf-test
 INF Attestation initialized! now you can check its status or add materials to it
 ┌───────────────────┬──────────────────────────────────────┐
 │ Initialized At    │ 22 May 24 13:38 UTC                  │
@@ -190,4 +184,4 @@ Attestation Digest: sha256:8a0b3a9db0372fdf571dbe85c8a9b5202f473ca97e9dbcdf77c3f
 ```
 
 ## In a nutshell
-Contract-less and auto-discovery and two features that walk hand by hand. They compose a new way of adding pieces of evidences to an existing contract in a frictionless way.
+Contract-less and auto-discovery and two features that walk hand by hand. They compose a new way of adding pieces of evidences to an existing contract in a frictionless way. You can see it in action in our [quickstart](../quickstart.md) guide.


### PR DESCRIPTION
This patch updates the documentation to include a section for contract-less and auto-discovery of materials.

Resulting page is the following, download for a better inspection:

![screencapture-localhost-3000-reference-attestations-2024-06-21-09_27_49](https://github.com/chainloop-dev/chainloop/assets/4128269/9f8711f5-1c08-48e6-840b-884d24e3cd24)


Closes #901 