### PR TITLE
chore(policies): support file:// to reference filesystem policies

### DIFF
--- a/docs/docs/reference/policies.mdx
+++ b/docs/docs/reference/policies.mdx
@@ -45,7 +45,7 @@ materials:
     type: CONTAINER_IMAGE
 policies:
   materials: # policies applied to materials
-    - ref: cyclonedx-licenses.yaml # (1)
+    - ref: file://cyclonedx-licenses.yaml # (1)
   attestation: # policies applied to the whole attestation
     - ref: https://github.com/chainloop/chainloop-dev/blob/main/docs/examples/policies/chainloop-commit.yaml # (2)
 ```
@@ -56,7 +56,7 @@ Here we can see that:
   ```yaml
   policies:
     materials:
-      - ref: cyclonedx-licenses.yaml
+      - ref: file://cyclonedx-licenses.yaml
         selector: # (3)
           name: sbom
   ```
@@ -68,11 +68,11 @@ Finally, note that material policies are evaluated during `chainloop attestation
 
 ### Embedding or referencing policies
 There are two ways to attach a policy to a contract:
-* **By referencing it**, as it can be seen in the examples above. `ref` property admits a local (filesystem) or remote reference (HTTPS). For example:
+* **By referencing it**, as it can be seen in the examples above. `ref` property admits a local `file://`` (filesystem) or remote reference `https://`. For example:
   ```yaml
   policies:
     materials: 
-      - ref: cyclonedx-licenses.yaml # local reference
+      - ref: file://cyclonedx-licenses.yaml # local reference
   ```
   and
   ```yaml

--- a/pkg/policies/policies_test.go
+++ b/pkg/policies/policies_test.go
@@ -569,6 +569,11 @@ func (s *testSuite) TestLoader() {
 			expected: &BlobLoader{},
 		},
 		{
+			name:     "file ref",
+			ref:      "file://local-policy.yaml",
+			expected: &BlobLoader{},
+		},
+		{
 			name:     "http ref",
 			ref:      "https://myhost/policy.yaml",
 			expected: &BlobLoader{},

--- a/pkg/policies/policies_test.go
+++ b/pkg/policies/policies_test.go
@@ -493,6 +493,17 @@ func (s *testSuite) TestLoadPolicySpec() {
 			expectedCategory: "SBOM",
 		},
 		{
+			name: "by file ref",
+			attachment: &v12.PolicyAttachment{
+				Policy: &v12.PolicyAttachment_Ref{
+					Ref: "file://testdata/sbom_syft.yaml",
+				},
+			},
+			expectedName:     "made-with-syft",
+			expectedDesc:     "This policy checks that the SPDX SBOM was created with syft",
+			expectedCategory: "SBOM",
+		},
+		{
 			name: "embedded invalid",
 			attachment: &v12.PolicyAttachment{
 				Policy: &v12.PolicyAttachment_Embedded{


### PR DESCRIPTION
this PR add support for explicit `file://` scheme when referencing a local policy. The goal is to slowly move to Chainloop provider policies when no scheme is present.
