### PR TITLE
feat(docs): Document telemetry endpoint

### DIFF
--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -21,3 +21,7 @@ That said, there are [benefits](/reference/operator/contract#runner-context) for
 #### Does Chainloop store my Artifacts and Attestation metadata?
 
 No. They are stored in [your Content-Addressable Storage (CAS)](/reference/operator/cas-backend).
+
+#### Our firewall is flagging a request to crb.chainloop.dev, what's this?
+
+That is our telemetry endpoint. We collect telemetry data to help us enhance Chainloop by gaining insights into its usage. You can learn more about it and even how to deactivate it [here](reference/operator/cli-telemetry.mdx#what-do-we-use-to-collect-telemetry-data).

--- a/docs/docs/reference/operator/cli-telemetry.mdx
+++ b/docs/docs/reference/operator/cli-telemetry.mdx
@@ -20,10 +20,11 @@ The following information is included in telemetry:
 
 Chainloop implements the Console [Do Not Track (DNT) standard](https://consoledonottrack.com). As a result, you can deactivate the telemetry by setting the environment variable DO_NOT_TRACK=1 before running the Chainloop CLI.
 
-
 ## What do we use to collect telemetry data?
 
 We use [PostHog](https://posthog.com/). PostHog is an open-source product analytics platform that allows us to collect and analyze telemetry data.
+All telemetry data is stored in our PostHog instance sent via the following endpoint: `https://crb.chainloop.dev`.
+
 We did it in such a way that anyone can set up their own PostHog instance and use it to collect telemetry. To do so
 compile Chainloop CLI from its source code and set up the following linker flags to the Golang compiler:
 


### PR DESCRIPTION
This patch documents the telemetry endpoint used by the CLI so users have and understanding in case they ran into problems.

Closes #1007 