### PR TITLE
fix(policies): fail adding material if policy cannot be parsed

### DIFF
--- a/internal/attestation/crafter/crafter.go
+++ b/internal/attestation/crafter/crafter.go
@@ -521,7 +521,8 @@ func (c *Crafter) AddMaterialContactFreeAutomatic(ctx context.Context, attestati
 		c.logger.Debug().Err(err).Str("kind", kind.String()).Msg("failed to add material")
 
 		// Handle base error for upload and craft errors except the opening file error
-		if errors.Is(err, materials.ErrBaseUploadAndCraft) {
+		var policyError *policies.PolicyError
+		if errors.Is(err, materials.ErrBaseUploadAndCraft) || errors.As(err, &policyError) {
 			return kind, err
 		}
 	}


### PR DESCRIPTION
By implementing a specific error type, we can stop the guess-type loop for contractless materials:

```
WRN API contacted in insecure mode
DBG loading state state=file:///var/folders/ls/cv3k03v57ns18mmwjjbgy8z00000gn/T/chainloop-attestation.tmp.json
DBG loaded state state=file:///var/folders/ls/cv3k03v57ns18mmwjjbgy8z00000gn/T/chainloop-attestation.tmp.json
DBG decoding OpenVex file path=sbom-spdx.json
DBG failed to add material error="crafting material: invalid OpenVEX file: unexpected material type" kind=OPENVEX
DBG error decoding file: [I#] [S#] doesn't validate with http://cyclonedx.org/schema/bom-1.6.schema.json#
  [I#] [S#/required] missing properties: 'bomFormat', 'specVersion'
  [I#] [S#/additionalProperties] additionalProperties 'relationships', 'spdxVersion', 'dataLicense', 'SPDXID', 'name', 'documentNamespace', 'creationInfo', 'packages' not allowed error="jsonschema: '' does not validate with http://cyclonedx.org/schema/bom-1.6.schema.json#/required: missing properties: 'bomFormat', 'specVersion'"
DBG failed to add material error="crafting material: invalid cyclonedx sbom file: unexpected material type" kind=SBOM_CYCLONEDX_JSON
DBG crafting file backend=AWS-S3 digest=sha256:ca7ac6acb955f8d094c89519101aced9fc716e51f0d9c80f5c8d343227347045 filename=sbom-spdx.json max_size=100M path=sbom-spdx.json size=69.1K
DBG uploading backend=AWS-S3
INF uploading sbom-spdx.json - sha256:ca7ac6acb955f8d094c89519101aced9fc716e51f0d9c80f5c8d343227347045
DBG uploading chunks=1M
DBG nobody listening to progress updates, dropping message
DBG uploaded current=69.1K
DBG finishing upload
INF evaluating policy 'another-sbom-policy' against material 'material-1721317186519639000'
DBG failed to add material error="error applying policies to material: policy error: failed to parse rego policy: 1 error occurred: another-sbom-policy:3: rego_parse_error: unexpected import path, must begin with one of: {data, future, input, rego}, got: futurse\n\timport futurse.keywords.in\n\t       ^" kind=SBOM_SPDX_JSON
ERR adding material: error applying policies to material: policy error: failed to parse rego policy: 1 error occurred: another-sbom-policy:3: rego_parse_error: unexpected import path, must begin with one of: {data, future, input, rego}, got: futurse
        import futurse.keywords.in
               ^
Exiting.


```

Fixes #1110 