### PR TITLE
chore(deployment): add certificate validity to file CA example

### DIFF
--- a/deployment/chainloop/README.md
+++ b/deployment/chainloop/README.md
@@ -371,12 +371,12 @@ secretsBackend:
 *This feature is experimental, as it doesn't yet support verification.*
 
 You can enable keyless signing mode by providing a custom Certificate Authority.
-For example, these commands generate a self-signed certificate with an RSA private key of length 4096 and AES256 encryption:
+For example, these commands generate a self-signed certificate with an RSA private key of length 4096 and AES256 encryption with a validity of 365 days:
 
 ```bash
 > openssl genrsa -aes256 -out ca.key 4096
 ...
-> openssl req -new -x509 -sha256 -key ca.key -out ca.crt
+> openssl req -new -x509 -sha256 -key ca.key -out ca.crt -days 365
 ...
 ```
 


### PR DESCRIPTION
Update the configuration example to add a certificate validity (as it defaults to 1 month).

