### PR TITLE
feat(jsonschema): Generate jsonschema for workflowcontract proto

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@ app/controlplane/pkg/data/ent/migrate/** linguist-generated=false
 app/controlplane/pkg/data/ent/migrate/** linguist-detectable=true
 app/controlplane/pkg/data/ent/schema/* linguist-generated=false
 app/controlplane/pkg/data/ent/schema/* linguist-detectable=true
+app/controlplane/api/gen/jsonschema/** linguist-generated=true

--- a/app/controlplane/Makefile
+++ b/app/controlplane/Makefile
@@ -10,8 +10,6 @@ config: check-buf-tool
 api: check-buf-tool
 	cd ./plugins/sdk/v1/plugin/api && buf generate
 	cd ./api && buf generate
-	# Remove all json schema that are not part of the workflowcontract since we don't need them
-	find ./api/gen/jsonschema -type f ! -name 'workflowcontract.*' -exec rm {} +
 
 .PHONY: build
 # build

--- a/app/controlplane/Makefile
+++ b/app/controlplane/Makefile
@@ -10,6 +10,8 @@ config: check-buf-tool
 api: check-buf-tool
 	cd ./plugins/sdk/v1/plugin/api && buf generate
 	cd ./api && buf generate
+	# Remove all json schema that are not part of the workflowcontract since we don't need them
+	find ./api/gen/jsonschema -type f ! -name 'workflowcontract.*' -exec rm {} +
 
 .PHONY: build
 # build

--- a/app/controlplane/api/buf.gen.yaml
+++ b/app/controlplane/api/buf.gen.yaml
@@ -19,3 +19,5 @@ plugins:
       - outputClientImpl=grpc-web # client implementation it generates
       - esModuleInterop=true # use imports as required in modern ts setups
       - useOptionals=messages # use optional TypeScript properties instead of undefined
+  - plugin: buf.build/bufbuild/protoschema-jsonschema
+    out: ./gen/jsonschema

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.Attestation.Material.Artifact.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.Attestation.Material.Artifact.jsonschema.json
@@ -1,0 +1,34 @@
+{
+  "$id": "attestation.v1.Attestation.Material.Artifact.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(is_subject)$": {
+      "type": "boolean"
+    }
+  },
+  "properties": {
+    "content": {
+      "description": "Inline content of the artifact.\n This is optional and is used for small artifacts that can be stored inline in the attestation",
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "digest": {
+      "description": "the digest is enough to retrieve the artifact since it's stored in a CAS\n which also has annotated the fileName",
+      "type": "string"
+    },
+    "id": {
+      "description": "ID of the artifact",
+      "type": "string"
+    },
+    "isSubject": {
+      "type": "boolean"
+    },
+    "name": {
+      "description": "filename, use for record purposes",
+      "type": "string"
+    }
+  },
+  "title": "Artifact",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.Attestation.Material.Artifact.schema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.Attestation.Material.Artifact.schema.json
@@ -1,0 +1,34 @@
+{
+  "$id": "attestation.v1.Attestation.Material.Artifact.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(isSubject)$": {
+      "type": "boolean"
+    }
+  },
+  "properties": {
+    "content": {
+      "description": "Inline content of the artifact.\n This is optional and is used for small artifacts that can be stored inline in the attestation",
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "digest": {
+      "description": "the digest is enough to retrieve the artifact since it's stored in a CAS\n which also has annotated the fileName",
+      "type": "string"
+    },
+    "id": {
+      "description": "ID of the artifact",
+      "type": "string"
+    },
+    "is_subject": {
+      "type": "boolean"
+    },
+    "name": {
+      "description": "filename, use for record purposes",
+      "type": "string"
+    }
+  },
+  "title": "Artifact",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.Attestation.Material.ContainerImage.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.Attestation.Material.ContainerImage.jsonschema.json
@@ -1,0 +1,30 @@
+{
+  "$id": "attestation.v1.Attestation.Material.ContainerImage.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(is_subject)$": {
+      "type": "boolean"
+    }
+  },
+  "properties": {
+    "digest": {
+      "type": "string"
+    },
+    "id": {
+      "type": "string"
+    },
+    "isSubject": {
+      "type": "boolean"
+    },
+    "name": {
+      "type": "string"
+    },
+    "tag": {
+      "description": "provided tag",
+      "type": "string"
+    }
+  },
+  "title": "Container Image",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.Attestation.Material.ContainerImage.schema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.Attestation.Material.ContainerImage.schema.json
@@ -1,0 +1,30 @@
+{
+  "$id": "attestation.v1.Attestation.Material.ContainerImage.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(isSubject)$": {
+      "type": "boolean"
+    }
+  },
+  "properties": {
+    "digest": {
+      "type": "string"
+    },
+    "id": {
+      "type": "string"
+    },
+    "is_subject": {
+      "type": "boolean"
+    },
+    "name": {
+      "type": "string"
+    },
+    "tag": {
+      "description": "provided tag",
+      "type": "string"
+    }
+  },
+  "title": "Container Image",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.Attestation.Material.KeyVal.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.Attestation.Material.KeyVal.jsonschema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "attestation.v1.Attestation.Material.KeyVal.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "value": {
+      "type": "string"
+    }
+  },
+  "title": "Key Val",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.Attestation.Material.KeyVal.schema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.Attestation.Material.KeyVal.schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "attestation.v1.Attestation.Material.KeyVal.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "value": {
+      "type": "string"
+    }
+  },
+  "title": "Key Val",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.Attestation.Material.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.Attestation.Material.jsonschema.json
@@ -1,0 +1,117 @@
+{
+  "$id": "attestation.v1.Attestation.Material.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(added_at)$": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "^(container_image)$": {
+      "$ref": "attestation.v1.Attestation.Material.ContainerImage.jsonschema.json"
+    },
+    "^(inline_cas)$": {
+      "description": "If the material content has been injected inline in the attestation\n leveraging a form of inline CAS",
+      "type": "boolean"
+    },
+    "^(material_type)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "MATERIAL_TYPE_UNSPECIFIED",
+            "STRING",
+            "CONTAINER_IMAGE",
+            "ARTIFACT",
+            "SBOM_CYCLONEDX_JSON",
+            "SBOM_SPDX_JSON",
+            "JUNIT_XML",
+            "OPENVEX",
+            "HELM_CHART",
+            "SARIF",
+            "EVIDENCE",
+            "ATTESTATION",
+            "CSAF_VEX",
+            "CSAF_INFORMATIONAL_ADVISORY",
+            "CSAF_SECURITY_ADVISORY",
+            "CSAF_SECURITY_INCIDENT_RESPONSE"
+          ],
+          "title": "Material Type",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "^(uploaded_to_cas)$": {
+      "description": "Whether the material has been uploaded to the CAS",
+      "type": "boolean"
+    }
+  },
+  "properties": {
+    "addedAt": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "annotations": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Annotations for the material",
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "artifact": {
+      "$ref": "attestation.v1.Attestation.Material.Artifact.jsonschema.json"
+    },
+    "containerImage": {
+      "$ref": "attestation.v1.Attestation.Material.ContainerImage.jsonschema.json"
+    },
+    "inlineCas": {
+      "description": "If the material content has been injected inline in the attestation\n leveraging a form of inline CAS",
+      "type": "boolean"
+    },
+    "materialType": {
+      "anyOf": [
+        {
+          "enum": [
+            "MATERIAL_TYPE_UNSPECIFIED",
+            "STRING",
+            "CONTAINER_IMAGE",
+            "ARTIFACT",
+            "SBOM_CYCLONEDX_JSON",
+            "SBOM_SPDX_JSON",
+            "JUNIT_XML",
+            "OPENVEX",
+            "HELM_CHART",
+            "SARIF",
+            "EVIDENCE",
+            "ATTESTATION",
+            "CSAF_VEX",
+            "CSAF_INFORMATIONAL_ADVISORY",
+            "CSAF_SECURITY_ADVISORY",
+            "CSAF_SECURITY_INCIDENT_RESPONSE"
+          ],
+          "title": "Material Type",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "string": {
+      "$ref": "attestation.v1.Attestation.Material.KeyVal.jsonschema.json"
+    },
+    "uploadedToCas": {
+      "description": "Whether the material has been uploaded to the CAS",
+      "type": "boolean"
+    }
+  },
+  "title": "Material",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.Attestation.Material.schema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.Attestation.Material.schema.json
@@ -1,0 +1,117 @@
+{
+  "$id": "attestation.v1.Attestation.Material.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(addedAt)$": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "^(containerImage)$": {
+      "$ref": "attestation.v1.Attestation.Material.ContainerImage.schema.json"
+    },
+    "^(inlineCas)$": {
+      "description": "If the material content has been injected inline in the attestation\n leveraging a form of inline CAS",
+      "type": "boolean"
+    },
+    "^(materialType)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "MATERIAL_TYPE_UNSPECIFIED",
+            "STRING",
+            "CONTAINER_IMAGE",
+            "ARTIFACT",
+            "SBOM_CYCLONEDX_JSON",
+            "SBOM_SPDX_JSON",
+            "JUNIT_XML",
+            "OPENVEX",
+            "HELM_CHART",
+            "SARIF",
+            "EVIDENCE",
+            "ATTESTATION",
+            "CSAF_VEX",
+            "CSAF_INFORMATIONAL_ADVISORY",
+            "CSAF_SECURITY_ADVISORY",
+            "CSAF_SECURITY_INCIDENT_RESPONSE"
+          ],
+          "title": "Material Type",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "^(uploadedToCas)$": {
+      "description": "Whether the material has been uploaded to the CAS",
+      "type": "boolean"
+    }
+  },
+  "properties": {
+    "added_at": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "annotations": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Annotations for the material",
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "artifact": {
+      "$ref": "attestation.v1.Attestation.Material.Artifact.schema.json"
+    },
+    "container_image": {
+      "$ref": "attestation.v1.Attestation.Material.ContainerImage.schema.json"
+    },
+    "inline_cas": {
+      "description": "If the material content has been injected inline in the attestation\n leveraging a form of inline CAS",
+      "type": "boolean"
+    },
+    "material_type": {
+      "anyOf": [
+        {
+          "enum": [
+            "MATERIAL_TYPE_UNSPECIFIED",
+            "STRING",
+            "CONTAINER_IMAGE",
+            "ARTIFACT",
+            "SBOM_CYCLONEDX_JSON",
+            "SBOM_SPDX_JSON",
+            "JUNIT_XML",
+            "OPENVEX",
+            "HELM_CHART",
+            "SARIF",
+            "EVIDENCE",
+            "ATTESTATION",
+            "CSAF_VEX",
+            "CSAF_INFORMATIONAL_ADVISORY",
+            "CSAF_SECURITY_ADVISORY",
+            "CSAF_SECURITY_INCIDENT_RESPONSE"
+          ],
+          "title": "Material Type",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "string": {
+      "$ref": "attestation.v1.Attestation.Material.KeyVal.schema.json"
+    },
+    "uploaded_to_cas": {
+      "description": "Whether the material has been uploaded to the CAS",
+      "type": "boolean"
+    }
+  },
+  "title": "Material",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.Attestation.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.Attestation.jsonschema.json
@@ -1,0 +1,133 @@
+{
+  "$id": "attestation.v1.Attestation.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(env_vars)$": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "List of env variables",
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(finished_at)$": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "^(initialized_at)$": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "^(policy_evaluations)$": {
+      "description": "Policies that materials in this attestation were validated against",
+      "items": {
+        "$ref": "attestation.v1.PolicyEvaluation.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(runner_type)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "RUNNER_TYPE_UNSPECIFIED",
+            "GITHUB_ACTION",
+            "GITLAB_PIPELINE",
+            "AZURE_PIPELINE",
+            "JENKINS_JOB",
+            "CIRCLECI_BUILD",
+            "DAGGER_PIPELINE"
+          ],
+          "title": "Runner Type",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "^(runner_url)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "annotations": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Annotations for the attestation",
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "envVars": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "List of env variables",
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "finishedAt": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "head": {
+      "$ref": "attestation.v1.Commit.jsonschema.json",
+      "description": "Head Commit of the environment where the attestation was executed (optional)"
+    },
+    "initializedAt": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "materials": {
+      "additionalProperties": {
+        "$ref": "attestation.v1.Attestation.Material.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "policyEvaluations": {
+      "description": "Policies that materials in this attestation were validated against",
+      "items": {
+        "$ref": "attestation.v1.PolicyEvaluation.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "runnerType": {
+      "anyOf": [
+        {
+          "enum": [
+            "RUNNER_TYPE_UNSPECIFIED",
+            "GITHUB_ACTION",
+            "GITLAB_PIPELINE",
+            "AZURE_PIPELINE",
+            "JENKINS_JOB",
+            "CIRCLECI_BUILD",
+            "DAGGER_PIPELINE"
+          ],
+          "title": "Runner Type",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "runnerUrl": {
+      "type": "string"
+    },
+    "workflow": {
+      "$ref": "attestation.v1.WorkflowMetadata.jsonschema.json"
+    }
+  },
+  "title": "Attestation",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.Attestation.schema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.Attestation.schema.json
@@ -1,0 +1,133 @@
+{
+  "$id": "attestation.v1.Attestation.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(envVars)$": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "List of env variables",
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "^(finishedAt)$": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "^(initializedAt)$": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "^(policyEvaluations)$": {
+      "description": "Policies that materials in this attestation were validated against",
+      "items": {
+        "$ref": "attestation.v1.PolicyEvaluation.schema.json"
+      },
+      "type": "array"
+    },
+    "^(runnerType)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "RUNNER_TYPE_UNSPECIFIED",
+            "GITHUB_ACTION",
+            "GITLAB_PIPELINE",
+            "AZURE_PIPELINE",
+            "JENKINS_JOB",
+            "CIRCLECI_BUILD",
+            "DAGGER_PIPELINE"
+          ],
+          "title": "Runner Type",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "^(runnerUrl)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "annotations": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Annotations for the attestation",
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "env_vars": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "List of env variables",
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "finished_at": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "head": {
+      "$ref": "attestation.v1.Commit.schema.json",
+      "description": "Head Commit of the environment where the attestation was executed (optional)"
+    },
+    "initialized_at": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "materials": {
+      "additionalProperties": {
+        "$ref": "attestation.v1.Attestation.Material.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "policy_evaluations": {
+      "description": "Policies that materials in this attestation were validated against",
+      "items": {
+        "$ref": "attestation.v1.PolicyEvaluation.schema.json"
+      },
+      "type": "array"
+    },
+    "runner_type": {
+      "anyOf": [
+        {
+          "enum": [
+            "RUNNER_TYPE_UNSPECIFIED",
+            "GITHUB_ACTION",
+            "GITLAB_PIPELINE",
+            "AZURE_PIPELINE",
+            "JENKINS_JOB",
+            "CIRCLECI_BUILD",
+            "DAGGER_PIPELINE"
+          ],
+          "title": "Runner Type",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "runner_url": {
+      "type": "string"
+    },
+    "workflow": {
+      "$ref": "attestation.v1.WorkflowMetadata.schema.json"
+    }
+  },
+  "title": "Attestation",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.Commit.Remote.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.Commit.Remote.jsonschema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "attestation.v1.Commit.Remote.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "url": {
+      "type": "string"
+    }
+  },
+  "title": "Remote",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.Commit.Remote.schema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.Commit.Remote.schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "attestation.v1.Commit.Remote.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "url": {
+      "type": "string"
+    }
+  },
+  "title": "Remote",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.Commit.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.Commit.jsonschema.json
@@ -1,0 +1,40 @@
+{
+  "$id": "attestation.v1.Commit.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(author_email)$": {
+      "description": "Commit authors might not include email i.e \"Flux \u003c\u003e\"",
+      "type": "string"
+    },
+    "^(author_name)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "authorEmail": {
+      "description": "Commit authors might not include email i.e \"Flux \u003c\u003e\"",
+      "type": "string"
+    },
+    "authorName": {
+      "type": "string"
+    },
+    "date": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "hash": {
+      "type": "string"
+    },
+    "message": {
+      "type": "string"
+    },
+    "remotes": {
+      "items": {
+        "$ref": "attestation.v1.Commit.Remote.jsonschema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Commit",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.Commit.schema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.Commit.schema.json
@@ -1,0 +1,40 @@
+{
+  "$id": "attestation.v1.Commit.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(authorEmail)$": {
+      "description": "Commit authors might not include email i.e \"Flux \u003c\u003e\"",
+      "type": "string"
+    },
+    "^(authorName)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "author_email": {
+      "description": "Commit authors might not include email i.e \"Flux \u003c\u003e\"",
+      "type": "string"
+    },
+    "author_name": {
+      "type": "string"
+    },
+    "date": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "hash": {
+      "type": "string"
+    },
+    "message": {
+      "type": "string"
+    },
+    "remotes": {
+      "items": {
+        "$ref": "attestation.v1.Commit.Remote.schema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Commit",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.CraftingState.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.CraftingState.jsonschema.json
@@ -1,0 +1,27 @@
+{
+  "$id": "attestation.v1.CraftingState.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Intermediate information that will get stored in the system while the run is being executed",
+  "patternProperties": {
+    "^(dry_run)$": {
+      "type": "boolean"
+    },
+    "^(input_schema)$": {
+      "$ref": "workflowcontract.v1.CraftingSchema.jsonschema.json"
+    }
+  },
+  "properties": {
+    "attestation": {
+      "$ref": "attestation.v1.Attestation.jsonschema.json"
+    },
+    "dryRun": {
+      "type": "boolean"
+    },
+    "inputSchema": {
+      "$ref": "workflowcontract.v1.CraftingSchema.jsonschema.json"
+    }
+  },
+  "title": "Crafting State",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.CraftingState.schema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.CraftingState.schema.json
@@ -1,0 +1,27 @@
+{
+  "$id": "attestation.v1.CraftingState.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Intermediate information that will get stored in the system while the run is being executed",
+  "patternProperties": {
+    "^(dryRun)$": {
+      "type": "boolean"
+    },
+    "^(inputSchema)$": {
+      "$ref": "workflowcontract.v1.CraftingSchema.schema.json"
+    }
+  },
+  "properties": {
+    "attestation": {
+      "$ref": "attestation.v1.Attestation.schema.json"
+    },
+    "dry_run": {
+      "type": "boolean"
+    },
+    "input_schema": {
+      "$ref": "workflowcontract.v1.CraftingSchema.schema.json"
+    }
+  },
+  "title": "Crafting State",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyEvaluation.Violation.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyEvaluation.Violation.jsonschema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "attestation.v1.PolicyEvaluation.Violation.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "message": {
+      "type": "string"
+    },
+    "subject": {
+      "type": "string"
+    }
+  },
+  "title": "Violation",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyEvaluation.Violation.schema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyEvaluation.Violation.schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "attestation.v1.PolicyEvaluation.Violation.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "message": {
+      "type": "string"
+    },
+    "subject": {
+      "type": "string"
+    }
+  },
+  "title": "Violation",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyEvaluation.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyEvaluation.jsonschema.json
@@ -1,0 +1,87 @@
+{
+  "$id": "attestation.v1.PolicyEvaluation.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "A policy executed against an attestation or material",
+  "patternProperties": {
+    "^(material_name)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "annotations": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "body": {
+      "description": "The body script of the policy",
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "materialName": {
+      "type": "string"
+    },
+    "name": {
+      "description": "The policy name from the policy spec",
+      "type": "string"
+    },
+    "type": {
+      "anyOf": [
+        {
+          "enum": [
+            "MATERIAL_TYPE_UNSPECIFIED",
+            "STRING",
+            "CONTAINER_IMAGE",
+            "ARTIFACT",
+            "SBOM_CYCLONEDX_JSON",
+            "SBOM_SPDX_JSON",
+            "JUNIT_XML",
+            "OPENVEX",
+            "HELM_CHART",
+            "SARIF",
+            "EVIDENCE",
+            "ATTESTATION",
+            "CSAF_VEX",
+            "CSAF_INFORMATIONAL_ADVISORY",
+            "CSAF_SECURITY_ADVISORY",
+            "CSAF_SECURITY_INCIDENT_RESPONSE"
+          ],
+          "title": "Material Type",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ],
+      "description": "material type, if any, of the evaluated policy"
+    },
+    "violations": {
+      "description": "The policy violations, if any",
+      "items": {
+        "$ref": "attestation.v1.PolicyEvaluation.Violation.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "with": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "arguments, as they come from the policy attachment",
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    }
+  },
+  "title": "Policy Evaluation",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyEvaluation.schema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyEvaluation.schema.json
@@ -1,0 +1,87 @@
+{
+  "$id": "attestation.v1.PolicyEvaluation.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "A policy executed against an attestation or material",
+  "patternProperties": {
+    "^(materialName)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "annotations": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "body": {
+      "description": "The body script of the policy",
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "material_name": {
+      "type": "string"
+    },
+    "name": {
+      "description": "The policy name from the policy spec",
+      "type": "string"
+    },
+    "type": {
+      "anyOf": [
+        {
+          "enum": [
+            "MATERIAL_TYPE_UNSPECIFIED",
+            "STRING",
+            "CONTAINER_IMAGE",
+            "ARTIFACT",
+            "SBOM_CYCLONEDX_JSON",
+            "SBOM_SPDX_JSON",
+            "JUNIT_XML",
+            "OPENVEX",
+            "HELM_CHART",
+            "SARIF",
+            "EVIDENCE",
+            "ATTESTATION",
+            "CSAF_VEX",
+            "CSAF_INFORMATIONAL_ADVISORY",
+            "CSAF_SECURITY_ADVISORY",
+            "CSAF_SECURITY_INCIDENT_RESPONSE"
+          ],
+          "title": "Material Type",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ],
+      "description": "material type, if any, of the evaluated policy"
+    },
+    "violations": {
+      "description": "The policy violations, if any",
+      "items": {
+        "$ref": "attestation.v1.PolicyEvaluation.Violation.schema.json"
+      },
+      "type": "array"
+    },
+    "with": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "arguments, as they come from the policy attachment",
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    }
+  },
+  "title": "Policy Evaluation",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.WorkflowMetadata.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.WorkflowMetadata.jsonschema.json
@@ -1,0 +1,42 @@
+{
+  "$id": "attestation.v1.WorkflowMetadata.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(schema_revision)$": {
+      "type": "string"
+    },
+    "^(workflow_id)$": {
+      "type": "string"
+    },
+    "^(workflow_run_id)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "organization": {
+      "description": "organization name",
+      "type": "string"
+    },
+    "project": {
+      "type": "string"
+    },
+    "schemaRevision": {
+      "type": "string"
+    },
+    "team": {
+      "type": "string"
+    },
+    "workflowId": {
+      "type": "string"
+    },
+    "workflowRunId": {
+      "type": "string"
+    }
+  },
+  "title": "Workflow Metadata",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.WorkflowMetadata.schema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.WorkflowMetadata.schema.json
@@ -1,0 +1,42 @@
+{
+  "$id": "attestation.v1.WorkflowMetadata.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(schemaRevision)$": {
+      "type": "string"
+    },
+    "^(workflowId)$": {
+      "type": "string"
+    },
+    "^(workflowRunId)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "organization": {
+      "description": "organization name",
+      "type": "string"
+    },
+    "project": {
+      "type": "string"
+    },
+    "schema_revision": {
+      "type": "string"
+    },
+    "team": {
+      "type": "string"
+    },
+    "workflow_id": {
+      "type": "string"
+    },
+    "workflow_run_id": {
+      "type": "string"
+    }
+  },
+  "title": "Workflow Metadata",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.APITokenItem.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.APITokenItem.jsonschema.json
@@ -1,0 +1,50 @@
+{
+  "$id": "controlplane.v1.APITokenItem.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(created_at)$": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "^(expires_at)$": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "^(organization_id)$": {
+      "type": "string"
+    },
+    "^(organization_name)$": {
+      "type": "string"
+    },
+    "^(revoked_at)$": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    }
+  },
+  "properties": {
+    "createdAt": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "description": {
+      "type": "string"
+    },
+    "expiresAt": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "id": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "organizationId": {
+      "type": "string"
+    },
+    "organizationName": {
+      "type": "string"
+    },
+    "revokedAt": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    }
+  },
+  "title": "API Token Item",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.APITokenItem.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.APITokenItem.schema.json
@@ -1,0 +1,50 @@
+{
+  "$id": "controlplane.v1.APITokenItem.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(createdAt)$": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "^(expiresAt)$": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "^(organizationId)$": {
+      "type": "string"
+    },
+    "^(organizationName)$": {
+      "type": "string"
+    },
+    "^(revokedAt)$": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    }
+  },
+  "properties": {
+    "created_at": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "description": {
+      "type": "string"
+    },
+    "expires_at": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "id": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "organization_id": {
+      "type": "string"
+    },
+    "organization_name": {
+      "type": "string"
+    },
+    "revoked_at": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    }
+  },
+  "title": "API Token Item",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.APITokenServiceCreateRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.APITokenServiceCreateRequest.jsonschema.json
@@ -1,0 +1,23 @@
+{
+  "$id": "controlplane.v1.APITokenServiceCreateRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(expires_in)$": {
+      "$ref": "google.protobuf.Duration.jsonschema.json"
+    }
+  },
+  "properties": {
+    "description": {
+      "type": "string"
+    },
+    "expiresIn": {
+      "$ref": "google.protobuf.Duration.jsonschema.json"
+    },
+    "name": {
+      "type": "string"
+    }
+  },
+  "title": "API Token Service Create Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.APITokenServiceCreateRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.APITokenServiceCreateRequest.schema.json
@@ -1,0 +1,23 @@
+{
+  "$id": "controlplane.v1.APITokenServiceCreateRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(expiresIn)$": {
+      "$ref": "google.protobuf.Duration.schema.json"
+    }
+  },
+  "properties": {
+    "description": {
+      "type": "string"
+    },
+    "expires_in": {
+      "$ref": "google.protobuf.Duration.schema.json"
+    },
+    "name": {
+      "type": "string"
+    }
+  },
+  "title": "API Token Service Create Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.APITokenServiceCreateResponse.APITokenFull.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.APITokenServiceCreateResponse.APITokenFull.jsonschema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.APITokenServiceCreateResponse.APITokenFull.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "item": {
+      "$ref": "controlplane.v1.APITokenItem.jsonschema.json"
+    },
+    "jwt": {
+      "type": "string"
+    }
+  },
+  "title": "API Token Full",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.APITokenServiceCreateResponse.APITokenFull.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.APITokenServiceCreateResponse.APITokenFull.schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.APITokenServiceCreateResponse.APITokenFull.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "item": {
+      "$ref": "controlplane.v1.APITokenItem.schema.json"
+    },
+    "jwt": {
+      "type": "string"
+    }
+  },
+  "title": "API Token Full",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.APITokenServiceCreateResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.APITokenServiceCreateResponse.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.APITokenServiceCreateResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.APITokenServiceCreateResponse.APITokenFull.jsonschema.json"
+    }
+  },
+  "title": "API Token Service Create Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.APITokenServiceCreateResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.APITokenServiceCreateResponse.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.APITokenServiceCreateResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.APITokenServiceCreateResponse.APITokenFull.schema.json"
+    }
+  },
+  "title": "API Token Service Create Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.APITokenServiceListRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.APITokenServiceListRequest.jsonschema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "controlplane.v1.APITokenServiceListRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(include_revoked)$": {
+      "type": "boolean"
+    }
+  },
+  "properties": {
+    "includeRevoked": {
+      "type": "boolean"
+    }
+  },
+  "title": "API Token Service List Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.APITokenServiceListRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.APITokenServiceListRequest.schema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "controlplane.v1.APITokenServiceListRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(includeRevoked)$": {
+      "type": "boolean"
+    }
+  },
+  "properties": {
+    "include_revoked": {
+      "type": "boolean"
+    }
+  },
+  "title": "API Token Service List Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.APITokenServiceListResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.APITokenServiceListResponse.jsonschema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.APITokenServiceListResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "items": {
+        "$ref": "controlplane.v1.APITokenItem.jsonschema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "API Token Service List Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.APITokenServiceListResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.APITokenServiceListResponse.schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.APITokenServiceListResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "items": {
+        "$ref": "controlplane.v1.APITokenItem.schema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "API Token Service List Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.APITokenServiceRevokeRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.APITokenServiceRevokeRequest.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.APITokenServiceRevokeRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "title": "API Token Service Revoke Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.APITokenServiceRevokeRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.APITokenServiceRevokeRequest.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.APITokenServiceRevokeRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "title": "API Token Service Revoke Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.APITokenServiceRevokeResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.APITokenServiceRevokeResponse.jsonschema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.APITokenServiceRevokeResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "API Token Service Revoke Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.APITokenServiceRevokeResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.APITokenServiceRevokeResponse.schema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.APITokenServiceRevokeResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "API Token Service Revoke Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationItem.EnvVariable.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationItem.EnvVariable.jsonschema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.AttestationItem.EnvVariable.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "value": {
+      "type": "string"
+    }
+  },
+  "title": "Env Variable",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationItem.EnvVariable.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationItem.EnvVariable.schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.AttestationItem.EnvVariable.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "value": {
+      "type": "string"
+    }
+  },
+  "title": "Env Variable",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationItem.Material.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationItem.Material.jsonschema.json
@@ -1,0 +1,58 @@
+{
+  "$id": "controlplane.v1.AttestationItem.Material.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(embedded_inline)$": {
+      "description": "the content instead if inline",
+      "type": "boolean"
+    },
+    "^(uploaded_to_cas)$": {
+      "description": "it's been uploaded to an actual CAS backend",
+      "type": "boolean"
+    }
+  },
+  "properties": {
+    "annotations": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "embeddedInline": {
+      "description": "the content instead if inline",
+      "type": "boolean"
+    },
+    "filename": {
+      "description": "filename of the artifact that was either uploaded or injected inline in \"value\"",
+      "type": "string"
+    },
+    "hash": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "tag": {
+      "description": "in the case of a container image, the tag of the attested image",
+      "type": "string"
+    },
+    "type": {
+      "description": "Material type, i.e ARTIFACT",
+      "type": "string"
+    },
+    "uploadedToCas": {
+      "description": "it's been uploaded to an actual CAS backend",
+      "type": "boolean"
+    },
+    "value": {
+      "description": "This might be the raw value, the container image name, the filename and so on",
+      "type": "string"
+    }
+  },
+  "title": "Material",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationItem.Material.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationItem.Material.schema.json
@@ -1,0 +1,58 @@
+{
+  "$id": "controlplane.v1.AttestationItem.Material.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(embeddedInline)$": {
+      "description": "the content instead if inline",
+      "type": "boolean"
+    },
+    "^(uploadedToCas)$": {
+      "description": "it's been uploaded to an actual CAS backend",
+      "type": "boolean"
+    }
+  },
+  "properties": {
+    "annotations": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "embedded_inline": {
+      "description": "the content instead if inline",
+      "type": "boolean"
+    },
+    "filename": {
+      "description": "filename of the artifact that was either uploaded or injected inline in \"value\"",
+      "type": "string"
+    },
+    "hash": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "tag": {
+      "description": "in the case of a container image, the tag of the attested image",
+      "type": "string"
+    },
+    "type": {
+      "description": "Material type, i.e ARTIFACT",
+      "type": "string"
+    },
+    "uploaded_to_cas": {
+      "description": "it's been uploaded to an actual CAS backend",
+      "type": "boolean"
+    },
+    "value": {
+      "description": "This might be the raw value, the container image name, the filename and so on",
+      "type": "string"
+    }
+  },
+  "title": "Material",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationItem.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationItem.jsonschema.json
@@ -1,0 +1,71 @@
+{
+  "$id": "controlplane.v1.AttestationItem.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(digest_in_cas_backend)$": {
+      "description": "sha256sum of the envelope in json format, used as a key in the CAS backend",
+      "type": "string"
+    },
+    "^(env_vars)$": {
+      "description": "denormalized envelope/statement content",
+      "items": {
+        "$ref": "controlplane.v1.AttestationItem.EnvVariable.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(policy_evaluations)$": {
+      "additionalProperties": {
+        "$ref": "controlplane.v1.PolicyEvaluations.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    }
+  },
+  "properties": {
+    "annotations": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "digestInCasBackend": {
+      "description": "sha256sum of the envelope in json format, used as a key in the CAS backend",
+      "type": "string"
+    },
+    "envVars": {
+      "description": "denormalized envelope/statement content",
+      "items": {
+        "$ref": "controlplane.v1.AttestationItem.EnvVariable.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "envelope": {
+      "description": "encoded DSEE envelope",
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "materials": {
+      "items": {
+        "$ref": "controlplane.v1.AttestationItem.Material.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "policyEvaluations": {
+      "additionalProperties": {
+        "$ref": "controlplane.v1.PolicyEvaluations.jsonschema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    }
+  },
+  "title": "Attestation Item",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationItem.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationItem.schema.json
@@ -1,0 +1,71 @@
+{
+  "$id": "controlplane.v1.AttestationItem.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(digestInCasBackend)$": {
+      "description": "sha256sum of the envelope in json format, used as a key in the CAS backend",
+      "type": "string"
+    },
+    "^(envVars)$": {
+      "description": "denormalized envelope/statement content",
+      "items": {
+        "$ref": "controlplane.v1.AttestationItem.EnvVariable.schema.json"
+      },
+      "type": "array"
+    },
+    "^(policyEvaluations)$": {
+      "additionalProperties": {
+        "$ref": "controlplane.v1.PolicyEvaluations.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    }
+  },
+  "properties": {
+    "annotations": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "digest_in_cas_backend": {
+      "description": "sha256sum of the envelope in json format, used as a key in the CAS backend",
+      "type": "string"
+    },
+    "env_vars": {
+      "description": "denormalized envelope/statement content",
+      "items": {
+        "$ref": "controlplane.v1.AttestationItem.EnvVariable.schema.json"
+      },
+      "type": "array"
+    },
+    "envelope": {
+      "description": "encoded DSEE envelope",
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "materials": {
+      "items": {
+        "$ref": "controlplane.v1.AttestationItem.Material.schema.json"
+      },
+      "type": "array"
+    },
+    "policy_evaluations": {
+      "additionalProperties": {
+        "$ref": "controlplane.v1.PolicyEvaluations.schema.json"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    }
+  },
+  "title": "Attestation Item",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceCancelRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceCancelRequest.jsonschema.json
@@ -1,0 +1,38 @@
+{
+  "$id": "controlplane.v1.AttestationServiceCancelRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(workflow_run_id)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "reason": {
+      "type": "string"
+    },
+    "trigger": {
+      "anyOf": [
+        {
+          "enum": [
+            "TRIGGER_TYPE_UNSPECIFIED",
+            "TRIGGER_TYPE_FAILURE",
+            "TRIGGER_TYPE_CANCELLATION"
+          ],
+          "title": "Trigger Type",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "workflowRunId": {
+      "type": "string"
+    }
+  },
+  "title": "Attestation Service Cancel Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceCancelRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceCancelRequest.schema.json
@@ -1,0 +1,38 @@
+{
+  "$id": "controlplane.v1.AttestationServiceCancelRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(workflowRunId)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "reason": {
+      "type": "string"
+    },
+    "trigger": {
+      "anyOf": [
+        {
+          "enum": [
+            "TRIGGER_TYPE_UNSPECIFIED",
+            "TRIGGER_TYPE_FAILURE",
+            "TRIGGER_TYPE_CANCELLATION"
+          ],
+          "title": "Trigger Type",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "workflow_run_id": {
+      "type": "string"
+    }
+  },
+  "title": "Attestation Service Cancel Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceCancelResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceCancelResponse.jsonschema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.AttestationServiceCancelResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Attestation Service Cancel Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceCancelResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceCancelResponse.schema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.AttestationServiceCancelResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Attestation Service Cancel Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceGetContractRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceGetContractRequest.jsonschema.json
@@ -1,0 +1,29 @@
+{
+  "$id": "controlplane.v1.AttestationServiceGetContractRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(contract_revision)$": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(workflow_name)$": {
+      "description": "This parameter is not needed by Robot Account since they have the workflowID embedded.\n API Tokens will send the parameter explicitly",
+      "type": "string"
+    }
+  },
+  "properties": {
+    "contractRevision": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "workflowName": {
+      "description": "This parameter is not needed by Robot Account since they have the workflowID embedded.\n API Tokens will send the parameter explicitly",
+      "type": "string"
+    }
+  },
+  "title": "Attestation Service Get Contract Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceGetContractRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceGetContractRequest.schema.json
@@ -1,0 +1,29 @@
+{
+  "$id": "controlplane.v1.AttestationServiceGetContractRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(contractRevision)$": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(workflowName)$": {
+      "description": "This parameter is not needed by Robot Account since they have the workflowID embedded.\n API Tokens will send the parameter explicitly",
+      "type": "string"
+    }
+  },
+  "properties": {
+    "contract_revision": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "workflow_name": {
+      "description": "This parameter is not needed by Robot Account since they have the workflowID embedded.\n API Tokens will send the parameter explicitly",
+      "type": "string"
+    }
+  },
+  "title": "Attestation Service Get Contract Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceGetContractResponse.Result.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceGetContractResponse.Result.jsonschema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.AttestationServiceGetContractResponse.Result.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "contract": {
+      "$ref": "controlplane.v1.WorkflowContractVersionItem.jsonschema.json"
+    },
+    "workflow": {
+      "$ref": "controlplane.v1.WorkflowItem.jsonschema.json"
+    }
+  },
+  "title": "Result",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceGetContractResponse.Result.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceGetContractResponse.Result.schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.AttestationServiceGetContractResponse.Result.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "contract": {
+      "$ref": "controlplane.v1.WorkflowContractVersionItem.schema.json"
+    },
+    "workflow": {
+      "$ref": "controlplane.v1.WorkflowItem.schema.json"
+    }
+  },
+  "title": "Result",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceGetContractResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceGetContractResponse.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.AttestationServiceGetContractResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.AttestationServiceGetContractResponse.Result.jsonschema.json"
+    }
+  },
+  "title": "Attestation Service Get Contract Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceGetContractResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceGetContractResponse.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.AttestationServiceGetContractResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.AttestationServiceGetContractResponse.Result.schema.json"
+    }
+  },
+  "title": "Attestation Service Get Contract Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceGetPolicyRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceGetPolicyRequest.jsonschema.json
@@ -1,0 +1,23 @@
+{
+  "$id": "controlplane.v1.AttestationServiceGetPolicyRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(policy_name)$": {
+      "description": "Policy name (it must exist in the provider)",
+      "type": "string"
+    }
+  },
+  "properties": {
+    "policyName": {
+      "description": "Policy name (it must exist in the provider)",
+      "type": "string"
+    },
+    "provider": {
+      "description": "Provider name. If not set, the default provider will be used",
+      "type": "string"
+    }
+  },
+  "title": "Attestation Service Get Policy Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceGetPolicyRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceGetPolicyRequest.schema.json
@@ -1,0 +1,23 @@
+{
+  "$id": "controlplane.v1.AttestationServiceGetPolicyRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(policyName)$": {
+      "description": "Policy name (it must exist in the provider)",
+      "type": "string"
+    }
+  },
+  "properties": {
+    "policy_name": {
+      "description": "Policy name (it must exist in the provider)",
+      "type": "string"
+    },
+    "provider": {
+      "description": "Provider name. If not set, the default provider will be used",
+      "type": "string"
+    }
+  },
+  "title": "Attestation Service Get Policy Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceGetPolicyResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceGetPolicyResponse.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.AttestationServiceGetPolicyResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "policy": {
+      "$ref": "workflowcontract.v1.Policy.jsonschema.json"
+    }
+  },
+  "title": "Attestation Service Get Policy Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceGetPolicyResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceGetPolicyResponse.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.AttestationServiceGetPolicyResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "policy": {
+      "$ref": "workflowcontract.v1.Policy.schema.json"
+    }
+  },
+  "title": "Attestation Service Get Policy Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceGetUploadCredsRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceGetUploadCredsRequest.jsonschema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "controlplane.v1.AttestationServiceGetUploadCredsRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(workflow_run_id)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "workflowRunId": {
+      "type": "string"
+    }
+  },
+  "title": "Attestation Service Get Upload Creds Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceGetUploadCredsRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceGetUploadCredsRequest.schema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "controlplane.v1.AttestationServiceGetUploadCredsRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(workflowRunId)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "workflow_run_id": {
+      "type": "string"
+    }
+  },
+  "title": "Attestation Service Get Upload Creds Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceGetUploadCredsResponse.Result.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceGetUploadCredsResponse.Result.jsonschema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.AttestationServiceGetUploadCredsResponse.Result.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "backend": {
+      "$ref": "controlplane.v1.CASBackendItem.jsonschema.json"
+    },
+    "token": {
+      "type": "string"
+    }
+  },
+  "title": "Result",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceGetUploadCredsResponse.Result.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceGetUploadCredsResponse.Result.schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.AttestationServiceGetUploadCredsResponse.Result.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "backend": {
+      "$ref": "controlplane.v1.CASBackendItem.schema.json"
+    },
+    "token": {
+      "type": "string"
+    }
+  },
+  "title": "Result",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceGetUploadCredsResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceGetUploadCredsResponse.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.AttestationServiceGetUploadCredsResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.AttestationServiceGetUploadCredsResponse.Result.jsonschema.json"
+    }
+  },
+  "title": "Attestation Service Get Upload Creds Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceGetUploadCredsResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceGetUploadCredsResponse.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.AttestationServiceGetUploadCredsResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.AttestationServiceGetUploadCredsResponse.Result.schema.json"
+    }
+  },
+  "title": "Attestation Service Get Upload Creds Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceInitRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceInitRequest.jsonschema.json
@@ -1,0 +1,55 @@
+{
+  "$id": "controlplane.v1.AttestationServiceInitRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(contract_revision)$": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(job_url)$": {
+      "type": "string"
+    },
+    "^(workflow_name)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "contractRevision": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "jobUrl": {
+      "type": "string"
+    },
+    "runner": {
+      "anyOf": [
+        {
+          "enum": [
+            "RUNNER_TYPE_UNSPECIFIED",
+            "GITHUB_ACTION",
+            "GITLAB_PIPELINE",
+            "AZURE_PIPELINE",
+            "JENKINS_JOB",
+            "CIRCLECI_BUILD",
+            "DAGGER_PIPELINE"
+          ],
+          "title": "Runner Type",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "workflowName": {
+      "type": "string"
+    }
+  },
+  "title": "Attestation Service Init Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceInitRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceInitRequest.schema.json
@@ -1,0 +1,55 @@
+{
+  "$id": "controlplane.v1.AttestationServiceInitRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(contractRevision)$": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(jobUrl)$": {
+      "type": "string"
+    },
+    "^(workflowName)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "contract_revision": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "job_url": {
+      "type": "string"
+    },
+    "runner": {
+      "anyOf": [
+        {
+          "enum": [
+            "RUNNER_TYPE_UNSPECIFIED",
+            "GITHUB_ACTION",
+            "GITLAB_PIPELINE",
+            "AZURE_PIPELINE",
+            "JENKINS_JOB",
+            "CIRCLECI_BUILD",
+            "DAGGER_PIPELINE"
+          ],
+          "title": "Runner Type",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "workflow_name": {
+      "type": "string"
+    }
+  },
+  "title": "Attestation Service Init Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceInitResponse.Result.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceInitResponse.Result.jsonschema.json
@@ -1,0 +1,21 @@
+{
+  "$id": "controlplane.v1.AttestationServiceInitResponse.Result.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(workflow_run)$": {
+      "$ref": "controlplane.v1.WorkflowRunItem.jsonschema.json"
+    }
+  },
+  "properties": {
+    "organization": {
+      "description": "organization name",
+      "type": "string"
+    },
+    "workflowRun": {
+      "$ref": "controlplane.v1.WorkflowRunItem.jsonschema.json"
+    }
+  },
+  "title": "Result",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceInitResponse.Result.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceInitResponse.Result.schema.json
@@ -1,0 +1,21 @@
+{
+  "$id": "controlplane.v1.AttestationServiceInitResponse.Result.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(workflowRun)$": {
+      "$ref": "controlplane.v1.WorkflowRunItem.schema.json"
+    }
+  },
+  "properties": {
+    "organization": {
+      "description": "organization name",
+      "type": "string"
+    },
+    "workflow_run": {
+      "$ref": "controlplane.v1.WorkflowRunItem.schema.json"
+    }
+  },
+  "title": "Result",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceInitResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceInitResponse.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.AttestationServiceInitResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.AttestationServiceInitResponse.Result.jsonschema.json"
+    }
+  },
+  "title": "Attestation Service Init Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceInitResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceInitResponse.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.AttestationServiceInitResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.AttestationServiceInitResponse.Result.schema.json"
+    }
+  },
+  "title": "Attestation Service Init Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceStoreRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceStoreRequest.jsonschema.json
@@ -1,0 +1,22 @@
+{
+  "$id": "controlplane.v1.AttestationServiceStoreRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(workflow_run_id)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "attestation": {
+      "description": "encoded DSEE envelope",
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "workflowRunId": {
+      "type": "string"
+    }
+  },
+  "title": "Attestation Service Store Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceStoreRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceStoreRequest.schema.json
@@ -1,0 +1,22 @@
+{
+  "$id": "controlplane.v1.AttestationServiceStoreRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(workflowRunId)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "attestation": {
+      "description": "encoded DSEE envelope",
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "workflow_run_id": {
+      "type": "string"
+    }
+  },
+  "title": "Attestation Service Store Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceStoreResponse.Result.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceStoreResponse.Result.jsonschema.json
@@ -1,0 +1,13 @@
+{
+  "$id": "controlplane.v1.AttestationServiceStoreResponse.Result.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "digest": {
+      "description": "attestation digest",
+      "type": "string"
+    }
+  },
+  "title": "Result",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceStoreResponse.Result.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceStoreResponse.Result.schema.json
@@ -1,0 +1,13 @@
+{
+  "$id": "controlplane.v1.AttestationServiceStoreResponse.Result.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "digest": {
+      "description": "attestation digest",
+      "type": "string"
+    }
+  },
+  "title": "Result",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceStoreResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceStoreResponse.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.AttestationServiceStoreResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.AttestationServiceStoreResponse.Result.jsonschema.json"
+    }
+  },
+  "title": "Attestation Service Store Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceStoreResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationServiceStoreResponse.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.AttestationServiceStoreResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.AttestationServiceStoreResponse.Result.schema.json"
+    }
+  },
+  "title": "Attestation Service Store Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceInitializedRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceInitializedRequest.jsonschema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "controlplane.v1.AttestationStateServiceInitializedRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(workflow_run_id)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "workflowRunId": {
+      "type": "string"
+    }
+  },
+  "title": "Attestation State Service Initialized Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceInitializedRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceInitializedRequest.schema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "controlplane.v1.AttestationStateServiceInitializedRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(workflowRunId)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "workflow_run_id": {
+      "type": "string"
+    }
+  },
+  "title": "Attestation State Service Initialized Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceInitializedResponse.Result.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceInitializedResponse.Result.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.AttestationStateServiceInitializedResponse.Result.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "initialized": {
+      "type": "boolean"
+    }
+  },
+  "title": "Result",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceInitializedResponse.Result.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceInitializedResponse.Result.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.AttestationStateServiceInitializedResponse.Result.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "initialized": {
+      "type": "boolean"
+    }
+  },
+  "title": "Result",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceInitializedResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceInitializedResponse.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.AttestationStateServiceInitializedResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.AttestationStateServiceInitializedResponse.Result.jsonschema.json"
+    }
+  },
+  "title": "Attestation State Service Initialized Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceInitializedResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceInitializedResponse.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.AttestationStateServiceInitializedResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.AttestationStateServiceInitializedResponse.Result.schema.json"
+    }
+  },
+  "title": "Attestation State Service Initialized Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceReadRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceReadRequest.jsonschema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "controlplane.v1.AttestationStateServiceReadRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(workflow_run_id)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "workflowRunId": {
+      "type": "string"
+    }
+  },
+  "title": "Attestation State Service Read Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceReadRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceReadRequest.schema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "controlplane.v1.AttestationStateServiceReadRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(workflowRunId)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "workflow_run_id": {
+      "type": "string"
+    }
+  },
+  "title": "Attestation State Service Read Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceReadResponse.Result.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceReadResponse.Result.jsonschema.json
@@ -1,0 +1,21 @@
+{
+  "$id": "controlplane.v1.AttestationStateServiceReadResponse.Result.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(attestation_state)$": {
+      "$ref": "attestation.v1.CraftingState.jsonschema.json"
+    }
+  },
+  "properties": {
+    "attestationState": {
+      "$ref": "attestation.v1.CraftingState.jsonschema.json"
+    },
+    "digest": {
+      "description": "digest of the attestation state to implement Optimistic Concurrency Control",
+      "type": "string"
+    }
+  },
+  "title": "Result",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceReadResponse.Result.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceReadResponse.Result.schema.json
@@ -1,0 +1,21 @@
+{
+  "$id": "controlplane.v1.AttestationStateServiceReadResponse.Result.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(attestationState)$": {
+      "$ref": "attestation.v1.CraftingState.schema.json"
+    }
+  },
+  "properties": {
+    "attestation_state": {
+      "$ref": "attestation.v1.CraftingState.schema.json"
+    },
+    "digest": {
+      "description": "digest of the attestation state to implement Optimistic Concurrency Control",
+      "type": "string"
+    }
+  },
+  "title": "Result",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceReadResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceReadResponse.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.AttestationStateServiceReadResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.AttestationStateServiceReadResponse.Result.jsonschema.json"
+    }
+  },
+  "title": "Attestation State Service Read Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceReadResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceReadResponse.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.AttestationStateServiceReadResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.AttestationStateServiceReadResponse.Result.schema.json"
+    }
+  },
+  "title": "Attestation State Service Read Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceResetRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceResetRequest.jsonschema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "controlplane.v1.AttestationStateServiceResetRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(workflow_run_id)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "workflowRunId": {
+      "type": "string"
+    }
+  },
+  "title": "Attestation State Service Reset Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceResetRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceResetRequest.schema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "controlplane.v1.AttestationStateServiceResetRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(workflowRunId)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "workflow_run_id": {
+      "type": "string"
+    }
+  },
+  "title": "Attestation State Service Reset Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceResetResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceResetResponse.jsonschema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.AttestationStateServiceResetResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Attestation State Service Reset Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceResetResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceResetResponse.schema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.AttestationStateServiceResetResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Attestation State Service Reset Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceSaveRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceSaveRequest.jsonschema.json
@@ -1,0 +1,31 @@
+{
+  "$id": "controlplane.v1.AttestationStateServiceSaveRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(attestation_state)$": {
+      "$ref": "attestation.v1.CraftingState.jsonschema.json"
+    },
+    "^(base_digest)$": {
+      "description": "digest of the attestation state this update was performed on top of\n The digest might be empty the first time",
+      "type": "string"
+    },
+    "^(workflow_run_id)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "attestationState": {
+      "$ref": "attestation.v1.CraftingState.jsonschema.json"
+    },
+    "baseDigest": {
+      "description": "digest of the attestation state this update was performed on top of\n The digest might be empty the first time",
+      "type": "string"
+    },
+    "workflowRunId": {
+      "type": "string"
+    }
+  },
+  "title": "Attestation State Service Save Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceSaveRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceSaveRequest.schema.json
@@ -1,0 +1,31 @@
+{
+  "$id": "controlplane.v1.AttestationStateServiceSaveRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(attestationState)$": {
+      "$ref": "attestation.v1.CraftingState.schema.json"
+    },
+    "^(baseDigest)$": {
+      "description": "digest of the attestation state this update was performed on top of\n The digest might be empty the first time",
+      "type": "string"
+    },
+    "^(workflowRunId)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "attestation_state": {
+      "$ref": "attestation.v1.CraftingState.schema.json"
+    },
+    "base_digest": {
+      "description": "digest of the attestation state this update was performed on top of\n The digest might be empty the first time",
+      "type": "string"
+    },
+    "workflow_run_id": {
+      "type": "string"
+    }
+  },
+  "title": "Attestation State Service Save Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceSaveResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceSaveResponse.jsonschema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.AttestationStateServiceSaveResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Attestation State Service Save Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceSaveResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AttestationStateServiceSaveResponse.schema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.AttestationStateServiceSaveResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Attestation State Service Save Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AuthServiceDeleteAccountRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AuthServiceDeleteAccountRequest.jsonschema.json
@@ -1,0 +1,9 @@
+{
+  "$id": "controlplane.v1.AuthServiceDeleteAccountRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "AuthServiceDeleteAccountResponse is the response for the DeleteAccount method.",
+  "properties": {},
+  "title": "Auth Service Delete Account Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AuthServiceDeleteAccountRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AuthServiceDeleteAccountRequest.schema.json
@@ -1,0 +1,9 @@
+{
+  "$id": "controlplane.v1.AuthServiceDeleteAccountRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "AuthServiceDeleteAccountResponse is the response for the DeleteAccount method.",
+  "properties": {},
+  "title": "Auth Service Delete Account Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AuthServiceDeleteAccountResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AuthServiceDeleteAccountResponse.jsonschema.json
@@ -1,0 +1,9 @@
+{
+  "$id": "controlplane.v1.AuthServiceDeleteAccountResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "AuthServiceDeleteAccountResponse is the response for the DeleteAccount method.",
+  "properties": {},
+  "title": "Auth Service Delete Account Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.AuthServiceDeleteAccountResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.AuthServiceDeleteAccountResponse.schema.json
@@ -1,0 +1,9 @@
+{
+  "$id": "controlplane.v1.AuthServiceDeleteAccountResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "AuthServiceDeleteAccountResponse is the response for the DeleteAccount method.",
+  "properties": {},
+  "title": "Auth Service Delete Account Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendItem.Limits.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendItem.Limits.jsonschema.json
@@ -1,0 +1,39 @@
+{
+  "$id": "controlplane.v1.CASBackendItem.Limits.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(max_bytes)$": {
+      "anyOf": [
+        {
+          "maximum": 9223372036854776000,
+          "minimum": -9223372036854776000,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ],
+      "description": "Max number of bytes allowed to be stored in this backend"
+    }
+  },
+  "properties": {
+    "maxBytes": {
+      "anyOf": [
+        {
+          "maximum": 9223372036854776000,
+          "minimum": -9223372036854776000,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ],
+      "description": "Max number of bytes allowed to be stored in this backend"
+    }
+  },
+  "title": "Limits",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendItem.Limits.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendItem.Limits.schema.json
@@ -1,0 +1,39 @@
+{
+  "$id": "controlplane.v1.CASBackendItem.Limits.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(maxBytes)$": {
+      "anyOf": [
+        {
+          "maximum": 9223372036854776000,
+          "minimum": -9223372036854776000,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ],
+      "description": "Max number of bytes allowed to be stored in this backend"
+    }
+  },
+  "properties": {
+    "max_bytes": {
+      "anyOf": [
+        {
+          "maximum": 9223372036854776000,
+          "minimum": -9223372036854776000,
+          "type": "integer"
+        },
+        {
+          "pattern": "^[0-9]+$",
+          "type": "string"
+        }
+      ],
+      "description": "Max number of bytes allowed to be stored in this backend"
+    }
+  },
+  "title": "Limits",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendItem.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendItem.jsonschema.json
@@ -1,0 +1,92 @@
+{
+  "$id": "controlplane.v1.CASBackendItem.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(created_at)$": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "^(is_inline)$": {
+      "description": "Is it an inline backend?\n inline means that the content is stored in the attestation itself",
+      "type": "boolean"
+    },
+    "^(validated_at)$": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "^(validation_status)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "VALIDATION_STATUS_UNSPECIFIED",
+            "VALIDATION_STATUS_OK",
+            "VALIDATION_STATUS_INVALID"
+          ],
+          "title": "Validation Status",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "properties": {
+    "createdAt": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "default": {
+      "description": "Wether it's the default backend in the organization",
+      "type": "boolean"
+    },
+    "description": {
+      "type": "string"
+    },
+    "id": {
+      "type": "string"
+    },
+    "isInline": {
+      "description": "Is it an inline backend?\n inline means that the content is stored in the attestation itself",
+      "type": "boolean"
+    },
+    "limits": {
+      "$ref": "controlplane.v1.CASBackendItem.Limits.jsonschema.json",
+      "description": "Limits for this backend"
+    },
+    "location": {
+      "description": "e.g. myregistry.io/myrepo s3 bucket and so on",
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "provider": {
+      "description": "OCI, S3, ...",
+      "type": "string"
+    },
+    "validatedAt": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "validationStatus": {
+      "anyOf": [
+        {
+          "enum": [
+            "VALIDATION_STATUS_UNSPECIFIED",
+            "VALIDATION_STATUS_OK",
+            "VALIDATION_STATUS_INVALID"
+          ],
+          "title": "Validation Status",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "title": "CAS Backend Item",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendItem.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendItem.schema.json
@@ -1,0 +1,92 @@
+{
+  "$id": "controlplane.v1.CASBackendItem.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(createdAt)$": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "^(isInline)$": {
+      "description": "Is it an inline backend?\n inline means that the content is stored in the attestation itself",
+      "type": "boolean"
+    },
+    "^(validatedAt)$": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "^(validationStatus)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "VALIDATION_STATUS_UNSPECIFIED",
+            "VALIDATION_STATUS_OK",
+            "VALIDATION_STATUS_INVALID"
+          ],
+          "title": "Validation Status",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "properties": {
+    "created_at": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "default": {
+      "description": "Wether it's the default backend in the organization",
+      "type": "boolean"
+    },
+    "description": {
+      "type": "string"
+    },
+    "id": {
+      "type": "string"
+    },
+    "is_inline": {
+      "description": "Is it an inline backend?\n inline means that the content is stored in the attestation itself",
+      "type": "boolean"
+    },
+    "limits": {
+      "$ref": "controlplane.v1.CASBackendItem.Limits.schema.json",
+      "description": "Limits for this backend"
+    },
+    "location": {
+      "description": "e.g. myregistry.io/myrepo s3 bucket and so on",
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "provider": {
+      "description": "OCI, S3, ...",
+      "type": "string"
+    },
+    "validated_at": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "validation_status": {
+      "anyOf": [
+        {
+          "enum": [
+            "VALIDATION_STATUS_UNSPECIFIED",
+            "VALIDATION_STATUS_OK",
+            "VALIDATION_STATUS_INVALID"
+          ],
+          "title": "Validation Status",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "title": "CAS Backend Item",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendServiceCreateRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendServiceCreateRequest.jsonschema.json
@@ -1,0 +1,32 @@
+{
+  "$id": "controlplane.v1.CASBackendServiceCreateRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "credentials": {
+      "$ref": "google.protobuf.Struct.jsonschema.json",
+      "description": "Arbitrary configuration for the integration"
+    },
+    "default": {
+      "description": "Set as default in your organization",
+      "type": "boolean"
+    },
+    "description": {
+      "description": "Descriptive name",
+      "type": "string"
+    },
+    "location": {
+      "description": "Location, e.g. bucket name, OCI bucket name, ...",
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "provider": {
+      "description": "Type of the backend, OCI, S3, ...",
+      "type": "string"
+    }
+  },
+  "title": "CAS Backend Service Create Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendServiceCreateRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendServiceCreateRequest.schema.json
@@ -1,0 +1,32 @@
+{
+  "$id": "controlplane.v1.CASBackendServiceCreateRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "credentials": {
+      "$ref": "google.protobuf.Struct.schema.json",
+      "description": "Arbitrary configuration for the integration"
+    },
+    "default": {
+      "description": "Set as default in your organization",
+      "type": "boolean"
+    },
+    "description": {
+      "description": "Descriptive name",
+      "type": "string"
+    },
+    "location": {
+      "description": "Location, e.g. bucket name, OCI bucket name, ...",
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "provider": {
+      "description": "Type of the backend, OCI, S3, ...",
+      "type": "string"
+    }
+  },
+  "title": "CAS Backend Service Create Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendServiceCreateResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendServiceCreateResponse.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.CASBackendServiceCreateResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.CASBackendItem.jsonschema.json"
+    }
+  },
+  "title": "CAS Backend Service Create Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendServiceCreateResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendServiceCreateResponse.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.CASBackendServiceCreateResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.CASBackendItem.schema.json"
+    }
+  },
+  "title": "CAS Backend Service Create Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendServiceDeleteRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendServiceDeleteRequest.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.CASBackendServiceDeleteRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "title": "CAS Backend Service Delete Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendServiceDeleteRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendServiceDeleteRequest.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.CASBackendServiceDeleteRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "title": "CAS Backend Service Delete Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendServiceDeleteResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendServiceDeleteResponse.jsonschema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.CASBackendServiceDeleteResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "CAS Backend Service Delete Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendServiceDeleteResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendServiceDeleteResponse.schema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.CASBackendServiceDeleteResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "CAS Backend Service Delete Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendServiceListRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendServiceListRequest.jsonschema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.CASBackendServiceListRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "CAS Backend Service List Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendServiceListRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendServiceListRequest.schema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.CASBackendServiceListRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "CAS Backend Service List Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendServiceListResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendServiceListResponse.jsonschema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.CASBackendServiceListResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "items": {
+        "$ref": "controlplane.v1.CASBackendItem.jsonschema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "CAS Backend Service List Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendServiceListResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendServiceListResponse.schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.CASBackendServiceListResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "items": {
+        "$ref": "controlplane.v1.CASBackendItem.schema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "CAS Backend Service List Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendServiceUpdateRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendServiceUpdateRequest.jsonschema.json
@@ -1,0 +1,25 @@
+{
+  "$id": "controlplane.v1.CASBackendServiceUpdateRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Update a CAS backend is limited to\n - description\n - set is as default\n - rotate credentials",
+  "properties": {
+    "credentials": {
+      "$ref": "google.protobuf.Struct.jsonschema.json",
+      "description": "Credentials, useful for rotation"
+    },
+    "default": {
+      "description": "Set as default in your organization",
+      "type": "boolean"
+    },
+    "description": {
+      "description": "Description",
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    }
+  },
+  "title": "CAS Backend Service Update Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendServiceUpdateRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendServiceUpdateRequest.schema.json
@@ -1,0 +1,25 @@
+{
+  "$id": "controlplane.v1.CASBackendServiceUpdateRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Update a CAS backend is limited to\n - description\n - set is as default\n - rotate credentials",
+  "properties": {
+    "credentials": {
+      "$ref": "google.protobuf.Struct.schema.json",
+      "description": "Credentials, useful for rotation"
+    },
+    "default": {
+      "description": "Set as default in your organization",
+      "type": "boolean"
+    },
+    "description": {
+      "description": "Description",
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    }
+  },
+  "title": "CAS Backend Service Update Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendServiceUpdateResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendServiceUpdateResponse.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.CASBackendServiceUpdateResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.CASBackendItem.jsonschema.json"
+    }
+  },
+  "title": "CAS Backend Service Update Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendServiceUpdateResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.CASBackendServiceUpdateResponse.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.CASBackendServiceUpdateResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.CASBackendItem.schema.json"
+    }
+  },
+  "title": "CAS Backend Service Update Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.CASCredentialsServiceGetRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.CASCredentialsServiceGetRequest.jsonschema.json
@@ -1,0 +1,31 @@
+{
+  "$id": "controlplane.v1.CASCredentialsServiceGetRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "digest": {
+      "description": "during the download we need the digest to find the proper cas backend",
+      "type": "string"
+    },
+    "role": {
+      "anyOf": [
+        {
+          "enum": [
+            "ROLE_UNSPECIFIED",
+            "ROLE_DOWNLOADER",
+            "ROLE_UPLOADER"
+          ],
+          "title": "Role",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "title": "CAS Credentials Service Get Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.CASCredentialsServiceGetRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.CASCredentialsServiceGetRequest.schema.json
@@ -1,0 +1,31 @@
+{
+  "$id": "controlplane.v1.CASCredentialsServiceGetRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "digest": {
+      "description": "during the download we need the digest to find the proper cas backend",
+      "type": "string"
+    },
+    "role": {
+      "anyOf": [
+        {
+          "enum": [
+            "ROLE_UNSPECIFIED",
+            "ROLE_DOWNLOADER",
+            "ROLE_UPLOADER"
+          ],
+          "title": "Role",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "title": "CAS Credentials Service Get Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.CASCredentialsServiceGetResponse.Result.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.CASCredentialsServiceGetResponse.Result.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.CASCredentialsServiceGetResponse.Result.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "token": {
+      "type": "string"
+    }
+  },
+  "title": "Result",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.CASCredentialsServiceGetResponse.Result.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.CASCredentialsServiceGetResponse.Result.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.CASCredentialsServiceGetResponse.Result.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "token": {
+      "type": "string"
+    }
+  },
+  "title": "Result",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.CASCredentialsServiceGetResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.CASCredentialsServiceGetResponse.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.CASCredentialsServiceGetResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.CASCredentialsServiceGetResponse.Result.jsonschema.json"
+    }
+  },
+  "title": "CAS Credentials Service Get Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.CASCredentialsServiceGetResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.CASCredentialsServiceGetResponse.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.CASCredentialsServiceGetResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.CASCredentialsServiceGetResponse.Result.schema.json"
+    }
+  },
+  "title": "CAS Credentials Service Get Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.CertificateChain.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.CertificateChain.jsonschema.json
@@ -1,0 +1,16 @@
+{
+  "$id": "controlplane.v1.CertificateChain.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "certificates": {
+      "description": "The PEM-encoded certificate chain, ordered from leaf to intermediate to root as applicable.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Certificate Chain",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.CertificateChain.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.CertificateChain.schema.json
@@ -1,0 +1,16 @@
+{
+  "$id": "controlplane.v1.CertificateChain.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "certificates": {
+      "description": "The PEM-encoded certificate chain, ordered from leaf to intermediate to root as applicable.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Certificate Chain",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.ContextServiceCurrentRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.ContextServiceCurrentRequest.jsonschema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.ContextServiceCurrentRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Context Service Current Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.ContextServiceCurrentRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.ContextServiceCurrentRequest.schema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.ContextServiceCurrentRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Context Service Current Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.ContextServiceCurrentResponse.Result.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.ContextServiceCurrentResponse.Result.jsonschema.json
@@ -1,0 +1,29 @@
+{
+  "$id": "controlplane.v1.ContextServiceCurrentResponse.Result.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(current_cas_backend)$": {
+      "$ref": "controlplane.v1.CASBackendItem.jsonschema.json"
+    },
+    "^(current_membership)$": {
+      "$ref": "controlplane.v1.OrgMembershipItem.jsonschema.json"
+    },
+    "^(current_user)$": {
+      "$ref": "controlplane.v1.User.jsonschema.json"
+    }
+  },
+  "properties": {
+    "currentCasBackend": {
+      "$ref": "controlplane.v1.CASBackendItem.jsonschema.json"
+    },
+    "currentMembership": {
+      "$ref": "controlplane.v1.OrgMembershipItem.jsonschema.json"
+    },
+    "currentUser": {
+      "$ref": "controlplane.v1.User.jsonschema.json"
+    }
+  },
+  "title": "Result",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.ContextServiceCurrentResponse.Result.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.ContextServiceCurrentResponse.Result.schema.json
@@ -1,0 +1,29 @@
+{
+  "$id": "controlplane.v1.ContextServiceCurrentResponse.Result.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(currentCasBackend)$": {
+      "$ref": "controlplane.v1.CASBackendItem.schema.json"
+    },
+    "^(currentMembership)$": {
+      "$ref": "controlplane.v1.OrgMembershipItem.schema.json"
+    },
+    "^(currentUser)$": {
+      "$ref": "controlplane.v1.User.schema.json"
+    }
+  },
+  "properties": {
+    "current_cas_backend": {
+      "$ref": "controlplane.v1.CASBackendItem.schema.json"
+    },
+    "current_membership": {
+      "$ref": "controlplane.v1.OrgMembershipItem.schema.json"
+    },
+    "current_user": {
+      "$ref": "controlplane.v1.User.schema.json"
+    }
+  },
+  "title": "Result",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.ContextServiceCurrentResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.ContextServiceCurrentResponse.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.ContextServiceCurrentResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.ContextServiceCurrentResponse.Result.jsonschema.json"
+    }
+  },
+  "title": "Context Service Current Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.ContextServiceCurrentResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.ContextServiceCurrentResponse.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.ContextServiceCurrentResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.ContextServiceCurrentResponse.Result.schema.json"
+    }
+  },
+  "title": "Context Service Current Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.CursorPaginationRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.CursorPaginationRequest.jsonschema.json
@@ -1,0 +1,18 @@
+{
+  "$id": "controlplane.v1.CursorPaginationRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "cursor": {
+      "type": "string"
+    },
+    "limit": {
+      "description": "Limit pagination to 100",
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    }
+  },
+  "title": "Cursor Pagination Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.CursorPaginationRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.CursorPaginationRequest.schema.json
@@ -1,0 +1,18 @@
+{
+  "$id": "controlplane.v1.CursorPaginationRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "cursor": {
+      "type": "string"
+    },
+    "limit": {
+      "description": "Limit pagination to 100",
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    }
+  },
+  "title": "Cursor Pagination Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.CursorPaginationResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.CursorPaginationResponse.jsonschema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "controlplane.v1.CursorPaginationResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(next_cursor)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "nextCursor": {
+      "type": "string"
+    }
+  },
+  "title": "Cursor Pagination Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.CursorPaginationResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.CursorPaginationResponse.schema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "controlplane.v1.CursorPaginationResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(nextCursor)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "next_cursor": {
+      "type": "string"
+    }
+  },
+  "title": "Cursor Pagination Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.DailyRunsCountRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.DailyRunsCountRequest.jsonschema.json
@@ -1,0 +1,58 @@
+{
+  "$id": "controlplane.v1.DailyRunsCountRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Get the dayly count of runs by status",
+  "patternProperties": {
+    "^(time_window)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "METRICS_TIME_WINDOW_UNSPECIFIED",
+            "METRICS_TIME_WINDOW_LAST_DAY",
+            "METRICS_TIME_WINDOW_LAST_7_DAYS",
+            "METRICS_TIME_WINDOW_LAST_30_DAYS",
+            "METRICS_TIME_WINDOW_LAST_90_DAYS"
+          ],
+          "title": "Metrics Time Window",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "^(workflow_id)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "timeWindow": {
+      "anyOf": [
+        {
+          "enum": [
+            "METRICS_TIME_WINDOW_UNSPECIFIED",
+            "METRICS_TIME_WINDOW_LAST_DAY",
+            "METRICS_TIME_WINDOW_LAST_7_DAYS",
+            "METRICS_TIME_WINDOW_LAST_30_DAYS",
+            "METRICS_TIME_WINDOW_LAST_90_DAYS"
+          ],
+          "title": "Metrics Time Window",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "workflowId": {
+      "type": "string"
+    }
+  },
+  "title": "Daily Runs Count Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.DailyRunsCountRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.DailyRunsCountRequest.schema.json
@@ -1,0 +1,58 @@
+{
+  "$id": "controlplane.v1.DailyRunsCountRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Get the dayly count of runs by status",
+  "patternProperties": {
+    "^(timeWindow)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "METRICS_TIME_WINDOW_UNSPECIFIED",
+            "METRICS_TIME_WINDOW_LAST_DAY",
+            "METRICS_TIME_WINDOW_LAST_7_DAYS",
+            "METRICS_TIME_WINDOW_LAST_30_DAYS",
+            "METRICS_TIME_WINDOW_LAST_90_DAYS"
+          ],
+          "title": "Metrics Time Window",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "^(workflowId)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "time_window": {
+      "anyOf": [
+        {
+          "enum": [
+            "METRICS_TIME_WINDOW_UNSPECIFIED",
+            "METRICS_TIME_WINDOW_LAST_DAY",
+            "METRICS_TIME_WINDOW_LAST_7_DAYS",
+            "METRICS_TIME_WINDOW_LAST_30_DAYS",
+            "METRICS_TIME_WINDOW_LAST_90_DAYS"
+          ],
+          "title": "Metrics Time Window",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "workflow_id": {
+      "type": "string"
+    }
+  },
+  "title": "Daily Runs Count Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.DailyRunsCountResponse.TotalByDay.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.DailyRunsCountResponse.TotalByDay.jsonschema.json
@@ -1,0 +1,16 @@
+{
+  "$id": "controlplane.v1.DailyRunsCountResponse.TotalByDay.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "date": {
+      "description": "string format: \"YYYY-MM-DD\"",
+      "type": "string"
+    },
+    "metrics": {
+      "$ref": "controlplane.v1.MetricsStatusCount.jsonschema.json"
+    }
+  },
+  "title": "Total By Day",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.DailyRunsCountResponse.TotalByDay.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.DailyRunsCountResponse.TotalByDay.schema.json
@@ -1,0 +1,16 @@
+{
+  "$id": "controlplane.v1.DailyRunsCountResponse.TotalByDay.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "date": {
+      "description": "string format: \"YYYY-MM-DD\"",
+      "type": "string"
+    },
+    "metrics": {
+      "$ref": "controlplane.v1.MetricsStatusCount.schema.json"
+    }
+  },
+  "title": "Total By Day",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.DailyRunsCountResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.DailyRunsCountResponse.jsonschema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.DailyRunsCountResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "items": {
+        "$ref": "controlplane.v1.DailyRunsCountResponse.TotalByDay.jsonschema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Daily Runs Count Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.DailyRunsCountResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.DailyRunsCountResponse.schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.DailyRunsCountResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "items": {
+        "$ref": "controlplane.v1.DailyRunsCountResponse.TotalByDay.schema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Daily Runs Count Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.DeleteMembershipRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.DeleteMembershipRequest.jsonschema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "controlplane.v1.DeleteMembershipRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(membership_id)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "membershipId": {
+      "type": "string"
+    }
+  },
+  "title": "Delete Membership Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.DeleteMembershipRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.DeleteMembershipRequest.schema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "controlplane.v1.DeleteMembershipRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(membershipId)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "membership_id": {
+      "type": "string"
+    }
+  },
+  "title": "Delete Membership Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.DeleteMembershipResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.DeleteMembershipResponse.jsonschema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.DeleteMembershipResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Delete Membership Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.DeleteMembershipResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.DeleteMembershipResponse.schema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.DeleteMembershipResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Delete Membership Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.DiscoverPublicSharedRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.DiscoverPublicSharedRequest.jsonschema.json
@@ -1,0 +1,16 @@
+{
+  "$id": "controlplane.v1.DiscoverPublicSharedRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "digest": {
+      "type": "string"
+    },
+    "kind": {
+      "description": "Optional kind of referrer, i.e CONTAINER_IMAGE, GIT_HEAD, ...\n Used to filter and resolve ambiguities",
+      "type": "string"
+    }
+  },
+  "title": "Discover Public Shared Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.DiscoverPublicSharedRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.DiscoverPublicSharedRequest.schema.json
@@ -1,0 +1,16 @@
+{
+  "$id": "controlplane.v1.DiscoverPublicSharedRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "digest": {
+      "type": "string"
+    },
+    "kind": {
+      "description": "Optional kind of referrer, i.e CONTAINER_IMAGE, GIT_HEAD, ...\n Used to filter and resolve ambiguities",
+      "type": "string"
+    }
+  },
+  "title": "Discover Public Shared Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.DiscoverPublicSharedResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.DiscoverPublicSharedResponse.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.DiscoverPublicSharedResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.ReferrerItem.jsonschema.json"
+    }
+  },
+  "title": "Discover Public Shared Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.DiscoverPublicSharedResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.DiscoverPublicSharedResponse.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.DiscoverPublicSharedResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.ReferrerItem.schema.json"
+    }
+  },
+  "title": "Discover Public Shared Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.GenerateSigningCertRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.GenerateSigningCertRequest.jsonschema.json
@@ -1,0 +1,19 @@
+{
+  "$id": "controlplane.v1.GenerateSigningCertRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(certificate_signing_request)$": {
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    }
+  },
+  "properties": {
+    "certificateSigningRequest": {
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    }
+  },
+  "title": "Generate Signing Cert Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.GenerateSigningCertRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.GenerateSigningCertRequest.schema.json
@@ -1,0 +1,19 @@
+{
+  "$id": "controlplane.v1.GenerateSigningCertRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(certificateSigningRequest)$": {
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    }
+  },
+  "properties": {
+    "certificate_signing_request": {
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    }
+  },
+  "title": "Generate Signing Cert Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.GenerateSigningCertResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.GenerateSigningCertResponse.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.GenerateSigningCertResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "chain": {
+      "$ref": "controlplane.v1.CertificateChain.jsonschema.json"
+    }
+  },
+  "title": "Generate Signing Cert Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.GenerateSigningCertResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.GenerateSigningCertResponse.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.GenerateSigningCertResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "chain": {
+      "$ref": "controlplane.v1.CertificateChain.schema.json"
+    }
+  },
+  "title": "Generate Signing Cert Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.GetDownloadURLRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.GetDownloadURLRequest.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.GetDownloadURLRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "digest": {
+      "type": "string"
+    }
+  },
+  "title": "Get DownloadURL Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.GetDownloadURLRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.GetDownloadURLRequest.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.GetDownloadURLRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "digest": {
+      "type": "string"
+    }
+  },
+  "title": "Get DownloadURL Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.GetDownloadURLResponse.Result.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.GetDownloadURLResponse.Result.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.GetDownloadURLResponse.Result.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "url": {
+      "type": "string"
+    }
+  },
+  "title": "Result",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.GetDownloadURLResponse.Result.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.GetDownloadURLResponse.Result.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.GetDownloadURLResponse.Result.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "url": {
+      "type": "string"
+    }
+  },
+  "title": "Result",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.GetDownloadURLResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.GetDownloadURLResponse.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.GetDownloadURLResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.GetDownloadURLResponse.Result.jsonschema.json"
+    }
+  },
+  "title": "Get DownloadURL Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.GetDownloadURLResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.GetDownloadURLResponse.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.GetDownloadURLResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.GetDownloadURLResponse.Result.schema.json"
+    }
+  },
+  "title": "Get DownloadURL Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.InfozRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.InfozRequest.jsonschema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.InfozRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Infoz Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.InfozRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.InfozRequest.schema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.InfozRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Infoz Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.InfozResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.InfozResponse.jsonschema.json
@@ -1,0 +1,20 @@
+{
+  "$id": "controlplane.v1.InfozResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(login_url)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "loginURL": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    }
+  },
+  "title": "Infoz Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.InfozResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.InfozResponse.schema.json
@@ -1,0 +1,20 @@
+{
+  "$id": "controlplane.v1.InfozResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(loginURL)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "login_url": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    }
+  },
+  "title": "Infoz Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationAttachmentItem.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationAttachmentItem.jsonschema.json
@@ -1,0 +1,31 @@
+{
+  "$id": "controlplane.v1.IntegrationAttachmentItem.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(created_at)$": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    }
+  },
+  "properties": {
+    "config": {
+      "description": "Arbitrary configuration for the attachment",
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "createdAt": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "id": {
+      "type": "string"
+    },
+    "integration": {
+      "$ref": "controlplane.v1.RegisteredIntegrationItem.jsonschema.json"
+    },
+    "workflow": {
+      "$ref": "controlplane.v1.WorkflowItem.jsonschema.json"
+    }
+  },
+  "title": "Integration Attachment Item",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationAttachmentItem.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationAttachmentItem.schema.json
@@ -1,0 +1,31 @@
+{
+  "$id": "controlplane.v1.IntegrationAttachmentItem.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(createdAt)$": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    }
+  },
+  "properties": {
+    "config": {
+      "description": "Arbitrary configuration for the attachment",
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "created_at": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "id": {
+      "type": "string"
+    },
+    "integration": {
+      "$ref": "controlplane.v1.RegisteredIntegrationItem.schema.json"
+    },
+    "workflow": {
+      "$ref": "controlplane.v1.WorkflowItem.schema.json"
+    }
+  },
+  "title": "Integration Attachment Item",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationAvailableItem.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationAvailableItem.jsonschema.json
@@ -1,0 +1,22 @@
+{
+  "$id": "controlplane.v1.IntegrationAvailableItem.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "description": {
+      "type": "string"
+    },
+    "fanout": {
+      "$ref": "controlplane.v1.PluginFanout.jsonschema.json"
+    },
+    "name": {
+      "description": "Integration identifier",
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    }
+  },
+  "title": "Integration Available Item",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationAvailableItem.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationAvailableItem.schema.json
@@ -1,0 +1,22 @@
+{
+  "$id": "controlplane.v1.IntegrationAvailableItem.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "description": {
+      "type": "string"
+    },
+    "fanout": {
+      "$ref": "controlplane.v1.PluginFanout.schema.json"
+    },
+    "name": {
+      "description": "Integration identifier",
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    }
+  },
+  "title": "Integration Available Item",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceAttachRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceAttachRequest.jsonschema.json
@@ -1,0 +1,31 @@
+{
+  "$id": "controlplane.v1.IntegrationsServiceAttachRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(integration_name)$": {
+      "description": "Name of the registered integration",
+      "type": "string"
+    },
+    "^(workflow_name)$": {
+      "description": "Name of the workflow to attach",
+      "type": "string"
+    }
+  },
+  "properties": {
+    "config": {
+      "$ref": "google.protobuf.Struct.jsonschema.json",
+      "description": "Arbitrary configuration for the integration"
+    },
+    "integrationName": {
+      "description": "Name of the registered integration",
+      "type": "string"
+    },
+    "workflowName": {
+      "description": "Name of the workflow to attach",
+      "type": "string"
+    }
+  },
+  "title": "Integrations Service Attach Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceAttachRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceAttachRequest.schema.json
@@ -1,0 +1,31 @@
+{
+  "$id": "controlplane.v1.IntegrationsServiceAttachRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(integrationName)$": {
+      "description": "Name of the registered integration",
+      "type": "string"
+    },
+    "^(workflowName)$": {
+      "description": "Name of the workflow to attach",
+      "type": "string"
+    }
+  },
+  "properties": {
+    "config": {
+      "$ref": "google.protobuf.Struct.schema.json",
+      "description": "Arbitrary configuration for the integration"
+    },
+    "integration_name": {
+      "description": "Name of the registered integration",
+      "type": "string"
+    },
+    "workflow_name": {
+      "description": "Name of the workflow to attach",
+      "type": "string"
+    }
+  },
+  "title": "Integrations Service Attach Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceAttachResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceAttachResponse.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.IntegrationsServiceAttachResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.IntegrationAttachmentItem.jsonschema.json"
+    }
+  },
+  "title": "Integrations Service Attach Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceAttachResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceAttachResponse.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.IntegrationsServiceAttachResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.IntegrationAttachmentItem.schema.json"
+    }
+  },
+  "title": "Integrations Service Attach Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceDeregisterRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceDeregisterRequest.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.IntegrationsServiceDeregisterRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "title": "Integrations Service Deregister Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceDeregisterRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceDeregisterRequest.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.IntegrationsServiceDeregisterRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "title": "Integrations Service Deregister Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceDeregisterResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceDeregisterResponse.jsonschema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.IntegrationsServiceDeregisterResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Integrations Service Deregister Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceDeregisterResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceDeregisterResponse.schema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.IntegrationsServiceDeregisterResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Integrations Service Deregister Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceDescribeRegistrationRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceDescribeRegistrationRequest.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.IntegrationsServiceDescribeRegistrationRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "title": "Integrations Service Describe Registration Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceDescribeRegistrationRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceDescribeRegistrationRequest.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.IntegrationsServiceDescribeRegistrationRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "title": "Integrations Service Describe Registration Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceDescribeRegistrationResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceDescribeRegistrationResponse.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.IntegrationsServiceDescribeRegistrationResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.RegisteredIntegrationItem.jsonschema.json"
+    }
+  },
+  "title": "Integrations Service Describe Registration Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceDescribeRegistrationResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceDescribeRegistrationResponse.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.IntegrationsServiceDescribeRegistrationResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.RegisteredIntegrationItem.schema.json"
+    }
+  },
+  "title": "Integrations Service Describe Registration Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceDetachRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceDetachRequest.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.IntegrationsServiceDetachRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string"
+    }
+  },
+  "title": "Integrations Service Detach Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceDetachRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceDetachRequest.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.IntegrationsServiceDetachRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string"
+    }
+  },
+  "title": "Integrations Service Detach Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceDetachResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceDetachResponse.jsonschema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.IntegrationsServiceDetachResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Integrations Service Detach Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceDetachResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceDetachResponse.schema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.IntegrationsServiceDetachResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Integrations Service Detach Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceListAvailableRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceListAvailableRequest.jsonschema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.IntegrationsServiceListAvailableRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Integrations Service List Available Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceListAvailableRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceListAvailableRequest.schema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.IntegrationsServiceListAvailableRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Integrations Service List Available Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceListAvailableResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceListAvailableResponse.jsonschema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.IntegrationsServiceListAvailableResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "items": {
+        "$ref": "controlplane.v1.IntegrationAvailableItem.jsonschema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Integrations Service List Available Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceListAvailableResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceListAvailableResponse.schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.IntegrationsServiceListAvailableResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "items": {
+        "$ref": "controlplane.v1.IntegrationAvailableItem.schema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Integrations Service List Available Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceListRegistrationsRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceListRegistrationsRequest.jsonschema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.IntegrationsServiceListRegistrationsRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Integrations Service List Registrations Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceListRegistrationsRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceListRegistrationsRequest.schema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.IntegrationsServiceListRegistrationsRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Integrations Service List Registrations Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceListRegistrationsResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceListRegistrationsResponse.jsonschema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.IntegrationsServiceListRegistrationsResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "items": {
+        "$ref": "controlplane.v1.RegisteredIntegrationItem.jsonschema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Integrations Service List Registrations Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceListRegistrationsResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceListRegistrationsResponse.schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.IntegrationsServiceListRegistrationsResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "items": {
+        "$ref": "controlplane.v1.RegisteredIntegrationItem.schema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Integrations Service List Registrations Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceRegisterRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceRegisterRequest.jsonschema.json
@@ -1,0 +1,31 @@
+{
+  "$id": "controlplane.v1.IntegrationsServiceRegisterRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(plugin_id)$": {
+      "description": "Kind of integration to register\n This should match the ID of an existing plugin",
+      "type": "string"
+    }
+  },
+  "properties": {
+    "config": {
+      "$ref": "google.protobuf.Struct.jsonschema.json",
+      "description": "Arbitrary configuration for the integration"
+    },
+    "description": {
+      "description": "Description of the registration, used for display purposes",
+      "type": "string"
+    },
+    "name": {
+      "description": "unique, DNS-like name for the registration",
+      "type": "string"
+    },
+    "pluginId": {
+      "description": "Kind of integration to register\n This should match the ID of an existing plugin",
+      "type": "string"
+    }
+  },
+  "title": "Integrations Service Register Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceRegisterRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceRegisterRequest.schema.json
@@ -1,0 +1,31 @@
+{
+  "$id": "controlplane.v1.IntegrationsServiceRegisterRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(pluginId)$": {
+      "description": "Kind of integration to register\n This should match the ID of an existing plugin",
+      "type": "string"
+    }
+  },
+  "properties": {
+    "config": {
+      "$ref": "google.protobuf.Struct.schema.json",
+      "description": "Arbitrary configuration for the integration"
+    },
+    "description": {
+      "description": "Description of the registration, used for display purposes",
+      "type": "string"
+    },
+    "name": {
+      "description": "unique, DNS-like name for the registration",
+      "type": "string"
+    },
+    "plugin_id": {
+      "description": "Kind of integration to register\n This should match the ID of an existing plugin",
+      "type": "string"
+    }
+  },
+  "title": "Integrations Service Register Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceRegisterResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceRegisterResponse.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.IntegrationsServiceRegisterResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.RegisteredIntegrationItem.jsonschema.json"
+    }
+  },
+  "title": "Integrations Service Register Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceRegisterResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.IntegrationsServiceRegisterResponse.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.IntegrationsServiceRegisterResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.RegisteredIntegrationItem.schema.json"
+    }
+  },
+  "title": "Integrations Service Register Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.ListAttachmentsRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.ListAttachmentsRequest.jsonschema.json
@@ -1,0 +1,19 @@
+{
+  "$id": "controlplane.v1.ListAttachmentsRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(workflow_name)$": {
+      "description": "Filter by workflow",
+      "type": "string"
+    }
+  },
+  "properties": {
+    "workflowName": {
+      "description": "Filter by workflow",
+      "type": "string"
+    }
+  },
+  "title": "List Attachments Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.ListAttachmentsRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.ListAttachmentsRequest.schema.json
@@ -1,0 +1,19 @@
+{
+  "$id": "controlplane.v1.ListAttachmentsRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(workflowName)$": {
+      "description": "Filter by workflow",
+      "type": "string"
+    }
+  },
+  "properties": {
+    "workflow_name": {
+      "description": "Filter by workflow",
+      "type": "string"
+    }
+  },
+  "title": "List Attachments Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.ListAttachmentsResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.ListAttachmentsResponse.jsonschema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.ListAttachmentsResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "items": {
+        "$ref": "controlplane.v1.IntegrationAttachmentItem.jsonschema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "List Attachments Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.ListAttachmentsResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.ListAttachmentsResponse.schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.ListAttachmentsResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "items": {
+        "$ref": "controlplane.v1.IntegrationAttachmentItem.schema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "List Attachments Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.MetricsRunnerCount.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.MetricsRunnerCount.jsonschema.json
@@ -1,0 +1,60 @@
+{
+  "$id": "controlplane.v1.MetricsRunnerCount.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(runner_type)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "RUNNER_TYPE_UNSPECIFIED",
+            "GITHUB_ACTION",
+            "GITLAB_PIPELINE",
+            "AZURE_PIPELINE",
+            "JENKINS_JOB",
+            "CIRCLECI_BUILD",
+            "DAGGER_PIPELINE"
+          ],
+          "title": "Runner Type",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "properties": {
+    "count": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "runnerType": {
+      "anyOf": [
+        {
+          "enum": [
+            "RUNNER_TYPE_UNSPECIFIED",
+            "GITHUB_ACTION",
+            "GITLAB_PIPELINE",
+            "AZURE_PIPELINE",
+            "JENKINS_JOB",
+            "CIRCLECI_BUILD",
+            "DAGGER_PIPELINE"
+          ],
+          "title": "Runner Type",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "title": "Metrics Runner Count",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.MetricsRunnerCount.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.MetricsRunnerCount.schema.json
@@ -1,0 +1,60 @@
+{
+  "$id": "controlplane.v1.MetricsRunnerCount.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(runnerType)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "RUNNER_TYPE_UNSPECIFIED",
+            "GITHUB_ACTION",
+            "GITLAB_PIPELINE",
+            "AZURE_PIPELINE",
+            "JENKINS_JOB",
+            "CIRCLECI_BUILD",
+            "DAGGER_PIPELINE"
+          ],
+          "title": "Runner Type",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "properties": {
+    "count": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "runner_type": {
+      "anyOf": [
+        {
+          "enum": [
+            "RUNNER_TYPE_UNSPECIFIED",
+            "GITHUB_ACTION",
+            "GITLAB_PIPELINE",
+            "AZURE_PIPELINE",
+            "JENKINS_JOB",
+            "CIRCLECI_BUILD",
+            "DAGGER_PIPELINE"
+          ],
+          "title": "Runner Type",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "title": "Metrics Runner Count",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.MetricsStatusCount.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.MetricsStatusCount.jsonschema.json
@@ -1,0 +1,35 @@
+{
+  "$id": "controlplane.v1.MetricsStatusCount.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "count": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "status": {
+      "anyOf": [
+        {
+          "enum": [
+            "RUN_STATUS_UNSPECIFIED",
+            "RUN_STATUS_INITIALIZED",
+            "RUN_STATUS_SUCCEEDED",
+            "RUN_STATUS_FAILED",
+            "RUN_STATUS_EXPIRED",
+            "RUN_STATUS_CANCELLED"
+          ],
+          "title": "Run Status",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "title": "Metrics Status Count",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.MetricsStatusCount.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.MetricsStatusCount.schema.json
@@ -1,0 +1,35 @@
+{
+  "$id": "controlplane.v1.MetricsStatusCount.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "count": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "status": {
+      "anyOf": [
+        {
+          "enum": [
+            "RUN_STATUS_UNSPECIFIED",
+            "RUN_STATUS_INITIALIZED",
+            "RUN_STATUS_SUCCEEDED",
+            "RUN_STATUS_FAILED",
+            "RUN_STATUS_EXPIRED",
+            "RUN_STATUS_CANCELLED"
+          ],
+          "title": "Run Status",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "title": "Metrics Status Count",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgInvitationItem.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgInvitationItem.jsonschema.json
@@ -1,0 +1,54 @@
+{
+  "$id": "controlplane.v1.OrgInvitationItem.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(created_at)$": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "^(receiver_email)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "createdAt": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "id": {
+      "type": "string"
+    },
+    "organization": {
+      "$ref": "controlplane.v1.OrgItem.jsonschema.json"
+    },
+    "receiverEmail": {
+      "type": "string"
+    },
+    "role": {
+      "anyOf": [
+        {
+          "enum": [
+            "MEMBERSHIP_ROLE_UNSPECIFIED",
+            "MEMBERSHIP_ROLE_ORG_VIEWER",
+            "MEMBERSHIP_ROLE_ORG_ADMIN",
+            "MEMBERSHIP_ROLE_ORG_OWNER"
+          ],
+          "title": "Membership Role",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "sender": {
+      "$ref": "controlplane.v1.User.jsonschema.json"
+    },
+    "status": {
+      "type": "string"
+    }
+  },
+  "title": "Org Invitation Item",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgInvitationItem.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgInvitationItem.schema.json
@@ -1,0 +1,54 @@
+{
+  "$id": "controlplane.v1.OrgInvitationItem.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(createdAt)$": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "^(receiverEmail)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "created_at": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "id": {
+      "type": "string"
+    },
+    "organization": {
+      "$ref": "controlplane.v1.OrgItem.schema.json"
+    },
+    "receiver_email": {
+      "type": "string"
+    },
+    "role": {
+      "anyOf": [
+        {
+          "enum": [
+            "MEMBERSHIP_ROLE_UNSPECIFIED",
+            "MEMBERSHIP_ROLE_ORG_VIEWER",
+            "MEMBERSHIP_ROLE_ORG_ADMIN",
+            "MEMBERSHIP_ROLE_ORG_OWNER"
+          ],
+          "title": "Membership Role",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "sender": {
+      "$ref": "controlplane.v1.User.schema.json"
+    },
+    "status": {
+      "type": "string"
+    }
+  },
+  "title": "Org Invitation Item",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgInvitationServiceCreateRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgInvitationServiceCreateRequest.jsonschema.json
@@ -1,0 +1,44 @@
+{
+  "$id": "controlplane.v1.OrgInvitationServiceCreateRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(organization_id)$": {
+      "description": "organization is deprecated and not used anymore",
+      "type": "string"
+    },
+    "^(receiver_email)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "organizationId": {
+      "description": "organization is deprecated and not used anymore",
+      "type": "string"
+    },
+    "receiverEmail": {
+      "type": "string"
+    },
+    "role": {
+      "anyOf": [
+        {
+          "enum": [
+            "MEMBERSHIP_ROLE_UNSPECIFIED",
+            "MEMBERSHIP_ROLE_ORG_VIEWER",
+            "MEMBERSHIP_ROLE_ORG_ADMIN",
+            "MEMBERSHIP_ROLE_ORG_OWNER"
+          ],
+          "title": "Membership Role",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "title": "Org Invitation Service Create Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgInvitationServiceCreateRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgInvitationServiceCreateRequest.schema.json
@@ -1,0 +1,44 @@
+{
+  "$id": "controlplane.v1.OrgInvitationServiceCreateRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(organizationId)$": {
+      "description": "organization is deprecated and not used anymore",
+      "type": "string"
+    },
+    "^(receiverEmail)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "organization_id": {
+      "description": "organization is deprecated and not used anymore",
+      "type": "string"
+    },
+    "receiver_email": {
+      "type": "string"
+    },
+    "role": {
+      "anyOf": [
+        {
+          "enum": [
+            "MEMBERSHIP_ROLE_UNSPECIFIED",
+            "MEMBERSHIP_ROLE_ORG_VIEWER",
+            "MEMBERSHIP_ROLE_ORG_ADMIN",
+            "MEMBERSHIP_ROLE_ORG_OWNER"
+          ],
+          "title": "Membership Role",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "title": "Org Invitation Service Create Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgInvitationServiceCreateResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgInvitationServiceCreateResponse.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.OrgInvitationServiceCreateResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.OrgInvitationItem.jsonschema.json"
+    }
+  },
+  "title": "Org Invitation Service Create Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgInvitationServiceCreateResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgInvitationServiceCreateResponse.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.OrgInvitationServiceCreateResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.OrgInvitationItem.schema.json"
+    }
+  },
+  "title": "Org Invitation Service Create Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgInvitationServiceListSentRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgInvitationServiceListSentRequest.jsonschema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.OrgInvitationServiceListSentRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Org Invitation Service List Sent Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgInvitationServiceListSentRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgInvitationServiceListSentRequest.schema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.OrgInvitationServiceListSentRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Org Invitation Service List Sent Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgInvitationServiceListSentResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgInvitationServiceListSentResponse.jsonschema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.OrgInvitationServiceListSentResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "items": {
+        "$ref": "controlplane.v1.OrgInvitationItem.jsonschema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Org Invitation Service List Sent Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgInvitationServiceListSentResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgInvitationServiceListSentResponse.schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.OrgInvitationServiceListSentResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "items": {
+        "$ref": "controlplane.v1.OrgInvitationItem.schema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Org Invitation Service List Sent Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgInvitationServiceRevokeRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgInvitationServiceRevokeRequest.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.OrgInvitationServiceRevokeRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string"
+    }
+  },
+  "title": "Org Invitation Service Revoke Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgInvitationServiceRevokeRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgInvitationServiceRevokeRequest.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.OrgInvitationServiceRevokeRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string"
+    }
+  },
+  "title": "Org Invitation Service Revoke Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgInvitationServiceRevokeResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgInvitationServiceRevokeResponse.jsonschema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.OrgInvitationServiceRevokeResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Org Invitation Service Revoke Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgInvitationServiceRevokeResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgInvitationServiceRevokeResponse.schema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.OrgInvitationServiceRevokeResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Org Invitation Service Revoke Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgItem.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgItem.jsonschema.json
@@ -1,0 +1,23 @@
+{
+  "$id": "controlplane.v1.OrgItem.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(created_at)$": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    }
+  },
+  "properties": {
+    "createdAt": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "id": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    }
+  },
+  "title": "Org Item",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgItem.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgItem.schema.json
@@ -1,0 +1,23 @@
+{
+  "$id": "controlplane.v1.OrgItem.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(createdAt)$": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    }
+  },
+  "properties": {
+    "created_at": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "id": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    }
+  },
+  "title": "Org Item",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgMembershipItem.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgMembershipItem.jsonschema.json
@@ -1,0 +1,54 @@
+{
+  "$id": "controlplane.v1.OrgMembershipItem.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(created_at)$": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "^(updated_at)$": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    }
+  },
+  "properties": {
+    "createdAt": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "current": {
+      "type": "boolean"
+    },
+    "id": {
+      "type": "string"
+    },
+    "org": {
+      "$ref": "controlplane.v1.OrgItem.jsonschema.json"
+    },
+    "role": {
+      "anyOf": [
+        {
+          "enum": [
+            "MEMBERSHIP_ROLE_UNSPECIFIED",
+            "MEMBERSHIP_ROLE_ORG_VIEWER",
+            "MEMBERSHIP_ROLE_ORG_ADMIN",
+            "MEMBERSHIP_ROLE_ORG_OWNER"
+          ],
+          "title": "Membership Role",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "updatedAt": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "user": {
+      "$ref": "controlplane.v1.User.jsonschema.json"
+    }
+  },
+  "title": "Org Membership Item",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgMembershipItem.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgMembershipItem.schema.json
@@ -1,0 +1,54 @@
+{
+  "$id": "controlplane.v1.OrgMembershipItem.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(createdAt)$": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "^(updatedAt)$": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    }
+  },
+  "properties": {
+    "created_at": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "current": {
+      "type": "boolean"
+    },
+    "id": {
+      "type": "string"
+    },
+    "org": {
+      "$ref": "controlplane.v1.OrgItem.schema.json"
+    },
+    "role": {
+      "anyOf": [
+        {
+          "enum": [
+            "MEMBERSHIP_ROLE_UNSPECIFIED",
+            "MEMBERSHIP_ROLE_ORG_VIEWER",
+            "MEMBERSHIP_ROLE_ORG_ADMIN",
+            "MEMBERSHIP_ROLE_ORG_OWNER"
+          ],
+          "title": "Membership Role",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "updated_at": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "user": {
+      "$ref": "controlplane.v1.User.schema.json"
+    }
+  },
+  "title": "Org Membership Item",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgMetricsServiceTotalsRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgMetricsServiceTotalsRequest.jsonschema.json
@@ -1,0 +1,51 @@
+{
+  "$id": "controlplane.v1.OrgMetricsServiceTotalsRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(time_window)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "METRICS_TIME_WINDOW_UNSPECIFIED",
+            "METRICS_TIME_WINDOW_LAST_DAY",
+            "METRICS_TIME_WINDOW_LAST_7_DAYS",
+            "METRICS_TIME_WINDOW_LAST_30_DAYS",
+            "METRICS_TIME_WINDOW_LAST_90_DAYS"
+          ],
+          "title": "Metrics Time Window",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "properties": {
+    "timeWindow": {
+      "anyOf": [
+        {
+          "enum": [
+            "METRICS_TIME_WINDOW_UNSPECIFIED",
+            "METRICS_TIME_WINDOW_LAST_DAY",
+            "METRICS_TIME_WINDOW_LAST_7_DAYS",
+            "METRICS_TIME_WINDOW_LAST_30_DAYS",
+            "METRICS_TIME_WINDOW_LAST_90_DAYS"
+          ],
+          "title": "Metrics Time Window",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "title": "Org Metrics Service Totals Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgMetricsServiceTotalsRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgMetricsServiceTotalsRequest.schema.json
@@ -1,0 +1,51 @@
+{
+  "$id": "controlplane.v1.OrgMetricsServiceTotalsRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(timeWindow)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "METRICS_TIME_WINDOW_UNSPECIFIED",
+            "METRICS_TIME_WINDOW_LAST_DAY",
+            "METRICS_TIME_WINDOW_LAST_7_DAYS",
+            "METRICS_TIME_WINDOW_LAST_30_DAYS",
+            "METRICS_TIME_WINDOW_LAST_90_DAYS"
+          ],
+          "title": "Metrics Time Window",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "properties": {
+    "time_window": {
+      "anyOf": [
+        {
+          "enum": [
+            "METRICS_TIME_WINDOW_UNSPECIFIED",
+            "METRICS_TIME_WINDOW_LAST_DAY",
+            "METRICS_TIME_WINDOW_LAST_7_DAYS",
+            "METRICS_TIME_WINDOW_LAST_30_DAYS",
+            "METRICS_TIME_WINDOW_LAST_90_DAYS"
+          ],
+          "title": "Metrics Time Window",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "title": "Org Metrics Service Totals Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgMetricsServiceTotalsResponse.Result.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgMetricsServiceTotalsResponse.Result.jsonschema.json
@@ -1,0 +1,45 @@
+{
+  "$id": "controlplane.v1.OrgMetricsServiceTotalsResponse.Result.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(runs_total)$": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(runs_total_by_runner_type)$": {
+      "items": {
+        "$ref": "controlplane.v1.MetricsRunnerCount.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "^(runs_total_by_status)$": {
+      "items": {
+        "$ref": "controlplane.v1.MetricsStatusCount.jsonschema.json"
+      },
+      "type": "array"
+    }
+  },
+  "properties": {
+    "runsTotal": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "runsTotalByRunnerType": {
+      "items": {
+        "$ref": "controlplane.v1.MetricsRunnerCount.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "runsTotalByStatus": {
+      "items": {
+        "$ref": "controlplane.v1.MetricsStatusCount.jsonschema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Result",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgMetricsServiceTotalsResponse.Result.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgMetricsServiceTotalsResponse.Result.schema.json
@@ -1,0 +1,45 @@
+{
+  "$id": "controlplane.v1.OrgMetricsServiceTotalsResponse.Result.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(runsTotal)$": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(runsTotalByRunnerType)$": {
+      "items": {
+        "$ref": "controlplane.v1.MetricsRunnerCount.schema.json"
+      },
+      "type": "array"
+    },
+    "^(runsTotalByStatus)$": {
+      "items": {
+        "$ref": "controlplane.v1.MetricsStatusCount.schema.json"
+      },
+      "type": "array"
+    }
+  },
+  "properties": {
+    "runs_total": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "runs_total_by_runner_type": {
+      "items": {
+        "$ref": "controlplane.v1.MetricsRunnerCount.schema.json"
+      },
+      "type": "array"
+    },
+    "runs_total_by_status": {
+      "items": {
+        "$ref": "controlplane.v1.MetricsStatusCount.schema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Result",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgMetricsServiceTotalsResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgMetricsServiceTotalsResponse.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.OrgMetricsServiceTotalsResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.OrgMetricsServiceTotalsResponse.Result.jsonschema.json"
+    }
+  },
+  "title": "Org Metrics Service Totals Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgMetricsServiceTotalsResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrgMetricsServiceTotalsResponse.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.OrgMetricsServiceTotalsResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.OrgMetricsServiceTotalsResponse.Result.schema.json"
+    }
+  },
+  "title": "Org Metrics Service Totals Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrganizationServiceCreateRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrganizationServiceCreateRequest.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.OrganizationServiceCreateRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "title": "Organization Service Create Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrganizationServiceCreateRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrganizationServiceCreateRequest.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.OrganizationServiceCreateRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "title": "Organization Service Create Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrganizationServiceCreateResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrganizationServiceCreateResponse.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.OrganizationServiceCreateResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.OrgItem.jsonschema.json"
+    }
+  },
+  "title": "Organization Service Create Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrganizationServiceCreateResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrganizationServiceCreateResponse.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.OrganizationServiceCreateResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.OrgItem.schema.json"
+    }
+  },
+  "title": "Organization Service Create Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrganizationServiceDeleteMembershipRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrganizationServiceDeleteMembershipRequest.jsonschema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "controlplane.v1.OrganizationServiceDeleteMembershipRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(membership_id)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "membershipId": {
+      "type": "string"
+    }
+  },
+  "title": "Organization Service Delete Membership Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrganizationServiceDeleteMembershipRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrganizationServiceDeleteMembershipRequest.schema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "controlplane.v1.OrganizationServiceDeleteMembershipRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(membershipId)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "membership_id": {
+      "type": "string"
+    }
+  },
+  "title": "Organization Service Delete Membership Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrganizationServiceDeleteMembershipResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrganizationServiceDeleteMembershipResponse.jsonschema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.OrganizationServiceDeleteMembershipResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Organization Service Delete Membership Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrganizationServiceDeleteMembershipResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrganizationServiceDeleteMembershipResponse.schema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.OrganizationServiceDeleteMembershipResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Organization Service Delete Membership Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrganizationServiceListMembershipsRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrganizationServiceListMembershipsRequest.jsonschema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.OrganizationServiceListMembershipsRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Organization Service List Memberships Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrganizationServiceListMembershipsRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrganizationServiceListMembershipsRequest.schema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.OrganizationServiceListMembershipsRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Organization Service List Memberships Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrganizationServiceListMembershipsResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrganizationServiceListMembershipsResponse.jsonschema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.OrganizationServiceListMembershipsResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "items": {
+        "$ref": "controlplane.v1.OrgMembershipItem.jsonschema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Organization Service List Memberships Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrganizationServiceListMembershipsResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrganizationServiceListMembershipsResponse.schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.OrganizationServiceListMembershipsResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "items": {
+        "$ref": "controlplane.v1.OrgMembershipItem.schema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Organization Service List Memberships Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrganizationServiceUpdateMembershipRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrganizationServiceUpdateMembershipRequest.jsonschema.json
@@ -1,0 +1,36 @@
+{
+  "$id": "controlplane.v1.OrganizationServiceUpdateMembershipRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(membership_id)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "membershipId": {
+      "type": "string"
+    },
+    "role": {
+      "anyOf": [
+        {
+          "enum": [
+            "MEMBERSHIP_ROLE_UNSPECIFIED",
+            "MEMBERSHIP_ROLE_ORG_VIEWER",
+            "MEMBERSHIP_ROLE_ORG_ADMIN",
+            "MEMBERSHIP_ROLE_ORG_OWNER"
+          ],
+          "title": "Membership Role",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "title": "Organization Service Update Membership Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrganizationServiceUpdateMembershipRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrganizationServiceUpdateMembershipRequest.schema.json
@@ -1,0 +1,36 @@
+{
+  "$id": "controlplane.v1.OrganizationServiceUpdateMembershipRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(membershipId)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "membership_id": {
+      "type": "string"
+    },
+    "role": {
+      "anyOf": [
+        {
+          "enum": [
+            "MEMBERSHIP_ROLE_UNSPECIFIED",
+            "MEMBERSHIP_ROLE_ORG_VIEWER",
+            "MEMBERSHIP_ROLE_ORG_ADMIN",
+            "MEMBERSHIP_ROLE_ORG_OWNER"
+          ],
+          "title": "Membership Role",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "title": "Organization Service Update Membership Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrganizationServiceUpdateMembershipResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrganizationServiceUpdateMembershipResponse.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.OrganizationServiceUpdateMembershipResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.OrgMembershipItem.jsonschema.json"
+    }
+  },
+  "title": "Organization Service Update Membership Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.OrganizationServiceUpdateMembershipResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.OrganizationServiceUpdateMembershipResponse.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.OrganizationServiceUpdateMembershipResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.OrgMembershipItem.schema.json"
+    }
+  },
+  "title": "Organization Service Update Membership Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.PluginFanout.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.PluginFanout.jsonschema.json
@@ -1,0 +1,46 @@
+{
+  "$id": "controlplane.v1.PluginFanout.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "PluginFanout describes a plugin that can be used to fanout attestation and materials to multiple integrations",
+  "patternProperties": {
+    "^(attachment_schema)$": {
+      "description": "Attachment JSON schema",
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "^(registration_schema)$": {
+      "description": "Registration JSON schema",
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "^(subscribed_materials)$": {
+      "description": "List of materials that the integration is subscribed to",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    }
+  },
+  "properties": {
+    "attachmentSchema": {
+      "description": "Attachment JSON schema",
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "registrationSchema": {
+      "description": "Registration JSON schema",
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "subscribedMaterials": {
+      "description": "List of materials that the integration is subscribed to",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Plugin Fanout",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.PluginFanout.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.PluginFanout.schema.json
@@ -1,0 +1,46 @@
+{
+  "$id": "controlplane.v1.PluginFanout.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "PluginFanout describes a plugin that can be used to fanout attestation and materials to multiple integrations",
+  "patternProperties": {
+    "^(attachmentSchema)$": {
+      "description": "Attachment JSON schema",
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "^(registrationSchema)$": {
+      "description": "Registration JSON schema",
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "^(subscribedMaterials)$": {
+      "description": "List of materials that the integration is subscribed to",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    }
+  },
+  "properties": {
+    "attachment_schema": {
+      "description": "Attachment JSON schema",
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "registration_schema": {
+      "description": "Registration JSON schema",
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "subscribed_materials": {
+      "description": "List of materials that the integration is subscribed to",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Plugin Fanout",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.PolicyEvaluations.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.PolicyEvaluations.jsonschema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.PolicyEvaluations.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "evaluations": {
+      "items": {
+        "$ref": "attestation.v1.PolicyEvaluation.jsonschema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Policy Evaluations",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.PolicyEvaluations.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.PolicyEvaluations.schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.PolicyEvaluations.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "evaluations": {
+      "items": {
+        "$ref": "attestation.v1.PolicyEvaluation.schema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Policy Evaluations",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.ReferrerItem.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.ReferrerItem.jsonschema.json
@@ -1,0 +1,57 @@
+{
+  "$id": "controlplane.v1.ReferrerItem.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(created_at)$": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    }
+  },
+  "properties": {
+    "annotations": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "createdAt": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "digest": {
+      "description": "Digest of the referrer, i.e sha256:deadbeef or sha1:beefdead",
+      "type": "string"
+    },
+    "downloadable": {
+      "description": "Whether the referrer is downloadable or not from CAS",
+      "type": "boolean"
+    },
+    "kind": {
+      "description": "Kind of referrer, i.e CONTAINER_IMAGE, GIT_HEAD, ...",
+      "type": "string"
+    },
+    "metadata": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "public": {
+      "description": "Whether the referrer is public since it belongs to a public workflow",
+      "type": "boolean"
+    },
+    "references": {
+      "items": {
+        "$ref": "controlplane.v1.ReferrerItem.jsonschema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Referrer Item",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.ReferrerItem.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.ReferrerItem.schema.json
@@ -1,0 +1,57 @@
+{
+  "$id": "controlplane.v1.ReferrerItem.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(createdAt)$": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    }
+  },
+  "properties": {
+    "annotations": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "created_at": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "digest": {
+      "description": "Digest of the referrer, i.e sha256:deadbeef or sha1:beefdead",
+      "type": "string"
+    },
+    "downloadable": {
+      "description": "Whether the referrer is downloadable or not from CAS",
+      "type": "boolean"
+    },
+    "kind": {
+      "description": "Kind of referrer, i.e CONTAINER_IMAGE, GIT_HEAD, ...",
+      "type": "string"
+    },
+    "metadata": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "public": {
+      "description": "Whether the referrer is public since it belongs to a public workflow",
+      "type": "boolean"
+    },
+    "references": {
+      "items": {
+        "$ref": "controlplane.v1.ReferrerItem.schema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Referrer Item",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.ReferrerServiceDiscoverPrivateRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.ReferrerServiceDiscoverPrivateRequest.jsonschema.json
@@ -1,0 +1,16 @@
+{
+  "$id": "controlplane.v1.ReferrerServiceDiscoverPrivateRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "digest": {
+      "type": "string"
+    },
+    "kind": {
+      "description": "Optional kind of referrer, i.e CONTAINER_IMAGE, GIT_HEAD, ...\n Used to filter and resolve ambiguities",
+      "type": "string"
+    }
+  },
+  "title": "Referrer Service Discover Private Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.ReferrerServiceDiscoverPrivateRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.ReferrerServiceDiscoverPrivateRequest.schema.json
@@ -1,0 +1,16 @@
+{
+  "$id": "controlplane.v1.ReferrerServiceDiscoverPrivateRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "digest": {
+      "type": "string"
+    },
+    "kind": {
+      "description": "Optional kind of referrer, i.e CONTAINER_IMAGE, GIT_HEAD, ...\n Used to filter and resolve ambiguities",
+      "type": "string"
+    }
+  },
+  "title": "Referrer Service Discover Private Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.ReferrerServiceDiscoverPrivateResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.ReferrerServiceDiscoverPrivateResponse.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.ReferrerServiceDiscoverPrivateResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.ReferrerItem.jsonschema.json"
+    }
+  },
+  "title": "Referrer Service Discover Private Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.ReferrerServiceDiscoverPrivateResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.ReferrerServiceDiscoverPrivateResponse.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.ReferrerServiceDiscoverPrivateResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.ReferrerItem.schema.json"
+    }
+  },
+  "title": "Referrer Service Discover Private Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.RegisteredIntegrationItem.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.RegisteredIntegrationItem.jsonschema.json
@@ -1,0 +1,36 @@
+{
+  "$id": "controlplane.v1.RegisteredIntegrationItem.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(created_at)$": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    }
+  },
+  "properties": {
+    "config": {
+      "description": "Arbitrary configuration for the integration",
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "createdAt": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "description": {
+      "description": "Description of the registration, used for display purposes",
+      "type": "string"
+    },
+    "id": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "name": {
+      "description": "unique, DNS-like name for the registration",
+      "type": "string"
+    }
+  },
+  "title": "Registered Integration Item",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.RegisteredIntegrationItem.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.RegisteredIntegrationItem.schema.json
@@ -1,0 +1,36 @@
+{
+  "$id": "controlplane.v1.RegisteredIntegrationItem.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(createdAt)$": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    }
+  },
+  "properties": {
+    "config": {
+      "description": "Arbitrary configuration for the integration",
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "created_at": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "description": {
+      "description": "Description of the registration, used for display purposes",
+      "type": "string"
+    },
+    "id": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "name": {
+      "description": "unique, DNS-like name for the registration",
+      "type": "string"
+    }
+  },
+  "title": "Registered Integration Item",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.RobotAccountServiceCreateRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.RobotAccountServiceCreateRequest.jsonschema.json
@@ -1,0 +1,20 @@
+{
+  "$id": "controlplane.v1.RobotAccountServiceCreateRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(workflow_id)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "workflowId": {
+      "type": "string"
+    }
+  },
+  "title": "Robot Account Service Create Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.RobotAccountServiceCreateRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.RobotAccountServiceCreateRequest.schema.json
@@ -1,0 +1,20 @@
+{
+  "$id": "controlplane.v1.RobotAccountServiceCreateRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(workflowId)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "workflow_id": {
+      "type": "string"
+    }
+  },
+  "title": "Robot Account Service Create Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.RobotAccountServiceCreateResponse.RobotAccountFull.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.RobotAccountServiceCreateResponse.RobotAccountFull.jsonschema.json
@@ -1,0 +1,39 @@
+{
+  "$id": "controlplane.v1.RobotAccountServiceCreateResponse.RobotAccountFull.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(created_at)$": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "^(revoked_at)$": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "^(workflow_id)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "createdAt": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "id": {
+      "type": "string"
+    },
+    "key": {
+      "description": "The key is returned only during creation",
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "revokedAt": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "workflowId": {
+      "type": "string"
+    }
+  },
+  "title": "Robot Account Full",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.RobotAccountServiceCreateResponse.RobotAccountFull.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.RobotAccountServiceCreateResponse.RobotAccountFull.schema.json
@@ -1,0 +1,39 @@
+{
+  "$id": "controlplane.v1.RobotAccountServiceCreateResponse.RobotAccountFull.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(createdAt)$": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "^(revokedAt)$": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "^(workflowId)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "created_at": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "id": {
+      "type": "string"
+    },
+    "key": {
+      "description": "The key is returned only during creation",
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "revoked_at": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "workflow_id": {
+      "type": "string"
+    }
+  },
+  "title": "Robot Account Full",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.RobotAccountServiceCreateResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.RobotAccountServiceCreateResponse.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.RobotAccountServiceCreateResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.RobotAccountServiceCreateResponse.RobotAccountFull.jsonschema.json"
+    }
+  },
+  "title": "Robot Account Service Create Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.RobotAccountServiceCreateResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.RobotAccountServiceCreateResponse.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.RobotAccountServiceCreateResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.RobotAccountServiceCreateResponse.RobotAccountFull.schema.json"
+    }
+  },
+  "title": "Robot Account Service Create Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.RobotAccountServiceListRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.RobotAccountServiceListRequest.jsonschema.json
@@ -1,0 +1,23 @@
+{
+  "$id": "controlplane.v1.RobotAccountServiceListRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(include_revoked)$": {
+      "type": "boolean"
+    },
+    "^(workflow_id)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "includeRevoked": {
+      "type": "boolean"
+    },
+    "workflowId": {
+      "type": "string"
+    }
+  },
+  "title": "Robot Account Service List Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.RobotAccountServiceListRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.RobotAccountServiceListRequest.schema.json
@@ -1,0 +1,23 @@
+{
+  "$id": "controlplane.v1.RobotAccountServiceListRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(includeRevoked)$": {
+      "type": "boolean"
+    },
+    "^(workflowId)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "include_revoked": {
+      "type": "boolean"
+    },
+    "workflow_id": {
+      "type": "string"
+    }
+  },
+  "title": "Robot Account Service List Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.RobotAccountServiceListResponse.RobotAccountItem.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.RobotAccountServiceListResponse.RobotAccountItem.jsonschema.json
@@ -1,0 +1,35 @@
+{
+  "$id": "controlplane.v1.RobotAccountServiceListResponse.RobotAccountItem.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(created_at)$": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "^(revoked_at)$": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "^(workflow_id)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "createdAt": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "id": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "revokedAt": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "workflowId": {
+      "type": "string"
+    }
+  },
+  "title": "Robot Account Item",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.RobotAccountServiceListResponse.RobotAccountItem.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.RobotAccountServiceListResponse.RobotAccountItem.schema.json
@@ -1,0 +1,35 @@
+{
+  "$id": "controlplane.v1.RobotAccountServiceListResponse.RobotAccountItem.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(createdAt)$": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "^(revokedAt)$": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "^(workflowId)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "created_at": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "id": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "revoked_at": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "workflow_id": {
+      "type": "string"
+    }
+  },
+  "title": "Robot Account Item",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.RobotAccountServiceListResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.RobotAccountServiceListResponse.jsonschema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.RobotAccountServiceListResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "items": {
+        "$ref": "controlplane.v1.RobotAccountServiceListResponse.RobotAccountItem.jsonschema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Robot Account Service List Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.RobotAccountServiceListResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.RobotAccountServiceListResponse.schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.RobotAccountServiceListResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "items": {
+        "$ref": "controlplane.v1.RobotAccountServiceListResponse.RobotAccountItem.schema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Robot Account Service List Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.RobotAccountServiceRevokeRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.RobotAccountServiceRevokeRequest.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.RobotAccountServiceRevokeRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string"
+    }
+  },
+  "title": "Robot Account Service Revoke Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.RobotAccountServiceRevokeRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.RobotAccountServiceRevokeRequest.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.RobotAccountServiceRevokeRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string"
+    }
+  },
+  "title": "Robot Account Service Revoke Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.RobotAccountServiceRevokeResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.RobotAccountServiceRevokeResponse.jsonschema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.RobotAccountServiceRevokeResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Robot Account Service Revoke Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.RobotAccountServiceRevokeResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.RobotAccountServiceRevokeResponse.schema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.RobotAccountServiceRevokeResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Robot Account Service Revoke Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.SetCurrentMembershipRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.SetCurrentMembershipRequest.jsonschema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "controlplane.v1.SetCurrentMembershipRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(membership_id)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "membershipId": {
+      "type": "string"
+    }
+  },
+  "title": "Set Current Membership Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.SetCurrentMembershipRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.SetCurrentMembershipRequest.schema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "controlplane.v1.SetCurrentMembershipRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(membershipId)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "membership_id": {
+      "type": "string"
+    }
+  },
+  "title": "Set Current Membership Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.SetCurrentMembershipResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.SetCurrentMembershipResponse.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.SetCurrentMembershipResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.OrgMembershipItem.jsonschema.json"
+    }
+  },
+  "title": "Set Current Membership Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.SetCurrentMembershipResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.SetCurrentMembershipResponse.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.SetCurrentMembershipResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.OrgMembershipItem.schema.json"
+    }
+  },
+  "title": "Set Current Membership Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.StatuszRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.StatuszRequest.jsonschema.json
@@ -1,0 +1,13 @@
+{
+  "$id": "controlplane.v1.StatuszRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "readiness": {
+      "description": "Parameter that can be used by readiness probes\n The main difference is that readiness probes will take into account that all\n dependent services are up and ready",
+      "type": "boolean"
+    }
+  },
+  "title": "Statusz Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.StatuszRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.StatuszRequest.schema.json
@@ -1,0 +1,13 @@
+{
+  "$id": "controlplane.v1.StatuszRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "readiness": {
+      "description": "Parameter that can be used by readiness probes\n The main difference is that readiness probes will take into account that all\n dependent services are up and ready",
+      "type": "boolean"
+    }
+  },
+  "title": "Statusz Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.StatuszResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.StatuszResponse.jsonschema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.StatuszResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Statusz Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.StatuszResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.StatuszResponse.schema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.StatuszResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Statusz Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.TopWorkflowsByRunsCountRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.TopWorkflowsByRunsCountRequest.jsonschema.json
@@ -1,0 +1,63 @@
+{
+  "$id": "controlplane.v1.TopWorkflowsByRunsCountRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(num_workflows)$": {
+      "description": "top x number of runs to return",
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(time_window)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "METRICS_TIME_WINDOW_UNSPECIFIED",
+            "METRICS_TIME_WINDOW_LAST_DAY",
+            "METRICS_TIME_WINDOW_LAST_7_DAYS",
+            "METRICS_TIME_WINDOW_LAST_30_DAYS",
+            "METRICS_TIME_WINDOW_LAST_90_DAYS"
+          ],
+          "title": "Metrics Time Window",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "properties": {
+    "numWorkflows": {
+      "description": "top x number of runs to return",
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "timeWindow": {
+      "anyOf": [
+        {
+          "enum": [
+            "METRICS_TIME_WINDOW_UNSPECIFIED",
+            "METRICS_TIME_WINDOW_LAST_DAY",
+            "METRICS_TIME_WINDOW_LAST_7_DAYS",
+            "METRICS_TIME_WINDOW_LAST_30_DAYS",
+            "METRICS_TIME_WINDOW_LAST_90_DAYS"
+          ],
+          "title": "Metrics Time Window",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "title": "Top Workflows By Runs Count Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.TopWorkflowsByRunsCountRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.TopWorkflowsByRunsCountRequest.schema.json
@@ -1,0 +1,63 @@
+{
+  "$id": "controlplane.v1.TopWorkflowsByRunsCountRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(numWorkflows)$": {
+      "description": "top x number of runs to return",
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(timeWindow)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "METRICS_TIME_WINDOW_UNSPECIFIED",
+            "METRICS_TIME_WINDOW_LAST_DAY",
+            "METRICS_TIME_WINDOW_LAST_7_DAYS",
+            "METRICS_TIME_WINDOW_LAST_30_DAYS",
+            "METRICS_TIME_WINDOW_LAST_90_DAYS"
+          ],
+          "title": "Metrics Time Window",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "properties": {
+    "num_workflows": {
+      "description": "top x number of runs to return",
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "time_window": {
+      "anyOf": [
+        {
+          "enum": [
+            "METRICS_TIME_WINDOW_UNSPECIFIED",
+            "METRICS_TIME_WINDOW_LAST_DAY",
+            "METRICS_TIME_WINDOW_LAST_7_DAYS",
+            "METRICS_TIME_WINDOW_LAST_30_DAYS",
+            "METRICS_TIME_WINDOW_LAST_90_DAYS"
+          ],
+          "title": "Metrics Time Window",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "title": "Top Workflows By Runs Count Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.TopWorkflowsByRunsCountResponse.TotalByStatus.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.TopWorkflowsByRunsCountResponse.TotalByStatus.jsonschema.json
@@ -1,0 +1,26 @@
+{
+  "$id": "controlplane.v1.TopWorkflowsByRunsCountResponse.TotalByStatus.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(runs_total_by_status)$": {
+      "items": {
+        "$ref": "controlplane.v1.MetricsStatusCount.jsonschema.json"
+      },
+      "type": "array"
+    }
+  },
+  "properties": {
+    "runsTotalByStatus": {
+      "items": {
+        "$ref": "controlplane.v1.MetricsStatusCount.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "workflow": {
+      "$ref": "controlplane.v1.WorkflowItem.jsonschema.json"
+    }
+  },
+  "title": "Total By Status",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.TopWorkflowsByRunsCountResponse.TotalByStatus.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.TopWorkflowsByRunsCountResponse.TotalByStatus.schema.json
@@ -1,0 +1,26 @@
+{
+  "$id": "controlplane.v1.TopWorkflowsByRunsCountResponse.TotalByStatus.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(runsTotalByStatus)$": {
+      "items": {
+        "$ref": "controlplane.v1.MetricsStatusCount.schema.json"
+      },
+      "type": "array"
+    }
+  },
+  "properties": {
+    "runs_total_by_status": {
+      "items": {
+        "$ref": "controlplane.v1.MetricsStatusCount.schema.json"
+      },
+      "type": "array"
+    },
+    "workflow": {
+      "$ref": "controlplane.v1.WorkflowItem.schema.json"
+    }
+  },
+  "title": "Total By Status",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.TopWorkflowsByRunsCountResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.TopWorkflowsByRunsCountResponse.jsonschema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.TopWorkflowsByRunsCountResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "items": {
+        "$ref": "controlplane.v1.TopWorkflowsByRunsCountResponse.TotalByStatus.jsonschema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Top Workflows By Runs Count Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.TopWorkflowsByRunsCountResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.TopWorkflowsByRunsCountResponse.schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.TopWorkflowsByRunsCountResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "items": {
+        "$ref": "controlplane.v1.TopWorkflowsByRunsCountResponse.TotalByStatus.schema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Top Workflows By Runs Count Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.User.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.User.jsonschema.json
@@ -1,0 +1,23 @@
+{
+  "$id": "controlplane.v1.User.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(created_at)$": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    }
+  },
+  "properties": {
+    "createdAt": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "email": {
+      "type": "string"
+    },
+    "id": {
+      "type": "string"
+    }
+  },
+  "title": "User",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.User.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.User.schema.json
@@ -1,0 +1,23 @@
+{
+  "$id": "controlplane.v1.User.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(createdAt)$": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    }
+  },
+  "properties": {
+    "created_at": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "email": {
+      "type": "string"
+    },
+    "id": {
+      "type": "string"
+    }
+  },
+  "title": "User",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.UserServiceListMembershipsRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.UserServiceListMembershipsRequest.jsonschema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.UserServiceListMembershipsRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "User Service List Memberships Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.UserServiceListMembershipsRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.UserServiceListMembershipsRequest.schema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.UserServiceListMembershipsRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "User Service List Memberships Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.UserServiceListMembershipsResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.UserServiceListMembershipsResponse.jsonschema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.UserServiceListMembershipsResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "items": {
+        "$ref": "controlplane.v1.OrgMembershipItem.jsonschema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "User Service List Memberships Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.UserServiceListMembershipsResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.UserServiceListMembershipsResponse.schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.UserServiceListMembershipsResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "items": {
+        "$ref": "controlplane.v1.OrgMembershipItem.schema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "User Service List Memberships Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractItem.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractItem.jsonschema.json
@@ -1,0 +1,50 @@
+{
+  "$id": "controlplane.v1.WorkflowContractItem.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(created_at)$": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "^(latest_revision)$": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(workflow_names)$": {
+      "description": "Workflows associated with this contract",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    }
+  },
+  "properties": {
+    "createdAt": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "description": {
+      "type": "string"
+    },
+    "id": {
+      "type": "string"
+    },
+    "latestRevision": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "name": {
+      "type": "string"
+    },
+    "workflowNames": {
+      "description": "Workflows associated with this contract",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Workflow Contract Item",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractItem.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractItem.schema.json
@@ -1,0 +1,50 @@
+{
+  "$id": "controlplane.v1.WorkflowContractItem.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(createdAt)$": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "^(latestRevision)$": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(workflowNames)$": {
+      "description": "Workflows associated with this contract",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    }
+  },
+  "properties": {
+    "created_at": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "description": {
+      "type": "string"
+    },
+    "id": {
+      "type": "string"
+    },
+    "latest_revision": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "name": {
+      "type": "string"
+    },
+    "workflow_names": {
+      "description": "Workflows associated with this contract",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Workflow Contract Item",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceCreateRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceCreateRequest.jsonschema.json
@@ -1,0 +1,27 @@
+{
+  "$id": "controlplane.v1.WorkflowContractServiceCreateRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(raw_contract)$": {
+      "description": "Raw representation of the contract in json, yaml or cue",
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    }
+  },
+  "properties": {
+    "description": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "rawContract": {
+      "description": "Raw representation of the contract in json, yaml or cue",
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    }
+  },
+  "title": "Workflow Contract Service Create Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceCreateRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceCreateRequest.schema.json
@@ -1,0 +1,27 @@
+{
+  "$id": "controlplane.v1.WorkflowContractServiceCreateRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(rawContract)$": {
+      "description": "Raw representation of the contract in json, yaml or cue",
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    }
+  },
+  "properties": {
+    "description": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "raw_contract": {
+      "description": "Raw representation of the contract in json, yaml or cue",
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    }
+  },
+  "title": "Workflow Contract Service Create Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceCreateResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceCreateResponse.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.WorkflowContractServiceCreateResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.WorkflowContractItem.jsonschema.json"
+    }
+  },
+  "title": "Workflow Contract Service Create Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceCreateResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceCreateResponse.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.WorkflowContractServiceCreateResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.WorkflowContractItem.schema.json"
+    }
+  },
+  "title": "Workflow Contract Service Create Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceDeleteRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceDeleteRequest.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.WorkflowContractServiceDeleteRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "title": "Workflow Contract Service Delete Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceDeleteRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceDeleteRequest.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.WorkflowContractServiceDeleteRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "title": "Workflow Contract Service Delete Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceDeleteResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceDeleteResponse.jsonschema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.WorkflowContractServiceDeleteResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Workflow Contract Service Delete Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceDeleteResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceDeleteResponse.schema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.WorkflowContractServiceDeleteResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Workflow Contract Service Delete Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceDescribeRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceDescribeRequest.jsonschema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "controlplane.v1.WorkflowContractServiceDescribeRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "revision": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    }
+  },
+  "title": "Workflow Contract Service Describe Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceDescribeRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceDescribeRequest.schema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "controlplane.v1.WorkflowContractServiceDescribeRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "revision": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    }
+  },
+  "title": "Workflow Contract Service Describe Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceDescribeResponse.Result.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceDescribeResponse.Result.jsonschema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.WorkflowContractServiceDescribeResponse.Result.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "contract": {
+      "$ref": "controlplane.v1.WorkflowContractItem.jsonschema.json"
+    },
+    "revision": {
+      "$ref": "controlplane.v1.WorkflowContractVersionItem.jsonschema.json"
+    }
+  },
+  "title": "Result",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceDescribeResponse.Result.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceDescribeResponse.Result.schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.WorkflowContractServiceDescribeResponse.Result.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "contract": {
+      "$ref": "controlplane.v1.WorkflowContractItem.schema.json"
+    },
+    "revision": {
+      "$ref": "controlplane.v1.WorkflowContractVersionItem.schema.json"
+    }
+  },
+  "title": "Result",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceDescribeResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceDescribeResponse.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.WorkflowContractServiceDescribeResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.WorkflowContractServiceDescribeResponse.Result.jsonschema.json"
+    }
+  },
+  "title": "Workflow Contract Service Describe Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceDescribeResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceDescribeResponse.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.WorkflowContractServiceDescribeResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.WorkflowContractServiceDescribeResponse.Result.schema.json"
+    }
+  },
+  "title": "Workflow Contract Service Describe Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceListRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceListRequest.jsonschema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.WorkflowContractServiceListRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Workflow Contract Service List Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceListRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceListRequest.schema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.WorkflowContractServiceListRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Workflow Contract Service List Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceListResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceListResponse.jsonschema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.WorkflowContractServiceListResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "items": {
+        "$ref": "controlplane.v1.WorkflowContractItem.jsonschema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Workflow Contract Service List Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceListResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceListResponse.schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.WorkflowContractServiceListResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "items": {
+        "$ref": "controlplane.v1.WorkflowContractItem.schema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Workflow Contract Service List Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceUpdateRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceUpdateRequest.jsonschema.json
@@ -1,0 +1,27 @@
+{
+  "$id": "controlplane.v1.WorkflowContractServiceUpdateRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(raw_contract)$": {
+      "description": "Raw representation of the contract in json, yaml or cue",
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    }
+  },
+  "properties": {
+    "description": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "rawContract": {
+      "description": "Raw representation of the contract in json, yaml or cue",
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    }
+  },
+  "title": "Workflow Contract Service Update Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceUpdateRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceUpdateRequest.schema.json
@@ -1,0 +1,27 @@
+{
+  "$id": "controlplane.v1.WorkflowContractServiceUpdateRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(rawContract)$": {
+      "description": "Raw representation of the contract in json, yaml or cue",
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    }
+  },
+  "properties": {
+    "description": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "raw_contract": {
+      "description": "Raw representation of the contract in json, yaml or cue",
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    }
+  },
+  "title": "Workflow Contract Service Update Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceUpdateResponse.Result.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceUpdateResponse.Result.jsonschema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.WorkflowContractServiceUpdateResponse.Result.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "contract": {
+      "$ref": "controlplane.v1.WorkflowContractItem.jsonschema.json"
+    },
+    "revision": {
+      "$ref": "controlplane.v1.WorkflowContractVersionItem.jsonschema.json"
+    }
+  },
+  "title": "Result",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceUpdateResponse.Result.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceUpdateResponse.Result.schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.WorkflowContractServiceUpdateResponse.Result.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "contract": {
+      "$ref": "controlplane.v1.WorkflowContractItem.schema.json"
+    },
+    "revision": {
+      "$ref": "controlplane.v1.WorkflowContractVersionItem.schema.json"
+    }
+  },
+  "title": "Result",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceUpdateResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceUpdateResponse.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.WorkflowContractServiceUpdateResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.WorkflowContractServiceUpdateResponse.Result.jsonschema.json"
+    }
+  },
+  "title": "Workflow Contract Service Update Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceUpdateResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractServiceUpdateResponse.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.WorkflowContractServiceUpdateResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.WorkflowContractServiceUpdateResponse.Result.schema.json"
+    }
+  },
+  "title": "Workflow Contract Service Update Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractVersionItem.RawBody.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractVersionItem.RawBody.jsonschema.json
@@ -1,0 +1,32 @@
+{
+  "$id": "controlplane.v1.WorkflowContractVersionItem.RawBody.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "body": {
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "format": {
+      "anyOf": [
+        {
+          "enum": [
+            "FORMAT_UNSPECIFIED",
+            "FORMAT_JSON",
+            "FORMAT_YAML",
+            "FORMAT_CUE"
+          ],
+          "title": "Format",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "title": "Raw Body",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractVersionItem.RawBody.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractVersionItem.RawBody.schema.json
@@ -1,0 +1,32 @@
+{
+  "$id": "controlplane.v1.WorkflowContractVersionItem.RawBody.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "body": {
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "type": "string"
+    },
+    "format": {
+      "anyOf": [
+        {
+          "enum": [
+            "FORMAT_UNSPECIFIED",
+            "FORMAT_JSON",
+            "FORMAT_YAML",
+            "FORMAT_CUE"
+          ],
+          "title": "Format",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "title": "Raw Body",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractVersionItem.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractVersionItem.jsonschema.json
@@ -1,0 +1,43 @@
+{
+  "$id": "controlplane.v1.WorkflowContractVersionItem.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(contract_name)$": {
+      "description": "The name of the contract used for this run",
+      "type": "string"
+    },
+    "^(created_at)$": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "^(raw_contract)$": {
+      "$ref": "controlplane.v1.WorkflowContractVersionItem.RawBody.jsonschema.json"
+    }
+  },
+  "properties": {
+    "contractName": {
+      "description": "The name of the contract used for this run",
+      "type": "string"
+    },
+    "createdAt": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "id": {
+      "type": "string"
+    },
+    "rawContract": {
+      "$ref": "controlplane.v1.WorkflowContractVersionItem.RawBody.jsonschema.json"
+    },
+    "revision": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "v1": {
+      "$ref": "workflowcontract.v1.CraftingSchema.jsonschema.json",
+      "description": "Deprecated in favor of raw_contract"
+    }
+  },
+  "title": "Workflow Contract Version Item",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractVersionItem.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowContractVersionItem.schema.json
@@ -1,0 +1,43 @@
+{
+  "$id": "controlplane.v1.WorkflowContractVersionItem.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(contractName)$": {
+      "description": "The name of the contract used for this run",
+      "type": "string"
+    },
+    "^(createdAt)$": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "^(rawContract)$": {
+      "$ref": "controlplane.v1.WorkflowContractVersionItem.RawBody.schema.json"
+    }
+  },
+  "properties": {
+    "contract_name": {
+      "description": "The name of the contract used for this run",
+      "type": "string"
+    },
+    "created_at": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "id": {
+      "type": "string"
+    },
+    "raw_contract": {
+      "$ref": "controlplane.v1.WorkflowContractVersionItem.RawBody.schema.json"
+    },
+    "revision": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "v1": {
+      "$ref": "workflowcontract.v1.CraftingSchema.schema.json",
+      "description": "Deprecated in favor of raw_contract"
+    }
+  },
+  "title": "Workflow Contract Version Item",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowItem.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowItem.jsonschema.json
@@ -1,0 +1,70 @@
+{
+  "$id": "controlplane.v1.WorkflowItem.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(contract_name)$": {
+      "type": "string"
+    },
+    "^(contract_revision_latest)$": {
+      "description": "Current, latest revision of the contract",
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(created_at)$": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "^(last_run)$": {
+      "$ref": "controlplane.v1.WorkflowRunItem.jsonschema.json"
+    },
+    "^(runs_count)$": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    }
+  },
+  "properties": {
+    "contractName": {
+      "type": "string"
+    },
+    "contractRevisionLatest": {
+      "description": "Current, latest revision of the contract",
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "createdAt": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "description": {
+      "type": "string"
+    },
+    "id": {
+      "type": "string"
+    },
+    "lastRun": {
+      "$ref": "controlplane.v1.WorkflowRunItem.jsonschema.json"
+    },
+    "name": {
+      "type": "string"
+    },
+    "project": {
+      "type": "string"
+    },
+    "public": {
+      "description": "A public workflow means that any user can\n - access to all its workflow runs\n - their attestation and materials",
+      "type": "boolean"
+    },
+    "runsCount": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "team": {
+      "type": "string"
+    }
+  },
+  "title": "Workflow Item",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowItem.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowItem.schema.json
@@ -1,0 +1,70 @@
+{
+  "$id": "controlplane.v1.WorkflowItem.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(contractName)$": {
+      "type": "string"
+    },
+    "^(contractRevisionLatest)$": {
+      "description": "Current, latest revision of the contract",
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(createdAt)$": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "^(lastRun)$": {
+      "$ref": "controlplane.v1.WorkflowRunItem.schema.json"
+    },
+    "^(runsCount)$": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    }
+  },
+  "properties": {
+    "contract_name": {
+      "type": "string"
+    },
+    "contract_revision_latest": {
+      "description": "Current, latest revision of the contract",
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "created_at": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "description": {
+      "type": "string"
+    },
+    "id": {
+      "type": "string"
+    },
+    "last_run": {
+      "$ref": "controlplane.v1.WorkflowRunItem.schema.json"
+    },
+    "name": {
+      "type": "string"
+    },
+    "project": {
+      "type": "string"
+    },
+    "public": {
+      "description": "A public workflow means that any user can\n - access to all its workflow runs\n - their attestation and materials",
+      "type": "boolean"
+    },
+    "runs_count": {
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "team": {
+      "type": "string"
+    }
+  },
+  "title": "Workflow Item",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowRunItem.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowRunItem.jsonschema.json
@@ -1,0 +1,139 @@
+{
+  "$id": "controlplane.v1.WorkflowRunItem.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(contract_revision_latest)$": {
+      "description": "The latest revision available for this contract at the time of the run",
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(contract_revision_used)$": {
+      "description": "The revision of the contract used for this run",
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(contract_version)$": {
+      "$ref": "controlplane.v1.WorkflowContractVersionItem.jsonschema.json"
+    },
+    "^(created_at)$": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "^(finished_at)$": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "^(job_url)$": {
+      "type": "string"
+    },
+    "^(runner_type)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "RUNNER_TYPE_UNSPECIFIED",
+            "GITHUB_ACTION",
+            "GITLAB_PIPELINE",
+            "AZURE_PIPELINE",
+            "JENKINS_JOB",
+            "CIRCLECI_BUILD",
+            "DAGGER_PIPELINE"
+          ],
+          "title": "Runner Type",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ],
+      "description": "string runner_type = 8;"
+    }
+  },
+  "properties": {
+    "contractRevisionLatest": {
+      "description": "The latest revision available for this contract at the time of the run",
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "contractRevisionUsed": {
+      "description": "The revision of the contract used for this run",
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "contractVersion": {
+      "$ref": "controlplane.v1.WorkflowContractVersionItem.jsonschema.json"
+    },
+    "createdAt": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "finishedAt": {
+      "$ref": "google.protobuf.Timestamp.jsonschema.json"
+    },
+    "id": {
+      "type": "string"
+    },
+    "jobUrl": {
+      "type": "string"
+    },
+    "reason": {
+      "type": "string"
+    },
+    "runnerType": {
+      "anyOf": [
+        {
+          "enum": [
+            "RUNNER_TYPE_UNSPECIFIED",
+            "GITHUB_ACTION",
+            "GITLAB_PIPELINE",
+            "AZURE_PIPELINE",
+            "JENKINS_JOB",
+            "CIRCLECI_BUILD",
+            "DAGGER_PIPELINE"
+          ],
+          "title": "Runner Type",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ],
+      "description": "string runner_type = 8;"
+    },
+    "state": {
+      "description": "TODO: use runStatus enum below\n deprecated field, use status instead",
+      "type": "string"
+    },
+    "status": {
+      "anyOf": [
+        {
+          "enum": [
+            "RUN_STATUS_UNSPECIFIED",
+            "RUN_STATUS_INITIALIZED",
+            "RUN_STATUS_SUCCEEDED",
+            "RUN_STATUS_FAILED",
+            "RUN_STATUS_EXPIRED",
+            "RUN_STATUS_CANCELLED"
+          ],
+          "title": "Run Status",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "workflow": {
+      "$ref": "controlplane.v1.WorkflowItem.jsonschema.json"
+    }
+  },
+  "title": "Workflow Run Item",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowRunItem.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowRunItem.schema.json
@@ -1,0 +1,139 @@
+{
+  "$id": "controlplane.v1.WorkflowRunItem.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(contractRevisionLatest)$": {
+      "description": "The latest revision available for this contract at the time of the run",
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(contractRevisionUsed)$": {
+      "description": "The revision of the contract used for this run",
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "^(contractVersion)$": {
+      "$ref": "controlplane.v1.WorkflowContractVersionItem.schema.json"
+    },
+    "^(createdAt)$": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "^(finishedAt)$": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "^(jobUrl)$": {
+      "type": "string"
+    },
+    "^(runnerType)$": {
+      "anyOf": [
+        {
+          "enum": [
+            "RUNNER_TYPE_UNSPECIFIED",
+            "GITHUB_ACTION",
+            "GITLAB_PIPELINE",
+            "AZURE_PIPELINE",
+            "JENKINS_JOB",
+            "CIRCLECI_BUILD",
+            "DAGGER_PIPELINE"
+          ],
+          "title": "Runner Type",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ],
+      "description": "string runner_type = 8;"
+    }
+  },
+  "properties": {
+    "contract_revision_latest": {
+      "description": "The latest revision available for this contract at the time of the run",
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "contract_revision_used": {
+      "description": "The revision of the contract used for this run",
+      "exclusiveMaximum": 2147483648,
+      "minimum": -2147483648,
+      "type": "integer"
+    },
+    "contract_version": {
+      "$ref": "controlplane.v1.WorkflowContractVersionItem.schema.json"
+    },
+    "created_at": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "finished_at": {
+      "$ref": "google.protobuf.Timestamp.schema.json"
+    },
+    "id": {
+      "type": "string"
+    },
+    "job_url": {
+      "type": "string"
+    },
+    "reason": {
+      "type": "string"
+    },
+    "runner_type": {
+      "anyOf": [
+        {
+          "enum": [
+            "RUNNER_TYPE_UNSPECIFIED",
+            "GITHUB_ACTION",
+            "GITLAB_PIPELINE",
+            "AZURE_PIPELINE",
+            "JENKINS_JOB",
+            "CIRCLECI_BUILD",
+            "DAGGER_PIPELINE"
+          ],
+          "title": "Runner Type",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ],
+      "description": "string runner_type = 8;"
+    },
+    "state": {
+      "description": "TODO: use runStatus enum below\n deprecated field, use status instead",
+      "type": "string"
+    },
+    "status": {
+      "anyOf": [
+        {
+          "enum": [
+            "RUN_STATUS_UNSPECIFIED",
+            "RUN_STATUS_INITIALIZED",
+            "RUN_STATUS_SUCCEEDED",
+            "RUN_STATUS_FAILED",
+            "RUN_STATUS_EXPIRED",
+            "RUN_STATUS_CANCELLED"
+          ],
+          "title": "Run Status",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    },
+    "workflow": {
+      "$ref": "controlplane.v1.WorkflowItem.schema.json"
+    }
+  },
+  "title": "Workflow Run Item",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowRunServiceListRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowRunServiceListRequest.jsonschema.json
@@ -1,0 +1,45 @@
+{
+  "$id": "controlplane.v1.WorkflowRunServiceListRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(workflow_name)$": {
+      "description": "Filters\n by workflow",
+      "type": "string"
+    }
+  },
+  "properties": {
+    "pagination": {
+      "$ref": "controlplane.v1.CursorPaginationRequest.jsonschema.json",
+      "description": "pagination options"
+    },
+    "status": {
+      "anyOf": [
+        {
+          "enum": [
+            "RUN_STATUS_UNSPECIFIED",
+            "RUN_STATUS_INITIALIZED",
+            "RUN_STATUS_SUCCEEDED",
+            "RUN_STATUS_FAILED",
+            "RUN_STATUS_EXPIRED",
+            "RUN_STATUS_CANCELLED"
+          ],
+          "title": "Run Status",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ],
+      "description": "by run status"
+    },
+    "workflowName": {
+      "description": "Filters\n by workflow",
+      "type": "string"
+    }
+  },
+  "title": "Workflow Run Service List Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowRunServiceListRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowRunServiceListRequest.schema.json
@@ -1,0 +1,45 @@
+{
+  "$id": "controlplane.v1.WorkflowRunServiceListRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(workflowName)$": {
+      "description": "Filters\n by workflow",
+      "type": "string"
+    }
+  },
+  "properties": {
+    "pagination": {
+      "$ref": "controlplane.v1.CursorPaginationRequest.schema.json",
+      "description": "pagination options"
+    },
+    "status": {
+      "anyOf": [
+        {
+          "enum": [
+            "RUN_STATUS_UNSPECIFIED",
+            "RUN_STATUS_INITIALIZED",
+            "RUN_STATUS_SUCCEEDED",
+            "RUN_STATUS_FAILED",
+            "RUN_STATUS_EXPIRED",
+            "RUN_STATUS_CANCELLED"
+          ],
+          "title": "Run Status",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ],
+      "description": "by run status"
+    },
+    "workflow_name": {
+      "description": "Filters\n by workflow",
+      "type": "string"
+    }
+  },
+  "title": "Workflow Run Service List Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowRunServiceListResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowRunServiceListResponse.jsonschema.json
@@ -1,0 +1,18 @@
+{
+  "$id": "controlplane.v1.WorkflowRunServiceListResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "pagination": {
+      "$ref": "controlplane.v1.CursorPaginationResponse.jsonschema.json"
+    },
+    "result": {
+      "items": {
+        "$ref": "controlplane.v1.WorkflowRunItem.jsonschema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Workflow Run Service List Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowRunServiceListResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowRunServiceListResponse.schema.json
@@ -1,0 +1,18 @@
+{
+  "$id": "controlplane.v1.WorkflowRunServiceListResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "pagination": {
+      "$ref": "controlplane.v1.CursorPaginationResponse.schema.json"
+    },
+    "result": {
+      "items": {
+        "$ref": "controlplane.v1.WorkflowRunItem.schema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Workflow Run Service List Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowRunServiceViewRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowRunServiceViewRequest.jsonschema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.WorkflowRunServiceViewRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "digest": {
+      "type": "string"
+    },
+    "id": {
+      "type": "string"
+    }
+  },
+  "title": "Workflow Run Service View Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowRunServiceViewRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowRunServiceViewRequest.schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.WorkflowRunServiceViewRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "digest": {
+      "type": "string"
+    },
+    "id": {
+      "type": "string"
+    }
+  },
+  "title": "Workflow Run Service View Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowRunServiceViewResponse.Result.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowRunServiceViewResponse.Result.jsonschema.json
@@ -1,0 +1,20 @@
+{
+  "$id": "controlplane.v1.WorkflowRunServiceViewResponse.Result.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(workflow_run)$": {
+      "$ref": "controlplane.v1.WorkflowRunItem.jsonschema.json"
+    }
+  },
+  "properties": {
+    "attestation": {
+      "$ref": "controlplane.v1.AttestationItem.jsonschema.json"
+    },
+    "workflowRun": {
+      "$ref": "controlplane.v1.WorkflowRunItem.jsonschema.json"
+    }
+  },
+  "title": "Result",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowRunServiceViewResponse.Result.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowRunServiceViewResponse.Result.schema.json
@@ -1,0 +1,20 @@
+{
+  "$id": "controlplane.v1.WorkflowRunServiceViewResponse.Result.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(workflowRun)$": {
+      "$ref": "controlplane.v1.WorkflowRunItem.schema.json"
+    }
+  },
+  "properties": {
+    "attestation": {
+      "$ref": "controlplane.v1.AttestationItem.schema.json"
+    },
+    "workflow_run": {
+      "$ref": "controlplane.v1.WorkflowRunItem.schema.json"
+    }
+  },
+  "title": "Result",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowRunServiceViewResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowRunServiceViewResponse.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.WorkflowRunServiceViewResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.WorkflowRunServiceViewResponse.Result.jsonschema.json"
+    }
+  },
+  "title": "Workflow Run Service View Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowRunServiceViewResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowRunServiceViewResponse.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.WorkflowRunServiceViewResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.WorkflowRunServiceViewResponse.Result.schema.json"
+    }
+  },
+  "title": "Workflow Run Service View Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceCreateRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceCreateRequest.jsonschema.json
@@ -1,0 +1,34 @@
+{
+  "$id": "controlplane.v1.WorkflowServiceCreateRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(contract_name)$": {
+      "description": "The name of the workflow contract",
+      "type": "string"
+    }
+  },
+  "properties": {
+    "contractName": {
+      "description": "The name of the workflow contract",
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "project": {
+      "type": "string"
+    },
+    "public": {
+      "type": "boolean"
+    },
+    "team": {
+      "type": "string"
+    }
+  },
+  "title": "Workflow Service Create Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceCreateRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceCreateRequest.schema.json
@@ -1,0 +1,34 @@
+{
+  "$id": "controlplane.v1.WorkflowServiceCreateRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(contractName)$": {
+      "description": "The name of the workflow contract",
+      "type": "string"
+    }
+  },
+  "properties": {
+    "contract_name": {
+      "description": "The name of the workflow contract",
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "project": {
+      "type": "string"
+    },
+    "public": {
+      "type": "boolean"
+    },
+    "team": {
+      "type": "string"
+    }
+  },
+  "title": "Workflow Service Create Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceCreateResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceCreateResponse.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.WorkflowServiceCreateResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.WorkflowItem.jsonschema.json"
+    }
+  },
+  "title": "Workflow Service Create Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceCreateResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceCreateResponse.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.WorkflowServiceCreateResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.WorkflowItem.schema.json"
+    }
+  },
+  "title": "Workflow Service Create Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceDeleteRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceDeleteRequest.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.WorkflowServiceDeleteRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "title": "Workflow Service Delete Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceDeleteRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceDeleteRequest.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.WorkflowServiceDeleteRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "title": "Workflow Service Delete Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceDeleteResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceDeleteResponse.jsonschema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.WorkflowServiceDeleteResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Workflow Service Delete Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceDeleteResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceDeleteResponse.schema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.WorkflowServiceDeleteResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Workflow Service Delete Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceListRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceListRequest.jsonschema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.WorkflowServiceListRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Workflow Service List Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceListRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceListRequest.schema.json
@@ -1,0 +1,8 @@
+{
+  "$id": "controlplane.v1.WorkflowServiceListRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {},
+  "title": "Workflow Service List Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceListResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceListResponse.jsonschema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.WorkflowServiceListResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "items": {
+        "$ref": "controlplane.v1.WorkflowItem.jsonschema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Workflow Service List Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceListResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceListResponse.schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "controlplane.v1.WorkflowServiceListResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "items": {
+        "$ref": "controlplane.v1.WorkflowItem.schema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Workflow Service List Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceUpdateRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceUpdateRequest.jsonschema.json
@@ -1,0 +1,33 @@
+{
+  "$id": "controlplane.v1.WorkflowServiceUpdateRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(contract_name)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "contractName": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "project": {
+      "description": "\"optional\" allow us to detect if the value is explicitly set\n and not just the default value",
+      "type": "string"
+    },
+    "public": {
+      "type": "boolean"
+    },
+    "team": {
+      "type": "string"
+    }
+  },
+  "title": "Workflow Service Update Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceUpdateRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceUpdateRequest.schema.json
@@ -1,0 +1,33 @@
+{
+  "$id": "controlplane.v1.WorkflowServiceUpdateRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^(contractName)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "contract_name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "project": {
+      "description": "\"optional\" allow us to detect if the value is explicitly set\n and not just the default value",
+      "type": "string"
+    },
+    "public": {
+      "type": "boolean"
+    },
+    "team": {
+      "type": "string"
+    }
+  },
+  "title": "Workflow Service Update Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceUpdateResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceUpdateResponse.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.WorkflowServiceUpdateResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.WorkflowItem.jsonschema.json"
+    }
+  },
+  "title": "Workflow Service Update Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceUpdateResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceUpdateResponse.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.WorkflowServiceUpdateResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.WorkflowItem.schema.json"
+    }
+  },
+  "title": "Workflow Service Update Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceViewRequest.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceViewRequest.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.WorkflowServiceViewRequest.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "title": "Workflow Service View Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceViewRequest.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceViewRequest.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.WorkflowServiceViewRequest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "title": "Workflow Service View Request",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceViewResponse.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceViewResponse.jsonschema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.WorkflowServiceViewResponse.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.WorkflowItem.jsonschema.json"
+    }
+  },
+  "title": "Workflow Service View Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceViewResponse.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.WorkflowServiceViewResponse.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "controlplane.v1.WorkflowServiceViewResponse.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "$ref": "controlplane.v1.WorkflowItem.schema.json"
+    }
+  },
+  "title": "Workflow Service View Response",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/google.protobuf.Duration.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/google.protobuf.Duration.jsonschema.json
@@ -1,0 +1,7 @@
+{
+  "$id": "google.protobuf.Duration.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "format": "duration",
+  "title": "Duration",
+  "type": "string"
+}

--- a/app/controlplane/api/gen/jsonschema/google.protobuf.Duration.schema.json
+++ b/app/controlplane/api/gen/jsonschema/google.protobuf.Duration.schema.json
@@ -1,0 +1,7 @@
+{
+  "$id": "google.protobuf.Duration.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "format": "duration",
+  "title": "Duration",
+  "type": "string"
+}

--- a/app/controlplane/api/gen/jsonschema/google.protobuf.Struct.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/google.protobuf.Struct.jsonschema.json
@@ -1,0 +1,6 @@
+{
+  "$id": "google.protobuf.Struct.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Struct",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/google.protobuf.Struct.schema.json
+++ b/app/controlplane/api/gen/jsonschema/google.protobuf.Struct.schema.json
@@ -1,0 +1,6 @@
+{
+  "$id": "google.protobuf.Struct.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Struct",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/google.protobuf.Timestamp.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/google.protobuf.Timestamp.jsonschema.json
@@ -1,0 +1,7 @@
+{
+  "$id": "google.protobuf.Timestamp.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "format": "date-time",
+  "title": "Timestamp",
+  "type": "string"
+}

--- a/app/controlplane/api/gen/jsonschema/google.protobuf.Timestamp.schema.json
+++ b/app/controlplane/api/gen/jsonschema/google.protobuf.Timestamp.schema.json
@@ -1,0 +1,7 @@
+{
+  "$id": "google.protobuf.Timestamp.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "format": "date-time",
+  "title": "Timestamp",
+  "type": "string"
+}

--- a/app/controlplane/api/gen/jsonschema/workflowcontract.v1.Annotation.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/workflowcontract.v1.Annotation.jsonschema.json
@@ -1,0 +1,16 @@
+{
+  "$id": "workflowcontract.v1.Annotation.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "value": {
+      "description": "This value can be set in the contract or provided during the attestation",
+      "type": "string"
+    }
+  },
+  "title": "Annotation",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/workflowcontract.v1.Annotation.schema.json
+++ b/app/controlplane/api/gen/jsonschema/workflowcontract.v1.Annotation.schema.json
@@ -1,0 +1,16 @@
+{
+  "$id": "workflowcontract.v1.Annotation.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "value": {
+      "description": "This value can be set in the contract or provided during the attestation",
+      "type": "string"
+    }
+  },
+  "title": "Annotation",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/workflowcontract.v1.CraftingSchema.Material.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/workflowcontract.v1.CraftingSchema.Material.jsonschema.json
@@ -1,0 +1,57 @@
+{
+  "$id": "workflowcontract.v1.CraftingSchema.Material.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "annotations": {
+      "description": "List of annotations that can be used to add metadata to the material\n this metadata can be used later on by the integrations engine to filter and interpolate data",
+      "items": {
+        "$ref": "workflowcontract.v1.Annotation.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "name": {
+      "type": "string"
+    },
+    "optional": {
+      "type": "boolean"
+    },
+    "output": {
+      "description": "If a material is set as output it will get added to the subject in the statement",
+      "type": "boolean"
+    },
+    "type": {
+      "anyOf": [
+        {
+          "enum": [
+            "MATERIAL_TYPE_UNSPECIFIED",
+            "STRING",
+            "CONTAINER_IMAGE",
+            "ARTIFACT",
+            "SBOM_CYCLONEDX_JSON",
+            "SBOM_SPDX_JSON",
+            "JUNIT_XML",
+            "OPENVEX",
+            "HELM_CHART",
+            "SARIF",
+            "EVIDENCE",
+            "ATTESTATION",
+            "CSAF_VEX",
+            "CSAF_INFORMATIONAL_ADVISORY",
+            "CSAF_SECURITY_ADVISORY",
+            "CSAF_SECURITY_INCIDENT_RESPONSE"
+          ],
+          "title": "Material Type",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "title": "Material",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/workflowcontract.v1.CraftingSchema.Material.schema.json
+++ b/app/controlplane/api/gen/jsonschema/workflowcontract.v1.CraftingSchema.Material.schema.json
@@ -1,0 +1,57 @@
+{
+  "$id": "workflowcontract.v1.CraftingSchema.Material.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "annotations": {
+      "description": "List of annotations that can be used to add metadata to the material\n this metadata can be used later on by the integrations engine to filter and interpolate data",
+      "items": {
+        "$ref": "workflowcontract.v1.Annotation.schema.json"
+      },
+      "type": "array"
+    },
+    "name": {
+      "type": "string"
+    },
+    "optional": {
+      "type": "boolean"
+    },
+    "output": {
+      "description": "If a material is set as output it will get added to the subject in the statement",
+      "type": "boolean"
+    },
+    "type": {
+      "anyOf": [
+        {
+          "enum": [
+            "MATERIAL_TYPE_UNSPECIFIED",
+            "STRING",
+            "CONTAINER_IMAGE",
+            "ARTIFACT",
+            "SBOM_CYCLONEDX_JSON",
+            "SBOM_SPDX_JSON",
+            "JUNIT_XML",
+            "OPENVEX",
+            "HELM_CHART",
+            "SARIF",
+            "EVIDENCE",
+            "ATTESTATION",
+            "CSAF_VEX",
+            "CSAF_INFORMATIONAL_ADVISORY",
+            "CSAF_SECURITY_ADVISORY",
+            "CSAF_SECURITY_INCIDENT_RESPONSE"
+          ],
+          "title": "Material Type",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "title": "Material",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/workflowcontract.v1.CraftingSchema.Runner.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/workflowcontract.v1.CraftingSchema.Runner.jsonschema.json
@@ -1,0 +1,31 @@
+{
+  "$id": "workflowcontract.v1.CraftingSchema.Runner.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "anyOf": [
+        {
+          "enum": [
+            "RUNNER_TYPE_UNSPECIFIED",
+            "GITHUB_ACTION",
+            "GITLAB_PIPELINE",
+            "AZURE_PIPELINE",
+            "JENKINS_JOB",
+            "CIRCLECI_BUILD",
+            "DAGGER_PIPELINE"
+          ],
+          "title": "Runner Type",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "title": "Runner",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/workflowcontract.v1.CraftingSchema.Runner.schema.json
+++ b/app/controlplane/api/gen/jsonschema/workflowcontract.v1.CraftingSchema.Runner.schema.json
@@ -1,0 +1,31 @@
+{
+  "$id": "workflowcontract.v1.CraftingSchema.Runner.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "anyOf": [
+        {
+          "enum": [
+            "RUNNER_TYPE_UNSPECIFIED",
+            "GITHUB_ACTION",
+            "GITLAB_PIPELINE",
+            "AZURE_PIPELINE",
+            "JENKINS_JOB",
+            "CIRCLECI_BUILD",
+            "DAGGER_PIPELINE"
+          ],
+          "title": "Runner Type",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ]
+    }
+  },
+  "title": "Runner",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/workflowcontract.v1.CraftingSchema.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/workflowcontract.v1.CraftingSchema.jsonschema.json
@@ -1,0 +1,52 @@
+{
+  "$id": "workflowcontract.v1.CraftingSchema.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Schema definition provided by the user to the tool\n that defines the schema of the workflowRun",
+  "patternProperties": {
+    "^(env_allow_list)$": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "^(schema_version)$": {
+      "description": "Version of the schema, do not confuse with the revision of the content",
+      "type": "string"
+    }
+  },
+  "properties": {
+    "annotations": {
+      "description": "List of annotations that can be used to add metadata to the attestation\n this metadata can be used later on by the integrations engine to filter and interpolate data\n It works in addition to the annotations defined in the materials and the runner",
+      "items": {
+        "$ref": "workflowcontract.v1.Annotation.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "envAllowList": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "materials": {
+      "items": {
+        "$ref": "workflowcontract.v1.CraftingSchema.Material.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "policies": {
+      "$ref": "workflowcontract.v1.Policies.jsonschema.json",
+      "description": "Policies to apply to this schema"
+    },
+    "runner": {
+      "$ref": "workflowcontract.v1.CraftingSchema.Runner.jsonschema.json"
+    },
+    "schemaVersion": {
+      "description": "Version of the schema, do not confuse with the revision of the content",
+      "type": "string"
+    }
+  },
+  "title": "Crafting Schema",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/workflowcontract.v1.CraftingSchema.schema.json
+++ b/app/controlplane/api/gen/jsonschema/workflowcontract.v1.CraftingSchema.schema.json
@@ -1,0 +1,52 @@
+{
+  "$id": "workflowcontract.v1.CraftingSchema.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Schema definition provided by the user to the tool\n that defines the schema of the workflowRun",
+  "patternProperties": {
+    "^(envAllowList)$": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "^(schemaVersion)$": {
+      "description": "Version of the schema, do not confuse with the revision of the content",
+      "type": "string"
+    }
+  },
+  "properties": {
+    "annotations": {
+      "description": "List of annotations that can be used to add metadata to the attestation\n this metadata can be used later on by the integrations engine to filter and interpolate data\n It works in addition to the annotations defined in the materials and the runner",
+      "items": {
+        "$ref": "workflowcontract.v1.Annotation.schema.json"
+      },
+      "type": "array"
+    },
+    "env_allow_list": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "materials": {
+      "items": {
+        "$ref": "workflowcontract.v1.CraftingSchema.Material.schema.json"
+      },
+      "type": "array"
+    },
+    "policies": {
+      "$ref": "workflowcontract.v1.Policies.schema.json",
+      "description": "Policies to apply to this schema"
+    },
+    "runner": {
+      "$ref": "workflowcontract.v1.CraftingSchema.Runner.schema.json"
+    },
+    "schema_version": {
+      "description": "Version of the schema, do not confuse with the revision of the content",
+      "type": "string"
+    }
+  },
+  "title": "Crafting Schema",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/workflowcontract.v1.Metadata.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/workflowcontract.v1.Metadata.jsonschema.json
@@ -1,0 +1,25 @@
+{
+  "$id": "workflowcontract.v1.Metadata.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "annotations": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "description": {
+      "type": "string"
+    },
+    "name": {
+      "description": "the name of the policy",
+      "type": "string"
+    }
+  },
+  "title": "Metadata",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/workflowcontract.v1.Metadata.schema.json
+++ b/app/controlplane/api/gen/jsonschema/workflowcontract.v1.Metadata.schema.json
@@ -1,0 +1,25 @@
+{
+  "$id": "workflowcontract.v1.Metadata.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "annotations": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "description": {
+      "type": "string"
+    },
+    "name": {
+      "description": "the name of the policy",
+      "type": "string"
+    }
+  },
+  "title": "Metadata",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/workflowcontract.v1.Policies.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/workflowcontract.v1.Policies.jsonschema.json
@@ -1,0 +1,23 @@
+{
+  "$id": "workflowcontract.v1.Policies.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "attestation": {
+      "description": "Policies to be applied to attestation metadata",
+      "items": {
+        "$ref": "workflowcontract.v1.PolicyAttachment.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "materials": {
+      "description": "Policies to be applied to materials",
+      "items": {
+        "$ref": "workflowcontract.v1.PolicyAttachment.jsonschema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Policies",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/workflowcontract.v1.Policies.schema.json
+++ b/app/controlplane/api/gen/jsonschema/workflowcontract.v1.Policies.schema.json
@@ -1,0 +1,23 @@
+{
+  "$id": "workflowcontract.v1.Policies.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "attestation": {
+      "description": "Policies to be applied to attestation metadata",
+      "items": {
+        "$ref": "workflowcontract.v1.PolicyAttachment.schema.json"
+      },
+      "type": "array"
+    },
+    "materials": {
+      "description": "Policies to be applied to materials",
+      "items": {
+        "$ref": "workflowcontract.v1.PolicyAttachment.schema.json"
+      },
+      "type": "array"
+    }
+  },
+  "title": "Policies",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/workflowcontract.v1.Policy.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/workflowcontract.v1.Policy.jsonschema.json
@@ -1,0 +1,27 @@
+{
+  "$id": "workflowcontract.v1.Policy.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Represents a policy to be applied to a material or attestation",
+  "patternProperties": {
+    "^(api_version)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "apiVersion": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "metadata": {
+      "$ref": "workflowcontract.v1.Metadata.jsonschema.json"
+    },
+    "spec": {
+      "$ref": "workflowcontract.v1.PolicySpec.jsonschema.json"
+    }
+  },
+  "title": "Policy",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/workflowcontract.v1.Policy.schema.json
+++ b/app/controlplane/api/gen/jsonschema/workflowcontract.v1.Policy.schema.json
@@ -1,0 +1,27 @@
+{
+  "$id": "workflowcontract.v1.Policy.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Represents a policy to be applied to a material or attestation",
+  "patternProperties": {
+    "^(apiVersion)$": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "api_version": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "metadata": {
+      "$ref": "workflowcontract.v1.Metadata.schema.json"
+    },
+    "spec": {
+      "$ref": "workflowcontract.v1.PolicySpec.schema.json"
+    }
+  },
+  "title": "Policy",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/workflowcontract.v1.PolicyAttachment.MaterialSelector.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/workflowcontract.v1.PolicyAttachment.MaterialSelector.jsonschema.json
@@ -1,0 +1,13 @@
+{
+  "$id": "workflowcontract.v1.PolicyAttachment.MaterialSelector.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "description": "material name",
+      "type": "string"
+    }
+  },
+  "title": "Material Selector",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/workflowcontract.v1.PolicyAttachment.MaterialSelector.schema.json
+++ b/app/controlplane/api/gen/jsonschema/workflowcontract.v1.PolicyAttachment.MaterialSelector.schema.json
@@ -1,0 +1,13 @@
+{
+  "$id": "workflowcontract.v1.PolicyAttachment.MaterialSelector.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "description": "material name",
+      "type": "string"
+    }
+  },
+  "title": "Material Selector",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/workflowcontract.v1.PolicyAttachment.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/workflowcontract.v1.PolicyAttachment.jsonschema.json
@@ -1,0 +1,36 @@
+{
+  "$id": "workflowcontract.v1.PolicyAttachment.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "A policy to be applied to this contract",
+  "properties": {
+    "disabled": {
+      "description": "set to true to disable this rule",
+      "type": "boolean"
+    },
+    "embedded": {
+      "$ref": "workflowcontract.v1.Policy.jsonschema.json",
+      "description": "meant to be used to embed the policy in the contract"
+    },
+    "ref": {
+      "description": "policy reference, it might be in URI format.",
+      "type": "string"
+    },
+    "selector": {
+      "$ref": "workflowcontract.v1.PolicyAttachment.MaterialSelector.jsonschema.json",
+      "description": "rules to select a material or materials to be validated by the policy.\n If none provided, the whole statement will be injected to the policy"
+    },
+    "with": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "optional arguments for policies. Multivalued arguments can be set through multiline strings or comma separated values. It will be\n parsed and passed as an array value to the policy engine.\n with:\n   user: john\n   users: john, sarah\n   licenses: |\n     AGPL-1.0\n     AGPL-3.0",
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    }
+  },
+  "title": "Policy Attachment",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/workflowcontract.v1.PolicyAttachment.schema.json
+++ b/app/controlplane/api/gen/jsonschema/workflowcontract.v1.PolicyAttachment.schema.json
@@ -1,0 +1,36 @@
+{
+  "$id": "workflowcontract.v1.PolicyAttachment.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "A policy to be applied to this contract",
+  "properties": {
+    "disabled": {
+      "description": "set to true to disable this rule",
+      "type": "boolean"
+    },
+    "embedded": {
+      "$ref": "workflowcontract.v1.Policy.schema.json",
+      "description": "meant to be used to embed the policy in the contract"
+    },
+    "ref": {
+      "description": "policy reference, it might be in URI format.",
+      "type": "string"
+    },
+    "selector": {
+      "$ref": "workflowcontract.v1.PolicyAttachment.MaterialSelector.schema.json",
+      "description": "rules to select a material or materials to be validated by the policy.\n If none provided, the whole statement will be injected to the policy"
+    },
+    "with": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "optional arguments for policies. Multivalued arguments can be set through multiline strings or comma separated values. It will be\n parsed and passed as an array value to the policy engine.\n with:\n   user: john\n   users: john, sarah\n   licenses: |\n     AGPL-1.0\n     AGPL-3.0",
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    }
+  },
+  "title": "Policy Attachment",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/workflowcontract.v1.PolicySpec.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/workflowcontract.v1.PolicySpec.jsonschema.json
@@ -1,0 +1,49 @@
+{
+  "$id": "workflowcontract.v1.PolicySpec.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "embedded": {
+      "description": "embedded source code (only Rego supported currently)",
+      "type": "string"
+    },
+    "path": {
+      "description": "path to a policy script. It might consist of a URI reference",
+      "type": "string"
+    },
+    "type": {
+      "anyOf": [
+        {
+          "enum": [
+            "MATERIAL_TYPE_UNSPECIFIED",
+            "STRING",
+            "CONTAINER_IMAGE",
+            "ARTIFACT",
+            "SBOM_CYCLONEDX_JSON",
+            "SBOM_SPDX_JSON",
+            "JUNIT_XML",
+            "OPENVEX",
+            "HELM_CHART",
+            "SARIF",
+            "EVIDENCE",
+            "ATTESTATION",
+            "CSAF_VEX",
+            "CSAF_INFORMATIONAL_ADVISORY",
+            "CSAF_SECURITY_ADVISORY",
+            "CSAF_SECURITY_INCIDENT_RESPONSE"
+          ],
+          "title": "Material Type",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ],
+      "description": "if set, it will match any material supported by Chainloop\n except those not having a direct schema (STRING, ARTIFACT, EVIDENCE), since their format cannot be guessed by the crafter.\n CONTAINER, HELM_CHART are also excluded, but we might implement custom policies for them in the future."
+    }
+  },
+  "title": "Policy Spec",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/workflowcontract.v1.PolicySpec.schema.json
+++ b/app/controlplane/api/gen/jsonschema/workflowcontract.v1.PolicySpec.schema.json
@@ -1,0 +1,49 @@
+{
+  "$id": "workflowcontract.v1.PolicySpec.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "embedded": {
+      "description": "embedded source code (only Rego supported currently)",
+      "type": "string"
+    },
+    "path": {
+      "description": "path to a policy script. It might consist of a URI reference",
+      "type": "string"
+    },
+    "type": {
+      "anyOf": [
+        {
+          "enum": [
+            "MATERIAL_TYPE_UNSPECIFIED",
+            "STRING",
+            "CONTAINER_IMAGE",
+            "ARTIFACT",
+            "SBOM_CYCLONEDX_JSON",
+            "SBOM_SPDX_JSON",
+            "JUNIT_XML",
+            "OPENVEX",
+            "HELM_CHART",
+            "SARIF",
+            "EVIDENCE",
+            "ATTESTATION",
+            "CSAF_VEX",
+            "CSAF_INFORMATIONAL_ADVISORY",
+            "CSAF_SECURITY_ADVISORY",
+            "CSAF_SECURITY_INCIDENT_RESPONSE"
+          ],
+          "title": "Material Type",
+          "type": "string"
+        },
+        {
+          "maximum": 2147483647,
+          "minimum": -2147483648,
+          "type": "integer"
+        }
+      ],
+      "description": "if set, it will match any material supported by Chainloop\n except those not having a direct schema (STRING, ARTIFACT, EVIDENCE), since their format cannot be guessed by the crafter.\n CONTAINER, HELM_CHART are also excluded, but we might implement custom policies for them in the future."
+    }
+  },
+  "title": "Policy Spec",
+  "type": "object"
+}


### PR DESCRIPTION
This patch adds a plugin to generate json schemas based on the `proto` defines in the code. Since we are only interested in the ones about `workflowcontracts`, I've modified the Make file to get rid of those unwanted files.