### PR TITLE
Revert "chore: push controlplane protos to BSR (#1153)"

### DIFF
--- a/.github/workflows/build_and_package.yaml
+++ b/.github/workflows/build_and_package.yaml
@@ -105,13 +105,6 @@ jobs:
           CHAINLOOP_SIGNING_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
           CHAINLOOP_SIGNING_KEY: ${{ secrets.COSIGN_KEY }}
 
-      - uses: bufbuild/buf-setup-action@v1
-      - name: Buf push
-        uses: bufbuild/buf-push-action@v1
-        with:
-          input: "app/controlplane/api"
-          buf_token: ${{ secrets.buf_api_token }}
-
       - name: Bump Chart Version
         run: .github/workflows/utils/bump-chart-version.sh deployment/chainloop ${{ github.ref_name }}
 

--- a/app/controlplane/api/buf.yaml
+++ b/app/controlplane/api/buf.yaml
@@ -1,5 +1,4 @@
 version: v1
-name: buf.build/chainloop/controlplane
 breaking:
   use:
     - FILE


### PR DESCRIPTION
This reverts commit 0271723b17ed56d17d68b5da67c6c14ff7140c65.

There are imports that need to be resolved as well. This might imply moving protos in the repository, or just creating new BSR repositories for them:
```
✗ buf push
Failure: controlplane/v1/attestation_state.proto:20:8:import "attestation/v1/crafting_state.proto": file does not exist
```
