### PR TITLE
chore(deployment): record CLI in Helm Chart images annotations

### DIFF
--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -7,7 +7,7 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.92.0
+version: 1.92.1
 # Do not update appVersion, this is handled automatically by the release process
 appVersion: v0.96.3
 
@@ -38,3 +38,5 @@ annotations:
           name: control-plane
         - image: ghcr.io/chainloop-dev/chainloop/control-plane-migrations:v0.96.3
           name: control-plane-migrations
+        - image: ghcr.io/chainloop-dev/chainloop/cli:v0.96.3
+          name: cli


### PR DESCRIPTION
Adding the CLI image in our Helm Chart so it can be part of the relocation process 