### PR TITLE
feat(chart): Modify TLS config param

### DIFF
--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -7,7 +7,7 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.87.0
+version: 1.87.1
 # Do not update appVersion, this is handled automatically by the release process
 appVersion: v0.95.5
 

--- a/deployment/chainloop/README.md
+++ b/deployment/chainloop/README.md
@@ -529,7 +529,7 @@ chainloop config save \
 | `controlplane.containerPorts.http`             | controlplane HTTP container port                                                                | `8000`            |
 | `controlplane.containerPorts.grpc`             | controlplane gRPC container port                                                                | `9000`            |
 | `controlplane.containerPorts.metrics`          | controlplane prometheus metrics container port                                                  | `5000`            |
-| `controlplane.tlsConfig.secret.name`           | name of a secret containing TLS certificate to be used by the controlplane grpc server.         | `""`              |
+| `controlplane.tls.existingSecret`              | Existing secret name containing TLS certificate to be used by the controlplane grpc server      | `random`          |
 | `controlplane.pluginsDir`                      | Directory where to look for plugins                                                             | `/plugins`        |
 | `controlplane.referrerSharedIndex`             | Configure the shared, public index API endpoint that can be used to discover metadata referrers |                   |
 | `controlplane.referrerSharedIndex.enabled`     | Enable index API endpoint                                                                       | `false`           |
@@ -713,15 +713,15 @@ chainloop config save \
 
 ### Artifact Content Addressable (CAS) API
 
-| Name                         | Description                                                                             | Value             |
-| ---------------------------- | --------------------------------------------------------------------------------------- | ----------------- |
-| `cas.replicaCount`           | Number of replicas                                                                      | `2`               |
-| `cas.image.registry`         | Image registry                                                                          | `REGISTRY_NAME`   |
-| `cas.image.repository`       | Image repository                                                                        | `REPOSITORY_NAME` |
-| `cas.containerPorts.http`    | controlplane HTTP container port                                                        | `8000`            |
-| `cas.containerPorts.grpc`    | controlplane gRPC container port                                                        | `9000`            |
-| `cas.containerPorts.metrics` | controlplane prometheus metrics container port                                          | `5000`            |
-| `cas.tlsConfig.secret.name`  | name of a secret containing TLS certificate to be used by the controlplane grpc server. | `""`              |
+| Name                         | Description                                                                                | Value             |
+| ---------------------------- | ------------------------------------------------------------------------------------------ | ----------------- |
+| `cas.replicaCount`           | Number of replicas                                                                         | `2`               |
+| `cas.image.registry`         | Image registry                                                                             | `REGISTRY_NAME`   |
+| `cas.image.repository`       | Image repository                                                                           | `REPOSITORY_NAME` |
+| `cas.containerPorts.http`    | controlplane HTTP container port                                                           | `8000`            |
+| `cas.containerPorts.grpc`    | controlplane gRPC container port                                                           | `9000`            |
+| `cas.containerPorts.metrics` | controlplane prometheus metrics container port                                             | `5000`            |
+| `cas.tls.existingSecret`     | Existing secret name containing TLS certificate to be used by the controlplane grpc server | `""`              |
 
 ### CAS Networking
 

--- a/deployment/chainloop/templates/_helpers.tpl
+++ b/deployment/chainloop/templates/_helpers.tpl
@@ -169,6 +169,17 @@ Migration labels
 app.kubernetes.io/component: controlplane-migration
 {{- end }}
 
+{{/*
+Controlplane TLS Config Name
+*/}}
+{{- define "controlplane.tls-secret-name" -}}
+{{- if .Values.controlplane.tls.existingSecret }}
+{{- .Values.controlplane.tls.existingSecret }}
+{{/* Legacy option for existing secret configuration */}}
+{{- else if .Values.controlplane.tlsConfig }}
+{{- .Values.controlplane.tlsConfig.secret.name }}
+{{- end }}
+{{- end }}
 
 {{/*
 OIDC settings, will fallback to development settings if needed
@@ -376,6 +387,18 @@ Create the name of the service account to use
 {{- default (include "chainloop.cas.fullname" .) .Values.cas.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.cas.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+CAS TLS Config Name
+*/}}
+{{- define "cas.tls-secret-name" -}}
+{{- if .Values.cas.tls.existingSecret }}
+{{- .Values.cas.tls.existingSecret }}
+{{/* Legacy option for existing secret configuration */}}
+{{- else if .Values.cas.tlsConfig }}
+{{- .Values.cas.tlsConfig.secret.name }}
 {{- end }}
 {{- end }}
 

--- a/deployment/chainloop/templates/cas/configmap.yaml
+++ b/deployment/chainloop/templates/cas/configmap.yaml
@@ -21,7 +21,7 @@ data:
         # grpc downloads/uploads don't require this because they don't have timeouts
         timeout: 300s
       grpc:
-        {{- if .Values.cas.tlsConfig.secret.name  }}
+        {{- if include "cas.tls-secret-name" .  }}
         tls_config:
           certificate: /data/server-certs/tls.crt
           private_key: /data/server-certs/tls.key

--- a/deployment/chainloop/templates/cas/deployment.yaml
+++ b/deployment/chainloop/templates/cas/deployment.yaml
@@ -125,7 +125,7 @@ spec:
             - name: gcp-secretmanager-serviceaccountkey
               mountPath: /gcp-secrets
             {{- end }}
-            {{- if .Values.cas.tlsConfig.secret.name  }}
+            {{- if include "cas.tls-secret-name" .  }}
             - name: server-certs
               mountPath: /data/server-certs
             {{- end }}
@@ -153,10 +153,10 @@ spec:
         - name: jwt-public-key
           secret:
             secretName: {{ include "chainloop.cas.fullname" . }}-jwt-public-key
-        {{- if .Values.cas.tlsConfig.secret.name  }}
+        {{- if include "cas.tls-secret-name" .  }}
         - name: server-certs
           secret:
-            secretName: {{ .Values.cas.tlsConfig.secret.name  }}
+            secretName: {{ .Values.cas.tls.existingSecret  }}
         {{- end }}
         {{- if eq "gcpSecretManager" .Values.secretsBackend.backend  }}
         - name: gcp-secretmanager-serviceaccountkey

--- a/deployment/chainloop/templates/controlplane/configmap.yaml
+++ b/deployment/chainloop/templates/controlplane/configmap.yaml
@@ -30,7 +30,7 @@ data:
       grpc:
         addr: "0.0.0.0:{{ .Values.controlplane.containerPorts.grpc }}"
         timeout: 10s
-        {{- if .Values.controlplane.tlsConfig.secret.name  }}
+        {{- if include "controlplane.tls-secret-name" .  }}
         tls_config:
           certificate: /data/server-certs/tls.crt
           private_key: /data/server-certs/tls.key
@@ -38,7 +38,7 @@ data:
     cas_server:
       grpc:
         addr: {{ printf "%s-api:%.0f" (include "chainloop.cas.fullname" .) (coalesce .Values.cas.serviceAPI.port .Values.cas.serviceAPI.ports.http) }}
-      insecure: {{ empty .Values.cas.tlsConfig.secret.name }}
+      insecure: {{ empty (include "controlplane.tls-secret-name" .) }}
       download_url: {{ include "chainloop.cas.external_url" . }}/download
     plugins_dir: {{ .Values.controlplane.pluginsDir }}
     referrer_shared_index:

--- a/deployment/chainloop/templates/controlplane/deployment.yaml
+++ b/deployment/chainloop/templates/controlplane/deployment.yaml
@@ -150,7 +150,7 @@ spec:
             - name: ejbca-ca-client
               mountPath: /ca_secrets
             {{- end }}
-            {{- if .Values.controlplane.tlsConfig.secret.name  }}
+            {{- if include "controlplane.tls-secret-name" . }}
             - name: server-certs
               mountPath: /data/server-certs
             {{- end }}
@@ -192,10 +192,10 @@ spec:
         - name: jwt-cas-private-key
           secret:
             secretName: {{ include "chainloop.controlplane.fullname" . }}-jwt-cas
-        {{- if .Values.controlplane.tlsConfig.secret.name }}
+        {{- if include "controlplane.tls-secret-name" . }}
         - name: server-certs
           secret:
-            secretName: {{ .Values.controlplane.tlsConfig.secret.name  }}
+            secretName: {{ include "controlplane.tls-secret-name" . }}
         {{- end }}
         {{- if eq "gcpSecretManager" .Values.secretsBackend.backend  }}
         - name: gcp-secretmanager-serviceaccountkey

--- a/deployment/chainloop/values.yaml
+++ b/deployment/chainloop/values.yaml
@@ -150,11 +150,14 @@ controlplane:
     grpc: 9000
     metrics: 5000
 
-  ## @param controlplane.tlsConfig.secret.name name of a secret containing TLS certificate to be used by the controlplane grpc server.
-  tlsConfig:
-    secret:
-      # the secret must contains 2 keys: tls.crt and tls.key respectively containing the certificate and private key.
-      name: ""
+  ##
+  ## TLS configuration
+  ##
+  tls:
+    ## @param controlplane.tls.existingSecret Existing secret name containing TLS certificate to be used by the controlplane grpc server
+    ## NOTE: When it's set it will disable secret creation. The secret must contains 2 keys: tls.crt and tls.key respectively containing the certificate and private key.
+    ##
+    existingSecret: ""
 
   ## @param controlplane.pluginsDir Directory where to look for plugins
   pluginsDir: /plugins
@@ -919,11 +922,14 @@ cas:
     grpc: 9000
     metrics: 5000
 
-  ## @param cas.tlsConfig.secret.name name of a secret containing TLS certificate to be used by the controlplane grpc server.
-  tlsConfig:
-    secret:
-      # the secret must contains 2 keys: tls.crt and tls.key respectively containing the certificate and private key.
-      name: ""
+  ##
+  ## TLS configuration
+  ##
+  tls:
+    ## @param cas.tls.existingSecret Existing secret name containing TLS certificate to be used by the cas grpc server
+    ## NOTE: When it's set it will disable secret creation. The secret must contains 2 keys: tls.crt and tls.key respectively containing the certificate and private key.
+    ##
+    existingSecret: ""
 
   ## @skip cas.serviceAccount
   serviceAccount:


### PR DESCRIPTION
This patch modifies the name of the TLS config param.

Diff:
```diff
diff --git a/old.yml b/new.yml
index 7bb317e..bb56aef 100644
--- a/old.yml	
+++ b/new.yml	
@@ -441,7 +441,7 @@ metadata:
 type: Opaque
 data:
   # We store it also as a different key so it can be reused during upgrades by the common.secrets.passwords.manage helper
-  generated_jws_hmac_secret: "dkNTVk5SaTVrWg=="
+  generated_jws_hmac_secret: "MWh5U2p1eVVnVw=="
   db_migrate_source: "cG9zdGdyZXM6Ly9jaGFpbmxvb3A6Y2hhaW5sb29wcHdkQGNoYWlubG9vcC1wb3N0Z3Jlc3FsOjU0MzIvY2hhaW5sb29wLWNwP3NzbG1vZGU9ZGlzYWJsZQ=="
 stringData:
   config.secret.yaml: |
@@ -465,7 +465,7 @@ stringData:
       # HMAC key used to sign the JWTs generated by the controlplane
       # The helper returns the base64 quoted value of the secret
       # We need to remove the quotes and then decoding it so it's compatible with the stringData stanza
-      generated_jws_hmac_secret: "vCSVNRi5kZ"
+      generated_jws_hmac_secret: "1hySjuyUgW"
 
       # Private key used to sign the JWTs meant to be consumed by the CAS
       cas_robot_account_private_key_path: "/secrets/cas.private.key"
@@ -1582,7 +1582,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 7ebb40b21af918bef7decf41a5d6bbfcbdcab8a7b275e06922e7174f4ecfd98d
-        checksum/secret-config: 27987b6cef61e3d5de9c475a14e38d0f827fa1e895fccc0adbe02b88a2222226
+        checksum/secret-config: 1d5c3ebbfabb0b512373e7d4bab0ce81800aeb3ecf1866fd9fa4deb56957880c
         checksum/cas-private-key: 0bb2f0ef78066c0debed29e25af937f54deaa1c53b7b278afe0719308d271ef6
         kubectl.kubernetes.io/default-container: controlplane
       labels:

```

Refs #1151 