### PR TITLE
fix(chart): Remove duplicated label

### DIFF
--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -7,7 +7,7 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.86.14
+version: 1.86.15
 # Do not update appVersion, this is handled automatically by the release process
 appVersion: v0.95.3
 

--- a/deployment/chainloop/templates/controlplane/networkpolicy.yaml
+++ b/deployment/chainloop/templates/controlplane/networkpolicy.yaml
@@ -10,7 +10,6 @@ metadata:
   name: {{ printf "%s-controlplane" (include "common.names.fullname" .) }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{ include "chainloop.controlplane.labels" . | nindent 4 }}
-    app.kubernetes.io/component: controlplane
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
This patch removes a duplicated label present on the deployment of the `controlplane`.

Diff:
```diff
diff --git a/Users/javirln/Library/Application Support/JetBrains/GoLand2024.1/scratches/scratch_13.yml b/Users/javirln/Library/Application Support/JetBrains/GoLand2024.1/scratches/scratch_14.yml
index 3a2aa37..842836f 100644
--- a/Users/javirln/Library/Application Support/JetBrains/GoLand2024.1/scratches/scratch_13.yml
+++ b/Users/javirln/Library/Application Support/JetBrains/GoLand2024.1/scratches/scratch_14.yml
@@ -103,7 +103,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: chainloop
     app.kubernetes.io/version: v0.95.3
-    helm.sh/chart: chainloop-1.86.14
+    helm.sh/chart: chainloop-1.86.15
     app.kubernetes.io/component: cas
 spec:
   podSelector:
@@ -131,8 +131,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: chainloop
     app.kubernetes.io/version: v0.95.3
-    helm.sh/chart: chainloop-1.86.14
-    app.kubernetes.io/component: controlplane
+    helm.sh/chart: chainloop-1.86.15
     app.kubernetes.io/component: controlplane
 spec:
   podSelector:
@@ -307,7 +306,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: chainloop
     app.kubernetes.io/version: v0.95.3
-    helm.sh/chart: chainloop-1.86.14
+    helm.sh/chart: chainloop-1.86.15
     app.kubernetes.io/component: cas
 ---
 # Source: chainloop/templates/controlplane/service-account.yaml
@@ -321,7 +320,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: chainloop
     app.kubernetes.io/version: v0.95.3
-    helm.sh/chart: chainloop-1.86.14
+    helm.sh/chart: chainloop-1.86.15
     app.kubernetes.io/component: controlplane
 ---
 # Source: chainloop/charts/dex/templates/secret.yaml
@@ -393,7 +392,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: chainloop
     app.kubernetes.io/version: v0.95.3
-    helm.sh/chart: chainloop-1.86.14
+    helm.sh/chart: chainloop-1.86.15
     app.kubernetes.io/component: cas
 type: Opaque
 stringData:
@@ -419,7 +418,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: chainloop
     app.kubernetes.io/version: v0.95.3
-    helm.sh/chart: chainloop-1.86.14
+    helm.sh/chart: chainloop-1.86.15
     app.kubernetes.io/component: cas
 type: Opaque
 data:
@@ -436,12 +435,12 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: chainloop
     app.kubernetes.io/version: v0.95.3
-    helm.sh/chart: chainloop-1.86.14
+    helm.sh/chart: chainloop-1.86.15
     app.kubernetes.io/component: controlplane
 type: Opaque
 data:
   # We store it also as a different key so it can be reused during upgrades by the common.secrets.passwords.manage helper
-  generated_jws_hmac_secret: "UHVnb1Vha2t3cA=="
+  generated_jws_hmac_secret: "b1B5ZUhYOHo3TA=="
   db_migrate_source: "cG9zdGdyZXM6Ly9jaGFpbmxvb3A6Y2hhaW5sb29wcHdkQGNoYWlubG9vcC1wb3N0Z3Jlc3FsOjU0MzIvY2hhaW5sb29wLWNwP3NzbG1vZGU9ZGlzYWJsZQ=="
 stringData:
   config.secret.yaml: |
@@ -465,7 +464,7 @@ stringData:
       # HMAC key used to sign the JWTs generated by the controlplane
       # The helper returns the base64 quoted value of the secret
       # We need to remove the quotes and then decoding it so it's compatible with the stringData stanza
-      generated_jws_hmac_secret: "PugoUakkwp"
+      generated_jws_hmac_secret: "oPyeHX8z7L"

       # Private key used to sign the JWTs meant to be consumed by the CAS
       cas_robot_account_private_key_path: "/secrets/cas.private.key"
@@ -480,7 +479,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: chainloop
     app.kubernetes.io/version: v0.95.3
-    helm.sh/chart: chainloop-1.86.14
+    helm.sh/chart: chainloop-1.86.15
     app.kubernetes.io/component: controlplane
 type: Opaque
 data:
@@ -518,7 +517,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: chainloop
     app.kubernetes.io/version: v0.95.3
-    helm.sh/chart: chainloop-1.86.14
+    helm.sh/chart: chainloop-1.86.15
     app.kubernetes.io/component: cas
 data:
   server.yaml: |
@@ -546,7 +545,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: chainloop
     app.kubernetes.io/version: v0.95.3
-    helm.sh/chart: chainloop-1.86.14
+    helm.sh/chart: chainloop-1.86.15
     app.kubernetes.io/component: controlplane
 data:
   config.yaml: |
@@ -1060,7 +1059,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: chainloop
     app.kubernetes.io/version: v0.95.3
-    helm.sh/chart: chainloop-1.86.14
+    helm.sh/chart: chainloop-1.86.15
     app.kubernetes.io/component: cas
   annotations:
     traefik.ingress.kubernetes.io/service.serversscheme: h2c
@@ -1089,7 +1088,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: chainloop
     app.kubernetes.io/version: v0.95.3
-    helm.sh/chart: chainloop-1.86.14
+    helm.sh/chart: chainloop-1.86.15
     app.kubernetes.io/component: cas
 spec:
   type: ClusterIP
@@ -1116,7 +1115,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: chainloop
     app.kubernetes.io/version: v0.95.3
-    helm.sh/chart: chainloop-1.86.14
+    helm.sh/chart: chainloop-1.86.15
     app.kubernetes.io/component: controlplane
   annotations:
     traefik.ingress.kubernetes.io/service.serversscheme: h2c
@@ -1145,7 +1144,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: chainloop
     app.kubernetes.io/version: v0.95.3
-    helm.sh/chart: chainloop-1.86.14
+    helm.sh/chart: chainloop-1.86.15
     app.kubernetes.io/component: controlplane
 spec:
   type: ClusterIP
@@ -1194,11 +1193,11 @@ spec:
         app.kubernetes.io/component: dex
     spec:
       serviceAccountName: chainloop-dex
-
+
       automountServiceAccountToken: true
       affinity:
         podAffinity:
-
+
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - podAffinityTerm:
@@ -1210,7 +1209,7 @@ spec:
                 topologyKey: kubernetes.io/hostname
               weight: 1
         nodeAffinity:
-
+
       securityContext:
         fsGroup: 1001
         fsGroupChangePolicy: Always
@@ -1339,11 +1338,11 @@ spec:
         app.kubernetes.io/component: injector
     spec:
       serviceAccountName: chainloop-vault-injector
-
+
       automountServiceAccountToken: true
       affinity:
         podAffinity:
-
+
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - podAffinityTerm:
@@ -1355,7 +1354,7 @@ spec:
                 topologyKey: kubernetes.io/hostname
               weight: 1
         nodeAffinity:
-
+
       securityContext:
         fsGroup: 1001
         fsGroupChangePolicy: Always
@@ -1442,7 +1441,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: chainloop
     app.kubernetes.io/version: v0.95.3
-    helm.sh/chart: chainloop-1.86.14
+    helm.sh/chart: chainloop-1.86.15
     app.kubernetes.io/component: cas
 spec:
   replicas: 2
@@ -1456,23 +1455,23 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c34558205634a2ad45db22025c414ece6e056f3d7d4e40f00879a47d01fbb3a0
-        checksum/config-secret: 78ab295064f950d3ed6bb5f394d1113879d92139e0c7db6ce3ed76289b1649c6
-        checksum/public-key-secret: 3c38cae1f73f5b9579d66f16bd5f06966731d6f733702b87cb5ed2c038a87d2a
+        checksum/config: 6750e9cf58dc7103161e2ac6fd7416e17318063a6ad604d0f4d707f3c1ac2199
+        checksum/config-secret: fa4345870eb8be493a1e17ba6ed535a99d1f1ffa45b85902173801618f418054
+        checksum/public-key-secret: 79872de1c51582e3e7e5384437a8043bb6ff9e2a8e59af56455f38aadd957601
       labels:
         app.kubernetes.io/instance: chainloop
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: chainloop
         app.kubernetes.io/version: v0.95.3
-        helm.sh/chart: chainloop-1.86.14
+        helm.sh/chart: chainloop-1.86.15
         app.kubernetes.io/component: cas
     spec:
-
+
       serviceAccountName: chainloop-cas
       automountServiceAccountToken: false
       affinity:
         podAffinity:
-
+
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - podAffinityTerm:
@@ -1484,7 +1483,7 @@ spec:
                 topologyKey: kubernetes.io/hostname
               weight: 1
         nodeAffinity:
-
+
       securityContext:
         fsGroup: 1001
         fsGroupChangePolicy: Always
@@ -1567,7 +1566,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: chainloop
     app.kubernetes.io/version: v0.95.3
-    helm.sh/chart: chainloop-1.86.14
+    helm.sh/chart: chainloop-1.86.15
     app.kubernetes.io/component: controlplane
 spec:
   replicas: 2
@@ -1581,24 +1580,24 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c47be9c50a759749840250e12239dd9533c456bc060a1c6d8f1f9b1b32cbd0b9
-        checksum/secret-config: 00f94f6ccde660e25b3db354bd03bf8b7dc2c3f89ae687c5dce20093fc913bb9
-        checksum/cas-private-key: f2625ad6d3493b333831121743baa728e51ee621c24571397d156b76cdcd16fe
+        checksum/config: d2feef17b9b03e6572f6a78d1ea1ff3cb863fb7c744dc11450bfb5d82bf755c1
+        checksum/secret-config: 7543ecb65c9a294686a4acd4faa2ffd7023bc75c41c7653613065950f606aa8b
+        checksum/cas-private-key: 0dac886beb312e4242d37c74812e1e5ab0d7d48c2e3d1f1bd6546632efd33d6f
         kubectl.kubernetes.io/default-container: controlplane
       labels:
         app.kubernetes.io/instance: chainloop
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: chainloop
         app.kubernetes.io/version: v0.95.3
-        helm.sh/chart: chainloop-1.86.14
+        helm.sh/chart: chainloop-1.86.15
         app.kubernetes.io/component: controlplane
     spec:
-
+
       serviceAccountName: chainloop-controlplane
       automountServiceAccountToken: false
       affinity:
         podAffinity:
-
+
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - podAffinityTerm:
@@ -1610,7 +1609,7 @@ spec:
                 topologyKey: kubernetes.io/hostname
               weight: 1
         nodeAffinity:
-
+
       securityContext:
         fsGroup: 1001
         fsGroupChangePolicy: Always
@@ -1741,11 +1740,11 @@ spec:
         app.kubernetes.io/component: primary
     spec:
       serviceAccountName: chainloop-postgresql
-
+
       automountServiceAccountToken: false
       affinity:
         podAffinity:
-
+
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - podAffinityTerm:
@@ -1757,7 +1756,7 @@ spec:
                 topologyKey: kubernetes.io/hostname
               weight: 1
         nodeAffinity:
-
+
       securityContext:
         fsGroup: 1001
         fsGroupChangePolicy: Always
@@ -1928,11 +1927,11 @@ spec:
         app.kubernetes.io/component: server
     spec:
       serviceAccountName: chainloop-vault-server
-
+
       automountServiceAccountToken: true
       affinity:
         podAffinity:
-
+
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - podAffinityTerm:
@@ -1944,7 +1943,7 @@ spec:
                 topologyKey: kubernetes.io/hostname
               weight: 1
         nodeAffinity:
-
+
       securityContext:
         fsGroup: 1001
         fsGroupChangePolicy: Always

```

Closes #1208 