### PR TITLE
chore: fix lint error

### DIFF
--- a/pkg/policies/policies_test.go
+++ b/pkg/policies/policies_test.go
@@ -272,7 +272,6 @@ func (s *testSuite) TestProviderParts() {
 			s.Equal(tc.name, name)
 		})
 	}
-
 }
 
 func (s *testSuite) TestArgumentsInViolations() {


### PR DESCRIPTION
Fixes an annoying lint error in our CI (caused by a previous merge)
<img width="565" alt="image" src="https://github.com/user-attachments/assets/ef8eaef8-662e-4f79-96aa-d414521aa954">
