### PR TITLE
fix: scope down revocation

### DIFF
--- a/app/controlplane/pkg/biz/apitoken.go
+++ b/app/controlplane/pkg/biz/apitoken.go
@@ -52,7 +52,7 @@ type APITokenRepo interface {
 	List(ctx context.Context, orgID *uuid.UUID, includeRevoked bool) ([]*APIToken, error)
 	Revoke(ctx context.Context, orgID, ID uuid.UUID) error
 	FindByID(ctx context.Context, ID uuid.UUID) (*APIToken, error)
-	FindByName(ctx context.Context, name string) (*APIToken, error)
+	FindByNameInOrg(ctx context.Context, orgID uuid.UUID, name string) (*APIToken, error)
 }
 
 type APITokenUseCase struct {
@@ -183,11 +183,9 @@ func (uc *APITokenUseCase) FindByNameInOrg(ctx context.Context, orgID, name stri
 		return nil, NewErrInvalidUUID(err)
 	}
 
-	t, err := uc.apiTokenRepo.FindByName(ctx, name)
+	t, err := uc.apiTokenRepo.FindByNameInOrg(ctx, orgUUID, name)
 	if err != nil {
 		return nil, fmt.Errorf("finding token: %w", err)
-	} else if t.OrganizationID != orgUUID {
-		return nil, NewErrNotFound("token")
 	}
 
 	return t, nil

--- a/app/controlplane/pkg/biz/mocks/APITokenRepo.go
+++ b/app/controlplane/pkg/biz/mocks/APITokenRepo.go
@@ -79,29 +79,29 @@ func (_m *APITokenRepo) FindByID(ctx context.Context, ID uuid.UUID) (*biz.APITok
 	return r0, r1
 }
 
-// FindByName provides a mock function with given fields: ctx, name
-func (_m *APITokenRepo) FindByName(ctx context.Context, name string) (*biz.APIToken, error) {
-	ret := _m.Called(ctx, name)
+// FindByNameInOrg provides a mock function with given fields: ctx, orgID, name
+func (_m *APITokenRepo) FindByNameInOrg(ctx context.Context, orgID uuid.UUID, name string) (*biz.APIToken, error) {
+	ret := _m.Called(ctx, orgID, name)
 
 	if len(ret) == 0 {
-		panic("no return value specified for FindByName")
+		panic("no return value specified for FindByNameInOrg")
 	}
 
 	var r0 *biz.APIToken
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) (*biz.APIToken, error)); ok {
-		return rf(ctx, name)
+	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID, string) (*biz.APIToken, error)); ok {
+		return rf(ctx, orgID, name)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) *biz.APIToken); ok {
-		r0 = rf(ctx, name)
+	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID, string) *biz.APIToken); ok {
+		r0 = rf(ctx, orgID, name)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*biz.APIToken)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, name)
+	if rf, ok := ret.Get(1).(func(context.Context, uuid.UUID, string) error); ok {
+		r1 = rf(ctx, orgID, name)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/app/controlplane/pkg/data/apitoken.go
+++ b/app/controlplane/pkg/data/apitoken.go
@@ -23,6 +23,7 @@ import (
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/biz"
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/data/ent"
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/data/ent/apitoken"
+	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/data/ent/organization"
 	"github.com/go-kratos/kratos/v2/log"
 	"github.com/google/uuid"
 )
@@ -69,8 +70,8 @@ func (r *APITokenRepo) FindByID(ctx context.Context, id uuid.UUID) (*biz.APIToke
 	return entAPITokenToBiz(token), nil
 }
 
-func (r *APITokenRepo) FindByName(ctx context.Context, name string) (*biz.APIToken, error) {
-	token, err := r.data.DB.APIToken.Query().Where(apitoken.NameEQ(name)).Only(ctx)
+func (r *APITokenRepo) FindByNameInOrg(ctx context.Context, orgID uuid.UUID, name string) (*biz.APIToken, error) {
+	token, err := r.data.DB.APIToken.Query().Where(apitoken.NameEQ(name), apitoken.HasOrganizationWith(organization.ID(orgID)), apitoken.RevokedAtIsNil()).Only(ctx)
 	if err != nil {
 		if ent.IsNotFound(err) {
 			return nil, biz.NewErrNotFound("API token")


### PR DESCRIPTION
There was a bug that prevented revoking tokens which name might have existed in another organization. This fixes it by moving the authz scope to the query itself

```
finding token: ent: api_token not singular
```