### PR TITLE
chore(cli): manage organizations by name

### DIFF
--- a/app/cli/cmd/organization_leave.go
+++ b/app/cli/cmd/organization_leave.go
@@ -24,34 +24,34 @@ import (
 )
 
 // Get the membership entry associated to the current user for the given organization
-func membershipFromOrg(ctx context.Context, orgID string) (*action.MembershipItem, error) {
+func membershipFromOrg(ctx context.Context, name string) (*action.MembershipItem, error) {
 	memberships, err := action.NewMembershipList(actionOpts).ListOrgs(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("listing memberships: %w", err)
 	}
 
 	for _, m := range memberships {
-		if m.Org.ID == orgID {
+		if m.Org.Name == name {
 			return m, nil
 		}
 	}
 
-	return nil, fmt.Errorf("organization %s not found", orgID)
+	return nil, fmt.Errorf("organization %s not found", name)
 }
 
 func newOrganizationLeaveCmd() *cobra.Command {
-	var orgID string
+	var orgName string
 	cmd := &cobra.Command{
 		Use:   "leave",
 		Short: "leave an organization",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			// To find the membership ID, we need to iterate and filter by org
-			membership, err := membershipFromOrg(ctx, orgID)
+			membership, err := membershipFromOrg(ctx, orgName)
 			if err != nil {
 				return fmt.Errorf("getting membership: %w", err)
 			} else if membership == nil {
-				return fmt.Errorf("organization %s not found", orgID)
+				return fmt.Errorf("organization %s not found", orgName)
 			}
 
 			fmt.Printf("You are about to leave the organization %q\n", membership.Org.Name)
@@ -71,7 +71,7 @@ func newOrganizationLeaveCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&orgID, "id", "", "organization ID to leave")
-	cobra.CheckErr(cmd.MarkFlagRequired("id"))
+	cmd.Flags().StringVar(&orgName, "name", "", "organization name")
+	cobra.CheckErr(cmd.MarkFlagRequired("name"))
 	return cmd
 }

--- a/app/cli/cmd/organization_list.go
+++ b/app/cli/cmd/organization_list.go
@@ -51,10 +51,10 @@ func orgMembershipTableOutput(items []*action.MembershipItem) error {
 	}
 
 	t := newTableWriter()
-	t.AppendHeader(table.Row{"Org ID", "Org Name", "Current", "Role", "Joined At"})
+	t.AppendHeader(table.Row{"Name", "Current", "Role", "Joined At"})
 
 	for _, i := range items {
-		t.AppendRow(table.Row{i.Org.ID, i.Org.Name, i.Current, i.Role, i.CreatedAt.Format(time.RFC822)})
+		t.AppendRow(table.Row{i.Org.Name, i.Current, i.Role, i.CreatedAt.Format(time.RFC822)})
 		t.AppendSeparator()
 	}
 

--- a/app/cli/cmd/organization_set.go
+++ b/app/cli/cmd/organization_set.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 The Chainloop Authors.
+// Copyright 2024 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,19 +23,19 @@ import (
 )
 
 func newOrganizationSet() *cobra.Command {
-	var orgID string
+	var orgName string
 
 	cmd := &cobra.Command{
 		Use:   "set",
 		Short: "Set the current organization associated with this user",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 			// To find the membership ID, we need to iterate and filter by org
-			membership, err := membershipFromOrg(ctx, orgID)
+			membership, err := membershipFromOrg(ctx, orgName)
 			if err != nil {
 				return fmt.Errorf("getting membership: %w", err)
 			} else if membership == nil {
-				return fmt.Errorf("organization %s not found", orgID)
+				return fmt.Errorf("organization %s not found", orgName)
 			}
 
 			m, err := action.NewMembershipSet(actionOpts).Run(ctx, membership.ID)
@@ -48,8 +48,8 @@ func newOrganizationSet() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&orgID, "id", "", "organization ID to make the switch")
-	cobra.CheckErr(cmd.MarkFlagRequired("id"))
+	cmd.Flags().StringVar(&orgName, "name", "", "organization name to make the switch")
+	cobra.CheckErr(cmd.MarkFlagRequired("name"))
 
 	return cmd
 }


### PR DESCRIPTION
org leave and set now uses `name` instead of `id`

Closes https://github.com/chainloop-dev/chainloop/issues/1034