### PR TITLE
chore(policies): improve error message when policy is not found

### DIFF
--- a/pkg/policies/loader.go
+++ b/pkg/policies/loader.go
@@ -111,7 +111,7 @@ func (c *ChainloopLoader) Load(ctx context.Context, attachment *v1.PolicyAttachm
 		PolicyName: name,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("loading policy: %w", err)
+		return nil, fmt.Errorf("requesting remote policy (provider: %s, name: %s): %w", provider, name, err)
 	}
 
 	// cache result

--- a/pkg/policies/policies.go
+++ b/pkg/policies/policies.go
@@ -50,6 +50,10 @@ func (e *PolicyError) Error() string {
 	return fmt.Sprintf("policy error: %s", e.err.Error())
 }
 
+func (e *PolicyError) Unwrap() error {
+	return e.err
+}
+
 type PolicyVerifier struct {
 	schema *v1.CraftingSchema
 	logger *zerolog.Logger


### PR DESCRIPTION
This PR fixes 2 issues:
* properly wrap upstream error
* add provider and policy name to the error messsage
```
ERR applying policies to statement: policy error: loading policy spec: requesting remote policy (provider: idontexist, name: sbom-present): rpc error: code = NotFound desc = policy not found
```

Fixes #1225 