### PR TITLE
feat(cli): increase retry time

### DIFF
--- a/app/cli/cmd/attestation_add.go
+++ b/app/cli/cmd/attestation_add.go
@@ -110,7 +110,7 @@ func newAttestationAddCmd() *cobra.Command {
 
 					return nil
 				},
-				backoff.NewExponentialBackOff(backoff.WithMaxElapsedTime(10*time.Second)),
+				backoff.NewExponentialBackOff(backoff.WithMaxElapsedTime(3*time.Minute)),
 				func(err error, delay time.Duration) {
 					logger.Err(err).Msgf("retrying in %s", delay)
 				})


### PR DESCRIPTION
I noticed in the wild that 10 seconds was not enough in some cases to recover from conflicts. This patch increases the upper limit so I'll watch it