### PR TITLE
feat(chart): Change container names

### DIFF
--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -7,7 +7,7 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.86.13
+version: 1.86.14
 # Do not update appVersion, this is handled automatically by the release process
 appVersion: v0.95.3
 

--- a/deployment/chainloop/templates/cas/deployment.yaml
+++ b/deployment/chainloop/templates/cas/deployment.yaml
@@ -71,7 +71,7 @@ spec:
           {{- include "common.tplvalues.render" (dict "value" .Values.cas.initContainers "context" $) | nindent 8 }}
         {{- end }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: cas
           securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.cas.containerSecurityContext "context" $) | nindent 12 }}
           image: {{ include "chainloop.cas.image" . }}
           imagePullPolicy: {{ .Values.cas.image.pullPolicy }}

--- a/deployment/chainloop/templates/cas/deployment.yaml
+++ b/deployment/chainloop/templates/cas/deployment.yaml
@@ -71,7 +71,7 @@ spec:
           {{- include "common.tplvalues.render" (dict "value" .Values.cas.initContainers "context" $) | nindent 8 }}
         {{- end }}
       containers:
-        - name: cas
+        - name: cas-proxy
           securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.cas.containerSecurityContext "context" $) | nindent 12 }}
           image: {{ include "chainloop.cas.image" . }}
           imagePullPolicy: {{ .Values.cas.image.pullPolicy }}

--- a/deployment/chainloop/templates/controlplane/deployment.yaml
+++ b/deployment/chainloop/templates/controlplane/deployment.yaml
@@ -88,7 +88,7 @@ spec:
                   name: {{ include "chainloop.controlplane.fullname" . }}
                   key: db_migrate_source
       containers:
-        - name: {{ .Chart.Name }}
+        - name: controlplane
           securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.controlplane.containerSecurityContext "context" $) | nindent 12 }}
           image: {{ include "chainloop.controlplane.image" . }}
           imagePullPolicy: {{ .Values.controlplane.image.pullPolicy }}


### PR DESCRIPTION
This patch changes the names of the main container in `cas` and `controlplane`.

Will bump the chart patch version.

Diff:
```diff
diff --git a/old.yml b/new.yml
index 7bb317e..d56b0e5 100644
--- a/old.yml
+++ b/new.yml
@@ -103,7 +103,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: chainloop
     app.kubernetes.io/version: v0.95.3
-    helm.sh/chart: chainloop-1.86.13
+    helm.sh/chart: chainloop-1.86.14
     app.kubernetes.io/component: cas
 spec:
   podSelector:
@@ -131,7 +131,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: chainloop
     app.kubernetes.io/version: v0.95.3
-    helm.sh/chart: chainloop-1.86.13
+    helm.sh/chart: chainloop-1.86.14
     app.kubernetes.io/component: controlplane
     app.kubernetes.io/component: controlplane
 spec:
@@ -307,7 +307,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: chainloop
     app.kubernetes.io/version: v0.95.3
-    helm.sh/chart: chainloop-1.86.13
+    helm.sh/chart: chainloop-1.86.14
     app.kubernetes.io/component: cas
 ---
 # Source: chainloop/templates/controlplane/service-account.yaml
@@ -321,7 +321,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: chainloop
     app.kubernetes.io/version: v0.95.3
-    helm.sh/chart: chainloop-1.86.13
+    helm.sh/chart: chainloop-1.86.14
     app.kubernetes.io/component: controlplane
 ---
 # Source: chainloop/charts/dex/templates/secret.yaml
@@ -393,7 +393,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: chainloop
     app.kubernetes.io/version: v0.95.3
-    helm.sh/chart: chainloop-1.86.13
+    helm.sh/chart: chainloop-1.86.14
     app.kubernetes.io/component: cas
 type: Opaque
 stringData:
@@ -419,7 +419,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: chainloop
     app.kubernetes.io/version: v0.95.3
-    helm.sh/chart: chainloop-1.86.13
+    helm.sh/chart: chainloop-1.86.14
     app.kubernetes.io/component: cas
 type: Opaque
 data:
@@ -436,12 +436,12 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: chainloop
     app.kubernetes.io/version: v0.95.3
-    helm.sh/chart: chainloop-1.86.13
+    helm.sh/chart: chainloop-1.86.14
     app.kubernetes.io/component: controlplane
 type: Opaque
 data:
   # We store it also as a different key so it can be reused during upgrades by the common.secrets.passwords.manage helper
-  generated_jws_hmac_secret: "dkNTVk5SaTVrWg=="
+  generated_jws_hmac_secret: "NVoyNjAxQWtpaQ=="
   db_migrate_source: "cG9zdGdyZXM6Ly9jaGFpbmxvb3A6Y2hhaW5sb29wcHdkQGNoYWlubG9vcC1wb3N0Z3Jlc3FsOjU0MzIvY2hhaW5sb29wLWNwP3NzbG1vZGU9ZGlzYWJsZQ=="
 stringData:
   config.secret.yaml: |
@@ -465,7 +465,7 @@ stringData:
       # HMAC key used to sign the JWTs generated by the controlplane
       # The helper returns the base64 quoted value of the secret
       # We need to remove the quotes and then decoding it so it's compatible with the stringData stanza
-      generated_jws_hmac_secret: "vCSVNRi5kZ"
+      generated_jws_hmac_secret: "5Z2601Akii"

       # Private key used to sign the JWTs meant to be consumed by the CAS
       cas_robot_account_private_key_path: "/secrets/cas.private.key"
@@ -480,7 +480,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: chainloop
     app.kubernetes.io/version: v0.95.3
-    helm.sh/chart: chainloop-1.86.13
+    helm.sh/chart: chainloop-1.86.14
     app.kubernetes.io/component: controlplane
 type: Opaque
 data:
@@ -518,7 +518,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: chainloop
     app.kubernetes.io/version: v0.95.3
-    helm.sh/chart: chainloop-1.86.13
+    helm.sh/chart: chainloop-1.86.14
     app.kubernetes.io/component: cas
 data:
   server.yaml: |
@@ -546,7 +546,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: chainloop
     app.kubernetes.io/version: v0.95.3
-    helm.sh/chart: chainloop-1.86.13
+    helm.sh/chart: chainloop-1.86.14
     app.kubernetes.io/component: controlplane
 data:
   config.yaml: |
@@ -1060,7 +1060,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: chainloop
     app.kubernetes.io/version: v0.95.3
-    helm.sh/chart: chainloop-1.86.13
+    helm.sh/chart: chainloop-1.86.14
     app.kubernetes.io/component: cas
   annotations:
     traefik.ingress.kubernetes.io/service.serversscheme: h2c
@@ -1089,7 +1089,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: chainloop
     app.kubernetes.io/version: v0.95.3
-    helm.sh/chart: chainloop-1.86.13
+    helm.sh/chart: chainloop-1.86.14
     app.kubernetes.io/component: cas
 spec:
   type: ClusterIP
@@ -1116,7 +1116,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: chainloop
     app.kubernetes.io/version: v0.95.3
-    helm.sh/chart: chainloop-1.86.13
+    helm.sh/chart: chainloop-1.86.14
     app.kubernetes.io/component: controlplane
   annotations:
     traefik.ingress.kubernetes.io/service.serversscheme: h2c
@@ -1145,7 +1145,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: chainloop
     app.kubernetes.io/version: v0.95.3
-    helm.sh/chart: chainloop-1.86.13
+    helm.sh/chart: chainloop-1.86.14
     app.kubernetes.io/component: controlplane
 spec:
   type: ClusterIP
@@ -1442,7 +1442,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: chainloop
     app.kubernetes.io/version: v0.95.3
-    helm.sh/chart: chainloop-1.86.13
+    helm.sh/chart: chainloop-1.86.14
     app.kubernetes.io/component: cas
 spec:
   replicas: 2
@@ -1456,15 +1456,15 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6738e7e9aa401e531f8dc6e4047371e7fb34a4a2ce67310ac45005d56c9e3cc8
-        checksum/config-secret: c6dd5559dafcba0e78233c71da8c1a7233965f345256d6dcf6ecde467a668972
-        checksum/public-key-secret: 1ddf6b58296dad2dda51ecf7f300112ca97f48b2bfa39adef8f080141bb8cf6c
+        checksum/config: c5bbfd9b8458d0441ca6c43e2a3a28192fa766c885af7a293c12ea5ac05a2ea4
+        checksum/config-secret: 1cec1c309eda178a3ad6af51ac767311a2ed57312b08b454100b881622025ffc
+        checksum/public-key-secret: 3c38cae1f73f5b9579d66f16bd5f06966731d6f733702b87cb5ed2c038a87d2a
       labels:
         app.kubernetes.io/instance: chainloop
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: chainloop
         app.kubernetes.io/version: v0.95.3
-        helm.sh/chart: chainloop-1.86.13
+        helm.sh/chart: chainloop-1.86.14
         app.kubernetes.io/component: cas
     spec:

@@ -1492,7 +1492,7 @@ spec:
         sysctls: []
       initContainers:
       containers:
-        - name: chainloop
+        - name: cas-proxy
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -1567,7 +1567,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: chainloop
     app.kubernetes.io/version: v0.95.3
-    helm.sh/chart: chainloop-1.86.13
+    helm.sh/chart: chainloop-1.86.14
     app.kubernetes.io/component: controlplane
 spec:
   replicas: 2
@@ -1581,16 +1581,16 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7ebb40b21af918bef7decf41a5d6bbfcbdcab8a7b275e06922e7174f4ecfd98d
-        checksum/secret-config: 27987b6cef61e3d5de9c475a14e38d0f827fa1e895fccc0adbe02b88a2222226
-        checksum/cas-private-key: 0bb2f0ef78066c0debed29e25af937f54deaa1c53b7b278afe0719308d271ef6
+        checksum/config: de55de32686c8ea467563bf43d8d2a5af938c27431964d824e582e445553b13c
+        checksum/secret-config: 361589ff71301398793a941fc9436b961256b609aeaf476247bac0d6f5dd3f6a
+        checksum/cas-private-key: f2625ad6d3493b333831121743baa728e51ee621c24571397d156b76cdcd16fe
         kubectl.kubernetes.io/default-container: controlplane
       labels:
         app.kubernetes.io/instance: chainloop
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: chainloop
         app.kubernetes.io/version: v0.95.3
-        helm.sh/chart: chainloop-1.86.13
+        helm.sh/chart: chainloop-1.86.14
         app.kubernetes.io/component: controlplane
     spec:

@@ -1634,7 +1634,7 @@ spec:
                   name: chainloop-controlplane
                   key: db_migrate_source
       containers:
-        - name: chainloop
+        - name: controlplane
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

```

Refs #1151 