### PR TITLE
feat(attestations): Allow custom name on external evidence

### DIFF
--- a/app/cli/internal/action/attestation_add.go
+++ b/app/cli/internal/action/attestation_add.go
@@ -147,18 +147,19 @@ func (action *AttestationAdd) Run(ctx context.Context, attestationID, materialNa
 		}
 		action.Logger.Info().Str("kind", kind.String()).Msg("material kind detected")
 	case materialName != "":
+		switch {
 		// If the material is in the contract, add it from the contract
-		if crafter.IsMaterialInContract(materialName) {
+		case crafter.IsMaterialInContract(materialName):
 			err = crafter.AddMaterialFromContract(ctx, attestationID, materialName, materialValue, casBackend, annotations)
-		} else if materialType == "" {
-			// If the material is not in the contract and the materialType is not provided, add material contract free with auto-detected kind, guessing the kind
+		// If the material is not in the contract and the materialType is not provided, add material contract free with auto-detected kind, guessing the kind
+		case materialType == "":
 			kind, err = crafter.AddMaterialContactFreeWithAutoDetectedKind(ctx, attestationID, materialName, materialValue, casBackend, annotations)
 			if err != nil {
 				return fmt.Errorf("adding material: %w", err)
 			}
 			action.Logger.Info().Str("kind", kind.String()).Msg("material kind detected")
-		} else {
-			// If the material is not in the contract and has a materialType, add material contract free with the provided materialType
+		// If the material is not in the contract and has a materialType, add material contract free with the provided materialType
+		default:
 			err = crafter.AddMaterialContractFree(ctx, attestationID, materialType, materialName, materialValue, casBackend, annotations)
 		}
 	default:

--- a/app/cli/internal/action/attestation_add.go
+++ b/app/cli/internal/action/attestation_add.go
@@ -133,24 +133,33 @@ func (action *AttestationAdd) Run(ctx context.Context, attestationID, materialNa
 	}
 
 	// Add material to the attestation crafting state based on if the material is contract free or not.
-	// By default, try to detect the material kind automatically
+	// The checks are performed in the following order:
+	// 1. If materialName is empty and materialType is empty, we don't know anything about the material so, we add it with auto-detected kind and random name
+	// 2. If materialName is not empty, check if the material is in the contract. If it is, add material from contract
+	// 2.1. If materialType is empty, try to guess the material kind with auto-detected kind and materialName
+	// 3. If materialType is not empty, add material contract free with materialType and materialName
 	var kind schemaapi.CraftingSchema_Material_MaterialType
 	switch {
 	case materialName == "" && materialType == "":
-		if kind, err = crafter.AddMaterialContactFreeAutomatic(ctx, attestationID, materialName, materialValue, casBackend, annotations); err != nil {
+		kind, err = crafter.AddMaterialContactFreeWithAutoDetectedKind(ctx, attestationID, "", materialValue, casBackend, annotations)
+		if err != nil {
 			return fmt.Errorf("adding material: %w", err)
 		}
 		action.Logger.Info().Str("kind", kind.String()).Msg("material kind detected")
 	case materialName != "":
-		// If materialType and materialName are set we assume the material is on the contract
-		if materialType != "" {
+		// If the material is in the contract, add it from the contract
+		if crafter.IsMaterialInContract(materialName) {
 			err = crafter.AddMaterialFromContract(ctx, attestationID, materialName, materialValue, casBackend, annotations)
-		} else {
-			// If materialType is not set we try to detect the material kind automatically passing the material name
-			if kind, err = crafter.AddMaterialContactFreeAutomatic(ctx, attestationID, materialName, materialValue, casBackend, annotations); err != nil {
+		} else if materialType == "" {
+			// If the material is not in the contract and the materialType is not provided, add material contract free with auto-detected kind, guessing the kind
+			kind, err = crafter.AddMaterialContactFreeWithAutoDetectedKind(ctx, attestationID, materialName, materialValue, casBackend, annotations)
+			if err != nil {
 				return fmt.Errorf("adding material: %w", err)
 			}
 			action.Logger.Info().Str("kind", kind.String()).Msg("material kind detected")
+		} else {
+			// If the material is not in the contract and has a materialType, add material contract free with the provided materialType
+			err = crafter.AddMaterialContractFree(ctx, attestationID, materialType, materialName, materialValue, casBackend, annotations)
 		}
 	default:
 		err = crafter.AddMaterialContractFree(ctx, attestationID, materialType, materialName, materialValue, casBackend, annotations)

--- a/internal/attestation/crafter/crafter.go
+++ b/internal/attestation/crafter/crafter.go
@@ -468,8 +468,8 @@ func (c *Crafter) ResolveEnvVars(ctx context.Context, attestationID string) erro
 
 // AddMaterialContractFree adds a material to the crafting state without checking the contract schema.
 // This is useful for adding materials that are not defined in the schema.
-// The name of the material is automatically calculated to conform the API contract.
-func (c *Crafter) AddMaterialContractFree(ctx context.Context, attestationID, kind, value string, casBackend *casclient.CASBackend, runtimeAnnotations map[string]string) error {
+// The name of the material is automatically calculated to conform the API contract if not provided.
+func (c *Crafter) AddMaterialContractFree(ctx context.Context, attestationID, kind, name, value string, casBackend *casclient.CASBackend, runtimeAnnotations map[string]string) error {
 	if err := c.requireStateLoaded(); err != nil {
 		return fmt.Errorf("adding materials outisde the contract: %w", err)
 	}
@@ -482,8 +482,12 @@ func (c *Crafter) AddMaterialContractFree(ctx context.Context, attestationID, ki
 		return fmt.Errorf("%q kind not found. Available options are %q", kind, schemaapi.ListAvailableMaterialKind())
 	}
 
-	// 2 - Generate a random name for the material
-	m.Name = fmt.Sprintf("material-%d", time.Now().UnixNano())
+	// 2 - Set the name of the material if provided
+	m.Name = name
+	if m.Name == "" {
+		// 2.1 - Generate a random name for the material since it was not provided
+		m.Name = fmt.Sprintf("material-%d", time.Now().UnixNano())
+	}
 
 	// 3 - Craft resulting material
 	return c.addMaterial(ctx, &m, attestationID, value, casBackend, runtimeAnnotations)
@@ -519,9 +523,9 @@ func (c *Crafter) AddMaterialFromContract(ctx context.Context, attestationID, ke
 
 // AddMaterialContactFreeAutomatic adds a material to the crafting state checking the incoming material matches any of the
 // supported types in validation order. If the material is not found it will return an error.
-func (c *Crafter) AddMaterialContactFreeAutomatic(ctx context.Context, attestationID, value string, casBackend *casclient.CASBackend, runtimeAnnotations map[string]string) (schemaapi.CraftingSchema_Material_MaterialType, error) {
+func (c *Crafter) AddMaterialContactFreeAutomatic(ctx context.Context, attestationID, name, value string, casBackend *casclient.CASBackend, runtimeAnnotations map[string]string) (schemaapi.CraftingSchema_Material_MaterialType, error) {
 	for _, kind := range schemaapi.CraftingMaterialInValidationOrder {
-		err := c.AddMaterialContractFree(ctx, attestationID, kind.String(), value, casBackend, runtimeAnnotations)
+		err := c.AddMaterialContractFree(ctx, attestationID, kind.String(), name, value, casBackend, runtimeAnnotations)
 		if err == nil {
 			// Successfully added material, return the kind
 			return kind, nil

--- a/internal/attestation/crafter/crafter.go
+++ b/internal/attestation/crafter/crafter.go
@@ -521,9 +521,24 @@ func (c *Crafter) AddMaterialFromContract(ctx context.Context, attestationID, ke
 	return c.addMaterial(ctx, m, attestationID, value, casBackend, runtimeAnnotations)
 }
 
-// AddMaterialContactFreeAutomatic adds a material to the crafting state checking the incoming material matches any of the
+// IsMaterialInContract checks if the material is in the contract schema
+func (c *Crafter) IsMaterialInContract(key string) bool {
+	if err := c.requireStateLoaded(); err != nil {
+		return false
+	}
+
+	for _, d := range c.CraftingState.InputSchema.Materials {
+		if d.Name == key {
+			return true
+		}
+	}
+
+	return false
+}
+
+// AddMaterialContactFreeWithAutoDetectedKind adds a material to the crafting state checking the incoming material matches any of the
 // supported types in validation order. If the material is not found it will return an error.
-func (c *Crafter) AddMaterialContactFreeAutomatic(ctx context.Context, attestationID, name, value string, casBackend *casclient.CASBackend, runtimeAnnotations map[string]string) (schemaapi.CraftingSchema_Material_MaterialType, error) {
+func (c *Crafter) AddMaterialContactFreeWithAutoDetectedKind(ctx context.Context, attestationID, name, value string, casBackend *casclient.CASBackend, runtimeAnnotations map[string]string) (schemaapi.CraftingSchema_Material_MaterialType, error) {
 	for _, kind := range schemaapi.CraftingMaterialInValidationOrder {
 		err := c.AddMaterialContractFree(ctx, attestationID, kind.String(), name, value, casBackend, runtimeAnnotations)
 		if err == nil {

--- a/internal/attestation/crafter/crafter_test.go
+++ b/internal/attestation/crafter/crafter_test.go
@@ -560,7 +560,7 @@ func (s *crafterSuite) TestAddMaterialsAutomatic() {
 			c, err := newInitializedCrafter(s.T(), contract, &v1.WorkflowMetadata{}, false, "", runner)
 			require.NoError(s.T(), err)
 
-			kind, err := c.AddMaterialContactFreeAutomatic(context.Background(), "random-id", tc.materialName, tc.materialPath, backend, nil)
+			kind, err := c.AddMaterialContactFreeWithAutoDetectedKind(context.Background(), "random-id", tc.materialName, tc.materialPath, backend, nil)
 			if tc.wantErr {
 				assert.ErrorIs(s.T(), err, materials.ErrBaseUploadAndCraft)
 			} else {

--- a/internal/attestation/crafter/crafter_test.go
+++ b/internal/attestation/crafter/crafter_test.go
@@ -474,6 +474,7 @@ func (s *crafterSuite) TestAddMaterialsAutomatic() {
 	testCases := []struct {
 		name           string
 		materialPath   string
+		materialName   string
 		expectedType   schemaapi.CraftingSchema_Material_MaterialType
 		uploadArtifact bool
 		wantErr        bool
@@ -495,6 +496,12 @@ func (s *crafterSuite) TestAddMaterialsAutomatic() {
 		},
 		{
 			name:         "junit",
+			materialPath: "./materials/testdata/junit.xml",
+			expectedType: schemaapi.CraftingSchema_Material_JUNIT_XML,
+		},
+		{
+			name:         "junit with custom material name",
+			materialName: "custom-junit-material",
 			materialPath: "./materials/testdata/junit.xml",
 			expectedType: schemaapi.CraftingSchema_Material_JUNIT_XML,
 		},
@@ -553,13 +560,18 @@ func (s *crafterSuite) TestAddMaterialsAutomatic() {
 			c, err := newInitializedCrafter(s.T(), contract, &v1.WorkflowMetadata{}, false, "", runner)
 			require.NoError(s.T(), err)
 
-			kind, err := c.AddMaterialContactFreeAutomatic(context.Background(), "random-id", tc.materialPath, backend, nil)
+			kind, err := c.AddMaterialContactFreeAutomatic(context.Background(), "random-id", tc.materialName, tc.materialPath, backend, nil)
 			if tc.wantErr {
 				assert.ErrorIs(s.T(), err, materials.ErrBaseUploadAndCraft)
 			} else {
 				require.NoError(s.T(), err)
 			}
 			assert.Equal(s.T(), tc.expectedType.String(), kind.String())
+			if tc.materialName != "" {
+				attestationMaterials := c.CraftingState.Attestation.Materials
+				_, found := attestationMaterials[tc.materialName]
+				assert.True(s.T(), found)
+			}
 		})
 	}
 }


### PR DESCRIPTION
This patch allows materials that are not part of a contract to have a custom name if desired instead of auto generating
Example:

```shell
$ chainloop --insecure wf contract describe --name core-deployment
WRN API contacted in insecure mode
INF To download the contract, run the command with the "--output schema" option
┌────────────────────────────────────────────┐
│ Contract                                   │
├──────────────────────┬─────────────────────┤
│ Name                 │ core-deployment     │
├──────────────────────┼─────────────────────┤
│ Description          │                     │
├──────────────────────┼─────────────────────┤
│ Associated Workflows │                     │
├──────────────────────┼─────────────────────┤
│ Revision number      │ 1                   │
├──────────────────────┼─────────────────────┤
│ Revision Created At  │ 31 Jul 24 12:19 UTC │
└──────────────────────┴─────────────────────┘
┌─────────────────────────────┐
│ {                           │
│   "schemaVersion":  "v1",   │
│   "materials":  [           │
│     {                       │
│       "type":  "JUNIT_XML", │
│       "name":  "junit",     │
│       "output":  true       │
│     }                       │
│   ]                         │
│ }                           │
└─────────────────────────────┘

$ chainloop --insecure attestation init --name deployment --replace
WRN API contacted in insecure mode
INF Attestation initialized! now you can check its status or add materials to it
┌───────────────────┬──────────────────────────────────────┐
│ Initialized At    │ 31 Jul 24 12:24 UTC                  │
├───────────────────┼──────────────────────────────────────┤
│ Attestation ID    │ d5c8086e-ad37-472a-9181-cca29edc0f0b │
│ Name              │ deployment                           │
│ Team              │                                      │
│ Project           │ core                                 │
│ Contract Revision │ 1                                    │
└───────────────────┴──────────────────────────────────────┘
$ chainloop --insecure attestation add --value ./internal/attestation/crafter/materials/testdata/junit.xml --name junit
WRN API contacted in insecure mode
INF material kind detected kind=JUNIT_XML
INF material added to attestation

$ chainloop --insecure attestation add --value ./internal/attestation/crafter/materials/testdata/openvex_v0.2.0.json
WRN API contacted in insecure mode
INF material kind detected kind=OPENVEX
INF material added to attestation

$ chainloop --insecure attestation add --value ./internal/attestation/crafter/materials/testdata/valid-chart.tgz --name release-chart
WRN API contacted in insecure mode
INF material kind detected kind=HELM_CHART
INF material added to attestation

$ chainloop --insecure attestation push --key cosign.key
WRN API contacted in insecure mode
Enter password for private key:
INF push completed
┌───────────────────┬──────────────────────────────────────┐
│ Initialized At    │ 31 Jul 24 12:24 UTC                  │
├───────────────────┼──────────────────────────────────────┤
│ Attestation ID    │ d5c8086e-ad37-472a-9181-cca29edc0f0b │
│ Name              │ deployment                           │
│ Team              │                                      │
│ Project           │ core                                 │
│ Contract Revision │ 1                                    │
└───────────────────┴──────────────────────────────────────┘
┌────────────────────────────────────────────────────────────────────────────────────┐
│ Materials                                                                          │
├──────────┬─────────────────────────────────────────────────────────────────────────┤
│ Name     │ junit                                                                   │
│ Type     │ JUNIT_XML                                                               │
│ Set      │ Yes                                                                     │
│ Required │ No                                                                      │
│ Value    │ junit.xml                                                               │
│ Digest   │ sha256:e9c941b25c06d8bd98205122cbc827504c6d03d37b7f4afd7ed03b3eeec789e2 │
├──────────┼─────────────────────────────────────────────────────────────────────────┤
│ Name     │ material-1722428682935626000                                            │
│ Type     │ OPENVEX                                                                 │
│ Set      │ Yes                                                                     │
│ Required │ No                                                                      │
│ Value    │ openvex_v0.2.0.json                                                     │
│ Digest   │ sha256:b4bd86d5855f94bcac0a92d3100ae7b85d050bd2e5fb9037a200e5f5f0b073a2 │
├──────────┼─────────────────────────────────────────────────────────────────────────┤
│ Name     │ release-chart                                                           │
│ Type     │ HELM_CHART                                                              │
│ Set      │ Yes                                                                     │
│ Required │ No                                                                      │
│ Value    │ valid-chart.tgz                                                         │
│ Digest   │ sha256:08a46a850789938ede61d6a53552f48cb8ba74c4e17dcf30c9c50e5783ca6a13 │
└──────────┴─────────────────────────────────────────────────────────────────────────┘
Attestation Digest: sha256:ebfaba0a791c79f0fbe2b09d1e111e435efcf6146d189a8e2a2a943bb35ebfba%
```

Refs #911 