### PR TITLE
chore(policies): log policy violations

### DIFF
--- a/internal/attestation/crafter/crafter.go
+++ b/internal/attestation/crafter/crafter.go
@@ -577,6 +577,8 @@ func (c *Crafter) addMaterial(ctx context.Context, m *schemaapi.CraftingSchema_M
 	if err != nil {
 		return fmt.Errorf("error applying policies to material: %w", err)
 	}
+	// log policy violations
+	policies.LogPolicyViolations(policyResults, c.logger)
 	// store policy results
 	c.CraftingState.Attestation.PolicyEvaluations = append(c.CraftingState.Attestation.PolicyEvaluations, policyResults...)
 

--- a/internal/attestation/renderer/renderer.go
+++ b/internal/attestation/renderer/renderer.go
@@ -113,6 +113,8 @@ func (ab *AttestationRenderer) Render(ctx context.Context) (*dsse.Envelope, erro
 	if err != nil {
 		return nil, fmt.Errorf("applying policies to statement: %w", err)
 	}
+	// log policy violations
+	policies.LogPolicyViolations(policyResults, &ab.logger)
 
 	// insert attestation level policy results into statement
 	if err = addPolicyResults(statement, policyResults); err != nil {

--- a/pkg/policies/policies.go
+++ b/pkg/policies/policies.go
@@ -316,3 +316,14 @@ func LoadPolicyScriptFromSpec(spec *v1.Policy) (*engine.Policy, error) {
 		Source: content,
 	}, nil
 }
+
+func LogPolicyViolations(evaluations []*v12.PolicyEvaluation, logger *zerolog.Logger) {
+	for _, policyEval := range evaluations {
+		if len(policyEval.Violations) > 0 {
+			logger.Warn().Msgf("found policy violations (%s) for %s", policyEval.Name, policyEval.MaterialName)
+			for _, v := range policyEval.Violations {
+				logger.Warn().Msgf(" - %s", v.Message)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Logging violations in the CLI was implemented in a prior version of policies, but got lost somehow.

![image](https://github.com/user-attachments/assets/138c9951-1fb0-43ea-bbb0-dd765c6669b0)

Refs #122