### PR TITLE
feat(chart): Change template to allow prometheus integration config

### DIFF
--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -7,7 +7,7 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.79.0
+version: 1.79.1
 # Do not update appVersion, this is handled automatically by the release process
 appVersion: v0.94.0
 

--- a/deployment/chainloop/README.md
+++ b/deployment/chainloop/README.md
@@ -532,7 +532,7 @@ chainloop config save \
 | `controlplane.referrerSharedIndex.allowedOrgs` | List of UUIDs of organizations that are allowed to publish to the shared index                  | `[]`                                               |
 | `controlplane.onboarding.name`                 | Name of the organization to onboard                                                             |                                                    |
 | `controlplane.onboarding.role`                 | Role of the organization to onboard                                                             |                                                    |
-| `controlplane.prometheus_integration.org_name` | Name of the organization to integrate with Prometheus                                           |                                                    |
+| `controlplane.prometheus_org_metrics`          | List of organizations to expose metrics for using Prometheus                                    |                                                    |
 | `controlplane.migration.image.registry`        | Image registry                                                                                  | `ghcr.io`                                          |
 | `controlplane.migration.image.repository`      | Image repository                                                                                | `chainloop-dev/chainloop/control-plane-migrations` |
 | `controlplane.migration.ssl`                   | Connect to the database using SSL (required fro AWS RDS, etc)                                   | `false`                                            |

--- a/deployment/chainloop/README.md
+++ b/deployment/chainloop/README.md
@@ -532,6 +532,7 @@ chainloop config save \
 | `controlplane.referrerSharedIndex.allowedOrgs` | List of UUIDs of organizations that are allowed to publish to the shared index                  | `[]`                                               |
 | `controlplane.onboarding.name`                 | Name of the organization to onboard                                                             |                                                    |
 | `controlplane.onboarding.role`                 | Role of the organization to onboard                                                             |                                                    |
+| `controlplane.prometheus_integration.org_name` | Name of the organization to integrate with Prometheus                                           |                                                    |
 | `controlplane.migration.image.registry`        | Image registry                                                                                  | `ghcr.io`                                          |
 | `controlplane.migration.image.repository`      | Image repository                                                                                | `chainloop-dev/chainloop/control-plane-migrations` |
 | `controlplane.migration.ssl`                   | Connect to the database using SSL (required fro AWS RDS, etc)                                   | `false`                                            |

--- a/deployment/chainloop/templates/controlplane/config.configmap.yaml
+++ b/deployment/chainloop/templates/controlplane/config.configmap.yaml
@@ -44,7 +44,7 @@ data:
     onboarding:
       {{- toYaml .Values.controlplane.onboarding | nindent 6 }}
     {{- end }}
-    {{ if .Values.controlplane.prometheus_integration }}
+    {{ if .Values.controlplane.prometheus_org_metrics }}
     prometheus_integration:
-      {{- toYaml .Values.controlplane.prometheus_integration | nindent 6 }}
+      {{- toYaml .Values.controlplane.prometheus_org_metrics | nindent 6 }}
     {{- end }}

--- a/deployment/chainloop/templates/controlplane/config.configmap.yaml
+++ b/deployment/chainloop/templates/controlplane/config.configmap.yaml
@@ -44,3 +44,7 @@ data:
     onboarding:
       {{- toYaml .Values.controlplane.onboarding | nindent 6 }}
     {{- end }}
+    {{ if .Values.controlplane.prometheus_integration }}
+    prometheus_integration:
+      {{- toYaml .Values.controlplane.prometheus_integration | nindent 6 }}
+    {{- end }}

--- a/deployment/chainloop/values.yaml
+++ b/deployment/chainloop/values.yaml
@@ -144,8 +144,8 @@ controlplane:
   #    - name: "read-only-demo"
   #      role: "MEMBERSHIP_ROLE_ORG_VIEWER"
 
-  ## @extra controlplane.prometheus_integration.org_name Name of the organization to integrate with Prometheus
-  #  prometheus_integration:
+  ## @extra controlplane.prometheus_org_metrics List of organizations to expose metrics for using Prometheus
+  #  prometheus_org_metrics:
   #    - org_name: "read-only-demo"
 
   # Database migration

--- a/deployment/chainloop/values.yaml
+++ b/deployment/chainloop/values.yaml
@@ -144,6 +144,10 @@ controlplane:
   #    - name: "read-only-demo"
   #      role: "MEMBERSHIP_ROLE_ORG_VIEWER"
 
+  ## @extra controlplane.prometheus_integration.org_name Name of the organization to integrate with Prometheus
+  #  prometheus_integration:
+  #    - org_name: "read-only-demo"
+
   # Database migration
   ## @param controlplane.migration.image.registry Image registry
   ## @param controlplane.migration.image.repository Image repository


### PR DESCRIPTION
This patch allows to include a set of organizations as part of the configuration to activate the Prometheus integration:

Refs https://github.com/chainloop-dev/chainloop/issues/1098