### PR TITLE
fix: show only grpc error

### DIFF
--- a/app/cli/main.go
+++ b/app/cli/main.go
@@ -27,6 +27,7 @@ import (
 	_ "github.com/sigstore/sigstore/pkg/signature/kms/azure"
 	_ "github.com/sigstore/sigstore/pkg/signature/kms/gcp"
 	_ "github.com/sigstore/sigstore/pkg/signature/kms/hashivault"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
@@ -55,18 +56,27 @@ func errorInfo(err error, logger zerolog.Logger) (string, int) {
 		msg = err.Error()
 	} else {
 		msg = st.Message()
-		// Extract message from grpc status if possible
+		// Sanitize error message for validation and other known errors
 		// by default status.fromError(err).Message() returns the whole error chain
 		// i.e "creating API token: creating API token: rpc error: code = AlreadyExists desc = duplicated: name already taken"
-		// We do not want in this case the whole error chain but just the one part of the gRPC response
+		// We do not want to show that in some specific error codes, we just want to show the part of the gRPC response
 		// i.e "duplicated: name already taken"
 		// To do what we perform an additional parsing of the error similar to
 		// https://github.com/grpc/grpc-go/blob/ced812e3287e15a009eab5b271c25750050a2f82/status/status.go#L123
 		type grpcstatus interface{ GRPCStatus() *status.Status }
 		var gs grpcstatus
 		if errors.As(err, &gs) {
+			knownCodes := []codes.Code{
+				codes.AlreadyExists, codes.InvalidArgument, codes.NotFound, codes.PermissionDenied,
+			}
+
 			grpcStatus := gs.GRPCStatus()
-			msg = grpcStatus.Message()
+			for _, code := range knownCodes {
+				if st.Code() == code {
+					msg = grpcStatus.Message()
+					break
+				}
+			}
 		}
 	}
 

--- a/app/controlplane/internal/service/service.go
+++ b/app/controlplane/internal/service/service.go
@@ -134,6 +134,9 @@ func WithLogger(logger log.Logger) NewOpt {
 	}
 }
 
+// NOTE: some of these http errors get automatically translated to gRPC status codes
+// because they implement the gRPC status error interface
+// so it is safe to return either a gRPC status error or a kratos error
 func handleUseCaseErr(err error, l *log.Helper) error {
 	switch {
 	case errors.Is(err, context.Canceled):


### PR DESCRIPTION
Shows just the gRPC error not the whole wrapped chain to the user for expected gRPC errors.

Examples

Before

```
$ go run main.go --insecure org api-token create --name test
ERR creating API token: creating API token: rpc error: code = AlreadyExists desc = duplicated: name already taken
```

after

```
$ go run main.go --insecure org api-token create --name test
ERR duplicated: name already taken
```

before

```
$ go run main.go --insecure org api-token create --name test_foo
ERR creating API token: creating API token: rpc error: code = InvalidArgument desc = validation error: "test_foo": a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')
```

after
```
$ go run main.go --insecure org api-token create --name test_foo
ERR validation error: "test_foo": a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')
```

fixes https://github.com/chainloop-dev/chainloop/issues/1207