### PR TITLE
chore: do not require remote-state flag

### DIFF
--- a/app/cli/cmd/attestation.go
+++ b/app/cli/cmd/attestation.go
@@ -64,6 +64,10 @@ func newAttestationCmd() *cobra.Command {
 		attAPIToken = os.Getenv(tokenEnvVarName)
 	}
 
+	cmd.PersistentFlags().Bool("remote-state", false, "Store the attestation state remotely (preview feature)")
+	// We do not need this flag in all the attestation subcommands just in init, but we don't want to remove it to not to break current integrations
+	cobra.CheckErr(cmd.PersistentFlags().MarkHidden("remote-state"))
+
 	cmd.PersistentFlags().BoolVar(&GracefulExit, "graceful-exit", false, "exit 0 in case of error. NOTE: this flag will be removed once Chainloop reaches 1.0")
 
 	cmd.AddCommand(newAttestationInitCmd(), newAttestationAddCmd(), newAttestationStatusCmd(), newAttestationPushCmd(), newAttestationResetCmd())

--- a/app/cli/cmd/attestation.go
+++ b/app/cli/cmd/attestation.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 The Chainloop Authors.
+// Copyright 2024 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -65,7 +65,6 @@ func newAttestationCmd() *cobra.Command {
 	}
 
 	cmd.PersistentFlags().BoolVar(&GracefulExit, "graceful-exit", false, "exit 0 in case of error. NOTE: this flag will be removed once Chainloop reaches 1.0")
-	cmd.PersistentFlags().BoolVar(&useAttestationRemoteState, "remote-state", false, "Store the attestation state remotely (preview feature)")
 
 	cmd.AddCommand(newAttestationInitCmd(), newAttestationAddCmd(), newAttestationStatusCmd(), newAttestationPushCmd(), newAttestationResetCmd())
 

--- a/app/cli/cmd/attestation_init.go
+++ b/app/cli/cmd/attestation_init.go
@@ -72,7 +72,7 @@ func newAttestationInitCmd() *cobra.Command {
 			logger.Info().Msg("Attestation initialized! now you can check its status or add materials to it")
 
 			// Show the status information
-			statusAction, err := action.NewAttestationStatus(&action.AttestationStatusOpts{ActionsOpts: actionOpts})
+			statusAction, err := action.NewAttestationStatus(&action.AttestationStatusOpts{ActionsOpts: actionOpts, UseAttestationRemoteState: useAttestationRemoteState})
 			if err != nil {
 				return newGracefulError(err)
 			}

--- a/app/cli/cmd/attestation_init.go
+++ b/app/cli/cmd/attestation_init.go
@@ -47,9 +47,10 @@ func newAttestationInitCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			a, err := action.NewAttestationInit(
 				&action.AttestationInitOpts{
-					ActionsOpts: actionOpts,
-					DryRun:      attestationDryRun,
-					Force:       force,
+					ActionsOpts:    actionOpts,
+					DryRun:         attestationDryRun,
+					Force:          force,
+					UseRemoteState: useAttestationRemoteState,
 				},
 			)
 			if err != nil {
@@ -93,6 +94,7 @@ func newAttestationInitCmd() *cobra.Command {
 	cmd.Flags().BoolVarP(&force, "replace", "f", false, "replace any existing in-progress attestation")
 	cmd.Flags().BoolVar(&attestationDryRun, "dry-run", false, "do not record attestation in the control plane, useful for development")
 	cmd.Flags().IntVar(&contractRevision, "contract-revision", 0, "revision of the contract to retrieve, \"latest\" by default")
+	cmd.Flags().BoolVar(&useAttestationRemoteState, "remote-state", false, "Store the attestation state remotely (preview feature)")
 
 	// workflow-name has been replaced by --name flag
 	cmd.Flags().StringVar(&workflowName, "workflow-name", "", "name of the workflow to run the attestation")

--- a/app/cli/cmd/attestation_init.go
+++ b/app/cli/cmd/attestation_init.go
@@ -94,7 +94,7 @@ func newAttestationInitCmd() *cobra.Command {
 	cmd.Flags().BoolVarP(&force, "replace", "f", false, "replace any existing in-progress attestation")
 	cmd.Flags().BoolVar(&attestationDryRun, "dry-run", false, "do not record attestation in the control plane, useful for development")
 	cmd.Flags().IntVar(&contractRevision, "contract-revision", 0, "revision of the contract to retrieve, \"latest\" by default")
-	cmd.Flags().BoolVar(&useAttestationRemoteState, "remote-state", false, "Store the attestation state remotely (preview feature)")
+	cmd.Flags().BoolVar(&useAttestationRemoteState, "remote-state", false, "Store the attestation state remotely")
 
 	// workflow-name has been replaced by --name flag
 	cmd.Flags().StringVar(&workflowName, "workflow-name", "", "name of the workflow to run the attestation")

--- a/app/cli/cmd/attestation_push.go
+++ b/app/cli/cmd/attestation_push.go
@@ -19,10 +19,11 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/chainloop-dev/chainloop/app/cli/internal/action"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/chainloop-dev/chainloop/app/cli/internal/action"
 )
 
 func newAttestationPushCmd() *cobra.Command {

--- a/app/cli/cmd/attestation_status.go
+++ b/app/cli/cmd/attestation_status.go
@@ -38,7 +38,8 @@ func newAttestationStatusCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			a, err := action.NewAttestationStatus(
 				&action.AttestationStatusOpts{
-					ActionsOpts: actionOpts,
+					UseAttestationRemoteState: attestationID != "",
+					ActionsOpts:               actionOpts,
 				},
 			)
 			if err != nil {

--- a/app/cli/cmd/root.go
+++ b/app/cli/cmd/root.go
@@ -239,7 +239,7 @@ func initConfigFile() {
 }
 
 func newActionOpts(logger zerolog.Logger, conn *grpc.ClientConn) *action.ActionsOpts {
-	return &action.ActionsOpts{CPConnection: conn, Logger: logger, UseAttestationRemoteState: useAttestationRemoteState}
+	return &action.ActionsOpts{CPConnection: conn, Logger: logger}
 }
 
 func cleanup(conn *grpc.ClientConn) error {

--- a/app/cli/internal/action/action.go
+++ b/app/cli/internal/action/action.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 The Chainloop Authors.
+// Copyright 2024 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,9 +30,8 @@ import (
 )
 
 type ActionsOpts struct {
-	CPConnection              *grpc.ClientConn
-	Logger                    zerolog.Logger
-	UseAttestationRemoteState bool
+	CPConnection *grpc.ClientConn
+	Logger       zerolog.Logger
 }
 
 func toTimePtr(t time.Time) *time.Time {

--- a/app/cli/internal/action/attestation_push.go
+++ b/app/cli/internal/action/attestation_push.go
@@ -64,8 +64,9 @@ func NewAttestationPush(cfg *AttestationPushOpts) (*AttestationPush, error) {
 }
 
 func (action *AttestationPush) Run(ctx context.Context, attestationID string, runtimeAnnotations map[string]string) (*AttestationResult, error) {
+	useRemoteState := attestationID != ""
 	// initialize the crafter. If attestation-id is provided we assume the attestation is performed using remote state
-	crafter, err := newCrafter(attestationID != "", action.CPConnection, action.newCrafterOpts.opts...)
+	crafter, err := newCrafter(useRemoteState, action.CPConnection, action.newCrafterOpts.opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load crafter: %w", err)
 	}
@@ -77,7 +78,7 @@ func (action *AttestationPush) Run(ctx context.Context, attestationID string, ru
 	}
 
 	// Retrieve attestation status
-	statusAction, err := NewAttestationStatus(&AttestationStatusOpts{ActionsOpts: action.ActionsOpts})
+	statusAction, err := NewAttestationStatus(&AttestationStatusOpts{ActionsOpts: action.ActionsOpts, UseAttestationRemoteState: useRemoteState})
 	if err != nil {
 		return nil, fmt.Errorf("creating status action: %w", err)
 	}

--- a/app/cli/internal/action/attestation_reset.go
+++ b/app/cli/internal/action/attestation_reset.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2025 The Chainloop Authors.
+// Copyright 2024 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/app/cli/internal/action/attestation_status.go
+++ b/app/cli/internal/action/attestation_status.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	pbc "github.com/chainloop-dev/chainloop/app/controlplane/api/workflowcontract/v1"
-	"github.com/chainloop-dev/chainloop/internal/attestation/crafter"
 	v1 "github.com/chainloop-dev/chainloop/internal/attestation/crafter/api/attestation/v1"
 )
 
@@ -31,7 +30,7 @@ type AttestationStatusOpts struct {
 
 type AttestationStatus struct {
 	*ActionsOpts
-	c *crafter.Crafter
+	*newCrafterOpts
 }
 
 type AttestationStatusResult struct {
@@ -60,16 +59,18 @@ type AttestationStatusResultMaterial struct {
 }
 
 func NewAttestationStatus(cfg *AttestationStatusOpts) (*AttestationStatus, error) {
-	c, err := newCrafter(cfg.UseAttestationRemoteState, cfg.CPConnection, crafter.WithLogger(&cfg.Logger))
-	if err != nil {
-		return nil, fmt.Errorf("failed to load crafter: %w", err)
-	}
-
-	return &AttestationStatus{ActionsOpts: cfg.ActionsOpts, c: c}, nil
+	return &AttestationStatus{
+		ActionsOpts:    cfg.ActionsOpts,
+		newCrafterOpts: &newCrafterOpts{cpConnection: cfg.CPConnection},
+	}, nil
 }
 
 func (action *AttestationStatus) Run(ctx context.Context, attestationID string) (*AttestationStatusResult, error) {
-	c := action.c
+	// initialize the crafter. If attestation-id is provided we assume the attestation is performed using remote state
+	c, err := newCrafter(attestationID != "", action.CPConnection, action.newCrafterOpts.opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load crafter: %w", err)
+	}
 
 	if initialized, err := c.AlreadyInitialized(ctx, attestationID); err != nil {
 		return nil, fmt.Errorf("checking if attestation is already initialized: %w", err)


### PR DESCRIPTION
Removes the requirement of passing --remote-state to each subsequent command after init.

Now, by having initialized the attestation with `--remote-state` you can just use `attestation-id` in `add, reset, status or push`

Closes #972