### PR TITLE
fix(cli): set explicit empty callback URL

### DIFF
--- a/app/cli/cmd/auth_login.go
+++ b/app/cli/cmd/auth_login.go
@@ -113,7 +113,7 @@ func interactiveAuth(forceHeadless bool) error {
 func headlessAuth(loginURL *url.URL) error {
 	// Remove cli-callback query parameter to indicate the server to show it inline
 	q := loginURL.Query()
-	q.Del("callback")
+	q.Set("callback", "")
 	loginURL.RawQuery = q.Encode()
 	fmt.Printf("To authenticate, click on the following link and paste the result back here\n\n  %s\n\n", loginURL.String())
 


### PR DESCRIPTION
Instead of not setting the callback value, we now make it empty to indicate that it has no value.

```
$ go run main.go auth login --skip-browser --insecure
To authenticate, click on the following link and paste the result back here

  http://0.0.0.0:8000/auth/login?callback=&long-lived=true
```

Fixes #1273