### PR TITLE
feat(orgmetrics): Accept start and end date for metrics

### DIFF
--- a/app/controlplane/internal/service/orgmetric.go
+++ b/app/controlplane/internal/service/orgmetric.go
@@ -120,10 +120,10 @@ func (s *OrgMetricsService) DailyRunsCount(ctx context.Context, req *pb.DailyRun
 }
 
 // calculateTimeWindow calculates the time window based on the request
-func calculateTimeWindow(req *pb.MetricsTimeWindow) biz.TimeWindow {
-	return biz.TimeWindow{
-		StartDate: time.Now().UTC().Add(-*req.ToDuration()),
-		EndDate:   time.Now().UTC(),
+func calculateTimeWindow(req *pb.MetricsTimeWindow) *biz.TimeWindow {
+	return &biz.TimeWindow{
+		From: time.Now().UTC().Add(-*req.ToDuration()),
+		To:   time.Now().UTC(),
 	}
 }
 

--- a/app/controlplane/internal/service/service.go
+++ b/app/controlplane/internal/service/service.go
@@ -137,7 +137,7 @@ func handleUseCaseErr(err error, l *log.Helper) error {
 	switch {
 	case errors.Is(err, context.Canceled):
 		return errors.ClientClosed("client closed", err.Error())
-	case biz.IsErrValidation(err) || biz.IsErrInvalidUUID(err):
+	case biz.IsErrValidation(err) || biz.IsErrInvalidUUID(err) || biz.IsErrInvalidTimeWindow(err):
 		return errors.BadRequest("invalid", err.Error())
 	case biz.IsNotFound(err):
 		return errors.NotFound("not found", err.Error())

--- a/app/controlplane/pkg/biz/errors.go
+++ b/app/controlplane/pkg/biz/errors.go
@@ -125,3 +125,23 @@ func NewErrReferrerAmbiguous(digest string, kinds []string) error {
 func (e ErrAmbiguousReferrer) Error() string {
 	return fmt.Sprintf("digest %s present in %d kinds %q", e.digest, len(e.kinds), e.kinds)
 }
+
+type ErrInvalidTimeWindow struct {
+	err error
+}
+
+func NewErrInvalidTimeWindowStr(errMsg string) ErrInvalidTimeWindow {
+	return ErrInvalidTimeWindow{errors.New(errMsg)}
+}
+
+func NewErrInvalidTimeWindow(err error) ErrInvalidTimeWindow {
+	return ErrInvalidTimeWindow{err}
+}
+
+func (e ErrInvalidTimeWindow) Error() string {
+	return fmt.Sprintf("time window error: %s", e.err.Error())
+}
+
+func IsErrInvalidTimeWindow(err error) bool {
+	return errors.As(err, &ErrInvalidTimeWindow{})
+}

--- a/app/controlplane/pkg/biz/orgmetrics.go
+++ b/app/controlplane/pkg/biz/orgmetrics.go
@@ -17,6 +17,7 @@ package biz
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-kratos/kratos/v2/log"
@@ -30,12 +31,12 @@ type OrgMetricsUseCase struct {
 
 type OrgMetricsRepo interface {
 	// Total number of runs within the provided time window (from now)
-	RunsTotal(ctx context.Context, orgID uuid.UUID, timeWindow TimeWindow) (int32, error)
+	RunsTotal(ctx context.Context, orgID uuid.UUID, timeWindow *TimeWindow) (int32, error)
 	// Total number by run status
-	RunsByStatusTotal(ctx context.Context, orgID uuid.UUID, timeWindow TimeWindow) (map[string]int32, error)
-	RunsByRunnerTypeTotal(ctx context.Context, orgID uuid.UUID, timeWindow TimeWindow) (map[string]int32, error)
-	TopWorkflowsByRunsCount(ctx context.Context, orgID uuid.UUID, numWorkflows int, timeWindow TimeWindow) ([]*TopWorkflowsByRunsCountItem, error)
-	DailyRunsCount(ctx context.Context, orgID, workflowID uuid.UUID, timeWindow TimeWindow) ([]*DayRunsCount, error)
+	RunsByStatusTotal(ctx context.Context, orgID uuid.UUID, timeWindow *TimeWindow) (map[string]int32, error)
+	RunsByRunnerTypeTotal(ctx context.Context, orgID uuid.UUID, timeWindow *TimeWindow) (map[string]int32, error)
+	TopWorkflowsByRunsCount(ctx context.Context, orgID uuid.UUID, numWorkflows int, timeWindow *TimeWindow) ([]*TopWorkflowsByRunsCountItem, error)
+	DailyRunsCount(ctx context.Context, orgID, workflowID uuid.UUID, timeWindow *TimeWindow) ([]*DayRunsCount, error)
 }
 
 type DayRunsCount struct {
@@ -50,35 +51,56 @@ type ByStatusCount struct {
 
 // TimeWindow represents in time.Time format not in time.Duration
 type TimeWindow struct {
-	StartDate time.Time
-	EndDate   time.Time
+	From time.Time
+	To   time.Time
+}
+
+// Validate validates the time window checking From and To are set
+func (tw *TimeWindow) Validate() error {
+	if tw.From.IsZero() || tw.To.IsZero() {
+		return NewErrInvalidTimeWindowStr("from and to time must be set in time window")
+	}
+
+	return nil
 }
 
 func NewOrgMetricsUseCase(r OrgMetricsRepo, l log.Logger) (*OrgMetricsUseCase, error) {
 	return &OrgMetricsUseCase{logger: log.NewHelper(l), repo: r}, nil
 }
 
-func (uc *OrgMetricsUseCase) RunsTotal(ctx context.Context, orgID string, timeWindow TimeWindow) (int32, error) {
+func (uc *OrgMetricsUseCase) RunsTotal(ctx context.Context, orgID string, timeWindow *TimeWindow) (int32, error) {
 	orgUUID, err := uuid.Parse(orgID)
 	if err != nil {
+		return 0, err
+	}
+
+	if err := validateTimeWindowIsSet(timeWindow); err != nil {
 		return 0, err
 	}
 
 	return uc.repo.RunsTotal(ctx, orgUUID, timeWindow)
 }
 
-func (uc *OrgMetricsUseCase) RunsTotalByStatus(ctx context.Context, orgID string, timeWindow TimeWindow) (map[string]int32, error) {
+func (uc *OrgMetricsUseCase) RunsTotalByStatus(ctx context.Context, orgID string, timeWindow *TimeWindow) (map[string]int32, error) {
 	orgUUID, err := uuid.Parse(orgID)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := validateTimeWindowIsSet(timeWindow); err != nil {
 		return nil, err
 	}
 
 	return uc.repo.RunsByStatusTotal(ctx, orgUUID, timeWindow)
 }
 
-func (uc *OrgMetricsUseCase) RunsTotalByRunnerType(ctx context.Context, orgID string, timeWindow TimeWindow) (map[string]int32, error) {
+func (uc *OrgMetricsUseCase) RunsTotalByRunnerType(ctx context.Context, orgID string, timeWindow *TimeWindow) (map[string]int32, error) {
 	orgUUID, err := uuid.Parse(orgID)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := validateTimeWindowIsSet(timeWindow); err != nil {
 		return nil, err
 	}
 
@@ -87,10 +109,14 @@ func (uc *OrgMetricsUseCase) RunsTotalByRunnerType(ctx context.Context, orgID st
 
 // DailyRunsCount returns the number of runs per day within the provided time window (from now)
 // Optionally filtered by workflowID
-func (uc *OrgMetricsUseCase) DailyRunsCount(ctx context.Context, orgID string, workflowID *string, timeWindow TimeWindow) ([]*DayRunsCount, error) {
+func (uc *OrgMetricsUseCase) DailyRunsCount(ctx context.Context, orgID string, workflowID *string, timeWindow *TimeWindow) ([]*DayRunsCount, error) {
 	orgUUID, err := uuid.Parse(orgID)
 	if err != nil {
 		return nil, NewErrInvalidUUID(err)
+	}
+
+	if err := validateTimeWindowIsSet(timeWindow); err != nil {
+		return nil, err
 	}
 
 	var workflowUUID uuid.UUID
@@ -110,11 +136,26 @@ type TopWorkflowsByRunsCountItem struct {
 	Total    int32
 }
 
-func (uc *OrgMetricsUseCase) TopWorkflowsByRunsCount(ctx context.Context, orgID string, numWorkflows int, timeWindow TimeWindow) ([]*TopWorkflowsByRunsCountItem, error) {
+func (uc *OrgMetricsUseCase) TopWorkflowsByRunsCount(ctx context.Context, orgID string, numWorkflows int, timeWindow *TimeWindow) ([]*TopWorkflowsByRunsCountItem, error) {
 	orgUUID, err := uuid.Parse(orgID)
 	if err != nil {
 		return nil, err
 	}
 
+	if err := validateTimeWindowIsSet(timeWindow); err != nil {
+		return nil, err
+	}
+
 	return uc.repo.TopWorkflowsByRunsCount(ctx, orgUUID, numWorkflows, timeWindow)
+}
+
+// validateTimeWindowIsSet validates that the time window is set
+func validateTimeWindowIsSet(tw *TimeWindow) error {
+	// Check if time window is set
+	if tw == nil {
+		return fmt.Errorf("time window is required")
+	}
+
+	// Validate time window
+	return tw.Validate()
 }

--- a/app/controlplane/pkg/biz/orgmetrics.go
+++ b/app/controlplane/pkg/biz/orgmetrics.go
@@ -30,12 +30,12 @@ type OrgMetricsUseCase struct {
 
 type OrgMetricsRepo interface {
 	// Total number of runs within the provided time window (from now)
-	RunsTotal(ctx context.Context, orgID uuid.UUID, timeWindow time.Duration) (int32, error)
+	RunsTotal(ctx context.Context, orgID uuid.UUID, timeWindow TimeWindow) (int32, error)
 	// Total number by run status
-	RunsByStatusTotal(ctx context.Context, orgID uuid.UUID, timeWindow time.Duration) (map[string]int32, error)
-	RunsByRunnerTypeTotal(ctx context.Context, orgID uuid.UUID, timeWindow time.Duration) (map[string]int32, error)
-	TopWorkflowsByRunsCount(ctx context.Context, orgID uuid.UUID, numWorkflows int, timeWindow time.Duration) ([]*TopWorkflowsByRunsCountItem, error)
-	DailyRunsCount(ctx context.Context, orgID, workflowID uuid.UUID, timeWindow time.Duration) ([]*DayRunsCount, error)
+	RunsByStatusTotal(ctx context.Context, orgID uuid.UUID, timeWindow TimeWindow) (map[string]int32, error)
+	RunsByRunnerTypeTotal(ctx context.Context, orgID uuid.UUID, timeWindow TimeWindow) (map[string]int32, error)
+	TopWorkflowsByRunsCount(ctx context.Context, orgID uuid.UUID, numWorkflows int, timeWindow TimeWindow) ([]*TopWorkflowsByRunsCountItem, error)
+	DailyRunsCount(ctx context.Context, orgID, workflowID uuid.UUID, timeWindow TimeWindow) ([]*DayRunsCount, error)
 }
 
 type DayRunsCount struct {
@@ -48,11 +48,17 @@ type ByStatusCount struct {
 	Count  int32
 }
 
+// TimeWindow represents in time.Time format not in time.Duration
+type TimeWindow struct {
+	StartDate time.Time
+	EndDate   time.Time
+}
+
 func NewOrgMetricsUseCase(r OrgMetricsRepo, l log.Logger) (*OrgMetricsUseCase, error) {
 	return &OrgMetricsUseCase{logger: log.NewHelper(l), repo: r}, nil
 }
 
-func (uc *OrgMetricsUseCase) RunsTotal(ctx context.Context, orgID string, timeWindow time.Duration) (int32, error) {
+func (uc *OrgMetricsUseCase) RunsTotal(ctx context.Context, orgID string, timeWindow TimeWindow) (int32, error) {
 	orgUUID, err := uuid.Parse(orgID)
 	if err != nil {
 		return 0, err
@@ -61,7 +67,7 @@ func (uc *OrgMetricsUseCase) RunsTotal(ctx context.Context, orgID string, timeWi
 	return uc.repo.RunsTotal(ctx, orgUUID, timeWindow)
 }
 
-func (uc *OrgMetricsUseCase) RunsTotalByStatus(ctx context.Context, orgID string, timeWindow time.Duration) (map[string]int32, error) {
+func (uc *OrgMetricsUseCase) RunsTotalByStatus(ctx context.Context, orgID string, timeWindow TimeWindow) (map[string]int32, error) {
 	orgUUID, err := uuid.Parse(orgID)
 	if err != nil {
 		return nil, err
@@ -70,7 +76,7 @@ func (uc *OrgMetricsUseCase) RunsTotalByStatus(ctx context.Context, orgID string
 	return uc.repo.RunsByStatusTotal(ctx, orgUUID, timeWindow)
 }
 
-func (uc *OrgMetricsUseCase) RunsTotalByRunnerType(ctx context.Context, orgID string, timeWindow time.Duration) (map[string]int32, error) {
+func (uc *OrgMetricsUseCase) RunsTotalByRunnerType(ctx context.Context, orgID string, timeWindow TimeWindow) (map[string]int32, error) {
 	orgUUID, err := uuid.Parse(orgID)
 	if err != nil {
 		return nil, err
@@ -81,7 +87,7 @@ func (uc *OrgMetricsUseCase) RunsTotalByRunnerType(ctx context.Context, orgID st
 
 // DailyRunsCount returns the number of runs per day within the provided time window (from now)
 // Optionally filtered by workflowID
-func (uc *OrgMetricsUseCase) DailyRunsCount(ctx context.Context, orgID string, workflowID *string, timeWindow time.Duration) ([]*DayRunsCount, error) {
+func (uc *OrgMetricsUseCase) DailyRunsCount(ctx context.Context, orgID string, workflowID *string, timeWindow TimeWindow) ([]*DayRunsCount, error) {
 	orgUUID, err := uuid.Parse(orgID)
 	if err != nil {
 		return nil, NewErrInvalidUUID(err)
@@ -104,7 +110,7 @@ type TopWorkflowsByRunsCountItem struct {
 	Total    int32
 }
 
-func (uc *OrgMetricsUseCase) TopWorkflowsByRunsCount(ctx context.Context, orgID string, numWorkflows int, timeWindow time.Duration) ([]*TopWorkflowsByRunsCountItem, error) {
+func (uc *OrgMetricsUseCase) TopWorkflowsByRunsCount(ctx context.Context, orgID string, numWorkflows int, timeWindow TimeWindow) ([]*TopWorkflowsByRunsCountItem, error) {
 	orgUUID, err := uuid.Parse(orgID)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This patch modifies the OrgMetrics use case to receive a start and end date which are more flexible that a time.Duration. Do all the changes up until the repository.

Ent does not have a between operator for dates that's the reason of using gte and lte. In operator does not produce the proper SQL query:

`In` operator:
```sql
SELECT COUNT(DISTINCT "workflow_runs"."id")
FROM "workflow_runs"
         JOIN (SELECT "workflows"."id"
               FROM "workflows"
                        JOIN (SELECT "organizations"."id" FROM "organizations" WHERE "organizations"."id" = $1) AS "t1"
                             ON "workflows"."organization_id" = "t1"."id") AS "t1"
              ON "workflow_runs"."workflow_workflowruns" = "t1"."id"
WHERE "workflow_runs"."created_at" IN ($2, $3)
```

`gte` and `lte` operators:
```sql
SELECT COUNT(DISTINCT "workflow_runs"."id")
FROM "workflow_runs"
         JOIN (SELECT "workflows"."id"
               FROM "workflows"
                        JOIN (SELECT "organizations"."id" FROM "organizations" WHERE "organizations"."id" = $1) AS "t1"
                             ON "workflows"."organization_id" = "t1"."id") AS "t1"
              ON "workflow_runs"."workflow_workflowruns" = "t1"."id"
WHERE "workflow_runs"."created_at" >= $2
  AND "workflow_runs"."created_at" <= $3
```

The difference being, `in` tries to matches within the specific items on the list where the `gte` and `lte` operators try to match within the range between those dates.