### PR TITLE
fix(chart): Missing ports on network policies

### DIFF
--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -7,7 +7,7 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.86.15
+version: 1.86.16
 # Do not update appVersion, this is handled automatically by the release process
 appVersion: v0.95.3
 

--- a/deployment/chainloop/templates/cas/networkpolicy.yaml
+++ b/deployment/chainloop/templates/cas/networkpolicy.yaml
@@ -33,9 +33,9 @@ spec:
           protocol: TCP
     # Allow outbound connections to other cluster pods
     - ports:
-        - port: {{ .Values.controlplane.containerPorts.http }}
-        - port: {{ .Values.controlplane.containerPorts.grpc }}
-        - port: {{ .Values.controlplane.containerPorts.metrics }}
+        - port: {{ .Values.cas.containerPorts.http }}
+        - port: {{ .Values.cas.containerPorts.grpc }}
+        - port: {{ .Values.cas.containerPorts.metrics }}
       to:
         - podSelector:
             matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
@@ -46,6 +46,8 @@ spec:
   ingress:
     - ports:
         - port: {{ .Values.cas.containerPorts.http }}
+        - port: {{ .Values.cas.containerPorts.grpc }}
+        - port: {{ .Values.cas.containerPorts.metrics }}
       {{- if not .Values.cas.networkPolicy.allowExternal }}
       from:
         - podSelector:

--- a/deployment/chainloop/templates/controlplane/networkpolicy.yaml
+++ b/deployment/chainloop/templates/controlplane/networkpolicy.yaml
@@ -34,6 +34,8 @@ spec:
     # Allow outbound connections to other cluster pods
     - ports:
         - port: {{ .Values.controlplane.containerPorts.http }}
+        - port: {{ .Values.controlplane.containerPorts.grpc }}
+        - port: {{ .Values.controlplane.containerPorts.metrics }}
       to:
         - podSelector:
             matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}


### PR DESCRIPTION
Add missing ports on `cas` and `controlplane` network policies.

Refs #1208 