### PR TITLE
feat(cli): add support for env vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,4 +52,4 @@ build_devel:
 .PHONY: build_devel_container_mages
 # build container images for development testing
 build_devel_container_mages:
-	goreleaser release --clean --snapshot --skip-sign --skip-sbom
+	goreleaser release --clean --snapshot --skip sign,sbom

--- a/app/cli/Dockerfile.goreleaser
+++ b/app/cli/Dockerfile.goreleaser
@@ -1,9 +1,11 @@
 FROM golang:1.22@sha256:fcae9e0e7313c6467a7c6632ebb5e5fab99bd39bd5eb6ee34a211353e647827a AS builder
+RUN mkdir -p /.config/chainloop
 
 FROM scratch
 
 COPY ./chainloop /
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder --chown=1001:1001 /.config/chainloop /.config/chainloop
 
 USER 1001
 

--- a/app/cli/cmd/config.go
+++ b/app/cli/cmd/config.go
@@ -21,8 +21,11 @@ import (
 
 // Map of all the possible configuration options that we expect viper to handle
 var confOptions = struct {
-	authToken, controlplaneAPI, CASAPI, controlplaneCA, CASCA *confOpt
+	authToken, controlplaneAPI, CASAPI, controlplaneCA, CASCA, insecure *confOpt
 }{
+	insecure: &confOpt{
+		viperKey: "api-insecure",
+	},
 	authToken: &confOpt{
 		viperKey: "auth.token",
 	},

--- a/app/cli/cmd/root.go
+++ b/app/cli/cmd/root.go
@@ -105,8 +105,6 @@ func NewRootCmd(l zerolog.Logger) *cobra.Command {
 			}
 
 			controlplaneURL := viper.GetString(confOptions.controlplaneAPI.viperKey)
-			logger.Debug().Msgf("controlplane URL: %s", controlplaneURL)
-			logger.Debug().Msgf("test: %s", viper.GetString("foo-foo.foo"))
 			conn, err := grpcconn.New(controlplaneURL, apiToken, opts...)
 			if err != nil {
 				return err


### PR DESCRIPTION
- Exposes main configuration through env vars and documents it in the CLI itself

```

Flags:
      --artifact-cas string       URL for the Artifacts Content Addressable Storage API ($CHAINLOOP_ARTIFACT_CAS_API) (default "api.cas.chainloop.dev:443")
      --artifact-cas-ca string    CUSTOM CA file for the Artifacts CAS API (optional) ($CHAINLOOP_ARTIFACT_CAS_API_CA)
  -c, --config string             Path to an existing config file (default is $HOME/.config/chainloop/config.toml)
      --control-plane string      URL for the Control Plane API ($CHAINLOOP_CONTROL_PLANE_API) (default "api.cp.chainloop.dev:443")
      --control-plane-ca string   CUSTOM CA file for the Control Plane API (optional) ($CHAINLOOP_CONTROL_PLANE_API_CA)
      --debug                     Enable debug/verbose logging mode
  -h, --help                      help for chainloop
  -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
```

- Fixes the container image to run commands (not to crash)

Fixes #1272 