### PR TITLE
refactor: prometheus packages

### DIFF
--- a/app/controlplane/configs/config.devel.yaml
+++ b/app/controlplane/configs/config.devel.yaml
@@ -76,3 +76,6 @@ auth:
 #   allowed_orgs:
 #     - deadbeef
 
+# Organizations with Prometheus integration enabled
+prometheus_integration:
+  - org_name: "development"

--- a/app/controlplane/configs/samples/config.yaml
+++ b/app/controlplane/configs/samples/config.yaml
@@ -85,3 +85,7 @@ onboarding:
 #    certificate_profile_name: "PlainSigner"
 #    end_entity_profile_name: "PlainSigner"
 #    certificate_authority_name: "ManagementCA"
+
+# Organizations with Prometheus integration enabled
+prometheus_integration:
+  - org_name: "my-org"

--- a/app/controlplane/pkg/biz/orgmetrics.go
+++ b/app/controlplane/pkg/biz/orgmetrics.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	prometheuscollector "github.com/chainloop-dev/chainloop/app/controlplane/pkg/metrics/prometheus"
+	prometheuscollector "github.com/chainloop-dev/chainloop/app/controlplane/pkg/metrics/prometheus/collector"
 
 	"github.com/go-kratos/kratos/v2/log"
 	"github.com/google/uuid"

--- a/app/controlplane/pkg/biz/prometheus.go
+++ b/app/controlplane/pkg/biz/prometheus.go
@@ -17,6 +17,7 @@ package biz
 
 import (
 	conf "github.com/chainloop-dev/chainloop/app/controlplane/internal/conf/controlplane/config/v1"
+	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/metrics/prometheus"
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/metrics/prometheus/registry"
 
 	"github.com/go-kratos/kratos/v2/log"
@@ -29,7 +30,7 @@ type PrometheusUseCase struct {
 	orgUseCase        *OrganizationUseCase
 	orgMetricsUseCase *OrgMetricsUseCase
 	// Other
-	registryManager *registry.ChainloopRegistryManager
+	registryManager *prometheus.ChainloopRegistryManager
 }
 
 // NewPrometheusUseCase creates a new PrometheusUseCase
@@ -47,8 +48,8 @@ func NewPrometheusUseCase(conf []*conf.PrometheusIntegrationSpec, orgUseCase *Or
 }
 
 // loadPrometheusRegistries loads the prometheus registries from the configuration
-func loadPrometheusRegistries(conf []*conf.PrometheusIntegrationSpec, useCase *OrgMetricsUseCase, logger log.Logger) *registry.ChainloopRegistryManager {
-	rm := registry.NewChainloopRegistryManager()
+func loadPrometheusRegistries(conf []*conf.PrometheusIntegrationSpec, useCase *OrgMetricsUseCase, logger log.Logger) *prometheus.ChainloopRegistryManager {
+	rm := prometheus.NewChainloopRegistryManager()
 
 	for _, spec := range conf {
 		reg := registry.NewPrometheusRegistry(spec.GetOrgName(), useCase, logger)

--- a/app/controlplane/pkg/metrics/prometheus/collector/collector.go
+++ b/app/controlplane/pkg/metrics/prometheus/collector/collector.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package prometheus
+package collector
 
 import (
 	"context"

--- a/app/controlplane/pkg/metrics/prometheus/manager.go
+++ b/app/controlplane/pkg/metrics/prometheus/manager.go
@@ -1,0 +1,45 @@
+//
+// Copyright 2024 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheus
+
+import (
+	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/metrics/prometheus/registry"
+)
+
+type ChainloopRegistryManager struct {
+	Registries map[string]*registry.PrometheusRegistry
+}
+
+func NewChainloopRegistryManager() *ChainloopRegistryManager {
+	return &ChainloopRegistryManager{
+		Registries: make(map[string]*registry.PrometheusRegistry),
+	}
+}
+
+// AddRegistry adds a registry to the manager
+func (rm *ChainloopRegistryManager) AddRegistry(reg *registry.PrometheusRegistry) {
+	rm.Registries[reg.Name] = reg
+}
+
+// GetRegistryByName returns a registry by name
+func (rm *ChainloopRegistryManager) GetRegistryByName(name string) *registry.PrometheusRegistry {
+	return rm.Registries[name]
+}
+
+// DeleteRegistryByName deletes a registry by name
+func (rm *ChainloopRegistryManager) DeleteRegistryByName(name string) {
+	delete(rm.Registries, name)
+}

--- a/app/controlplane/pkg/metrics/prometheus/registry/registry.go
+++ b/app/controlplane/pkg/metrics/prometheus/registry/registry.go
@@ -18,7 +18,7 @@ package registry
 import (
 	"github.com/go-kratos/kratos/v2/log"
 
-	chainloopprometheus "github.com/chainloop-dev/chainloop/app/controlplane/pkg/metrics/prometheus"
+	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/metrics/prometheus/collector"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -27,14 +27,14 @@ import (
 type PrometheusRegistry struct {
 	*prometheus.Registry
 	Name               string
-	chainloopCollector *chainloopprometheus.ChainloopCollector
+	chainloopCollector *collector.ChainloopCollector
 }
 
 // NewPrometheusRegistry creates a new Prometheus registry with a given ID and collector
-func NewPrometheusRegistry(name string, gatherer chainloopprometheus.ChainloopMetricsGatherer, logger log.Logger) *PrometheusRegistry {
+func NewPrometheusRegistry(name string, gatherer collector.ChainloopMetricsGatherer, logger log.Logger) *PrometheusRegistry {
 	reg := prometheus.NewRegistry()
 
-	bcc := chainloopprometheus.NewChainloopCollector(name, gatherer, logger)
+	bcc := collector.NewChainloopCollector(name, gatherer, logger)
 
 	reg.MustRegister(bcc)
 
@@ -43,29 +43,4 @@ func NewPrometheusRegistry(name string, gatherer chainloopprometheus.ChainloopMe
 		Registry:           reg,
 		chainloopCollector: bcc,
 	}
-}
-
-type ChainloopRegistryManager struct {
-	Registries map[string]*PrometheusRegistry
-}
-
-func NewChainloopRegistryManager() *ChainloopRegistryManager {
-	return &ChainloopRegistryManager{
-		Registries: make(map[string]*PrometheusRegistry),
-	}
-}
-
-// AddRegistry adds a registry to the manager
-func (rm *ChainloopRegistryManager) AddRegistry(reg *PrometheusRegistry) {
-	rm.Registries[reg.Name] = reg
-}
-
-// GetRegistryByName returns a registry by name
-func (rm *ChainloopRegistryManager) GetRegistryByName(name string) *PrometheusRegistry {
-	return rm.Registries[name]
-}
-
-// DeleteRegistryByName deletes a registry by name
-func (rm *ChainloopRegistryManager) DeleteRegistryByName(name string) {
-	delete(rm.Registries, name)
 }


### PR DESCRIPTION
Minor refactoring on the prometheus packages

- decouple `manager` from `collector` by moving the collector code to another package.
- moves `manager` to the top level `prometheus` package
- adds examples in the config and enables it in development

ref #1118