### PR TITLE
feat(policies): load and evaluate remote policies on attestation operations

### DIFF
--- a/app/cli/internal/action/action.go
+++ b/app/cli/internal/action/action.go
@@ -60,5 +60,7 @@ func newCrafter(enableRemoteState bool, conn *grpc.ClientConn, opts ...crafter.N
 		return nil, fmt.Errorf("failed to create state manager: %w", err)
 	}
 
-	return crafter.NewCrafter(stateManager, opts...)
+	attClient := pb.NewAttestationServiceClient(conn)
+
+	return crafter.NewCrafter(stateManager, attClient, opts...)
 }

--- a/app/cli/internal/action/attestation_push.go
+++ b/app/cli/internal/action/attestation_push.go
@@ -147,7 +147,8 @@ func (action *AttestationPush) Run(ctx context.Context, attestationID string, ru
 		return nil, fmt.Errorf("creating signer: %w", err)
 	}
 
-	renderer, err := renderer.NewAttestationRenderer(crafter.CraftingState, action.cliVersion, action.cliDigest, sig,
+	attClient := pb.NewAttestationServiceClient(action.CPConnection)
+	renderer, err := renderer.NewAttestationRenderer(crafter.CraftingState, attClient, action.cliVersion, action.cliDigest, sig,
 		renderer.WithLogger(action.Logger), renderer.WithBundleOutputPath(action.bundlePath))
 	if err != nil {
 		return nil, err

--- a/pkg/attestation/crafter/crafter_test.go
+++ b/pkg/attestation/crafter/crafter_test.go
@@ -164,7 +164,7 @@ func newInitializedCrafter(t *testing.T, contractPath string, wfMeta *v1.Workflo
 	}
 
 	statePath := fmt.Sprintf("%s/attestation.json", t.TempDir())
-	c, err := crafter.NewCrafter(testingStateManager(t, statePath), opts...)
+	c, err := crafter.NewCrafter(testingStateManager(t, statePath), nil, opts...)
 	require.NoError(t, err)
 	contract, err := crafter.LoadSchema(contractPath)
 	if err != nil {
@@ -219,48 +219,6 @@ func (s *crafterSuite) TestLoadSchema() {
 			name:         "non existing",
 			contractPath: "testdata/contracts/invalid.yaml",
 			wantErr:      true,
-		},
-		{
-			name:         "policies",
-			contractPath: "testdata/contracts/with_policy_embedded.yaml",
-			want: &schemaapi.CraftingSchema{
-				SchemaVersion: "v1",
-				Policies: &schemaapi.Policies{
-					Attestation: []*schemaapi.PolicyAttachment{
-						{
-							Policy: &schemaapi.PolicyAttachment_Ref{
-								Ref: "testdata/policies/policy_embedded.yaml",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name:         "missing policy",
-			contractPath: "testdata/contracts/with_missing_policy.yaml",
-			wantErr:      true,
-		},
-		{
-			name:         "missing script",
-			contractPath: "testdata/contracts/with_policy_missing_rego.yaml",
-			wantErr:      true,
-		},
-		{
-			name:         "rego policy",
-			contractPath: "testdata/contracts/with_rego.yaml",
-			want: &schemaapi.CraftingSchema{
-				SchemaVersion: "v1",
-				Policies: &schemaapi.Policies{
-					Attestation: []*schemaapi.PolicyAttachment{
-						{
-							Policy: &schemaapi.PolicyAttachment_Ref{
-								Ref: "testdata/policies/policy_rego.yaml",
-							},
-						},
-					},
-				},
-			},
 		},
 	}
 
@@ -410,14 +368,14 @@ func (s *crafterSuite) TestAlreadyInitialized() {
 		_, err := os.Create(statePath)
 		require.NoError(s.T(), err)
 		// TODO: replace by a mock
-		c, err := crafter.NewCrafter(testingStateManager(t, statePath))
+		c, err := crafter.NewCrafter(testingStateManager(t, statePath), nil)
 		require.NoError(s.T(), err)
 		s.True(c.AlreadyInitialized(context.Background(), ""))
 	})
 
 	s.T().Run("non existing", func(t *testing.T) {
 		statePath := fmt.Sprintf("%s/attestation.json", t.TempDir())
-		c, err := crafter.NewCrafter(testingStateManager(t, statePath))
+		c, err := crafter.NewCrafter(testingStateManager(t, statePath), nil)
 		require.NoError(s.T(), err)
 		s.False(c.AlreadyInitialized(context.Background(), ""))
 	})

--- a/pkg/attestation/renderer/renderer_test.go
+++ b/pkg/attestation/renderer/renderer_test.go
@@ -69,7 +69,7 @@ func (s *rendererSuite) SetupTest() {
 
 func (s *rendererSuite) TestRender() {
 	s.Run("generated envelope is always well-formed", func() {
-		renderer, err := NewAttestationRenderer(s.cs, "", "", s.sv)
+		renderer, err := NewAttestationRenderer(s.cs, nil, "", "", s.sv)
 		s.Require().NoError(err)
 
 		envelope, err := renderer.Render(context.TODO())
@@ -82,7 +82,7 @@ func (s *rendererSuite) TestRender() {
 	s.Run("simulates double wrapping bug", func() {
 		doubleWrapper := sigdsee.WrapSigner(s.sv, "application/vnd.in-toto+json")
 
-		renderer, err := NewAttestationRenderer(s.cs, "", "", doubleWrapper)
+		renderer, err := NewAttestationRenderer(s.cs, nil, "", "", doubleWrapper)
 		s.Require().NoError(err)
 
 		envelope, err := renderer.Render(context.TODO())
@@ -99,7 +99,7 @@ func (s *rendererSuite) TestEnvelopeToBundle() {
 		s.Require().NoError(err)
 
 		signer := cosign.NewSigner("", zerolog.Nop())
-		renderer, err := NewAttestationRenderer(s.cs, "", "", signer)
+		renderer, err := NewAttestationRenderer(s.cs, nil, "", "", signer)
 		s.Require().NoError(err)
 
 		bundle, err := renderer.envelopeToBundle(*envelope)
@@ -122,7 +122,7 @@ func (s *rendererSuite) TestEnvelopeToBundle() {
 
 		// 2 certs
 		signer.Chain = []string{cert, "ROOT"}
-		renderer, err := NewAttestationRenderer(s.cs, "", "", signer)
+		renderer, err := NewAttestationRenderer(s.cs, nil, "", "", signer)
 		s.Require().NoError(err)
 
 		bundle, err := renderer.envelopeToBundle(*envelope)

--- a/pkg/policies/loader.go
+++ b/pkg/policies/loader.go
@@ -1,0 +1,101 @@
+//
+// Copyright 2024 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policies
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	pb "github.com/chainloop-dev/chainloop/app/controlplane/api/controlplane/v1"
+	v1 "github.com/chainloop-dev/chainloop/app/controlplane/api/workflowcontract/v1"
+	"github.com/chainloop-dev/chainloop/pkg/attestation/crafter/materials"
+	"github.com/sigstore/cosign/v2/pkg/blob"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+// Loader defines the interface for policy loaders from contract attachments
+type Loader interface {
+	Load(context.Context, *v1.PolicyAttachment) (*v1.Policy, error)
+}
+
+// EmbeddedLoader returns embedded policies
+type EmbeddedLoader struct{}
+
+func (e *EmbeddedLoader) Load(_ context.Context, attachment *v1.PolicyAttachment) (*v1.Policy, error) {
+	return attachment.GetEmbedded(), nil
+}
+
+// URLLoader loader loads policies from filesystem and HTTPS references
+type URLLoader struct{}
+
+func (l *URLLoader) Load(_ context.Context, attachment *v1.PolicyAttachment) (*v1.Policy, error) {
+	reference := attachment.GetRef()
+
+	// look for the referenced policy spec (note: loading by `name` is not supported yet)
+	// this method understands env, http and https schemes, and defaults to file system.
+	rawData, err := blob.LoadFileOrURL(reference)
+	if err != nil {
+		return nil, fmt.Errorf("loading policy spec: %w", err)
+	}
+
+	jsonContent, err := materials.LoadJSONBytes(rawData, filepath.Ext(reference))
+	if err != nil {
+		return nil, fmt.Errorf("loading policy spec: %w", err)
+	}
+
+	var spec v1.Policy
+	if err := protojson.Unmarshal(jsonContent, &spec); err != nil {
+		return nil, fmt.Errorf("unmarshalling policy spec: %w", err)
+	}
+	return &spec, nil
+}
+
+const chainloopScheme = "chainloop"
+
+// ChainloopLoader loads policies referenced with chainloop://provider/name URLs
+type ChainloopLoader struct {
+	Client pb.AttestationServiceClient
+}
+
+func (c *ChainloopLoader) Load(ctx context.Context, attachment *v1.PolicyAttachment) (*v1.Policy, error) {
+	ref := attachment.GetRef()
+	parts := strings.SplitN(ref, "://", 2)
+	if len(parts) != 2 || parts[0] != chainloopScheme {
+		return nil, fmt.Errorf("invalid policy reference %q", ref)
+	}
+
+	pn := strings.SplitN(parts[1], "/", 2)
+	var (
+		name     = pn[0]
+		provider string
+	)
+	if len(pn) == 2 {
+		provider = pn[0]
+		name = pn[1]
+	}
+
+	resp, err := c.Client.GetPolicy(ctx, &pb.AttestationServiceGetPolicyRequest{
+		Provider:   provider,
+		PolicyName: name,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("loading policy: %w", err)
+	}
+
+	return resp.GetPolicy(), nil
+}

--- a/pkg/policies/loader.go
+++ b/pkg/policies/loader.go
@@ -71,16 +71,21 @@ const chainloopScheme = "chainloop"
 // ChainloopLoader loads policies referenced with chainloop://provider/name URLs
 type ChainloopLoader struct {
 	Client pb.AttestationServiceClient
+
+	cacheMutex sync.Mutex
 }
 
 var remotePolicyCache = make(map[string]*v1.Policy)
-var cacheMutex sync.Mutex
+
+func NewChainloopLoader(client pb.AttestationServiceClient) *ChainloopLoader {
+	return &ChainloopLoader{Client: client}
+}
 
 func (c *ChainloopLoader) Load(ctx context.Context, attachment *v1.PolicyAttachment) (*v1.Policy, error) {
 	ref := attachment.GetRef()
 
-	cacheMutex.Lock()
-	defer cacheMutex.Unlock()
+	c.cacheMutex.Lock()
+	defer c.cacheMutex.Unlock()
 
 	if remotePolicyCache[ref] != nil {
 		return remotePolicyCache[ref], nil

--- a/pkg/policies/policies.go
+++ b/pkg/policies/policies.go
@@ -171,13 +171,13 @@ func (pv *PolicyVerifier) loadPolicySpec(ctx context.Context, attachment *v1.Pol
 	// Figure out loader to use
 	var loader Loader
 	if emb != nil {
-		loader = &EmbeddedLoader{}
+		loader = new(EmbeddedLoader)
 	} else {
 		parts := strings.SplitN(ref, "://", 2)
 		if len(parts) == 2 && parts[0] == chainloopScheme {
-			loader = &ChainloopLoader{Client: pv.client}
+			loader = NewChainloopLoader(pv.client)
 		} else {
-			loader = &URLLoader{}
+			loader = new(URLLoader)
 		}
 	}
 

--- a/pkg/policies/policies.go
+++ b/pkg/policies/policies.go
@@ -181,6 +181,7 @@ func (pv *PolicyVerifier) loadPolicySpec(ctx context.Context, attachment *v1.Pol
 		}
 	}
 
+	pv.logger.Debug().Msgf("loading policy spec %q using %T", ref, loader)
 	spec, err := loader.Load(ctx, attachment)
 	if err != nil {
 		return nil, fmt.Errorf("loading policy spec: %w", err)

--- a/pkg/policies/policies_test.go
+++ b/pkg/policies/policies_test.go
@@ -226,7 +226,7 @@ func (s *testSuite) TestVerifyAttestations() {
 
 	for _, tc := range cases {
 		s.Run(tc.name, func() {
-			verifier := NewPolicyVerifier(tc.schema, &s.logger)
+			verifier := NewPolicyVerifier(tc.schema, nil, &s.logger)
 			stContent, err := os.ReadFile(tc.statement)
 			s.Require().NoError(err)
 			var statement intoto.Statement
@@ -340,8 +340,8 @@ func (s *testSuite) TestMaterialSelectionCriteria() {
 					Materials: tc.policies,
 				},
 			}
-			pv := NewPolicyVerifier(schema, &s.logger)
-			atts, err := pv.requiredPoliciesForMaterial(tc.material)
+			pv := NewPolicyVerifier(schema, nil, &s.logger)
+			atts, err := pv.requiredPoliciesForMaterial(context.TODO(), tc.material)
 			s.Require().NoError(err)
 			s.Require().Len(atts, tc.result)
 		})
@@ -376,7 +376,7 @@ func (s *testSuite) TestValidInlineMaterial() {
 		InlineCas:    true,
 	}
 
-	verifier := NewPolicyVerifier(schema, &s.logger)
+	verifier := NewPolicyVerifier(schema, nil, &s.logger)
 
 	res, err := verifier.VerifyMaterial(context.TODO(), material, "")
 	s.Require().NoError(err)
@@ -410,7 +410,7 @@ func (s *testSuite) TestInvalidInlineMaterial() {
 		InlineCas:    true,
 	}
 
-	verifier := NewPolicyVerifier(schema, &s.logger)
+	verifier := NewPolicyVerifier(schema, nil, &s.logger)
 
 	res, err := verifier.VerifyMaterial(context.TODO(), material, "")
 	s.Require().NoError(err)
@@ -479,9 +479,10 @@ func (s *testSuite) TestLoadPolicySpec() {
 		},
 	}
 
+	verifier := NewPolicyVerifier(nil, nil, &s.logger)
 	for _, tc := range cases {
 		s.Run(tc.name, func() {
-			p, err := LoadPolicySpec(tc.attachment)
+			p, err := verifier.loadPolicySpec(context.TODO(), tc.attachment)
 			if tc.wantErr {
 				s.Error(err)
 				return


### PR DESCRIPTION
This is the closing PR for #1180 

This change adds the capability to load policies from remote providers, by using the `chainloop://[provider-name/]policy-name` syntax in the `ref` field in contracts.

Note that for the feature to fully work, at least one provider must be configured in the control plane deployment. If no provider is set in the `ref` field, the default provider will be tried.
Previously, only policies coming from local filesystem and public HTTPS were supported.

Note that I've removed policy validations during contract craft operations, since they might not be present during contract creation.

Example execution:
```
> chainloop wf contract update --name embedded --contract test/my-contract.yaml
WRN API contacted in insecure mode
WRN Both user credentials and $CHAINLOOP_TOKEN set. Ignoring $CHAINLOOP_TOKEN.
INF Contract updated!
┌────────────────────────────────────────────┐
│ Contract                                   │
├──────────────────────┬─────────────────────┤
│ Name                 │ embedded            │
├──────────────────────┼─────────────────────┤
│ Description          │                     │
├──────────────────────┼─────────────────────┤
│ Associated Workflows │                     │
├──────────────────────┼─────────────────────┤
│ Revision number      │ 30                  │
├──────────────────────┼─────────────────────┤
│ Revision Created At  │ 13 Aug 24 23:11 UTC │
└──────────────────────┴─────────────────────┘
┌────────────────────────────────────────────────────┐
│ {                                                  │
│   "schemaVersion": "v1",                           │
│   "policies": {                                    │
│     "materials": [                                 │
│       {                                            │
│         "ref": "chainloop://cyclonedx-banned-agpl" │
│       }                                            │
│     ],                                             │
│     "attestation": [                               │
│       {                                            │
│         "ref": "chainloop://sbom-present"          │
│       }                                            │
│     ]                                              │
│   }                                                │
│ }                                                  │
└────────────────────────────────────────────────────┘
```


```
✗ chainloop att init --name policytest --replace
WRN API contacted in insecure mode
INF Attestation initialized! now you can check its status or add materials to it
┌───────────────────┬──────────────────────────────────────┐
│ Initialized At    │ 13 Aug 24 23:11 UTC                  │
├───────────────────┼──────────────────────────────────────┤
│ Attestation ID    │ 4967926c-b527-4a91-98ae-e868ff06f31b │
│ Name              │ policytest                           │
│ Team              │                                      │
│ Project           │ myproject                            │
│ Contract Revision │ 30                                   │
└───────────────────┴──────────────────────────────────────┘
```

```
✗ chainloop att push
WRN API contacted in insecure mode
INF evaluating policy 'sbom-present' on attestation
WRN found policy violations (sbom-present) for statement
WRN  - missing SBOM material
INF push completed
┌───────────────────┬──────────────────────────────────────┐
│ Initialized At    │ 13 Aug 24 23:27 UTC                  │
├───────────────────┼──────────────────────────────────────┤
│ Attestation ID    │ 31604952-2a73-4309-bc0d-30690c841e28 │
│ Name              │ policytest                           │
│ Team              │                                      │
│ Project           │ myproject                            │
│ Contract Revision │ 30                                   │
└───────────────────┴──────────────────────────────────────┘
```
