### PR TITLE
feat(chart): Modify configmaps

### DIFF
--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -7,7 +7,7 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.85.1
+version: 1.85.2
 # Do not update appVersion, this is handled automatically by the release process
 appVersion: v0.95.2
 

--- a/deployment/chainloop/README.md
+++ b/deployment/chainloop/README.md
@@ -478,6 +478,7 @@ chainloop config save \
 | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
 | `kubeVersion`       | Override Kubernetes version                                                                                                                                            | `""`    |
 | `commonAnnotations` | Annotations to add to all deployed objects                                                                                                                             | `{}`    |
+| `commonLabels`      | Labels to add to all deployed objects                                                                                                                                  | `{}`    |
 | `development`       | Deploys Chainloop pre-configured FOR DEVELOPMENT ONLY. It includes a Vault instance in development mode and pre-configured authentication certificates and passphrases | `false` |
 
 ### Secrets Backend

--- a/deployment/chainloop/templates/cas/config.configmap.yaml
+++ b/deployment/chainloop/templates/cas/config.configmap.yaml
@@ -7,8 +7,12 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "chainloop.cas.fullname" . }}
-  labels:
-    {{- include "chainloop.cas.labels" . | nindent 4 }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: cas
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 data:
   server.yaml: |
     server:

--- a/deployment/chainloop/templates/controlplane/config.configmap.yaml
+++ b/deployment/chainloop/templates/controlplane/config.configmap.yaml
@@ -7,8 +7,12 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "chainloop.controlplane.fullname" . }}
-  labels:
-    {{- include "chainloop.controlplane.labels" . | nindent 4 }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: controlplane
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 data:
   {{- if .Values.controlplane.auth.allowList }}
   allow_list.yaml: |

--- a/deployment/chainloop/values.yaml
+++ b/deployment/chainloop/values.yaml
@@ -29,6 +29,10 @@ kubeVersion: ""
 ##
 commonAnnotations: {}
 
+## @param commonLabels Labels to add to all deployed objects
+##
+commonLabels: {}
+
 ## @param development Deploys Chainloop pre-configured FOR DEVELOPMENT ONLY. It includes a Vault instance in development mode and pre-configured authentication certificates and passphrases
 ##
 development: false


### PR DESCRIPTION
This patch changes the configmaps so it's compliance with Bitnami's Chart standards.

Diff of changes:
```diff
diff --git a/old.yaml b/new.yaml
index a9b1acf..635b3d8 100644
--- a/old.yaml
+++ b/new.yaml
@@ -333,7 +333,7 @@ metadata:
 type: Opaque
 data:
   # We store it also as a different key so it can be reused during upgrades by the common.secrets.passwords.manage helper
-  generated_jws_hmac_secret: "MDVUY3NONkNCNA=="
+  generated_jws_hmac_secret: "Mkp4Y0NvdzkxVQ=="
   db_migrate_source: "cG9zdGdyZXM6Ly9jaGFpbmxvb3A6Y2hhaW5sb29wcHdkQGNoYWlubG9vcC1wb3N0Z3Jlc3FsOjU0MzIvY2hhaW5sb29wLWNwP3NzbG1vZGU9ZGlzYWJsZQ=="
 stringData:
   config.secret.yaml: |
@@ -357,7 +357,7 @@ stringData:
       # HMAC key used to sign the JWTs generated by the controlplane
       # The helper returns the base64 quoted value of the secret
       # We need to remove the quotes and then decoding it so it's compatible with the stringData stanza
-      generated_jws_hmac_secret: "05TcsN6CB4"
+      generated_jws_hmac_secret: "2JxcCow91U"

       # Private key used to sign the JWTs meant to be consumed by the CAS
       cas_robot_account_private_key_path: "/secrets/cas.private.key"
@@ -405,13 +405,13 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: chainloop-cas
+  namespace: "default"
   labels:
-    app.kubernetes.io/name: chainloop
-    helm.sh/chart: chainloop-1.85.0
     app.kubernetes.io/instance: chainloop
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "v0.95.2"
-    app.kubernetes.io/part-of: chainloop
+    app.kubernetes.io/name: chainloop
+    app.kubernetes.io/version: v0.95.2
+    helm.sh/chart: chainloop-1.85.0
     app.kubernetes.io/component: cas
 data:
   server.yaml: |
@@ -433,13 +433,13 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: chainloop-controlplane
+  namespace: "default"
   labels:
-    app.kubernetes.io/name: chainloop
-    helm.sh/chart: chainloop-1.85.0
     app.kubernetes.io/instance: chainloop
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "v0.95.2"
-    app.kubernetes.io/part-of: chainloop
+    app.kubernetes.io/name: chainloop
+    app.kubernetes.io/version: v0.95.2
+    helm.sh/chart: chainloop-1.85.0
     app.kubernetes.io/component: controlplane
 data:
   config.yaml: |
@@ -1346,7 +1346,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 278fdb31a5ded7c4b92fe2ac8c2f70b1c5b367767837fbf77bdf4b7787df9141
+        checksum/config: 2d6468170b2b3fd7caa275a45dc2ee9656d74b1936ea0d7f2c7938da30d89e4c
         checksum/config-secret: e48c2db45a545620c7394caa30bb394272ea4c58187be87234ded2153b82887c
         checksum/public-key-secret: 505c8dfebf4ca76a00f9c9c98cc1a1b85b721727339a124b17a6abe3a8628327
       labels:
@@ -1429,8 +1429,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: fa1773970a35862363367e0955a77c89f63e268cc4a7e6e38ff36c15161235b2
-        checksum/secret-config: 4bc5bc03ed71551258ebd07b9f6fdd7f416855de56fa8ae5d75b1365d5e9c383
+        checksum/config: 10566d6bfc6d73788d76a21a5b67fd9ddcf593bdf326096a023abeece5030521
+        checksum/secret-config: f9a368b99a9210ac08ed44b28d6fab6e18d04bab95d928aa39026ebbeec0b456
         checksum/cas-private-key: 41d2d392bf7a8bc471b2ff67e52e3c6e28742f182f213a05dd351ccc4cb66245
         kubectl.kubernetes.io/default-container: controlplane
       labels:
```

#1151 https://github.com/bitnami/charts/pull/27100