### PR TITLE
fix(cli): show wf output as json object instead of array

### DIFF
--- a/app/cli/cmd/output.go
+++ b/app/cli/cmd/output.go
@@ -32,6 +32,7 @@ const formatTable = "table"
 // Supported list of tabulated data that can be rendered as a table
 type tabulatedData interface {
 	[]*action.WorkflowItem |
+		*action.WorkflowItem |
 		*action.AttestationStatusResult |
 		[]*action.WorkflowRunItem |
 		*action.WorkflowRunItemFull |

--- a/app/cli/cmd/workflow_create.go
+++ b/app/cli/cmd/workflow_create.go
@@ -67,7 +67,7 @@ func newWorkflowCreateCmd() *cobra.Command {
 			}
 
 			// Print the workflow table
-			if err := encodeOutput([]*action.WorkflowItem{wf}, WorkflowListTableOutput); err != nil {
+			if err := encodeOutput(wf, workflowItemTableOutput); err != nil {
 				return fmt.Errorf("failed to print workflow: %w", err)
 			}
 

--- a/app/cli/cmd/workflow_describe.go
+++ b/app/cli/cmd/workflow_describe.go
@@ -32,7 +32,7 @@ func newWorkflowDescribeCmd() *cobra.Command {
 				return err
 			}
 
-			return encodeOutput([]*action.WorkflowItem{wf}, WorkflowListTableOutput)
+			return encodeOutput(wf, workflowItemTableOutput)
 		},
 	}
 

--- a/app/cli/cmd/workflow_list.go
+++ b/app/cli/cmd/workflow_list.go
@@ -44,6 +44,10 @@ func newWorkflowListCmd() *cobra.Command {
 	return cmd
 }
 
+func workflowItemTableOutput(workflow *action.WorkflowItem) error {
+	return WorkflowListTableOutput([]*action.WorkflowItem{workflow})
+}
+
 func WorkflowListTableOutput(workflows []*action.WorkflowItem) error {
 	if len(workflows) == 0 {
 		fmt.Println("there are no workflows yet")


### PR DESCRIPTION
Before

```
go run main.go --insecure wf describe --name sfooobar -o json
[
   {
      "name": "sfooobar",
      "id": "6d3e8897-e979-4086-9f2e-c7905ed34e2f",
      "team": "",
      "project": "bar",
      "createdAt": "2024-06-22T21:03:32.71815Z",
      "runsCount": 0,
      "contractID": "69e8a312-030e-4692-b20f-f8c16c34f54f",
      "contractRevisionLatest": 1,
      "public": false
   }
]
```
After

```
$ go run main.go --insecure wf describe --name sfooobar -o json           
{
   "name": "sfooobar",
   "id": "6d3e8897-e979-4086-9f2e-c7905ed34e2f",
   "team": "",
   "project": "bar",
   "createdAt": "2024-06-22T21:03:32.71815Z",
   "runsCount": 0,
   "contractID": "69e8a312-030e-4692-b20f-f8c16c34f54f",
   "contractRevisionLatest": 1,
   "public": false
}

```

Closes #1014 