### PR TITLE
feat(cas): Allow custom CAs in CAS deployment

### DIFF
--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -7,7 +7,7 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.75.0
+version: 1.75.1
 # Do not update appVersion, this is handled automatically by the release process
 appVersion: v0.93.5
 

--- a/deployment/chainloop/README.md
+++ b/deployment/chainloop/README.md
@@ -401,7 +401,7 @@ controlplane:
 
 ### Insert custom Certificate Authorities (CAs)
 
-In some scenarios, you might want to add custom Certificate Authorities to the Chainloop deployment. Like in the instance where your OIDC provider uses a self-signed certificate. To do so, add the PEM-encoded CA certificate to the `customCAs` list in your `values.yaml` file like in the example below.
+In some scenarios, you might want to add custom Certificate Authorities to the Chainloop deployment. Like in the instance where your OIDC provider uses a self-signed certificate. To do so, add the PEM-encoded CA certificate to the `customCAs` list in either `controlplane` or `cas` sections, in your `values.yaml` file like in the example below.
 
 ```yaml
   customCAs:
@@ -655,20 +655,21 @@ chainloop config save \
 
 ### CAS Misc
 
-| Name                                                | Description                        | Value        |
-| --------------------------------------------------- | ---------------------------------- | ------------ |
-| `cas.resources.limits.cpu`                          | Container resource limits CPU      | `250m`       |
-| `cas.resources.limits.memory`                       | Container resource limits memory   | `512Mi`      |
-| `cas.resources.requests.cpu`                        | Container resource requests CPU    | `250m`       |
-| `cas.resources.requests.memory`                     | Container resource requests memory | `512Mi`      |
-| `cas.autoscaling.enabled`                           | Enable deployment autoscaling      | `false`      |
-| `cas.autoscaling.minReplicas`                       | Minimum number of replicas         | `1`          |
-| `cas.autoscaling.maxReplicas`                       | Maximum number of replicas         | `100`        |
-| `cas.autoscaling.targetCPUUtilizationPercentage`    | Target CPU percentage              | `80`         |
-| `cas.autoscaling.targetMemoryUtilizationPercentage` | Target CPU memory                  | `80`         |
-| `cas.sentry.enabled`                                | Enable sentry.io alerting          | `false`      |
-| `cas.sentry.dsn`                                    | DSN endpoint                       | `""`         |
-| `cas.sentry.environment`                            | Environment tag                    | `production` |
+| Name                                                | Description                            | Value        |
+| --------------------------------------------------- | -------------------------------------- | ------------ |
+| `cas.resources.limits.cpu`                          | Container resource limits CPU          | `250m`       |
+| `cas.resources.limits.memory`                       | Container resource limits memory       | `512Mi`      |
+| `cas.resources.requests.cpu`                        | Container resource requests CPU        | `250m`       |
+| `cas.resources.requests.memory`                     | Container resource requests memory     | `512Mi`      |
+| `cas.autoscaling.enabled`                           | Enable deployment autoscaling          | `false`      |
+| `cas.autoscaling.minReplicas`                       | Minimum number of replicas             | `1`          |
+| `cas.autoscaling.maxReplicas`                       | Maximum number of replicas             | `100`        |
+| `cas.autoscaling.targetCPUUtilizationPercentage`    | Target CPU percentage                  | `80`         |
+| `cas.autoscaling.targetMemoryUtilizationPercentage` | Target CPU memory                      | `80`         |
+| `cas.sentry.enabled`                                | Enable sentry.io alerting              | `false`      |
+| `cas.sentry.dsn`                                    | DSN endpoint                           | `""`         |
+| `cas.sentry.environment`                            | Environment tag                        | `production` |
+| `cas.customCAs`                                     | List of custom CA certificates content | `[]`         |
 
 ### Dependencies
 

--- a/deployment/chainloop/templates/cas/customcas.secret.yaml
+++ b/deployment/chainloop/templates/cas/customcas.secret.yaml
@@ -1,0 +1,18 @@
+{{- /*
+Copyright Chainloop, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- $customCAs := .Values.cas.customCAs }}
+{{- if (not (empty $customCAs)) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "chainloop.cas.fullname" . }}-custom-cas
+  labels:
+    {{- include "chainloop.cas.labels" . | nindent 4 }}
+data:
+  {{- range $index, $pem := $customCAs }}
+  custom-{{ $index }}.crt: {{ $pem | b64enc | quote }}
+  {{- end -}}
+{{- end -}}

--- a/deployment/chainloop/templates/cas/deployment.yaml
+++ b/deployment/chainloop/templates/cas/deployment.yaml
@@ -71,13 +71,13 @@ spec:
             - name: server-certs
               mountPath: /data/server-certs
             {{- end }}
-            {{ - if (not (empty .Values.cas.customCAs)) }}
+            {{- if (not (empty .Values.cas.customCAs)) }}
             - name: custom-cas
               # NOTE: /etc/ssl/certs already contains the system CA certs
               # Let's use another known path https://go.dev/src/crypto/x509/root_linux.go
               mountPath: /etc/pki/tls/certs
               readOnly: true
-            {{ - end }}
+            {{- end }}
       volumes:
         - name: config
           projected:

--- a/deployment/chainloop/templates/cas/deployment.yaml
+++ b/deployment/chainloop/templates/cas/deployment.yaml
@@ -71,6 +71,13 @@ spec:
             - name: server-certs
               mountPath: /data/server-certs
             {{- end }}
+            {{ - if (not (empty .Values.cas.customCAs)) }}
+            - name: custom-cas
+              # NOTE: /etc/ssl/certs already contains the system CA certs
+              # Let's use another known path https://go.dev/src/crypto/x509/root_linux.go
+              mountPath: /etc/pki/tls/certs
+              readOnly: true
+            {{ - end }}
       volumes:
         - name: config
           projected:
@@ -91,4 +98,11 @@ spec:
         - name: gcp-secretmanager-serviceaccountkey
           secret:
             secretName: {{ include "chainloop.controlplane.fullname" . }}-gcp-secretmanager-serviceaccountkey
+        {{- end }}
+        {{- if (not (empty .Values.cas.customCAs)) }}
+        - name: custom-cas
+          projected:
+            sources:
+              - secret:
+                  name: {{ include "chainloop.cas.fullname" . }}-custom-cas
         {{- end }}

--- a/deployment/chainloop/values.yaml
+++ b/deployment/chainloop/values.yaml
@@ -824,6 +824,10 @@ cas:
     dsn: ""
     environment: production
 
+  ## Inject custom CA certificates to the CAS container
+  ## @param cas.customCAs List of custom CA certificates content
+  customCAs: []
+
 ## @section Dependencies
 # ##################################
 # #          Dependencies          #


### PR DESCRIPTION
This PR allows to mount system-wide CAs certificates in the CAS deployment. This is specially useful when connecting to custom backends like Minio.

Closes #1077 