### PR TITLE
fix(cli): wait for the command to finish

### DIFF
--- a/app/cli/cmd/auth_login.go
+++ b/app/cli/cmd/auth_login.go
@@ -167,20 +167,28 @@ func (a *app) handleCallback(w http.ResponseWriter, r *http.Request) {
 }
 
 func openbrowser(url string) error {
-	var err error
+	var cmd *exec.Cmd
 
 	switch runtime.GOOS {
 	case "linux":
-		err = exec.Command("xdg-open", url).Start()
+		cmd = exec.Command("xdg-open", url)
 	case "windows":
-		err = exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
 	case "darwin":
-		err = exec.Command("open", url).Start()
+		cmd = exec.Command("open", url)
 	default:
-		err = fmt.Errorf("unsupported platform")
+		return fmt.Errorf("unsupported platform")
 	}
 
-	return err
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	if err := cmd.Wait(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Retrieve loginURL from the control plane

--- a/app/cli/cmd/auth_login.go
+++ b/app/cli/cmd/auth_login.go
@@ -184,11 +184,7 @@ func openbrowser(url string) error {
 		return err
 	}
 
-	if err := cmd.Wait(); err != nil {
-		return err
-	}
-
-	return nil
+	return cmd.Wait()
 }
 
 // Retrieve loginURL from the control plane


### PR DESCRIPTION
This patch fixes a bug that made `xdg-open` not to return error and hence not triggering the headless login process