### PR TITLE
feat(chart): Modify NOTES.txt

### DIFF
--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -7,7 +7,7 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.85.0
+version: 1.85.1
 # Do not update appVersion, this is handled automatically by the release process
 appVersion: v0.95.2
 

--- a/deployment/chainloop/templates/NOTES.txt
+++ b/deployment/chainloop/templates/NOTES.txt
@@ -11,8 +11,8 @@ APP VERSION: {{ .Chart.AppVersion  }}
 Configure the CLI to point to this instance, for example
 
   chainloop --insecure config save \
-    --control-plane {{ include "chainloop.controlplane.grpc_url" . }} \
-    --artifact-cas {{ include "chainloop.cas.grpc_url" . }}
+    --control-plane my-controlplane.acme.com:80 \
+    --artifact-cas cas.acme.com:80
 
 Refer to this link for more information
 https://docs.chainloop.dev/getting-started/installation#configure-cli-optional

--- a/deployment/chainloop/templates/NOTES.txt
+++ b/deployment/chainloop/templates/NOTES.txt
@@ -1,27 +1,8 @@
+CHART NAME: {{ .Chart.Name  }}
+CHART VERSION: {{ .Chart.Version  }}
+APP VERSION: {{ .Chart.AppVersion  }}
 
 ** Please be patient while the chart is being deployed **
-
-{{- if .Values.development }}
-
-###########################################################################
-  DEVELOPMENT MODE
-###########################################################################
-
-██████╗ ███████╗██╗    ██╗ █████╗ ██████╗ ███████╗
-██╔══██╗██╔════╝██║    ██║██╔══██╗██╔══██╗██╔════╝
-██████╔╝█████╗  ██║ █╗ ██║███████║██████╔╝█████╗  
-██╔══██╗██╔══╝  ██║███╗██║██╔══██║██╔══██╗██╔══╝  
-██████╔╝███████╗╚███╔███╔╝██║  ██║██║  ██║███████╗
-╚═════╝ ╚══════╝ ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝
-                                                  
-Instance running in development mode!
-
-Development mode, by default 
-
-- Runs an insecure, unsealed, non-persistent instance of Vault
-- Is configured with development authentication keys
-
-DO NOT USE IT FOR PRODUCTION PURPOSES
 
 ###########################################################################
   CONFIGURE CLI
@@ -30,18 +11,22 @@ DO NOT USE IT FOR PRODUCTION PURPOSES
 Configure the CLI to point to this instance, for example
 
   chainloop --insecure config save \
-    --control-plane my-controlplane.acme.com:80 \
-    --artifact-cas cas.acme.com:80
+    --control-plane {{ include "chainloop.controlplane.grpc_url" . }} \
+    --artifact-cas {{ include "chainloop.cas.grpc_url" . }}
 
 Refer to this link for more information
-https://docs.chainloop.dev/getting-started/installation#configure-cli-optional 
+https://docs.chainloop.dev/getting-started/installation#configure-cli-optional
 
 ###########################################################################
   USEFUL LINKS
 ###########################################################################
 
 - GitHub repository: https://github.com/chainloop-dev/chainloop
-- Documentation: https://docs.chainloop.dev 
+- Documentation: https://docs.chainloop.dev
 
-{{- end }}
-                                           
+
+{{- include "common.warnings.rollingTag" .Values.controlplane.image }}
+{{- include "common.warnings.rollingTag" .Values.cas.image }}
+{{- include "common.warnings.rollingTag" .Values.controlplane.migration.image }}
+{{- include "chainloop.validateValues" . }}
+{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.controlplane.image .Values.cas.image .Values.controlplane.migration.image) "context" $) }}

--- a/deployment/chainloop/templates/_helpers.tpl
+++ b/deployment/chainloop/templates/_helpers.tpl
@@ -122,13 +122,6 @@ Controlplane helpers
 ##############################################################################
 */}}
 
-{{/*
-Chainloop Controlplane GRPC URL
-*/}}
-{{- define "chainloop.controlplane.grpc_url" -}}
-{{ printf "%s-api:%.0f" (include "chainloop.controlplane.fullname" .) (coalesce .Values.controlplane.serviceAPI.port .Values.cas.serviceAPI.ports.http) }}
-{{- end -}}
-
 {{- define "chainloop.controlplane.image" -}}
 {{ include "common.images.image" (dict "imageRoot" .Values.controlplane.image "global" .Values.global) }}
 {{- end -}}
@@ -339,13 +332,6 @@ observability:
 CAS Helpers
 ##############################################################################
 */}}
-
-{{/*
-Chainloop CAS GRPC URL
-*/}}
-{{- define "chainloop.cas.grpc_url" -}}
-{{ printf "%s-api:%.0f" (include "chainloop.cas.fullname" .) (coalesce .Values.cas.serviceAPI.port .Values.cas.serviceAPI.ports.http) }}
-{{- end -}}
 
 {{- define "chainloop.cas.image" -}}
 {{ include "common.images.image" (dict "imageRoot" .Values.cas.image "global" .Values.global) }}

--- a/deployment/chainloop/templates/_helpers.tpl
+++ b/deployment/chainloop/templates/_helpers.tpl
@@ -122,6 +122,13 @@ Controlplane helpers
 ##############################################################################
 */}}
 
+{{/*
+Chainloop Controlplane GRPC URL
+*/}}
+{{- define "chainloop.controlplane.grpc_url" -}}
+{{ printf "%s-api:%.0f" (include "chainloop.controlplane.fullname" .) (coalesce .Values.controlplane.serviceAPI.port .Values.cas.serviceAPI.ports.http) }}
+{{- end -}}
+
 {{- define "chainloop.controlplane.image" -}}
 {{ include "common.images.image" (dict "imageRoot" .Values.controlplane.image "global" .Values.global) }}
 {{- end -}}
@@ -333,6 +340,13 @@ CAS Helpers
 ##############################################################################
 */}}
 
+{{/*
+Chainloop CAS GRPC URL
+*/}}
+{{- define "chainloop.cas.grpc_url" -}}
+{{ printf "%s-api:%.0f" (include "chainloop.cas.fullname" .) (coalesce .Values.cas.serviceAPI.port .Values.cas.serviceAPI.ports.http) }}
+{{- end -}}
+
 {{- define "chainloop.cas.image" -}}
 {{ include "common.images.image" (dict "imageRoot" .Values.cas.image "global" .Values.global) }}
 {{- end -}}
@@ -392,5 +406,28 @@ NOTE: Load balancer service type is not supported
 {{- printf "%s://%s" (ternary "https" "http" $ingress.tls ) $ingress.hostname }}
 {{- else if (and (eq $service.type "NodePort") $service.nodePorts (not (empty $service.nodePorts.http))) }}
 {{- printf "http://localhost:%s" $service.nodePorts.http }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Check for Development mode
+*/}}
+{{- define "chainloop.validateValues.development" -}}
+{{- if .Values.development }}
+{{-     printf "\n###########################################################################\n  DEVELOPMENT MODE\n###########################################################################\n\n██████╗ ███████╗██╗    ██╗ █████╗ ██████╗ ███████╗\n██╔══██╗██╔════╝██║    ██║██╔══██╗██╔══██╗██╔════╝\n██████╔╝█████╗  ██║ █╗ ██║███████║██████╔╝█████╗\n██╔══██╗██╔══╝  ██║███╗██║██╔══██║██╔══██╗██╔══╝\n██████╔╝███████╗╚███╔███╔╝██║  ██║██║  ██║███████╗\n╚═════╝ ╚══════╝ ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝\n\nInstance running in development mode!\n\nDevelopment mode, by default\n\n- Runs an insecure, unsealed, non-persistent instance of Vault\n- Is configured with development authentication keys\n\nDO NOT USE IT FOR PRODUCTION PURPOSES" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Compile all warning messages into a single one
+*/}}
+{{- define "chainloop.validateValues" -}}
+{{- $messages := list -}}
+{{- $messages := append $messages (include "chainloop.validateValues.development" .) -}}
+{{- $messages := without $messages "" -}}
+{{- $message := join "\n" $messages -}}
+
+{{- if $message -}}
+{{-   printf "\n\nVALUES VALIDATION:\n%s" $message -}}
 {{- end -}}
 {{- end -}}

--- a/deployment/chainloop/templates/controlplane/config.configmap.yaml
+++ b/deployment/chainloop/templates/controlplane/config.configmap.yaml
@@ -34,7 +34,7 @@ data:
         {{- end }}
     cas_server:
       grpc:
-        addr: {{ printf "%s-api:%.0f" (include "chainloop.cas.fullname" .) (coalesce .Values.cas.serviceAPI.port .Values.cas.serviceAPI.ports.http) }}
+        addr: {{ include "chainloop.cas.grpc_url" . }}
       insecure: {{ empty .Values.cas.tlsConfig.secret.name }}
       download_url: {{ include "chainloop.cas.external_url" . }}/download
     plugins_dir: {{ .Values.controlplane.pluginsDir }}

--- a/deployment/chainloop/templates/controlplane/config.configmap.yaml
+++ b/deployment/chainloop/templates/controlplane/config.configmap.yaml
@@ -34,7 +34,7 @@ data:
         {{- end }}
     cas_server:
       grpc:
-        addr: {{ include "chainloop.cas.grpc_url" . }}
+        addr: {{ printf "%s-api:%.0f" (include "chainloop.cas.fullname" .) (coalesce .Values.cas.serviceAPI.port .Values.cas.serviceAPI.ports.http) }}
       insecure: {{ empty .Values.cas.tlsConfig.secret.name }}
       download_url: {{ include "chainloop.cas.external_url" . }}/download
     plugins_dir: {{ .Values.controlplane.pluginsDir }}


### PR DESCRIPTION
This patch includes changes on the NOTES.txt to comply with Bitnami's Chart standards.

Example of output in development mode:

```
NAME: chainloop
LAST DEPLOYED: Wed Jul 31 12:42:21 2024
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
CHART NAME: chainloop
CHART VERSION: 1.85.0
APP VERSION: v0.95.2

** Please be patient while the chart is being deployed **

###########################################################################
  CONFIGURE CLI
###########################################################################

Configure the CLI to point to this instance, for example

  chainloop --insecure config save \
    --control-plane my-controlplane.acme.com:80 \
    --artifact-cas cas.acme.com:80

Refer to this link for more information
https://docs.chainloop.dev/getting-started/installation#configure-cli-optional

###########################################################################
  USEFUL LINKS
###########################################################################

- GitHub repository: https://github.com/chainloop-dev/chainloop
- Documentation: https://docs.chainloop.dev

VALUES VALIDATION:

###########################################################################
  DEVELOPMENT MODE
###########################################################################

██████╗ ███████╗██╗    ██╗ █████╗ ██████╗ ███████╗
██╔══██╗██╔════╝██║    ██║██╔══██╗██╔══██╗██╔════╝
██████╔╝█████╗  ██║ █╗ ██║███████║██████╔╝█████╗
██╔══██╗██╔══╝  ██║███╗██║██╔══██║██╔══██╗██╔══╝
██████╔╝███████╗╚███╔███╔╝██║  ██║██║  ██║███████╗
╚═════╝ ╚══════╝ ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝

Instance running in development mode!

Development mode, by default

- Runs an insecure, unsealed, non-persistent instance of Vault
- Is configured with development authentication keys

DO NOT USE IT FOR PRODUCTION PURPOSES
```

#1151 https://github.com/bitnami/charts/pull/27100