### PR TITLE
chore(docs): fix README to use HTML-encoded characters

### DIFF
--- a/deployment/chainloop/README.md
+++ b/deployment/chainloop/README.md
@@ -51,7 +51,7 @@ During installation, you'll need to provide
 
 - Open ID Connect Identity Provider (IDp) settings i.e [Auth0 settings](https://auth0.com/docs/get-started/applications/application-settings#basic-information)
 - Connection settings for a secrets storage backend, either [Hashicorp Vault](https://www.vaultproject.io/) or [AWS Secrets Manager](https://aws.amazon.com/secrets-manager)
-- ECDSA (ES512) key-pair used for Controlplane <-> CAS Authentication
+- ECDSA (ES512) key-pair used for Controlplane &lt;-&gt; CAS Authentication
 
 Instructions on how to create the ECDSA keypair can be found [here](#generate-a-ecdsa-key-pair).
 
@@ -159,7 +159,7 @@ During installation, you'll need to provide
 
 - Open ID Connect Identity Provider (IDp) settings i.e [Auth0 settings](https://auth0.com/docs/get-started/applications/application-settings#basic-information)
 - ~~Connection settings for a secrets storage backend, either [Hashicorp Vault](https://www.vaultproject.io/) or [AWS Secrets Manager](https://aws.amazon.com/secrets-manager)~~
-- ~~ECDSA (ES512) key-pair used for Controlplane <-> CAS Authentication~~
+- ~~ECDSA (ES512) key-pair used for Controlplane &lt;-&gt; CAS Authentication~~
 
 #### Installation examples for development mode
 
@@ -484,7 +484,7 @@ chainloop config save \
 
 | Name               | Description                                                            | Value |
 | ------------------ | ---------------------------------------------------------------------- | ----- |
-| `casJWTPrivateKey` | ECDSA (ES512) private key used for Controlplane <-> CAS Authentication | `""`  |
+| `casJWTPrivateKey` | ECDSA (ES512) private key used for Controlplane &lt;-&gt; CAS Authentication | `""`  |
 | `casJWTPublicKey`  | ECDSA (ES512) public key                                               | `""`  |
 
 ### Control Plane
@@ -533,16 +533,16 @@ chainloop config save \
 ### Control Plane Networking
 
 | Name                                       | Description                                                                                                                      | Value                    |
-| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| ------------------------------------------ |----------------------------------------------------------------------------------------------------------------------------------| ------------------------ |
 | `controlplane.service.type`                | Service type                                                                                                                     | `ClusterIP`              |
 | `controlplane.service.port`                | Service port                                                                                                                     | `80`                     |
 | `controlplane.service.targetPort`          | Service target Port                                                                                                              | `http`                   |
-| `controlplane.service.nodePorts.http`      | Node port for HTTP. NOTE: choose port between <30000-32767>                                                                      |                          |
+| `controlplane.service.nodePorts.http`      | Node port for HTTP. NOTE: choose port between &lt;30000-32767&gt;                                                                |                          |
 | `controlplane.serviceAPI.type`             | Service type                                                                                                                     | `ClusterIP`              |
 | `controlplane.serviceAPI.port`             | Service port                                                                                                                     | `80`                     |
 | `controlplane.serviceAPI.targetPort`       | Service target Port                                                                                                              | `grpc`                   |
 | `controlplane.serviceAPI.annotations`      | Service annotations                                                                                                              |                          |
-| `controlplane.serviceAPI.nodePorts.http`   | Node port for HTTP. NOTE: choose port between <30000-32767>                                                                      |                          |
+| `controlplane.serviceAPI.nodePorts.http`   | Node port for HTTP. NOTE: choose port between &lt;30000-32767&gt;                                                                |                          |
 | `controlplane.ingress.enabled`             | Enable ingress record generation for %%MAIN_CONTAINER_NAME%%                                                                     | `false`                  |
 | `controlplane.ingress.pathType`            | Ingress path type                                                                                                                | `ImplementationSpecific` |
 | `controlplane.ingress.hostname`            | Default host for the ingress record                                                                                              | `cp.dev.local`           |
@@ -620,12 +620,12 @@ chainloop config save \
 | `cas.service.type`                | Service type                                                                                                                     | `ClusterIP`              |
 | `cas.service.port`                | Service port                                                                                                                     | `80`                     |
 | `cas.service.targetPort`          | Service target Port                                                                                                              | `http`                   |
-| `cas.service.nodePorts.http`      | Node port for HTTP. NOTE: choose port between <30000-32767>                                                                      |                          |
+| `cas.service.nodePorts.http`      | Node port for HTTP. NOTE: choose port between &lt;30000-32767&gt;                                                                      |                          |
 | `cas.serviceAPI.type`             | Service type                                                                                                                     | `ClusterIP`              |
 | `cas.serviceAPI.port`             | Service port                                                                                                                     | `80`                     |
 | `cas.serviceAPI.targetPort`       | Service target Port                                                                                                              | `grpc`                   |
 | `cas.serviceAPI.annotations`      | Service annotations                                                                                                              |                          |
-| `cas.serviceAPI.nodePorts.http`   | Node port for HTTP. NOTE: choose port between <30000-32767>                                                                      |                          |
+| `cas.serviceAPI.nodePorts.http`   | Node port for HTTP. NOTE: choose port between &lt;30000-32767&gt;                                                                      |                          |
 | `cas.ingress.enabled`             | Enable ingress record generation for %%MAIN_CONTAINER_NAME%%                                                                     | `false`                  |
 | `cas.ingress.pathType`            | Ingress path type                                                                                                                | `ImplementationSpecific` |
 | `cas.ingress.hostname`            | Default host for the ingress record                                                                                              | `cas.dev.local`          |

--- a/deployment/chainloop/README.md
+++ b/deployment/chainloop/README.md
@@ -482,10 +482,10 @@ chainloop config save \
 
 ### Authentication
 
-| Name               | Description                                                            | Value |
-| ------------------ | ---------------------------------------------------------------------- | ----- |
+| Name               | Description                                                                  | Value |
+| ------------------ | ---------------------------------------------------------------------------- | ----- |
 | `casJWTPrivateKey` | ECDSA (ES512) private key used for Controlplane &lt;-&gt; CAS Authentication | `""`  |
-| `casJWTPublicKey`  | ECDSA (ES512) public key                                               | `""`  |
+| `casJWTPublicKey`  | ECDSA (ES512) public key                                                     | `""`  |
 
 ### Control Plane
 
@@ -533,7 +533,7 @@ chainloop config save \
 ### Control Plane Networking
 
 | Name                                       | Description                                                                                                                      | Value                    |
-| ------------------------------------------ |----------------------------------------------------------------------------------------------------------------------------------| ------------------------ |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
 | `controlplane.service.type`                | Service type                                                                                                                     | `ClusterIP`              |
 | `controlplane.service.port`                | Service port                                                                                                                     | `80`                     |
 | `controlplane.service.targetPort`          | Service target Port                                                                                                              | `http`                   |
@@ -620,12 +620,12 @@ chainloop config save \
 | `cas.service.type`                | Service type                                                                                                                     | `ClusterIP`              |
 | `cas.service.port`                | Service port                                                                                                                     | `80`                     |
 | `cas.service.targetPort`          | Service target Port                                                                                                              | `http`                   |
-| `cas.service.nodePorts.http`      | Node port for HTTP. NOTE: choose port between &lt;30000-32767&gt;                                                                      |                          |
+| `cas.service.nodePorts.http`      | Node port for HTTP. NOTE: choose port between &lt;30000-32767&gt;                                                                |                          |
 | `cas.serviceAPI.type`             | Service type                                                                                                                     | `ClusterIP`              |
 | `cas.serviceAPI.port`             | Service port                                                                                                                     | `80`                     |
 | `cas.serviceAPI.targetPort`       | Service target Port                                                                                                              | `grpc`                   |
 | `cas.serviceAPI.annotations`      | Service annotations                                                                                                              |                          |
-| `cas.serviceAPI.nodePorts.http`   | Node port for HTTP. NOTE: choose port between &lt;30000-32767&gt;                                                                      |                          |
+| `cas.serviceAPI.nodePorts.http`   | Node port for HTTP. NOTE: choose port between &lt;30000-32767&gt;                                                                |                          |
 | `cas.ingress.enabled`             | Enable ingress record generation for %%MAIN_CONTAINER_NAME%%                                                                     | `false`                  |
 | `cas.ingress.pathType`            | Ingress path type                                                                                                                | `ImplementationSpecific` |
 | `cas.ingress.hostname`            | Default host for the ingress record                                                                                              | `cas.dev.local`          |

--- a/deployment/chainloop/README.md
+++ b/deployment/chainloop/README.md
@@ -51,7 +51,7 @@ During installation, you'll need to provide
 
 - Open ID Connect Identity Provider (IDp) settings i.e [Auth0 settings](https://auth0.com/docs/get-started/applications/application-settings#basic-information)
 - Connection settings for a secrets storage backend, either [Hashicorp Vault](https://www.vaultproject.io/) or [AWS Secrets Manager](https://aws.amazon.com/secrets-manager)
-- ECDSA (ES512) key-pair used for Controlplane &lt;-&gt; CAS Authentication
+- ECDSA (ES512) key-pair used for Controlplane to CAS Authentication
 
 Instructions on how to create the ECDSA keypair can be found [here](#generate-a-ecdsa-key-pair).
 
@@ -159,7 +159,7 @@ During installation, you'll need to provide
 
 - Open ID Connect Identity Provider (IDp) settings i.e [Auth0 settings](https://auth0.com/docs/get-started/applications/application-settings#basic-information)
 - ~~Connection settings for a secrets storage backend, either [Hashicorp Vault](https://www.vaultproject.io/) or [AWS Secrets Manager](https://aws.amazon.com/secrets-manager)~~
-- ~~ECDSA (ES512) key-pair used for Controlplane &lt;-&gt; CAS Authentication~~
+- ~~ECDSA (ES512) key-pair used for Controlplane to CAS Authentication~~
 
 #### Installation examples for development mode
 
@@ -482,10 +482,10 @@ chainloop config save \
 
 ### Authentication
 
-| Name               | Description                                                                  | Value |
-| ------------------ | ---------------------------------------------------------------------------- | ----- |
-| `casJWTPrivateKey` | ECDSA (ES512) private key used for Controlplane &lt;-&gt; CAS Authentication | `""`  |
-| `casJWTPublicKey`  | ECDSA (ES512) public key                                                     | `""`  |
+| Name               | Description                                                           | Value |
+| ------------------ | --------------------------------------------------------------------- | ----- |
+| `casJWTPrivateKey` | ECDSA (ES512) private key used for Controlplane to CAS Authentication | `""`  |
+| `casJWTPublicKey`  | ECDSA (ES512) public key                                              | `""`  |
 
 ### Control Plane
 
@@ -537,12 +537,12 @@ chainloop config save \
 | `controlplane.service.type`                | Service type                                                                                                                     | `ClusterIP`              |
 | `controlplane.service.port`                | Service port                                                                                                                     | `80`                     |
 | `controlplane.service.targetPort`          | Service target Port                                                                                                              | `http`                   |
-| `controlplane.service.nodePorts.http`      | Node port for HTTP. NOTE: choose port between &lt;30000-32767&gt;                                                                |                          |
+| `controlplane.service.nodePorts.http`      | Node port for HTTP. NOTE: choose port between [30000-32767]                                                                      |                          |
 | `controlplane.serviceAPI.type`             | Service type                                                                                                                     | `ClusterIP`              |
 | `controlplane.serviceAPI.port`             | Service port                                                                                                                     | `80`                     |
 | `controlplane.serviceAPI.targetPort`       | Service target Port                                                                                                              | `grpc`                   |
 | `controlplane.serviceAPI.annotations`      | Service annotations                                                                                                              |                          |
-| `controlplane.serviceAPI.nodePorts.http`   | Node port for HTTP. NOTE: choose port between &lt;30000-32767&gt;                                                                |                          |
+| `controlplane.serviceAPI.nodePorts.http`   | Node port for HTTP. NOTE: choose port between [30000-32767]                                                                      |                          |
 | `controlplane.ingress.enabled`             | Enable ingress record generation for %%MAIN_CONTAINER_NAME%%                                                                     | `false`                  |
 | `controlplane.ingress.pathType`            | Ingress path type                                                                                                                | `ImplementationSpecific` |
 | `controlplane.ingress.hostname`            | Default host for the ingress record                                                                                              | `cp.dev.local`           |
@@ -620,12 +620,12 @@ chainloop config save \
 | `cas.service.type`                | Service type                                                                                                                     | `ClusterIP`              |
 | `cas.service.port`                | Service port                                                                                                                     | `80`                     |
 | `cas.service.targetPort`          | Service target Port                                                                                                              | `http`                   |
-| `cas.service.nodePorts.http`      | Node port for HTTP. NOTE: choose port between &lt;30000-32767&gt;                                                                |                          |
+| `cas.service.nodePorts.http`      | Node port for HTTP. NOTE: choose port between [30000-32767]                                                                      |                          |
 | `cas.serviceAPI.type`             | Service type                                                                                                                     | `ClusterIP`              |
 | `cas.serviceAPI.port`             | Service port                                                                                                                     | `80`                     |
 | `cas.serviceAPI.targetPort`       | Service target Port                                                                                                              | `grpc`                   |
 | `cas.serviceAPI.annotations`      | Service annotations                                                                                                              |                          |
-| `cas.serviceAPI.nodePorts.http`   | Node port for HTTP. NOTE: choose port between &lt;30000-32767&gt;                                                                |                          |
+| `cas.serviceAPI.nodePorts.http`   | Node port for HTTP. NOTE: choose port between [30000-32767]                                                                      |                          |
 | `cas.ingress.enabled`             | Enable ingress record generation for %%MAIN_CONTAINER_NAME%%                                                                     | `false`                  |
 | `cas.ingress.pathType`            | Ingress path type                                                                                                                | `ImplementationSpecific` |
 | `cas.ingress.hostname`            | Default host for the ingress record                                                                                              | `cas.dev.local`          |

--- a/deployment/chainloop/values.yaml
+++ b/deployment/chainloop/values.yaml
@@ -69,13 +69,13 @@ secretsBackend:
 ## @section Authentication
 ##
 
-## ECDSA (ES512) key-pair used for Controlplane &lt;-&gt; CAS Authentication
+## ECDSA (ES512) key-pair used for Controlplane to; CAS Authentication
 ## The controlplane will use the private key to generate a JWT at user request
 ## The CAS will use the public key to verify the authenticity of that token
 ## If development=true is set, a development key will be configured automatically
 ## otherwise you'll need to provide new keys via .Values.casJWTPrivateKey and .Values.cas.casJWTPublicKey
 
-## @param casJWTPrivateKey ECDSA (ES512) private key used for Controlplane &lt;-&gt; CAS Authentication
+## @param casJWTPrivateKey ECDSA (ES512) private key used for Controlplane to CAS Authentication
 ##
 ## To generate one
 ## openssl ecparam -name secp521r1 -genkey -noout -out private.ec.key
@@ -208,7 +208,7 @@ controlplane:
     port: 80
     ## @param controlplane.service.targetPort Service target Port
     targetPort: http
-    ## @extra controlplane.service.nodePorts.http Node port for HTTP. NOTE: choose port between &lt;30000-32767&gt;
+    ## @extra controlplane.service.nodePorts.http Node port for HTTP. NOTE: choose port between [30000-32767]
     # nodePorts:
     #   http: "30800"
     annotations:
@@ -227,7 +227,7 @@ controlplane:
       ## @skip controlplane.serviceAPI.annotations.traefik.ingress.kubernetes.io/service.serversscheme
       traefik.ingress.kubernetes.io/service.serversscheme: h2c
 
-    ## @extra controlplane.serviceAPI.nodePorts.http Node port for HTTP. NOTE: choose port between &lt;30000-32767&gt;
+    ## @extra controlplane.serviceAPI.nodePorts.http Node port for HTTP. NOTE: choose port between [30000-32767]
     # nodePorts:
     #   http: "30900"
 
@@ -551,7 +551,7 @@ cas:
     port: 80
     ## @param cas.service.targetPort Service target Port
     targetPort: http
-    ## @extra cas.service.nodePorts.http Node port for HTTP. NOTE: choose port between &lt;30000-32767&gt;
+    ## @extra cas.service.nodePorts.http Node port for HTTP. NOTE: choose port between [30000-32767]
     # nodePorts:
     #   http: "30800"
     annotations:
@@ -570,7 +570,7 @@ cas:
       ## @skip cas.serviceAPI.annotations.traefik.ingress.kubernetes.io/service.serversscheme
       traefik.ingress.kubernetes.io/service.serversscheme: h2c
 
-    ## @extra cas.serviceAPI.nodePorts.http Node port for HTTP. NOTE: choose port between &lt;30000-32767&gt;
+    ## @extra cas.serviceAPI.nodePorts.http Node port for HTTP. NOTE: choose port between [30000-32767]
     # nodePorts:
     #   http: "30901"
 

--- a/deployment/chainloop/values.yaml
+++ b/deployment/chainloop/values.yaml
@@ -69,13 +69,13 @@ secretsBackend:
 ## @section Authentication
 ##
 
-## ECDSA (ES512) key-pair used for Controlplane <-> CAS Authentication
+## ECDSA (ES512) key-pair used for Controlplane &lt;-&gt; CAS Authentication
 ## The controlplane will use the private key to generate a JWT at user request
 ## The CAS will use the public key to verify the authenticity of that token
 ## If development=true is set, a development key will be configured automatically
 ## otherwise you'll need to provide new keys via .Values.casJWTPrivateKey and .Values.cas.casJWTPublicKey
 
-## @param casJWTPrivateKey ECDSA (ES512) private key used for Controlplane <-> CAS Authentication
+## @param casJWTPrivateKey ECDSA (ES512) private key used for Controlplane &lt;-&gt; CAS Authentication
 ##
 ## To generate one
 ## openssl ecparam -name secp521r1 -genkey -noout -out private.ec.key
@@ -208,7 +208,7 @@ controlplane:
     port: 80
     ## @param controlplane.service.targetPort Service target Port
     targetPort: http
-    ## @extra controlplane.service.nodePorts.http Node port for HTTP. NOTE: choose port between <30000-32767>
+    ## @extra controlplane.service.nodePorts.http Node port for HTTP. NOTE: choose port between &lt;30000-32767&gt;
     # nodePorts:
     #   http: "30800"
     annotations:
@@ -227,7 +227,7 @@ controlplane:
       ## @skip controlplane.serviceAPI.annotations.traefik.ingress.kubernetes.io/service.serversscheme
       traefik.ingress.kubernetes.io/service.serversscheme: h2c
 
-    ## @extra controlplane.serviceAPI.nodePorts.http Node port for HTTP. NOTE: choose port between <30000-32767>
+    ## @extra controlplane.serviceAPI.nodePorts.http Node port for HTTP. NOTE: choose port between &lt;30000-32767&gt;
     # nodePorts:
     #   http: "30900"
 
@@ -551,7 +551,7 @@ cas:
     port: 80
     ## @param cas.service.targetPort Service target Port
     targetPort: http
-    ## @extra cas.service.nodePorts.http Node port for HTTP. NOTE: choose port between <30000-32767>
+    ## @extra cas.service.nodePorts.http Node port for HTTP. NOTE: choose port between &lt;30000-32767&gt;
     # nodePorts:
     #   http: "30800"
     annotations:
@@ -570,7 +570,7 @@ cas:
       ## @skip cas.serviceAPI.annotations.traefik.ingress.kubernetes.io/service.serversscheme
       traefik.ingress.kubernetes.io/service.serversscheme: h2c
 
-    ## @extra cas.serviceAPI.nodePorts.http Node port for HTTP. NOTE: choose port between <30000-32767>
+    ## @extra cas.serviceAPI.nodePorts.http Node port for HTTP. NOTE: choose port between &lt;30000-32767&gt;
     # nodePorts:
     #   http: "30901"
 


### PR DESCRIPTION
This is a follow up of https://github.com/chainloop-dev/chainloop/pull/1056 to fix some other invalid characters when interpreting this doc as MDX