### PR TITLE
chore: lock atlas version in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,8 @@ jobs:
       # This could happen if the developer ran make generate but didn't run make migration_sync
       - name: Generate migrations
         if: ${{ matrix.app == 'controlplane' }}
+        env:
+          ATLAS_VERSION: v0.24.1
         run: |
           wget -q https://release.ariga.io/atlas/atlas-linux-amd64-latest -O /tmp/atlas
           sudo install /tmp/atlas /usr/local/bin/atlas

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
         env:
           ATLAS_VERSION: v0.24.1
         run: |
-          wget -q https://release.ariga.io/atlas/atlas-linux-amd64-latest -O /tmp/atlas
+          wget -q https://release.ariga.io/atlas/atlas-linux-amd64-$ATLAS_VERSION -O /tmp/atlas
           sudo install /tmp/atlas /usr/local/bin/atlas
 
           make -C app/controlplane migration_sync


### PR DESCRIPTION
This should mitigate #1146. We'd need probably a permanent fix which involves removing the deprecated feature.

Fixes #1146