### PR TITLE
feat(api): show error message

### DIFF
--- a/app/controlplane/internal/service/status.go
+++ b/app/controlplane/internal/service/status.go
@@ -37,7 +37,7 @@ func NewStatusService(logingURL, version string, casClient *biz.CASClientUseCase
 func (s *StatusService) Statusz(ctx context.Context, r *pb.StatuszRequest) (*pb.StatuszResponse, error) {
 	if r.Readiness {
 		if ok, err := s.casClient.IsReady(ctx); err != nil || !ok {
-			return nil, errors.ServiceUnavailable("CAS_NOT_READY", "Artifact CAS is not reachable")
+			return nil, errors.ServiceUnavailable("CAS_NOT_READY", err.Error())
 		}
 	}
 	return &pb.StatuszResponse{}, nil


### PR DESCRIPTION
Expose error message in StatusZ endpoint to help with troubleshooting the connection to CAS

```
2024-06-24T11:03:05.175+0200    ERROR   {"kind": "server", "component": "grpc", "operation": "/controlplane.v1.StatusService/Statusz", "args": "readiness:true", "code": 503, "reason": "CAS_NOT_READY", "stack": "error: code = 503 reason = CAS_NOT_READY message = contacting API to ge
t status: rpc error: code = Unavailable desc = connection error: desc = \"transport: authentication handshake failed: tls: failed to verify certificate: x509: certificate signed by unknown authority\" metadata = map[] cause = <nil>", "latency": 0.016060832}
```