### PR TITLE
feat(chart): configure CP-CAS TLS flag

### DIFF
--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -7,7 +7,7 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.66.1
+version: 1.66.2
 # Do not update appVersion, this is handled automatically by the release process
 appVersion: v0.92.3
 

--- a/deployment/chainloop/templates/controlplane/config.configmap.yaml
+++ b/deployment/chainloop/templates/controlplane/config.configmap.yaml
@@ -35,7 +35,7 @@ data:
     cas_server:
       grpc:
         addr: {{ printf "%s-api:%.0f" (include "chainloop.cas.fullname" .) .Values.cas.serviceAPI.port }}
-      insecure: true
+      insecure: {{ empty .Values.cas.tlsConfig.secret.name }}
       download_url: {{ include "chainloop.cas.external_url" . }}/download
     plugins_dir: {{ .Values.controlplane.pluginsDir }}
     referrer_shared_index:


### PR DESCRIPTION
Automatically configure the CP->CAS communication to be secure if TLS settings are set in CAS.

```diff
@@ -463,7 +463,7 @@                                                   
     cas_server:                                                      
       grpc:                                                          
         addr: chainloop-2-cas-api:80
-      insecure: true                                                 
+      insecure: false                                                
       download_url: /download                                        
     plugins_dir: /plugins                                            
     referrer_shared_index:     
```

Closes https://github.com/chainloop-dev/chainloop/issues/1018