### PR TITLE
feat(chart): Modify secrets

### DIFF
--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -7,7 +7,7 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.85.2
+version: 1.85.3
 # Do not update appVersion, this is handled automatically by the release process
 appVersion: v0.95.2
 

--- a/deployment/chainloop/templates/cas/config.secret.yaml
+++ b/deployment/chainloop/templates/cas/config.secret.yaml
@@ -7,8 +7,12 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "chainloop.cas.fullname" . }}
-  labels:
-    {{- include "chainloop.cas.labels" . | nindent 4 }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: cas
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 type: Opaque
 stringData:
   {{- if and .Values.cas.sentry .Values.cas.sentry.enabled }}

--- a/deployment/chainloop/templates/controlplane/config.secret.yaml
+++ b/deployment/chainloop/templates/controlplane/config.secret.yaml
@@ -7,8 +7,12 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "chainloop.controlplane.fullname" . }}
-  labels:
-    {{- include "chainloop.controlplane.labels" . | nindent 4 }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: controlplane
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 type: Opaque
 {{- $hmacpass := include "common.secrets.passwords.manage" (dict "secret" (include "chainloop.controlplane.fullname" .) "key" "generated_jws_hmac_secret" "providedValues" (list "controlplane.auth.passphrase") "context" $) }}
 data:


### PR DESCRIPTION
This patch changes the secrets so it's compliance with Bitnami's Chart standards.

Diff of changes:
```diff
diff --git a/old.yml b/new.yml
index a9b1acf..c9d81f8 100644
--- a/old.yml
+++ b/new.yml
@@ -278,13 +278,13 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: chainloop-cas
+  namespace: "default"
   labels:
-    app.kubernetes.io/name: chainloop
-    helm.sh/chart: chainloop-1.85.0
     app.kubernetes.io/instance: chainloop
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "v0.95.2"
-    app.kubernetes.io/part-of: chainloop
+    app.kubernetes.io/name: chainloop
+    app.kubernetes.io/version: v0.95.2
+    helm.sh/chart: chainloop-1.85.0
     app.kubernetes.io/component: cas
 type: Opaque
 stringData:
@@ -322,18 +322,18 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: chainloop-controlplane
+  namespace: "default"
   labels:
-    app.kubernetes.io/name: chainloop
-    helm.sh/chart: chainloop-1.85.0
     app.kubernetes.io/instance: chainloop
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "v0.95.2"
-    app.kubernetes.io/part-of: chainloop
+    app.kubernetes.io/name: chainloop
+    app.kubernetes.io/version: v0.95.2
+    helm.sh/chart: chainloop-1.85.0
     app.kubernetes.io/component: controlplane
 type: Opaque
 data:
   # We store it also as a different key so it can be reused during upgrades by the common.secrets.passwords.manage helper
-  generated_jws_hmac_secret: "MDVUY3NONkNCNA=="
+  generated_jws_hmac_secret: "THRhbXdjekx3MA=="
   db_migrate_source: "cG9zdGdyZXM6Ly9jaGFpbmxvb3A6Y2hhaW5sb29wcHdkQGNoYWlubG9vcC1wb3N0Z3Jlc3FsOjU0MzIvY2hhaW5sb29wLWNwP3NzbG1vZGU9ZGlzYWJsZQ=="
 stringData:
   config.secret.yaml: |
@@ -357,7 +357,7 @@ stringData:
       # HMAC key used to sign the JWTs generated by the controlplane
       # The helper returns the base64 quoted value of the secret
       # We need to remove the quotes and then decoding it so it's compatible with the stringData stanza
-      generated_jws_hmac_secret: "05TcsN6CB4"
+      generated_jws_hmac_secret: "LtamwczLw0"

       # Private key used to sign the JWTs meant to be consumed by the CAS
       cas_robot_account_private_key_path: "/secrets/cas.private.key"
@@ -1347,7 +1347,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 278fdb31a5ded7c4b92fe2ac8c2f70b1c5b367767837fbf77bdf4b7787df9141
-        checksum/config-secret: e48c2db45a545620c7394caa30bb394272ea4c58187be87234ded2153b82887c
+        checksum/config-secret: 0e8073510bb7be990dd68b1c2581ea118df2e6d15486735a32d9ac6c433e8c52
         checksum/public-key-secret: 505c8dfebf4ca76a00f9c9c98cc1a1b85b721727339a124b17a6abe3a8628327
       labels:
         app.kubernetes.io/name: chainloop
@@ -1430,7 +1430,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fa1773970a35862363367e0955a77c89f63e268cc4a7e6e38ff36c15161235b2
-        checksum/secret-config: 4bc5bc03ed71551258ebd07b9f6fdd7f416855de56fa8ae5d75b1365d5e9c383
+        checksum/secret-config: 5e8fdb9bb7efa0eb49991651af94746dfe959b8f838c3ddd3e595c019056dc0c
         checksum/cas-private-key: 41d2d392bf7a8bc471b2ff67e52e3c6e28742f182f213a05dd351ccc4cb66245
         kubectl.kubernetes.io/default-container: controlplane
       labels:
```

https://github.com/chainloop-dev/chainloop/issues/1151 https://github.com/bitnami/charts/pull/27100