### PR TITLE
chore: unlock Chainloop CLI version in github workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,6 @@ jobs:
       packages: write
       contents: write
     env:
-      CHAINLOOP_VERSION: 0.90.1
       CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
       CHAINLOOP_WORKFLOW_NAME: ${{ needs.onboard_workflow.outputs.workflow_name }}
       GH_TOKEN: ${{ github.token }}
@@ -33,7 +32,7 @@ jobs:
 
       - name: Install Chainloop
         run: |
-          curl -sfL https://raw.githubusercontent.com/chainloop-dev/chainloop/01ad13af08950b7bfbc83569bea207aeb4e1a285/docs/static/install.sh | bash -s -- --version v${{ env.CHAINLOOP_VERSION }}
+          curl -sfL https://raw.githubusercontent.com/chainloop-dev/chainloop/01ad13af08950b7bfbc83569bea207aeb4e1a285/docs/static/install.sh | bash -s
 
       - name: Initialize Attestation
         run: |


### PR DESCRIPTION
Removes the version from the installation script.

Fixes #1251 