### PR TITLE
fix(controlplane): skip allow-list for API tokens

### DIFF
--- a/app/controlplane/internal/usercontext/allowlist_middleware.go
+++ b/app/controlplane/internal/usercontext/allowlist_middleware.go
@@ -35,6 +35,11 @@ func CheckUserInAllowList(allowList *conf.Auth_AllowList) middleware.Middleware 
 				return handler(ctx, req)
 			}
 
+			// API tokens skip the allowlist since they are meant to represent a service
+			if token := CurrentAPIToken(ctx); token != nil {
+				return handler(ctx, req)
+			}
+
 			// Make sure that this middleware is ran after WithCurrentUser
 			user := CurrentUser(ctx)
 			if user == nil {

--- a/app/controlplane/internal/usercontext/allowlist_middleware_test.go
+++ b/app/controlplane/internal/usercontext/allowlist_middleware_test.go
@@ -72,6 +72,7 @@ func TestCheckUserInAllowList(t *testing.T) {
 		selectedRoutes []string
 		runningRoute   string
 		email          string
+		isApiToken     bool
 		wantErr        bool
 		customErrMsg   string
 	}{
@@ -84,6 +85,12 @@ func TestCheckUserInAllowList(t *testing.T) {
 			email:   email,
 			rules:   []string{"nothere@cyberdyne.io"},
 			wantErr: true,
+		},
+		{
+			name:       "is an API token so allow-list gets skipped",
+			isApiToken: true,
+			rules:      []string{"nothere@cyberdyne.io"},
+			wantErr:    false,
 		},
 		{
 			name:           "user not allowed to access the route",
@@ -159,7 +166,10 @@ func TestCheckUserInAllowList(t *testing.T) {
 			ctx := context.Background()
 			if tc.email != "" {
 				ctx = WithCurrentUser(ctx, &User{Email: tc.email, ID: "124"})
+			} else if tc.isApiToken {
+				ctx = WithCurrentAPIToken(ctx, &APIToken{ID: "124"})
 			}
+
 			if tc.runningRoute != "" {
 				ctx = transport.NewServerContext(ctx, &mockTransport{operation: tc.runningRoute})
 			}

--- a/app/controlplane/internal/usercontext/allowlist_middleware_test.go
+++ b/app/controlplane/internal/usercontext/allowlist_middleware_test.go
@@ -72,7 +72,7 @@ func TestCheckUserInAllowList(t *testing.T) {
 		selectedRoutes []string
 		runningRoute   string
 		email          string
-		isApiToken     bool
+		isAPIToken     bool
 		wantErr        bool
 		customErrMsg   string
 	}{
@@ -88,7 +88,7 @@ func TestCheckUserInAllowList(t *testing.T) {
 		},
 		{
 			name:       "is an API token so allow-list gets skipped",
-			isApiToken: true,
+			isAPIToken: true,
 			rules:      []string{"nothere@cyberdyne.io"},
 			wantErr:    false,
 		},
@@ -166,7 +166,7 @@ func TestCheckUserInAllowList(t *testing.T) {
 			ctx := context.Background()
 			if tc.email != "" {
 				ctx = WithCurrentUser(ctx, &User{Email: tc.email, ID: "124"})
-			} else if tc.isApiToken {
+			} else if tc.isAPIToken {
 				ctx = WithCurrentAPIToken(ctx, &APIToken{ID: "124"})
 			}
 


### PR DESCRIPTION
API tokens were being captured in the allowlist middleware. This meant in practice that any operations like `creating workflows` or `updating contracts` were failing with `USER not found` error.