### PR TITLE
feat(chart): Modify sevice accounts

### DIFF
--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -7,7 +7,7 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.86.0
+version: 1.86.1
 # Do not update appVersion, this is handled automatically by the release process
 appVersion: v0.95.3
 

--- a/deployment/chainloop/templates/cas/serviceaccount.yaml
+++ b/deployment/chainloop/templates/cas/serviceaccount.yaml
@@ -8,10 +8,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "chainloop.cas.serviceAccountName" . }}
-  labels:
-    {{- include "chainloop.cas.labels" . | nindent 4 }}
-  {{- with .Values.cas.serviceAccount.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: cas
+  {{- if or .Values.cas.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" (dict "values" (list .Values.cas.serviceAccount.annotations .Values.commonAnnotations) "context" .) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
-{{- end }}
+  {{- end }}

--- a/deployment/chainloop/templates/controlplane/serviceaccount.yaml
+++ b/deployment/chainloop/templates/controlplane/serviceaccount.yaml
@@ -8,10 +8,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "controlplane.serviceAccountName" . }}
-  labels:
-    {{- include "chainloop.controlplane.labels" . | nindent 4 }}
-  {{- with .Values.controlplane.serviceAccount.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: controlplane
+  {{- if or .Values.controlplane.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" (dict "values" (list .Values.controlplane.serviceAccount.annotations .Values.commonAnnotations) "context" .) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
-{{- end }}
+  {{- end }}


### PR DESCRIPTION
This patch modifies the service accounts to be compliant with Bitnami Charts' practices.

Diff of changes:
```diff
diff --git a/old.yml b/new.yml
index 96660cc..a18d00e 100644
--- a/old.yml
+++ b/new.yml
@@ -218,13 +218,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: chainloop-cas
+  namespace: "default"
   labels:
-    app.kubernetes.io/name: chainloop
-    helm.sh/chart: chainloop-1.86.0
     app.kubernetes.io/instance: chainloop
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "v0.95.3"
-    app.kubernetes.io/part-of: chainloop
+    app.kubernetes.io/name: chainloop
+    app.kubernetes.io/version: v0.95.3
+    helm.sh/chart: chainloop-1.86.0
     app.kubernetes.io/component: cas
 ---
 # Source: chainloop/templates/controlplane/serviceaccount.yaml
@@ -232,13 +232,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: chainloop-controlplane
+  namespace: "default"
   labels:
-    app.kubernetes.io/name: chainloop
-    helm.sh/chart: chainloop-1.86.0
     app.kubernetes.io/instance: chainloop
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "v0.95.3"
-    app.kubernetes.io/part-of: chainloop
+    app.kubernetes.io/name: chainloop
+    app.kubernetes.io/version: v0.95.3
+    helm.sh/chart: chainloop-1.86.0
     app.kubernetes.io/component: controlplane
 ---
 # Source: chainloop/charts/dex/templates/secret.yaml
@@ -333,7 +333,7 @@ metadata:
 type: Opaque
 data:
   # We store it also as a different key so it can be reused during upgrades by the common.secrets.passwords.manage helper
-  generated_jws_hmac_secret: "WjhCUHliOEdqTw=="
+  generated_jws_hmac_secret: "V3NRU1d4RG1QVQ=="
   db_migrate_source: "cG9zdGdyZXM6Ly9jaGFpbmxvb3A6Y2hhaW5sb29wcHdkQGNoYWlubG9vcC1wb3N0Z3Jlc3FsOjU0MzIvY2hhaW5sb29wLWNwP3NzbG1vZGU9ZGlzYWJsZQ=="
 stringData:
   config.secret.yaml: |
@@ -357,7 +357,7 @@ stringData:
       # HMAC key used to sign the JWTs generated by the controlplane
       # The helper returns the base64 quoted value of the secret
       # We need to remove the quotes and then decoding it so it's compatible with the stringData stanza
-      generated_jws_hmac_secret: "Z8BPyb8GjO"
+      generated_jws_hmac_secret: "WsQSWxDmPU"

       # Private key used to sign the JWTs meant to be consumed by the CAS
       cas_robot_account_private_key_path: "/secrets/cas.private.key"
@@ -1430,7 +1430,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 5da3428ee1fca058cf6afeae7074cf83d918c0570f16f49dd725da1ed1b93d4c
-        checksum/secret-config: 49f8ba69acfcc586cfe6d4f11a7ecabefaa4961e3d6958fbf18de5b14938c52f
+        checksum/secret-config: f75eb52c738ed1f431fdddcca9cc82f14f058cb2543f1f73aa23bc11c8912877
         checksum/cas-private-key: 475139d5a7cf2be347b5a6c38a89ed85f310aa7b88347594dddf32e936d6d984
         kubectl.kubernetes.io/default-container: controlplane
       labels:

```

Refs #1151 https://github.com/bitnami/charts/pull/27100