### PR TITLE
feat(casbackends): support for s3 compatible endpoints (minio, cloudflare R2, ...)

### DIFF
--- a/app/cli/cmd/casbackend_add_s3.go
+++ b/app/cli/cmd/casbackend_add_s3.go
@@ -48,14 +48,15 @@ func newCASBackendAddAWSS3Cmd() *cobra.Command {
 				}
 			}
 
+			location := bucketName
 			// If there is a custom endpoint we want to store it as part of the fqdn location
 			if endpoint != "" {
-				bucketName = fmt.Sprintf("%s/%s", endpoint, bucketName)
+				location = fmt.Sprintf("%s/%s", endpoint, bucketName)
 			}
 
 			opts := &action.NewCASBackendAddOpts{
 				Name:        name,
-				Location:    bucketName,
+				Location:    location,
 				Provider:    s3.ProviderID,
 				Description: description,
 				Credentials: map[string]any{

--- a/app/cli/cmd/casbackend_add_s3.go
+++ b/app/cli/cmd/casbackend_add_s3.go
@@ -16,6 +16,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/chainloop-dev/chainloop/app/cli/internal/action"
 	"github.com/chainloop-dev/chainloop/pkg/blobmanager/s3"
 	"github.com/go-kratos/kratos/v2/log"
@@ -46,6 +48,11 @@ func newCASBackendAddAWSS3Cmd() *cobra.Command {
 				}
 			}
 
+			// If there is a custom endpoint we want to store it as part of the fqdn location
+			if endpoint != "" {
+				bucketName = fmt.Sprintf("%s/%s", endpoint, bucketName)
+			}
+
 			opts := &action.NewCASBackendAddOpts{
 				Name:        name,
 				Location:    bucketName,
@@ -55,7 +62,6 @@ func newCASBackendAddAWSS3Cmd() *cobra.Command {
 					"accessKeyID":     accessKeyID,
 					"secretAccessKey": secretAccessKey,
 					"region":          region,
-					"endpoint":        endpoint,
 				},
 				Default: isDefault,
 			}

--- a/app/cli/cmd/casbackend_add_s3.go
+++ b/app/cli/cmd/casbackend_add_s3.go
@@ -23,7 +23,7 @@ import (
 )
 
 func newCASBackendAddAWSS3Cmd() *cobra.Command {
-	var bucketName, accessKeyID, secretAccessKey, region string
+	var bucketName, accessKeyID, secretAccessKey, region, endpoint string
 	cmd := &cobra.Command{
 		Use:   "aws-s3",
 		Short: "Register a AWS S3 storage bucket",
@@ -55,6 +55,7 @@ func newCASBackendAddAWSS3Cmd() *cobra.Command {
 					"accessKeyID":     accessKeyID,
 					"secretAccessKey": secretAccessKey,
 					"region":          region,
+					"endpoint":        endpoint,
 				},
 				Default: isDefault,
 			}
@@ -83,8 +84,9 @@ func newCASBackendAddAWSS3Cmd() *cobra.Command {
 	cobra.CheckErr(err)
 
 	cmd.Flags().StringVar(&region, "region", "", "AWS region for the bucket")
-	err = cmd.MarkFlagRequired("region")
 	cobra.CheckErr(err)
+
+	cmd.Flags().StringVar(&endpoint, "endpoint", "", "Custom Endpoint URL for other S3 compatible backends i.e MinIO")
 
 	return cmd
 }

--- a/pkg/blobmanager/s3/provider.go
+++ b/pkg/blobmanager/s3/provider.go
@@ -46,6 +46,8 @@ func (p *BackendProvider) FromCredentials(ctx context.Context, secretName string
 		return nil, err
 	}
 
+	fmt.Println("creds: ", creds)
+
 	if err := creds.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid credentials retrieved from storage: %w", err)
 	}
@@ -96,6 +98,8 @@ type Credentials struct {
 	BucketName string
 	// Region ID, i.e us-east-1
 	Region string
+	// Optional endpoint URL for other S3 compatible backends i.e MinIO
+	Endpoint string
 }
 
 // Validate that the APICreds has all its properties set
@@ -110,10 +114,6 @@ func (c *Credentials) Validate() error {
 
 	if c.BucketName == "" {
 		return fmt.Errorf("%w: missing bucket name", backend.ErrValidation)
-	}
-
-	if c.Region == "" {
-		return fmt.Errorf("%w: missing region", backend.ErrValidation)
 	}
 
 	return nil

--- a/pkg/blobmanager/s3/provider.go
+++ b/pkg/blobmanager/s3/provider.go
@@ -46,8 +46,6 @@ func (p *BackendProvider) FromCredentials(ctx context.Context, secretName string
 		return nil, err
 	}
 
-	fmt.Println("creds: ", creds)
-
 	if err := creds.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid credentials retrieved from storage: %w", err)
 	}

--- a/pkg/blobmanager/s3/provider.go
+++ b/pkg/blobmanager/s3/provider.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 The Chainloop Authors.
+// Copyright 2024 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -72,13 +72,14 @@ func (p *BackendProvider) ValidateAndExtractCredentials(location string, credsJS
 	return creds, nil
 }
 
-func extractCreds(bucketName string, credsJSON []byte) (*Credentials, error) {
+func extractCreds(location string, credsJSON []byte) (*Credentials, error) {
 	var creds *Credentials
 	if err := json.Unmarshal(credsJSON, &creds); err != nil {
 		return nil, fmt.Errorf("unmarshaling credentials: %w", err)
 	}
 
-	creds.BucketName = bucketName
+	// We do not allow overriding the location
+	creds.Location = location
 
 	if err := creds.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid credentials: %w", err)
@@ -92,12 +93,14 @@ type Credentials struct {
 	AccessKeyID string
 	// AWS Secret Access Key
 	SecretAccessKey string
-	// Bucket name
+	// Deprecated: use Location instead. Kept for backward compatibility with existing stored credentials
 	BucketName string
+	// Location is a combination of the bucket name and the endpoint
+	// custom endpoint + bucket-name https://123.r2.cloudflarestorage.com/bucket-name
+	// or just the bucket name i.e bucket-name
+	Location string
 	// Region ID, i.e us-east-1
 	Region string
-	// Optional endpoint URL for other S3 compatible backends i.e MinIO
-	Endpoint string
 }
 
 // Validate that the APICreds has all its properties set
@@ -110,8 +113,9 @@ func (c *Credentials) Validate() error {
 		return fmt.Errorf("%w: missing secretAccessKey", backend.ErrValidation)
 	}
 
-	if c.BucketName == "" {
-		return fmt.Errorf("%w: missing bucket name", backend.ErrValidation)
+	// BucketName is deprecated, we should use Location instead
+	if c.Location == "" && c.BucketName == "" {
+		return fmt.Errorf("%w: missing bucket and location", backend.ErrValidation)
 	}
 
 	return nil

--- a/pkg/blobmanager/s3/provider_test.go
+++ b/pkg/blobmanager/s3/provider_test.go
@@ -17,6 +17,7 @@ package s3
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/chainloop-dev/chainloop/pkg/credentials/mocks"
@@ -32,6 +33,15 @@ func TestValidate(t *testing.T) {
 	}{
 		{
 			name: "valid credentials",
+			creds: &Credentials{
+				AccessKeyID:     "test",
+				SecretAccessKey: "test",
+				Region:          "test",
+				Location:        "test",
+			},
+		},
+		{
+			name: "valid credentials with deprecated bucket name",
 			creds: &Credentials{
 				AccessKeyID:     "test",
 				SecretAccessKey: "test",
@@ -86,29 +96,45 @@ func TestFromCredentials(t *testing.T) {
 	r := mocks.NewReader(t)
 	const bucket, keyID, keySecret, region = "my-bucket", "key-id", "key-secret", "region-1"
 
-	r.On("ReadCredentials", ctx, "secretName", mock.AnythingOfType("*s3.Credentials")).Return(nil).Run(
-		func(args mock.Arguments) {
-			credentials := args.Get(2).(*Credentials)
-			credentials.BucketName = bucket
-			credentials.Region = region
-			credentials.SecretAccessKey = keySecret
-			credentials.AccessKeyID = keyID
-		})
+	t.Run("with deprecated bucketName", func(_ *testing.T) {
+		r.On("ReadCredentials", ctx, "secretName", mock.AnythingOfType("*s3.Credentials")).Return(nil).Run(
+			func(args mock.Arguments) {
+				credentials := args.Get(2).(*Credentials)
+				credentials.BucketName = bucket
+				credentials.Region = region
+				credentials.SecretAccessKey = keySecret
+				credentials.AccessKeyID = keyID
+			})
 
-	_, err := NewBackendProvider(r).FromCredentials(ctx, "secretName")
-	assert.NoError(err)
+		_, err := NewBackendProvider(r).FromCredentials(ctx, "secretName")
+		assert.NoError(err)
+	})
+
+	t.Run("with location", func(_ *testing.T) {
+		r.On("ReadCredentials", ctx, "secretName", mock.AnythingOfType("*s3.Credentials")).Return(nil).Run(
+			func(args mock.Arguments) {
+				credentials := args.Get(2).(*Credentials)
+				credentials.Location = fmt.Sprintf("https://123.r2.cloudflarestorage.com/%s", bucket)
+				credentials.Region = region
+				credentials.SecretAccessKey = keySecret
+				credentials.AccessKeyID = keyID
+			})
+
+		_, err := NewBackendProvider(r).FromCredentials(ctx, "secretName")
+		assert.NoError(err)
+	})
 }
 
 func TestExtractCreds(t *testing.T) {
 	tetCases := []struct {
-		name       string
-		bucketName string
-		credsJSON  []byte
-		wantErr    bool
+		name      string
+		location  string
+		credsJSON []byte
+		wantErr   bool
 	}{
 		{
-			name:       "valid credentials",
-			bucketName: "mybucket",
+			name:     "valid credentials",
+			location: "mybucket",
 			credsJSON: []byte(`{
 				"AccessKeyID": "keyID",
 				"SecretAccessKey": "keySecret",
@@ -116,9 +142,9 @@ func TestExtractCreds(t *testing.T) {
 			}`),
 		},
 		{
-			name:       "invalid location, missing bucket",
-			bucketName: "",
-			wantErr:    true,
+			name:     "invalid location, missing bucket",
+			location: "",
+			wantErr:  true,
 			credsJSON: []byte(`{
 				"AccessKeyID": "test",
 				"SecretAccessKey": "keySecret",
@@ -126,8 +152,8 @@ func TestExtractCreds(t *testing.T) {
 			}`),
 		},
 		{
-			name:       "invalid credentials, missing secret",
-			bucketName: "account/container",
+			name:     "invalid credentials, missing secret",
+			location: "account/container",
 			credsJSON: []byte(`{
 				"AccessKeyID": "test",
 				"Region": "region-1"
@@ -138,7 +164,7 @@ func TestExtractCreds(t *testing.T) {
 
 	for _, tc := range tetCases {
 		t.Run(tc.name, func(t *testing.T) {
-			creds, err := extractCreds(tc.bucketName, tc.credsJSON)
+			creds, err := extractCreds(tc.location, tc.credsJSON)
 			if tc.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -147,7 +173,7 @@ func TestExtractCreds(t *testing.T) {
 					Region:          "region-1",
 					SecretAccessKey: "keySecret",
 					AccessKeyID:     "keyID",
-					BucketName:      tc.bucketName,
+					Location:        tc.location,
 				}, creds)
 			}
 		})

--- a/pkg/blobmanager/s3/provider_test.go
+++ b/pkg/blobmanager/s3/provider_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 The Chainloop Authors.
+// Copyright 2024 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -54,15 +54,6 @@ func TestValidate(t *testing.T) {
 				AccessKeyID: "test",
 				Region:      "test",
 				BucketName:  "test",
-			},
-			wantErr: true,
-		},
-		{
-			name: "missing region",
-			creds: &Credentials{
-				AccessKeyID:     "test",
-				SecretAccessKey: "test",
-				BucketName:      "test",
 			},
 			wantErr: true,
 		},


### PR DESCRIPTION
Adds support to registering an S3-compatible CAS-backend by providing a custom endpoint. making it compatible with Minio and Cloudflare R2

AWS S3 support has not changed, except that the region now is optional. Region is optional now because it doesn't make much sense in the concept of other providers.
 
```
chainloop cas-backend add aws-s3 --access-key-id AKIA5CHQ4CJGSHYWLEZF --secret-access-key ${SECRET_KEY} --bucket chainloop-test --name aws-test                     
┌──────────┬────────────────┬──────────┬─────────────┬───────────────┬─────────┐
│ NAME     │ LOCATION       │ PROVIDER │ DESCRIPTION │ LIMITS        │ DEFAULT │
├──────────┼────────────────┼──────────┼─────────────┼───────────────┼─────────┤
│ aws-test │ chainloop-test │ AWS-S3   │             │ MaxSize: 100M │ false   │
└──────────┴────────────────┴──────────┴─────────────┴───────────────┴─────────┘
```

Minio 

```
chainloop cas-backend add aws-s3 --name minio-test --access-key-id asdivBQsihWhMU0L --secret-access-key REDACTED --bucket test-chainloop \
--endpoint http://localhost:19000 

┌────────────┬─────────────────────────────────────┬──────────┬─────────────┬───────────────┬─────────┐
│ NAME       │ LOCATION                            │ PROVIDER │ DESCRIPTION │ LIMITS        │ DEFAULT │
├────────────┼─────────────────────────────────────┼──────────┼─────────────┼───────────────┼─────────┤
│ minio-test │ http://localhost:19000/test-chainlo │ AWS-S3   │             │ MaxSize: 100M │ true    │
│            │ op                                  │          │             │               │         │
└────────────┴─────────────────────────────────────┴──────────┴─────────────┴───────────────┴─────────┘
```

Cloudflare R2

```
chainloop cas-backend add aws-s3 --access-key-id fa95fbfa470effd79fdbe28b61b0788e --secret-access-key REDACTED --bucket chainloop \
--endpoint https://35c24d45e1cd7bc36279b8a4d130c7fe.r2.cloudflarestorage.com --name cloud-flare-test
┌──────────────────┬─────────────────────────────────────┬──────────┬─────────────┬───────────────┬─────────┐
│ NAME             │ LOCATION                            │ PROVIDER │ DESCRIPTION │ LIMITS        │ DEFAULT │
├──────────────────┼─────────────────────────────────────┼──────────┼─────────────┼───────────────┼─────────┤
│ cloud-flare-test │ https://35c24d45e1cd7bc36279b8a4d13 │ AWS-S3   │             │ MaxSize: 100M │ true    │
│                  │ 0c7fe.r2.cloudflarestorage.com/chai │          │             │               │         │
│                  │ nloop                               │          │             │               │         │
└──────────────────┴─────────────────────────────────────┴──────────┴─────────────┴───────────────┴─────────┘
```

note that the location shows the custom endpoint provided during registration

Closes #1053 

cc/ @hanygirgis