### PR TITLE
chore(policies): add policies to table output

### DIFF
--- a/app/cli/cmd/workflow_workflow_run_describe.go
+++ b/app/cli/cmd/workflow_workflow_run_describe.go
@@ -21,9 +21,12 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/chainloop-dev/chainloop/app/cli/internal/action"
+	v1 "github.com/chainloop-dev/chainloop/internal/attestation/crafter/api/attestation/v1"
+	"github.com/chainloop-dev/chainloop/internal/attestation/renderer"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/muesli/reflow/wrap"
@@ -193,6 +196,12 @@ func predicateV1Table(att *action.WorkflowRunAttestationItem) {
 					mt.AppendRow(table.Row{"", fmt.Sprintf("%s: %s", a.Name, a.Value)})
 				}
 			}
+			evs := att.PolicyEvaluations[m.Name].GetEvaluations()
+			if evs != nil && len(evs) > 0 {
+				mt.AppendSeparator()
+				mt.AppendRow(table.Row{"Policies"})
+				policiesTable(evs, mt)
+			}
 			mt.AppendSeparator()
 		}
 
@@ -210,6 +219,28 @@ func predicateV1Table(att *action.WorkflowRunAttestationItem) {
 			mt.AppendRow(table.Row{e.Name, e.Value})
 		}
 		mt.Render()
+	}
+
+	evs := att.PolicyEvaluations[renderer.AttPolicyEvaluation].GetEvaluations()
+	if evs != nil && len(evs) > 0 {
+		mt := newTableWriter()
+		mt.SetTitle("Attestation policies")
+		policiesTable(evs, mt)
+		mt.Render()
+	}
+}
+
+func policiesTable(evs []*v1.PolicyEvaluation, mt table.Writer) {
+	for _, ev := range evs {
+		mt.AppendSeparator()
+		mt.AppendRow(table.Row{"Policy", ev.Name})
+		if len(ev.Violations) > 0 {
+			var violations []string
+			for _, v := range ev.Violations {
+				violations = append(violations, v.Message)
+			}
+			mt.AppendRow(table.Row{"Violations", fmt.Sprint(strings.Join(violations, "\n"))})
+		}
 	}
 }
 

--- a/app/cli/cmd/workflow_workflow_run_describe.go
+++ b/app/cli/cmd/workflow_workflow_run_describe.go
@@ -234,13 +234,15 @@ func policiesTable(evs []*v1.PolicyEvaluation, mt table.Writer) {
 	for _, ev := range evs {
 		mt.AppendSeparator()
 		mt.AppendRow(table.Row{"Policy", ev.Name})
+		var violations []string
 		if len(ev.Violations) > 0 {
-			var violations []string
 			for _, v := range ev.Violations {
 				violations = append(violations, v.Message)
 			}
-			mt.AppendRow(table.Row{"Violations", fmt.Sprint(strings.Join(violations, "\n"))})
+		} else {
+			violations = append(violations, "None")
 		}
+		mt.AppendRow(table.Row{"Violations", fmt.Sprint(strings.Join(violations, "\n"))})
 	}
 }
 

--- a/app/cli/cmd/workflow_workflow_run_describe.go
+++ b/app/cli/cmd/workflow_workflow_run_describe.go
@@ -197,7 +197,7 @@ func predicateV1Table(att *action.WorkflowRunAttestationItem) {
 				}
 			}
 			evs := att.PolicyEvaluations[m.Name].GetEvaluations()
-			if evs != nil && len(evs) > 0 {
+			if len(evs) > 0 {
 				mt.AppendSeparator()
 				mt.AppendRow(table.Row{"Policies"})
 				policiesTable(evs, mt)
@@ -222,7 +222,7 @@ func predicateV1Table(att *action.WorkflowRunAttestationItem) {
 	}
 
 	evs := att.PolicyEvaluations[renderer.AttPolicyEvaluation].GetEvaluations()
-	if evs != nil && len(evs) > 0 {
+	if len(evs) > 0 {
 		mt := newTableWriter()
 		mt.SetTitle("Attestation policies")
 		policiesTable(evs, mt)


### PR DESCRIPTION
This PR adds policies to `att describe` command:
```
┌──────────────────────────────────────────────────────────────────────────────────────────┐
│ Workflow                                                                                 │
├────────────────┬─────────────────────────────────────────────────────────────────────────┤
│ ID             │ e56ea38d-67f4-408a-8bb2-6ac54ba22da3                                    │
│ Name           │ policytest                                                              │
│ Team           │                                                                         │
│ Project        │ myproject                                                               │
├────────────────┼─────────────────────────────────────────────────────────────────────────┤
│ Workflow Run   │                                                                         │
├────────────────┼─────────────────────────────────────────────────────────────────────────┤
│ ID             │ 6f67eddc-0fc2-4fd4-8278-ce0600eaf275                                    │
│ Initialized At │ 24 Jul 24 16:30 UTC                                                     │
│ Finished At    │ 24 Jul 24 16:30 UTC                                                     │
│ State          │ success                                                                 │
│ Runner Link    │                                                                         │
├────────────────┼─────────────────────────────────────────────────────────────────────────┤
│ Statement      │                                                                         │
├────────────────┼─────────────────────────────────────────────────────────────────────────┤
│ Payload Type   │ application/vnd.in-toto+json                                            │
│ Digest         │ sha256:e27458af04acbcef69a345da86c9a7b1e7fcfc96c7f10eeb11913004e2f04ffc │
│ Verified       │ false                                                                   │
└────────────────┴─────────────────────────────────────────────────────────────────────────┘
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Materials                                                                                                                │
├────────────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Name       │ material-1721838619981462000                                                                                │
│ Type       │ SBOM_CYCLONEDX_JSON                                                                                         │
│ Filename   │ cyclonedx.json                                                                                              │
│ Value      │                                                                                                             │
│ Digest     │ sha256:eb08aa548e619dc9aae3b7e3471b5cf71ca0af761a2b7c111ecf9d3e7109cbc7                                     │
├────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Policies   │                                                                                                             │
├────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Policy     │ cyclonedx-licenses                                                                                          │
│ Violations │ Missing licenses for app/node_modules/@esbuild/linux-x64/bin/esbuild (91eeeffa-0fc8-4ed5-a72a-39866266ac09) │
│            │ Missing licenses for busboy (pkg:npm/busboy@1.6.0)                                                          │
│            │ Missing licenses for frontend (pkg:npm/frontend@0.1.0)                                                      │
│            │ Missing licenses for github.com/evanw/esbuild (pkg:golang/github.com/evanw/esbuild)                         │
│            │ Missing licenses for golang.org/x/sys (pkg:golang/golang.org/x/sys@v0.0.0-20220715151400-c0bba94af5f8)      │
│            │ Missing licenses for stdlib (pkg:golang/stdlib@1.22.4)                                                      │
│            │ Missing licenses for streamsearch (pkg:npm/streamsearch@1.1.0)                                              │
│            │ Missing licenses for wolfi (3f9ef123-4c6e-4be9-a56a-72e4ddc4fa22)                                           │
└────────────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
┌───────────────────────────┐
│ Attestation policies      │
├────────────┬──────────────┤
│ Policy     │ sbom-present │
│ Violations │ None         │
└────────────┴──────────────┘
```
Closes #1122 