### PR TITLE
feat(chart): Allow configuration of externalURL on values.yaml

### DIFF
--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -7,7 +7,7 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.66.0
+version: 1.66.1
 # Do not update appVersion, this is handled automatically by the release process
 appVersion: v0.92.3
 

--- a/deployment/chainloop/README.md
+++ b/deployment/chainloop/README.md
@@ -525,6 +525,7 @@ chainloop config save \
 | `controlplane.auth.oidc.clientID`            | OIDC IDp clientID                                                                                      | `""`  |
 | `controlplane.auth.oidc.clientSecret`        | OIDC IDp clientSecret                                                                                  | `""`  |
 | `controlplane.auth.oidc.loginURLOverride`    | Optional OIDC login URL override, useful to point to custom login pages                                |       |
+| `controlplane.auth.oidc.externalURL`         | Optional External URL for the controlplane to the outside world                                        |       |
 | `controlplane.auth.allowList.rules`          | List of domains or emails to allow                                                                     |       |
 | `controlplane.auth.allowList.selectedRoutes` | List of selected routes to allow. If not set it applies to all routes                                  |       |
 | `controlplane.auth.allowList.customMessage`  | Custom message to display when a user is not allowed                                                   |       |

--- a/deployment/chainloop/templates/_helpers.tpl
+++ b/deployment/chainloop/templates/_helpers.tpl
@@ -284,7 +284,9 @@ NOTE: Load balancer service type is not supported
 {{- $service := .Values.controlplane.service }}
 {{- $ingress := .Values.controlplane.ingress }}
 
-{{- if (and $ingress $ingress.enabled $ingress.hostname) }}
+{{- if .Values.controlplane.auth.oidc.externalURL }}
+{{- .Values.controlplane.auth.oidc.externalURL }}
+{{- else if (and $ingress $ingress.enabled $ingress.hostname) }}
 {{- printf "%s://%s" (ternary "https" "http" $ingress.tls ) $ingress.hostname }}
 {{- else if (and (eq $service.type "NodePort") $service.nodePorts (not (empty $service.nodePorts.http))) }}
 {{- printf "http://localhost:%s" $service.nodePorts.http }}

--- a/deployment/chainloop/values.yaml
+++ b/deployment/chainloop/values.yaml
@@ -184,11 +184,13 @@ controlplane:
     ## @param controlplane.auth.oidc.clientID OIDC IDp clientID
     ## @param controlplane.auth.oidc.clientSecret OIDC IDp clientSecret
     ## @extra controlplane.auth.oidc.loginURLOverride Optional OIDC login URL override, useful to point to custom login pages
+    ## @extra controlplane.auth.oidc.externalURL Optional External URL for the controlplane to the outside world
     oidc:
       url: ""
       clientID: ""
       clientSecret: ""
       # loginURLOverride: ""
+      # externalURL: ""
 
     ## @extra controlplane.auth.allowList.rules List of domains or emails to allow
     ## @extra controlplane.auth.allowList.selectedRoutes List of selected routes to allow. If not set it applies to all routes


### PR DESCRIPTION
This patch allows users to configure the `externalURL` of the chart and adds the option of not relaying on the ingress/svc.

Adding the value in custom `values.yaml` file:
```
development: true
controlplane:
  auth:
    oidc:
      url: http://chainloop-dex:5556/dex
      clientID: chainloop-dev
      clientSecret: REDACTED
      externalURL: http://random-instance.com
```

Produces the following changes:
```diff
diff --git a/old.yml b/new.yml
index c3d1213..65bcbd5 100644
--- a/old.yml	
+++ b/new.yml	
@@ -331,11 +331,11 @@ metadata:
     app.kubernetes.io/part-of: chainloop
     app.kubernetes.io/component: controlplane
 type: Opaque
 data:
   # We store it also as a different key so it can be reused during upgrades by the common.secrets.passwords.manage helper
-  generated_jws_hmac_secret: "cldaRE5nOE84Tw=="
+  generated_jws_hmac_secret: "aG5majRmZU9yZA=="
   db_migrate_source: "cG9zdGdyZXM6Ly9jaGFpbmxvb3A6Y2hhaW5sb29wcHdkQGNoYWlubG9vcC1wb3N0Z3Jlc3FsOjU0MzIvY2hhaW5sb29wLWNwP3NzbG1vZGU9ZGlzYWJsZQ=="
 stringData:
   config.secret.yaml: |
     data:
       database:
@@ -356,11 +356,11 @@ stringData:
         client_secret: "ZXhhbXBsZS1hcHAtc2VjcmV0"
 
       # HMAC key used to sign the JWTs generated by the controlplane
       # The helper returns the base64 quoted value of the secret
       # We need to remove the quotes and then decoding it so it's compatible with the stringData stanza
-      generated_jws_hmac_secret: "rWZDNg8O8O"
+      generated_jws_hmac_secret: "hnfj4feOrd"
 
       # Private key used to sign the JWTs meant to be consumed by the CAS
       cas_robot_account_private_key_path: "/secrets/cas.private.key"
 ---
 # Source: chainloop/templates/controlplane/jwt_cas_private_key.secret.yaml
@@ -446,11 +446,11 @@ data:
   config.yaml: |
     server:
       http:
         addr: 0.0.0.0:8000
         timeout: 10s
-        external_url: null
+        external_url: http://random-instance.com
       http_metrics:
         addr: 0.0.0.0:5000
       grpc:
         addr: 0.0.0.0:9000
         timeout: 10s
@@ -1428,12 +1428,12 @@ spec:
       app.kubernetes.io/instance: chainloop
       app.kubernetes.io/component: controlplane
   template:
     metadata:
       annotations:
-        checksum/config: 3c6f6bf01050a0dd69f630b5155e49fe51c4344a301d4e888056365878049a77
-        checksum/secret-config: 79c477ac5526e4808f3bb3a3d7a0aacd357a843d727fb42772fffd872c31e7dc
+        checksum/config: c90850c84097a5e635293b02f95b746baf84807ccfc2701627f948233500d71f
+        checksum/secret-config: d55ec812fd7ace4d2b2e706acb443732a2e0bd3fd6b866e84f91d94e12cebc8b
         checksum/cas-private-key: 41ce7c527180070ce29c73db2b3d354d5f75a683fad6c4f684d611b838fa5279
         kubectl.kubernetes.io/default-container: controlplane
       labels:
         app.kubernetes.io/name: chainloop
         app.kubernetes.io/instance: chainloop

```

Closes #1010