### PR TITLE
chore(docs): fix README link

### DIFF
--- a/deployment/chainloop/README.md
+++ b/deployment/chainloop/README.md
@@ -710,7 +710,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-<https://www.apache.org/licenses/LICENSE-2.0>
+[https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
The linter is complaining after doing a `yarn run docusaurus download-remote-deployment-readme` with this version of the README. This small PR fixes it.