### PR TITLE
chore(policies): update invalid config example

### DIFF
--- a/deployment/chainloop/values.yaml
+++ b/deployment/chainloop/values.yaml
@@ -181,9 +181,9 @@ controlplane:
 
   ## @extra controlplane.policy_providers List of endpoints providing external policies
   #  policy_providers:
-  #    - name: my_provider
+  #    - name: my-provider
   #      default: true
-  #      host: http://my_host:8002/v1/policies
+  #      host: http://my-host:8002/v1/policies
 
   # Database migration
   ## @param controlplane.migration.image.registry [default: REGISTRY_NAME] Image registry


### PR DESCRIPTION
Quick PR to update the values.yaml example, as it included an invalid name.
