### PR TITLE
feat: docker compose configuration for local testing

### DIFF
--- a/app/artifact-cas/configs/config.devel.yaml
+++ b/app/artifact-cas/configs/config.devel.yaml
@@ -28,4 +28,4 @@ credentials_service:
     token: ${VAULT_TOKEN:notasecret}
 
 auth:
-  public_key_path: "../../devel/devkeys/cas.pub"
+  public_key_path: ${PUBLIC_KEY_PATH:../../devel/devkeys/cas.pub}

--- a/app/controlplane/configs/config.devel.yaml
+++ b/app/controlplane/configs/config.devel.yaml
@@ -55,7 +55,7 @@ data:
 # Development credentials for the SSO authentication roundtrip
 auth:
   oidc:
-    domain: ${DEX_DOMAIN:http://0.0.0.0:5556/dex}
+    domain: ${DEX_DOMAIN:http://dex:5556/dex}
     client_id: "chainloop-dev"
     client_secret: "ZXhhbXBsZS1hcHAtc2VjcmV0"
 

--- a/app/controlplane/configs/config.devel.yaml
+++ b/app/controlplane/configs/config.devel.yaml
@@ -18,8 +18,8 @@ server:
 
 certificate_authority:
   file_ca:
-    cert_path: "../../devel/devkeys/ca.pub"
-    key_path: "../../devel/devkeys/ca.pem"
+    cert_path: ${FILE_CA_CERT_PATH:../../devel/devkeys/ca.pub}
+    key_path: ${FILE_CA_KEY_PATH:../../devel/devkeys/ca.pem}
     key_pass: chainloop
 #  ejbca_ca:
 #    server_url: "https://localhost/ejbca"
@@ -55,7 +55,7 @@ data:
 # Development credentials for the SSO authentication roundtrip
 auth:
   oidc:
-    domain: "http://0.0.0.0:5556/dex"
+    domain: ${DEX_DOMAIN:http://0.0.0.0:5556/dex}
     client_id: "chainloop-dev"
     client_secret: "ZXhhbXBsZS1hcHAtc2VjcmV0"
 
@@ -63,7 +63,7 @@ auth:
   generated_jws_hmac_secret: "developmentKey"
 
   # Private key used to sign the JWTs meant to be consumed by the CAS
-  cas_robot_account_private_key_path: "../../devel/devkeys/cas.pem"
+  cas_robot_account_private_key_path: ${CAS_KEY_PATH:../../devel/devkeys/cas.pem}
   # allow_list:
     # rules: ["@chainloop.local"]
     # selected_routes: ["/controlplane.v1.WorkflowRunService/List"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -50,9 +50,11 @@ services:
         condition: service_healthy
     command: "migrate apply --url postgres://postgres:@postgresql:5432/controlplane?sslmode=disable --dir file:///migrations"
 
-#  minio:
-#    image: quay.io/minio/minio
-#    ports:
-#      - 9002:9000
-#      - 9003:9001
-#    command: server /data --console-address ":9001"
+  minio:
+    image: quay.io/minio/minio
+    ports:
+      - 9002:9000
+      - 9003:9001
+    command: server /data --console-address ":9001"
+    profiles:
+      - optional

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,57 @@
+name: chainloop-lab
+
+include:
+  - ./devel/compose.yml
+services:
+  control-plane:
+    image: ghcr.io/chainloop-dev/chainloop/control-plane:v0.96.1
+    environment:
+      CP_DB_HOST: postgresql
+      CP_DEX_DOMAIN: http://dex:5556/dex
+      CP_VAULT_ADDRESS: http://vault:8200
+      CP_FILE_CA_CERT_PATH: /devkeys/ca.pub
+      CP_FILE_CA_KEY_PATH: /devkeys/ca.pem
+      CP_CAS_KEY_PATH: /devkeys/cas.pem
+    volumes:
+      # main configuration
+      - ./app/controlplane/configs:/data/conf
+      # development keys
+      - ./devel/devkeys:/devkeys
+    ports:
+      - 9000:9000
+      - 8000:8000
+    depends_on:
+      vault:
+        condition: service_started
+      db-init:
+        condition: service_completed_successfully
+
+  cas:
+    image: ghcr.io/chainloop-dev/chainloop/artifact-cas:v0.96.1
+    volumes:
+      # main configuration
+      - ./app/artifact-cas/configs:/data/conf
+      # development keys
+      - ./devel/devkeys:/devkeys
+    environment:
+      CAS_VAULT_ADDRESS: http://vault:8200
+      CAS_PUBLIC_KEY_PATH: /devkeys/cas.pem
+    ports:
+      - 9001:9001
+      - 8001:8001
+    depends_on:
+      - vault
+
+  db-init:
+    image: ghcr.io/chainloop-dev/chainloop/control-plane-migrations:v0.96.1
+    depends_on:
+      postgresql:
+        condition: service_healthy
+    command: "migrate apply --url postgres://postgres:@postgresql:5432/controlplane?sslmode=disable --dir file:///migrations"
+
+#  minio:
+#    image: quay.io/minio/minio
+#    ports:
+#      - 9002:9000
+#      - 9003:9001
+#    command: server /data --console-address ":9001"

--- a/compose.yaml
+++ b/compose.yaml
@@ -40,7 +40,8 @@ services:
       - 9001:9001
       - 8001:8001
     depends_on:
-      - vault
+      vault:
+        condition: service_healthy
 
   db-init:
     image: ghcr.io/chainloop-dev/chainloop/control-plane-migrations:v0.96.1

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,6 +3,7 @@ name: chainloop-lab
 include:
   - ./devel/compose.yml
 services:
+  # The control plane is the main service
   control-plane:
     image: ghcr.io/chainloop-dev/chainloop/control-plane:v0.96.1
     environment:
@@ -26,6 +27,7 @@ services:
       db-init:
         condition: service_completed_successfully
 
+  # CAS backend for artifact storage
   cas:
     image: ghcr.io/chainloop-dev/chainloop/artifact-cas:v0.96.1
     volumes:
@@ -43,6 +45,7 @@ services:
       vault:
         condition: service_healthy
 
+  # Ensures DB has the proper schema
   db-init:
     image: ghcr.io/chainloop-dev/chainloop/control-plane-migrations:v0.96.1
     depends_on:
@@ -50,6 +53,7 @@ services:
         condition: service_healthy
     command: "migrate apply --url postgres://postgres:@postgresql:5432/controlplane?sslmode=disable --dir file:///migrations"
 
+  # Optional Minio S3 backend. Run it with `--profile optional`
   minio:
     image: quay.io/minio/minio
     ports:

--- a/devel/compose.yml
+++ b/devel/compose.yml
@@ -26,6 +26,12 @@ services:
       - 8200:8200
     environment:
       - VAULT_DEV_ROOT_TOKEN_ID=notasecret
+    healthcheck:
+      test: [ "CMD", "wget", "--spider", "http://127.0.0.1:8200/v1/sys/health" ]
+      interval: 10s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
 
   # OIDC provider for development
   dex:

--- a/devel/compose.yml
+++ b/devel/compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 # NOTE: This setup is meant to be used for development purposes only.
 services:
   postgresql:

--- a/devel/dex/config.dev.yaml
+++ b/devel/dex/config.dev.yaml
@@ -1,4 +1,5 @@
-issuer: http://0.0.0.0:5556/dex
+# this requires adding an entry `127.0.0.1 dex` to /etc/hosts
+issuer: http://dex:5556/dex
 
 storage:
   type: memory

--- a/devel/labs.compose.yaml
+++ b/devel/labs.compose.yaml
@@ -1,7 +1,7 @@
 name: chainloop-lab
 
 include:
-  - ./devel/compose.yml
+  - ./compose.yml
 services:
   # The control plane is the main service
   control-plane:
@@ -15,9 +15,9 @@ services:
       CP_CAS_KEY_PATH: /devkeys/cas.pem
     volumes:
       # main configuration
-      - ./app/controlplane/configs:/data/conf
+      - ../app/controlplane/configs:/data/conf
       # development keys
-      - ./devel/devkeys:/devkeys
+      - ../devel/devkeys:/devkeys
     ports:
       - 9000:9000
       - 8000:8000
@@ -32,9 +32,9 @@ services:
     image: ghcr.io/chainloop-dev/chainloop/artifact-cas:v0.96.1
     volumes:
       # main configuration
-      - ./app/artifact-cas/configs:/data/conf
+      - ../app/artifact-cas/configs:/data/conf
       # development keys
-      - ./devel/devkeys:/devkeys
+      - ../devel/devkeys:/devkeys
     environment:
       CAS_VAULT_ADDRESS: http://vault:8200
       CAS_PUBLIC_KEY_PATH: /devkeys/cas.pem

--- a/devel/labs.compose.yaml
+++ b/devel/labs.compose.yaml
@@ -5,7 +5,7 @@ include:
 services:
   # The control plane is the main service
   control-plane:
-    image: ghcr.io/chainloop-dev/chainloop/control-plane:v0.96.1
+    image: ghcr.io/chainloop-dev/chainloop/control-plane:latest
     environment:
       CP_DB_HOST: postgresql
       CP_DEX_DOMAIN: http://dex:5556/dex
@@ -29,7 +29,7 @@ services:
 
   # CAS backend for artifact storage
   cas:
-    image: ghcr.io/chainloop-dev/chainloop/artifact-cas:v0.96.1
+    image: ghcr.io/chainloop-dev/chainloop/artifact-cas:latest
     volumes:
       # main configuration
       - ../app/artifact-cas/configs:/data/conf
@@ -47,7 +47,7 @@ services:
 
   # Ensures DB has the proper schema
   db-init:
-    image: ghcr.io/chainloop-dev/chainloop/control-plane-migrations:v0.96.1
+    image: ghcr.io/chainloop-dev/chainloop/control-plane-migrations:latest
     depends_on:
       postgresql:
         condition: service_healthy


### PR DESCRIPTION
This PR adds a new docker compose file for those who want to quickly setup a local instance of Chainloop using upstream images.
This configuration sets up: control-plane, artifacts-cas, control-plane-migrations, and leverages existing devel compose configuration for postgresql, vault and dex.
I've setup service dependencies properly so that they are run in order. Interestingly, I've added a service for running DB migrations.

Caveats:
* It uses `dex` as the Dex host (this is to ensure there is connectivity between docker instances). This means that users must add a `127.0.0.1 dex` entry in `/etc/hosts`, otherwise `chainloop auth login` won't work. This might be fixed by running all services with `host` networking, but it only works in Linux and recent versions of Docker Desktop.

How to use:
```
> docker compose up -d
```

And then just configure Chainloop CLI to use the local instance:
```
> chainloop config save --insecure --control-plane localhost:9000 --artifact-cas localhost:9001
```
And use as normal (note that `--insecure` is needed in every command, so maybe creating an alias could help `alias cl="chainloop --insecure --debug"`

Note that I've also included an "optional" Minio service, that must be explicitly run with `docker compose --profile optional up`, to be able to configure a S3-compatible backend for the CAS.

Fixes #1246 