### PR TITLE
feat(http): Create jwt middlewares for http servers

### DIFF
--- a/app/artifact-cas/internal/server/http.go
+++ b/app/artifact-cas/internal/server/http.go
@@ -17,19 +17,16 @@ package server
 
 import (
 	"fmt"
+	"github.com/golang-jwt/jwt/v4"
 	"os"
 
+	api "github.com/chainloop-dev/chainloop/app/artifact-cas/api/cas/v1"
 	"github.com/chainloop-dev/chainloop/app/artifact-cas/internal/conf"
 	"github.com/chainloop-dev/chainloop/app/artifact-cas/internal/service"
 	casJWT "github.com/chainloop-dev/chainloop/internal/robotaccount/cas"
-	jwt "github.com/golang-jwt/jwt/v4"
-
-	nhttp "net/http"
-
-	api "github.com/chainloop-dev/chainloop/app/artifact-cas/api/cas/v1"
 	backend "github.com/chainloop-dev/chainloop/pkg/blobmanager"
+	middlewares_http "github.com/chainloop-dev/chainloop/pkg/middlewares/http"
 	"github.com/go-kratos/kratos/v2/log"
-	jwtMiddleware "github.com/go-kratos/kratos/v2/middleware/auth/jwt"
 	"github.com/go-kratos/kratos/v2/middleware/logging"
 	"github.com/go-kratos/kratos/v2/middleware/recovery"
 	"github.com/go-kratos/kratos/v2/transport/http"
@@ -68,31 +65,14 @@ func NewHTTPServer(c *conf.Server, authConf *conf.Auth, downloadSvc *service.Dow
 
 	srv := http.NewServer(opts...)
 
-	srv.Handle(service.DownloadPath, authFromQueryMiddleware(loadPublicKey(rawKey), casJWT.SigningMethod, downloadSvc))
+	srv.Handle(service.DownloadPath, middlewares_http.AuthFromQueryParam(loadPublicKey(rawKey), claimsFunc(), casJWT.SigningMethod, downloadSvc))
 	api.RegisterStatusServiceHTTPServer(srv, service.NewStatusService(Version, providers))
 	return srv, nil
 }
 
-func authFromQueryMiddleware(keyFunc jwt.Keyfunc, signingMethod jwt.SigningMethod, next nhttp.Handler) nhttp.Handler {
-	return nhttp.HandlerFunc(func(w http.ResponseWriter, r *nhttp.Request) {
-		token := r.URL.Query().Get("t")
-		if token == "" {
-			nhttp.Error(w, "missing token", nhttp.StatusUnauthorized)
-			return
-		}
-
-		claims, err := verifyAndMarshalJWT(token, keyFunc, signingMethod)
-		if err != nil {
-			// return unauthorized
-			nhttp.Error(w, "invalid token", nhttp.StatusUnauthorized)
-			return
-		}
-
-		// Attach the claims to the context
-		ctx := jwtMiddleware.NewContext(r.Context(), claims)
-		r = r.WithContext(ctx)
-
-		// Run the next handler
-		next.ServeHTTP(w, r)
-	})
+// claimsFunc returns the claims function for the JWT middleware that casts the claims to the correct type
+func claimsFunc() middlewares_http.ClaimsFunc {
+	return func() jwt.Claims {
+		return &casJWT.Claims{}
+	}
 }

--- a/app/artifact-cas/internal/server/http.go
+++ b/app/artifact-cas/internal/server/http.go
@@ -17,7 +17,6 @@ package server
 
 import (
 	"fmt"
-	"github.com/golang-jwt/jwt/v4"
 	"os"
 
 	api "github.com/chainloop-dev/chainloop/app/artifact-cas/api/cas/v1"
@@ -30,6 +29,7 @@ import (
 	"github.com/go-kratos/kratos/v2/middleware/logging"
 	"github.com/go-kratos/kratos/v2/middleware/recovery"
 	"github.com/go-kratos/kratos/v2/transport/http"
+	"github.com/golang-jwt/jwt/v4"
 )
 
 // NewHTTPServer new a HTTP server.

--- a/pkg/middlewares/http/jwt.go
+++ b/pkg/middlewares/http/jwt.go
@@ -1,0 +1,125 @@
+//
+// Copyright 2024 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middlewares_http
+
+import (
+	nhttp "net/http"
+	"strings"
+
+	"github.com/go-kratos/kratos/v2/errors"
+	jwtMiddleware "github.com/go-kratos/kratos/v2/middleware/auth/jwt"
+	"github.com/go-kratos/kratos/v2/transport/http"
+	"github.com/golang-jwt/jwt/v4"
+)
+
+const (
+	// bearerWord the bearer key word for authorization
+	bearerWord string = "Bearer"
+	// authorizationKey holds the key used to store the JWT Token in the request tokenHeader.
+	authorizationKey string = "Authorization"
+)
+
+// ClaimsFunc is a function that returns a jwt.Claims with the custom claims and correct type
+type ClaimsFunc func() jwt.Claims
+
+// AuthFromQueryParam is a middleware that extracts the token from the query parameter and verifies it
+func AuthFromQueryParam(keyFunc jwt.Keyfunc, claimsFunc ClaimsFunc, signingMethod jwt.SigningMethod, next nhttp.Handler) nhttp.Handler {
+	return nhttp.HandlerFunc(func(w http.ResponseWriter, r *nhttp.Request) {
+		token := r.URL.Query().Get("t")
+		if token == "" {
+			nhttp.Error(w, "missing token", nhttp.StatusUnauthorized)
+			return
+		}
+
+		claims, err := verifyAndMarshalJWT(token, keyFunc, claimsFunc, signingMethod)
+		if err != nil {
+			// return unauthorized
+			nhttp.Error(w, "invalid token", nhttp.StatusUnauthorized)
+			return
+		}
+
+		// Attach the claims to the context
+		ctx := jwtMiddleware.NewContext(r.Context(), *claims)
+		r = r.WithContext(ctx)
+
+		// Run the next handler
+		next.ServeHTTP(w, r)
+	})
+}
+
+// AuthFromAuthorizationHeader is a middleware that extracts the token from the authorization header and verifies it
+func AuthFromAuthorizationHeader(keyFunc jwt.Keyfunc, claimsFunc ClaimsFunc, signingMethod jwt.SigningMethod, next nhttp.Handler) nhttp.Handler {
+	return nhttp.HandlerFunc(func(w http.ResponseWriter, r *nhttp.Request) {
+		auths := strings.SplitN(r.Header.Get(authorizationKey), " ", 2)
+		if len(auths) != 2 || !strings.EqualFold(auths[0], bearerWord) {
+			nhttp.Error(w, "JWT token is missing", nhttp.StatusUnauthorized)
+			return
+		}
+
+		jwtToken := auths[1]
+
+		claims, err := verifyAndMarshalJWT(jwtToken, keyFunc, claimsFunc, signingMethod)
+		if err != nil {
+			// return unauthorized
+			nhttp.Error(w, "invalid token", nhttp.StatusUnauthorized)
+			return
+		}
+
+		// Attach the claims to the context
+		ctx := jwtMiddleware.NewContext(r.Context(), *claims)
+		r = r.WithContext(ctx)
+
+		// Run the next handler
+		next.ServeHTTP(w, r)
+	})
+}
+
+// verifyAndMarshalJWT verifies the token and returns the map claims
+func verifyAndMarshalJWT(token string, keyFunc jwt.Keyfunc, claimsFunc ClaimsFunc, signingMethod jwt.SigningMethod) (*jwt.Claims, error) {
+	var tokenInfo *jwt.Token
+
+	tokenInfo, err := jwt.ParseWithClaims(token, claimsFunc(), keyFunc)
+	if err != nil {
+		var ve *jwt.ValidationError
+		if !errors.As(err, &ve) {
+			return nil, errors.Unauthorized("UNAUTHORIZED", err.Error())
+		}
+
+		if ve.Errors&jwt.ValidationErrorMalformed != 0 {
+			return nil, jwtMiddleware.ErrTokenInvalid
+		}
+
+		if ve.Errors&(jwt.ValidationErrorExpired) != 0 {
+			return nil, jwtMiddleware.ErrTokenExpired
+		}
+
+		if ve.Errors&(jwt.ValidationErrorNotValidYet) != 0 {
+			return nil, jwtMiddleware.ErrTokenExpired
+		}
+
+		return nil, err
+	}
+
+	if !tokenInfo.Valid {
+		return nil, jwtMiddleware.ErrTokenInvalid
+	}
+
+	if tokenInfo.Method != signingMethod {
+		return nil, jwtMiddleware.ErrUnSupportSigningMethod
+	}
+
+	return &tokenInfo.Claims, nil
+}

--- a/pkg/middlewares/http/jwt.go
+++ b/pkg/middlewares/http/jwt.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package middlewares_http
+package middlewareshttp
 
 import (
 	nhttp "net/http"

--- a/pkg/middlewares/http/jwt_test.go
+++ b/pkg/middlewares/http/jwt_test.go
@@ -1,0 +1,226 @@
+//
+// Copyright 2024 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middlewares_http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	jwtmiddleware "github.com/go-kratos/kratos/v2/middleware/auth/jwt"
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+// Mock Keyfunc
+func mockKeyFunc(_ *jwt.Token) (interface{}, error) {
+	return []byte("secret"), nil
+}
+
+// Mock signing method
+var mockSigningMethod = jwt.SigningMethodHS256
+
+// Helper function to generate a valid token with custom claims
+func generateValidToken() string {
+	token := jwt.NewWithClaims(mockSigningMethod, jwt.MapClaims{"foo": "bar"})
+	tokenString, _ := token.SignedString([]byte("secret"))
+	return tokenString
+}
+
+func genericClaimsFunc() ClaimsFunc {
+	return func() jwt.Claims {
+		return &jwt.MapClaims{}
+	}
+}
+
+func TestAuthFromQueryParam(t *testing.T) {
+	validToken := generateValidToken()
+
+	tests := []struct {
+		name       string
+		token      string
+		wantStatus int
+		wantClaims map[string]interface{}
+	}{
+		{"Valid Token", validToken, http.StatusOK, map[string]interface{}{"foo": "bar"}},
+		{"Missing Token", "", http.StatusUnauthorized, nil},
+		{"Invalid Token", "invalidtoken", http.StatusUnauthorized, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", "/?t="+tt.token, nil)
+			rr := httptest.NewRecorder()
+			handler := AuthFromQueryParam(mockKeyFunc, genericClaimsFunc(), mockSigningMethod, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				claims, ok := jwtmiddleware.FromContext(r.Context())
+				mapClaims := claims.(*jwt.MapClaims)
+				if tt.wantClaims != nil {
+					assert.True(t, ok, "claims not found in context")
+					for key, value := range tt.wantClaims {
+						claimsVal, exists := (*mapClaims)[key]
+						assert.True(t, exists, "claims missing key: %v", key)
+						assert.Equal(t, value, claimsVal, "claims value mismatch for key: %v", key)
+					}
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			handler.ServeHTTP(rr, req)
+
+			assert.Equal(t, tt.wantStatus, rr.Code, "handler returned wrong status code")
+		})
+	}
+}
+
+func TestAuthFromAuthorizationHeader(t *testing.T) {
+	validToken := generateValidToken()
+
+	tests := []struct {
+		name       string
+		header     string
+		wantStatus int
+		wantClaims map[string]interface{}
+	}{
+		{"Valid Token", "Bearer " + validToken, http.StatusOK, map[string]interface{}{"foo": "bar"}},
+		{"Missing Header", "", http.StatusUnauthorized, nil},
+		{"Invalid Header Format", "Bearer", http.StatusUnauthorized, nil},
+		{"Invalid Token", "Bearer invalidtoken", http.StatusUnauthorized, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", "/", nil)
+			if tt.header != "" {
+				req.Header.Set(authorizationKey, tt.header)
+			}
+			rr := httptest.NewRecorder()
+			handler := AuthFromAuthorizationHeader(mockKeyFunc, genericClaimsFunc(), mockSigningMethod, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				claims, ok := jwtmiddleware.FromContext(r.Context())
+				mapClaims := claims.(*jwt.MapClaims)
+				if tt.wantClaims != nil {
+					assert.True(t, ok, "claims not found in context")
+					for key, value := range tt.wantClaims {
+						claimsVal, exists := (*mapClaims)[key]
+						assert.True(t, exists, "claims missing key: %v", key)
+						assert.Equal(t, value, claimsVal, "claims value mismatch for key: %v", key)
+					}
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			handler.ServeHTTP(rr, req)
+
+			assert.Equal(t, tt.wantStatus, rr.Code, "handler returned wrong status code")
+		})
+	}
+}
+
+// CustomClaimsA represents the first custom JWT claims type
+type CustomClaimsA struct {
+	jwt.RegisteredClaims
+	Foo string `json:"foo"`
+}
+
+// CustomClaimsB represents the second custom JWT claims type
+type CustomClaimsB struct {
+	jwt.RegisteredClaims
+	Bar int `json:"bar"`
+}
+
+// Helper function to generate a valid token with CustomClaimsA
+func generateValidTokenA() string {
+	claims := CustomClaimsA{
+		Foo: "bar",
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer: "test",
+		},
+	}
+	token := jwt.NewWithClaims(mockSigningMethod, claims)
+	tokenString, _ := token.SignedString([]byte("secret"))
+	return tokenString
+}
+
+// Helper function to generate a valid token with CustomClaimsB
+func generateValidTokenB() string {
+	claims := CustomClaimsB{
+		Bar: 42,
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer: "test",
+		},
+	}
+	token := jwt.NewWithClaims(mockSigningMethod, claims)
+	tokenString, _ := token.SignedString([]byte("secret"))
+	return tokenString
+}
+
+func TestAuthWithCustomClaimsConversions(t *testing.T) {
+	validTokenA := generateValidTokenA()
+	validTokenB := generateValidTokenB()
+
+	tests := []struct {
+		name       string
+		header     string
+		first      bool
+		second     bool
+		claimsFunc ClaimsFunc
+		wantStatus int
+		wantClaims interface{}
+	}{
+		{"Valid Token A", "Bearer " + validTokenA, true, false, func() jwt.Claims { return &CustomClaimsA{} }, http.StatusOK, &CustomClaimsA{Foo: "bar"}},
+		{"Valid Token B", "Bearer " + validTokenB, false, true, func() jwt.Claims { return &CustomClaimsB{} }, http.StatusOK, &CustomClaimsB{Bar: 42}},
+		{"Missing Header", "", false, false, genericClaimsFunc(), http.StatusUnauthorized, nil},
+		{"Invalid Header Format", "Bearer", false, false, genericClaimsFunc(), http.StatusUnauthorized, nil},
+		{"Invalid Token", "Bearer invalidtoken", false, false, genericClaimsFunc(), http.StatusUnauthorized, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", "/", nil)
+			if tt.header != "" {
+				req.Header.Set(authorizationKey, tt.header)
+			}
+			rr := httptest.NewRecorder()
+			handler := AuthFromAuthorizationHeader(mockKeyFunc, tt.claimsFunc, mockSigningMethod, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				claims, _ := jwtmiddleware.FromContext(r.Context())
+				if tt.wantClaims != nil {
+					assert.NotNil(t, claims, "claims not found in context")
+					if tt.first {
+						actual, ok := claims.(*CustomClaimsA)
+						assert.True(t, ok, "claims type mismatch: expected CustomClaimsA")
+						assert.Equal(t, tt.wantClaims.(*CustomClaimsA).Foo, actual.Foo, "claims value mismatch for key: Foo")
+					} else if tt.second {
+						actual, ok := claims.(*CustomClaimsB)
+						assert.True(t, ok, "claims type mismatch: expected CustomClaimsB")
+						assert.Equal(t, tt.wantClaims.(*CustomClaimsB).Bar, actual.Bar, "claims value mismatch for key: Bar")
+					}
+
+					switch expected := tt.wantClaims.(type) {
+					case *CustomClaimsA:
+						actual, ok := claims.(*CustomClaimsA)
+						assert.True(t, ok, "claims type mismatch: expected CustomClaimsA")
+						assert.Equal(t, expected.Foo, actual.Foo, "claims value mismatch for key: Foo")
+					case *CustomClaimsB:
+						actual, ok := claims.(*CustomClaimsB)
+						assert.True(t, ok, "claims type mismatch: expected CustomClaimsB")
+						assert.Equal(t, expected.Bar, actual.Bar, "claims value mismatch for key: Bar")
+					}
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			handler.ServeHTTP(rr, req)
+
+			assert.Equal(t, tt.wantStatus, rr.Code, "handler returned wrong status code")
+		})
+	}
+}

--- a/pkg/middlewares/http/jwt_test.go
+++ b/pkg/middlewares/http/jwt_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package middlewares_http
+package middlewareshttp
 
 import (
 	"net/http"


### PR DESCRIPTION
This patch adds two jwt middleware to validate JWT tokens in http servers, one for tokens that are part of a query param and other from authorization headers.

Refs #1098