### PR TITLE
fix(cli): add timeout to telemetry

### DIFF
--- a/app/cli/internal/telemetry/posthog/posthog.go
+++ b/app/cli/internal/telemetry/posthog/posthog.go
@@ -19,6 +19,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"log"
 
 	"github.com/chainloop-dev/chainloop/app/cli/internal/telemetry"
 	"github.com/posthog/posthog-go"
@@ -34,8 +36,10 @@ func NewClient(apiKey string, endpointURL string) (*Tracker, error) {
 		return nil, ErrInvalidConfig
 	}
 
+	noopLogger := log.New(io.Discard, "", 0)
 	client, err := posthog.NewWithConfig(apiKey, posthog.Config{
 		Endpoint: endpointURL,
+		Logger:   posthog.StdLogger(noopLogger),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create PostHog client: %w", err)


### PR DESCRIPTION
Make the telemetry code less intrusive in scenarios where the connectivity is limited. This means removing the default logging and adding a timeout to the call so the CLI doesn't hang. 