### PR TITLE
feat(cli): allow graceful exit on workflow create

### DIFF
--- a/app/cli/cmd/workflow_create.go
+++ b/app/cli/cmd/workflow_create.go
@@ -75,7 +75,7 @@ func newWorkflowCreateCmd() *cobra.Command {
 					}
 				}
 
-				return fmt.Errorf("failed to create workflow: %w", err)
+				return err
 			}
 
 			// Print the workflow table

--- a/app/controlplane/internal/service/service.go
+++ b/app/controlplane/internal/service/service.go
@@ -146,6 +146,8 @@ func handleUseCaseErr(err error, l *log.Helper) error {
 		return errors.Forbidden("unauthorized", err.Error())
 	case biz.IsErrNotImplemented(err):
 		return status.Error(codes.Unimplemented, err.Error())
+	case errors.Is(err, biz.ErrAlreadyExists):
+		return status.Error(codes.AlreadyExists, err.Error())
 	default:
 		return servicelogger.LogAndMaskErr(err, l)
 	}

--- a/app/controlplane/internal/service/service.go
+++ b/app/controlplane/internal/service/service.go
@@ -146,7 +146,7 @@ func handleUseCaseErr(err error, l *log.Helper) error {
 		return errors.Forbidden("unauthorized", err.Error())
 	case biz.IsErrNotImplemented(err):
 		return status.Error(codes.Unimplemented, err.Error())
-	case errors.Is(err, biz.ErrAlreadyExists):
+	case biz.IsErrAlreadyExists(err):
 		return status.Error(codes.AlreadyExists, err.Error())
 	default:
 		return servicelogger.LogAndMaskErr(err, l)

--- a/app/controlplane/pkg/biz/apitoken.go
+++ b/app/controlplane/pkg/biz/apitoken.go
@@ -17,7 +17,6 @@ package biz
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -139,8 +138,8 @@ func (uc *APITokenUseCase) Create(ctx context.Context, name string, description 
 	// We store it since Chainloop will not have access to the JWT to check the expiration once created
 	token, err := uc.apiTokenRepo.Create(ctx, name, description, expiresAt, orgUUID)
 	if err != nil {
-		if errors.Is(err, ErrAlreadyExists) {
-			return nil, NewErrValidationStr("name already taken")
+		if IsErrAlreadyExists(err) {
+			return nil, NewErrAlreadyExistsStr("name already taken")
 		}
 		return nil, fmt.Errorf("storing token: %w", err)
 	}

--- a/app/controlplane/pkg/biz/casbackend.go
+++ b/app/controlplane/pkg/biz/casbackend.go
@@ -263,8 +263,8 @@ func (uc *CASBackendUseCase) Create(ctx context.Context, orgID, name, location, 
 	})
 
 	if err != nil {
-		if errors.Is(err, ErrAlreadyExists) {
-			return nil, NewErrValidationStr("name already taken")
+		if IsErrAlreadyExists(err) {
+			return nil, NewErrAlreadyExistsStr("name already taken")
 		}
 		return nil, fmt.Errorf("failed to create CAS backend: %w", err)
 	}

--- a/app/controlplane/pkg/biz/errors.go
+++ b/app/controlplane/pkg/biz/errors.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 The Chainloop Authors.
+// Copyright 2024 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,8 +19,6 @@ import (
 	"errors"
 	"fmt"
 )
-
-var ErrAlreadyExists = errors.New("duplicate")
 
 type ErrNotFound struct {
 	entity string
@@ -161,4 +159,24 @@ func (e *ErrAttestationStateConflict) Error() string {
 func IsErrAttestationStateConflict(err error) bool {
 	var e *ErrAttestationStateConflict
 	return errors.As(err, &e)
+}
+
+type ErrAlreadyExists struct {
+	err error
+}
+
+func NewErrAlreadyExists(err error) ErrAlreadyExists {
+	return ErrAlreadyExists{err}
+}
+
+func NewErrAlreadyExistsStr(errMsg string) ErrAlreadyExists {
+	return ErrAlreadyExists{errors.New(errMsg)}
+}
+
+func (e ErrAlreadyExists) Error() string {
+	return fmt.Sprintf("duplicated: %s", e.err.Error())
+}
+
+func IsErrAlreadyExists(err error) bool {
+	return errors.As(err, &ErrAlreadyExists{})
 }

--- a/app/controlplane/pkg/biz/integration.go
+++ b/app/controlplane/pkg/biz/integration.go
@@ -154,8 +154,8 @@ func (uc *IntegrationUseCase) RegisterAndSave(ctx context.Context, orgID, name, 
 		SecretName: secretID, Config: registrationResponse.Configuration,
 	})
 	if err != nil {
-		if errors.Is(err, ErrAlreadyExists) {
-			return nil, NewErrValidationStr("name already taken")
+		if IsErrAlreadyExists(err) {
+			return nil, NewErrAlreadyExistsStr("name already taken")
 		}
 
 		return nil, fmt.Errorf("failed to register integration: %w", err)

--- a/app/controlplane/pkg/biz/organization.go
+++ b/app/controlplane/pkg/biz/organization.go
@@ -93,7 +93,7 @@ func (uc *OrganizationUseCase) CreateWithRandomName(ctx context.Context, opts ..
 		org, err := uc.doCreate(ctx, name, opts...)
 		if err != nil {
 			// We retry if the organization already exists
-			if errors.Is(err, ErrAlreadyExists) {
+			if IsErrAlreadyExists(err) {
 				uc.logger.Debugw("msg", "Org exists!", "name", name)
 				continue
 			}
@@ -111,8 +111,8 @@ func (uc *OrganizationUseCase) CreateWithRandomName(ctx context.Context, opts ..
 func (uc *OrganizationUseCase) Create(ctx context.Context, name string, opts ...CreateOpt) (*Organization, error) {
 	org, err := uc.doCreate(ctx, name, opts...)
 	if err != nil {
-		if errors.Is(err, ErrAlreadyExists) {
-			return nil, NewErrValidationStr("organization already exists")
+		if IsErrAlreadyExists(err) {
+			return nil, NewErrAlreadyExistsStr("organization already exists")
 		}
 
 		return nil, fmt.Errorf("failed to create organization: %w", err)

--- a/app/controlplane/pkg/biz/organization_test.go
+++ b/app/controlplane/pkg/biz/organization_test.go
@@ -38,7 +38,7 @@ func (s *organizationTestSuite) TestCreateWithRandomName() {
 	s.Run("the org exists, we retry", func() {
 		ctx := context.Background()
 		// the first one fails because it already exists
-		repo.On("Create", ctx, mock.Anything).Once().Return(nil, biz.ErrAlreadyExists)
+		repo.On("Create", ctx, mock.Anything).Once().Return(nil, biz.NewErrAlreadyExistsStr("it already exists"))
 		// but the second call creates the org
 		repo.On("Create", ctx, mock.Anything).Once().Return(&biz.Organization{Name: "foobar"}, nil)
 		got, err := uc.CreateWithRandomName(ctx)
@@ -49,7 +49,7 @@ func (s *organizationTestSuite) TestCreateWithRandomName() {
 	s.Run("if it runs out of tries, it fails", func() {
 		ctx := context.Background()
 		// the first one fails because it already exists
-		repo.On("Create", ctx, mock.Anything).Times(biz.RandomNameMaxTries).Return(nil, biz.ErrAlreadyExists)
+		repo.On("Create", ctx, mock.Anything).Times(biz.RandomNameMaxTries).Return(nil, biz.NewErrAlreadyExistsStr("it already exists"))
 		got, err := uc.CreateWithRandomName(ctx)
 		s.Error(err)
 		s.Nil(got)

--- a/app/controlplane/pkg/biz/workflow.go
+++ b/app/controlplane/pkg/biz/workflow.go
@@ -109,10 +109,6 @@ func (uc *WorkflowUseCase) Create(ctx context.Context, opts *WorkflowCreateOpts)
 	opts.ContractID = contract.ID.String()
 	wf, err := uc.wfRepo.Create(ctx, opts)
 	if err != nil {
-		if errors.Is(err, ErrAlreadyExists) {
-			return nil, NewErrValidationStr("name already taken")
-		}
-
 		return nil, fmt.Errorf("failed to create workflow: %w", err)
 	}
 

--- a/app/controlplane/pkg/biz/workflow.go
+++ b/app/controlplane/pkg/biz/workflow.go
@@ -109,6 +109,11 @@ func (uc *WorkflowUseCase) Create(ctx context.Context, opts *WorkflowCreateOpts)
 	opts.ContractID = contract.ID.String()
 	wf, err := uc.wfRepo.Create(ctx, opts)
 	if err != nil {
+		if IsErrAlreadyExists(err) {
+			// mask the error but return a custom error
+			return nil, NewErrAlreadyExistsStr("name already taken")
+		}
+
 		return nil, fmt.Errorf("failed to create workflow: %w", err)
 	}
 
@@ -154,7 +159,7 @@ func (uc *WorkflowUseCase) Update(ctx context.Context, orgID, workflowID string,
 
 	wf, err := uc.wfRepo.Update(ctx, workflowUUID, opts)
 	if err != nil {
-		if errors.Is(err, ErrAlreadyExists) {
+		if IsErrAlreadyExists(err) {
 			return nil, NewErrValidationStr("name already taken")
 		}
 

--- a/app/controlplane/pkg/biz/workflowcontract.go
+++ b/app/controlplane/pkg/biz/workflowcontract.go
@@ -172,8 +172,8 @@ func (uc *WorkflowContractUseCase) Create(ctx context.Context, opts *WorkflowCon
 	}
 
 	if err != nil {
-		if errors.Is(err, ErrAlreadyExists) {
-			return nil, NewErrValidationStr("name already taken")
+		if IsErrAlreadyExists(err) {
+			return nil, NewErrAlreadyExistsStr("name already taken")
 		}
 
 		return nil, fmt.Errorf("failed to create contract: %w", err)
@@ -197,7 +197,7 @@ func (uc *WorkflowContractUseCase) createWithUniqueName(ctx context.Context, opt
 
 		c, err := uc.repo.Create(ctx, opts)
 		if err != nil {
-			if errors.Is(err, ErrAlreadyExists) {
+			if IsErrAlreadyExists(err) {
 				continue
 			}
 

--- a/app/controlplane/pkg/data/apitoken.go
+++ b/app/controlplane/pkg/data/apitoken.go
@@ -50,7 +50,7 @@ func (r *APITokenRepo) Create(ctx context.Context, name string, description *str
 		Save(ctx)
 	if err != nil {
 		if ent.IsConstraintError(err) {
-			return nil, biz.ErrAlreadyExists
+			return nil, biz.NewErrAlreadyExists(err)
 		}
 
 		return nil, fmt.Errorf("saving APIToken: %w", err)

--- a/app/controlplane/pkg/data/casbackend.go
+++ b/app/controlplane/pkg/data/casbackend.go
@@ -114,7 +114,7 @@ func (r *CASBackendRepo) Create(ctx context.Context, opts *biz.CASBackendCreateO
 		Save(ctx)
 	if err != nil {
 		if ent.IsConstraintError(err) {
-			return nil, biz.ErrAlreadyExists
+			return nil, biz.NewErrAlreadyExists(err)
 		}
 
 		return nil, fmt.Errorf("failed to create backend: %w", err)

--- a/app/controlplane/pkg/data/integration.go
+++ b/app/controlplane/pkg/data/integration.go
@@ -52,7 +52,7 @@ func (r *IntegrationRepo) Create(ctx context.Context, opts *biz.IntegrationCreat
 
 	if err != nil {
 		if ent.IsConstraintError(err) {
-			return nil, biz.ErrAlreadyExists
+			return nil, biz.NewErrAlreadyExists(err)
 		}
 
 		return nil, fmt.Errorf("failed to create registration: %w", err)

--- a/app/controlplane/pkg/data/organization.go
+++ b/app/controlplane/pkg/data/organization.go
@@ -42,7 +42,7 @@ func (r *OrganizationRepo) Create(ctx context.Context, name string) (*biz.Organi
 		SetName(name).
 		Save(ctx)
 	if err != nil && ent.IsConstraintError(err) {
-		return nil, biz.ErrAlreadyExists
+		return nil, biz.NewErrAlreadyExists(err)
 	} else if err != nil {
 		return nil, err
 	}

--- a/app/controlplane/pkg/data/workflow.go
+++ b/app/controlplane/pkg/data/workflow.go
@@ -66,7 +66,7 @@ func (r *WorkflowRepo) Create(ctx context.Context, opts *biz.WorkflowCreateOpts)
 		Save(ctx)
 	if err != nil {
 		if ent.IsConstraintError(err) {
-			return nil, biz.ErrAlreadyExists
+			return nil, biz.NewErrAlreadyExists(err)
 		}
 
 		return nil, fmt.Errorf("failed to create workflow: %w", err)
@@ -99,7 +99,7 @@ func (r *WorkflowRepo) Update(ctx context.Context, id uuid.UUID, opts *biz.Workf
 
 	if err != nil {
 		if ent.IsConstraintError(err) {
-			return nil, biz.ErrAlreadyExists
+			return nil, biz.NewErrAlreadyExists(err)
 		}
 
 		return nil, fmt.Errorf("failed to update workflow: %w", err)

--- a/app/controlplane/pkg/data/workflowcontract.go
+++ b/app/controlplane/pkg/data/workflowcontract.go
@@ -293,7 +293,7 @@ func rollback(tx *ent.Tx, err error) error {
 
 	// If the error is a constraint error, we return a more specific error to indicate the client that's a duplicate
 	if ent.IsConstraintError(err) {
-		return biz.ErrAlreadyExists
+		return biz.NewErrAlreadyExists(err)
 	}
 
 	return err


### PR DESCRIPTION
This patch adds a flag `--skip-if-exists` on `chainloop workflow create` command that performs a graceful exit (exit code 0) if the workflow with the same name exists.

First creation

```
chainloop wf create --name my-wf --project bar 
┌───────┬─────────┬───────────┬────────┬────────┬─────────────────┬─────────────────────┐
│ NAME  │ PROJECT │ CONTRACT  │ PUBLIC │ RUNNER │ LAST RUN STATUS │ CREATED AT          │
├───────┼─────────┼───────────┼────────┼────────┼─────────────────┼─────────────────────┤
│ my-wf │ bar     │ bar-my-wf │ false  │        │                 │ 12 Aug 24 20:58 UTC │
└───────┴─────────┴───────────┴────────┴────────┴─────────────────┴─────────────────────┘
```

as expected, it will fail if you try to create it again.

```
chainloop wf create --name my-wf --project bar
ERR duplicated: name already taken
exit status 1
```

but the new flag can be provided to 

```
chainloop wf create --name my-wf --project bar --skip-if-exists 
INF Workflow already exists
```

This pr makes a minor refactoring of the existing errors to ensure we can differentiate AlreadyExistErrors from regular validationErrors and customize the former.

Closes #1206 


 