### PR TITLE
feat(docs): Add meta tag to Prometheus

### DIFF
--- a/docs/docs/guides/prometheus/README.md
+++ b/docs/docs/guides/prometheus/README.md
@@ -1,5 +1,6 @@
 ---
 title: How to monitor your CI/CD systems with Chainloop and Prometheus
+image: ./integration-diagram.png
 ---
 
 Chainloop is an open-source Software Supply Chain control plane, a single source of truth for metadata and artifacts, plus a declarative attestation process.


### PR DESCRIPTION
This patch adds a missing meta tag for the new Prometheus documentation's page.

Refs #1115 