### PR TITLE
refactor(integration-attachments): Map all integration attachments properties

### DIFF
--- a/app/controlplane/internal/dispatcher/dispatcher.go
+++ b/app/controlplane/internal/dispatcher/dispatcher.go
@@ -185,7 +185,7 @@ func (d *FanOutDispatcher) initDispatchQueue(ctx context.Context, orgID, workflo
 		// All the required configuration needed to run the integration
 		queue = append(queue, &dispatchItem{
 			registrationConfig: dbIntegration.Config,
-			attachmentConfig:   attachment.Config,
+			attachmentConfig:   attachment.IntegrationAttachment.Config,
 			credentials:        creds,
 			plugin:             backend,
 		})

--- a/app/controlplane/internal/service/integration.go
+++ b/app/controlplane/internal/service/integration.go
@@ -237,7 +237,7 @@ func (s *IntegrationsService) ListAttachments(ctx context.Context, req *pb.ListA
 
 	result := make([]*pb.IntegrationAttachmentItem, 0, len(integrations))
 	for _, i := range integrations {
-		r, err := s.bizIntegrationAttachmentToPb(ctx, i, org.ID)
+		r, err := s.bizIntegrationAttachmentToPb(ctx, i.IntegrationAttachment, org.ID)
 		if err != nil {
 			return nil, handleUseCaseErr(err, s.log)
 		}

--- a/app/controlplane/pkg/biz/integration.go
+++ b/app/controlplane/pkg/biz/integration.go
@@ -77,7 +77,7 @@ type IntegrationRepo interface {
 
 type IntegrationAttachmentRepo interface {
 	Create(ctx context.Context, integrationID, workflowID uuid.UUID, config []byte) (*IntegrationAttachment, error)
-	List(ctx context.Context, orgID, workflowID uuid.UUID) ([]*IntegrationAttachment, error)
+	List(ctx context.Context, orgID, workflowID uuid.UUID) ([]*IntegrationAndAttachment, error)
 	FindByIDInOrg(ctx context.Context, orgID, ID uuid.UUID) (*IntegrationAttachment, error)
 	SoftDelete(ctx context.Context, ID uuid.UUID) error
 }
@@ -314,7 +314,7 @@ func (uc *IntegrationUseCase) Delete(ctx context.Context, orgID, integrationID s
 }
 
 // List attachments returns the list of attachments for a given organization and optionally workflow
-func (uc *IntegrationUseCase) ListAttachments(ctx context.Context, orgID, workflowID string) ([]*IntegrationAttachment, error) {
+func (uc *IntegrationUseCase) ListAttachments(ctx context.Context, orgID, workflowID string) ([]*IntegrationAndAttachment, error) {
 	orgUUID, err := uuid.Parse(orgID)
 	if err != nil {
 		return nil, NewErrInvalidUUID(err)

--- a/app/controlplane/pkg/data/integrationattachment.go
+++ b/app/controlplane/pkg/data/integrationattachment.go
@@ -49,7 +49,7 @@ func (r *IntegrationAttachmentRepo) Create(ctx context.Context, integrationID, w
 		return nil, err
 	}
 
-	res := entIntegrationAttachmentToBiz(ia)
+	res := entIntegrationAndAttachmentToBiz(ia)
 	if res != nil {
 		res.IntegrationID = integrationID
 		res.WorkflowID = workflowID
@@ -74,7 +74,7 @@ func (r *IntegrationAttachmentRepo) List(ctx context.Context, orgID, workflowID 
 
 	result := make([]*biz.IntegrationAndAttachment, 0, len(res))
 	for _, r := range res {
-		result = append(result, entIntegrationAttachmentToBiz(r))
+		result = append(result, entIntegrationAndAttachmentToBiz(r))
 	}
 
 	return result, nil
@@ -93,14 +93,14 @@ func (r *IntegrationAttachmentRepo) FindByIDInOrg(ctx context.Context, orgID, id
 		return nil, nil
 	}
 
-	return entIntegrationAttachmentToBiz(integration).IntegrationAttachment, nil
+	return entIntegrationAndAttachmentToBiz(integration).IntegrationAttachment, nil
 }
 
 func (r *IntegrationAttachmentRepo) SoftDelete(ctx context.Context, id uuid.UUID) error {
 	return r.data.DB.IntegrationAttachment.UpdateOneID(id).SetDeletedAt(time.Now()).Exec(ctx)
 }
 
-func entIntegrationAttachmentToBiz(i *ent.IntegrationAttachment) *biz.IntegrationAndAttachment {
+func entIntegrationAndAttachmentToBiz(i *ent.IntegrationAttachment) *biz.IntegrationAndAttachment {
 	if i == nil {
 		return nil
 	}

--- a/app/controlplane/pkg/data/integrationattachment.go
+++ b/app/controlplane/pkg/data/integrationattachment.go
@@ -55,10 +55,10 @@ func (r *IntegrationAttachmentRepo) Create(ctx context.Context, integrationID, w
 		res.WorkflowID = workflowID
 	}
 
-	return res, nil
+	return res.IntegrationAttachment, nil
 }
 
-func (r *IntegrationAttachmentRepo) List(ctx context.Context, orgID, workflowID uuid.UUID) ([]*biz.IntegrationAttachment, error) {
+func (r *IntegrationAttachmentRepo) List(ctx context.Context, orgID, workflowID uuid.UUID) ([]*biz.IntegrationAndAttachment, error) {
 	wfQuery := orgScopedQuery(r.data.DB, orgID).QueryWorkflows()
 	if workflowID != uuid.Nil {
 		wfQuery = wfQuery.Where(workflow.ID(workflowID))
@@ -72,7 +72,7 @@ func (r *IntegrationAttachmentRepo) List(ctx context.Context, orgID, workflowID 
 		return nil, err
 	}
 
-	result := make([]*biz.IntegrationAttachment, 0, len(res))
+	result := make([]*biz.IntegrationAndAttachment, 0, len(res))
 	for _, r := range res {
 		result = append(result, entIntegrationAttachmentToBiz(r))
 	}
@@ -93,28 +93,39 @@ func (r *IntegrationAttachmentRepo) FindByIDInOrg(ctx context.Context, orgID, id
 		return nil, nil
 	}
 
-	return entIntegrationAttachmentToBiz(integration), nil
+	return entIntegrationAttachmentToBiz(integration).IntegrationAttachment, nil
 }
 
 func (r *IntegrationAttachmentRepo) SoftDelete(ctx context.Context, id uuid.UUID) error {
 	return r.data.DB.IntegrationAttachment.UpdateOneID(id).SetDeletedAt(time.Now()).Exec(ctx)
 }
 
-func entIntegrationAttachmentToBiz(i *ent.IntegrationAttachment) *biz.IntegrationAttachment {
+func entIntegrationAttachmentToBiz(i *ent.IntegrationAttachment) *biz.IntegrationAndAttachment {
 	if i == nil {
 		return nil
 	}
 
-	r := &biz.IntegrationAttachment{ID: i.ID,
-		CreatedAt: toTimePtr(i.CreatedAt), Config: i.Configuration,
-	}
-
-	if i.Edges.Workflow != nil {
-		r.WorkflowID = i.Edges.Workflow.ID
+	r := &biz.IntegrationAndAttachment{
+		IntegrationAttachment: &biz.IntegrationAttachment{
+			ID:         i.ID,
+			CreatedAt:  toTimePtr(i.CreatedAt),
+			Config:     i.Configuration,
+			WorkflowID: i.WorkflowID,
+		},
 	}
 
 	if i.Edges.Integration != nil {
 		r.IntegrationID = i.Edges.Integration.ID
+
+		r.Integration = &biz.Integration{
+			ID:          i.Edges.Integration.ID,
+			Kind:        i.Edges.Integration.Kind,
+			Name:        i.Edges.Integration.Name,
+			Description: i.Edges.Integration.Description,
+			Config:      i.Edges.Integration.Configuration,
+			SecretName:  i.Edges.Integration.SecretName,
+			CreatedAt:   toTimePtr(i.Edges.Integration.CreatedAt),
+		}
 	}
 
 	return r


### PR DESCRIPTION
This patch wraps the integration attachments listing into a structure that holds both a `Integration` and `IntegrationAttachment`.