### PR TITLE
fix(policies): handle provider 404

### DIFF
--- a/app/controlplane/pkg/biz/workflowcontract.go
+++ b/app/controlplane/pkg/biz/workflowcontract.go
@@ -393,6 +393,10 @@ func (uc *WorkflowContractUseCase) GetPolicy(providerName, policyName, token str
 
 	policy, ref, err := provider.Resolve(policyName, token)
 	if err != nil {
+		if errors.Is(err, policies.ErrNotFound) {
+			return nil, NewErrNotFound(fmt.Sprintf("policy %q", policyName))
+		}
+
 		return nil, fmt.Errorf("failed to resolve policy: %w. Available providers: %s", err, uc.policyRegistry.GetProviderNames())
 	}
 

--- a/app/controlplane/pkg/policies/policyprovider.go
+++ b/app/controlplane/pkg/policies/policyprovider.go
@@ -42,6 +42,8 @@ type PolicyReference struct {
 	Digest string
 }
 
+var ErrNotFound = fmt.Errorf("policy not found")
+
 // Resolve calls the remote provider for retrieving a policy
 func (p *PolicyProvider) Resolve(policyName string, token string) (*schemaapi.Policy, *PolicyReference, error) {
 	if policyName == "" || token == "" {
@@ -60,7 +62,12 @@ func (p *PolicyProvider) Resolve(policyName string, token string) (*schemaapi.Po
 	if err != nil {
 		return nil, nil, fmt.Errorf("error executing policy request: %w", err)
 	}
+
 	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusNotFound {
+			return nil, nil, ErrNotFound
+		}
+
 		return nil, nil, fmt.Errorf("expected status code 200 but got %d", resp.StatusCode)
 	}
 


### PR DESCRIPTION
from

```
ERR validation error: failed to get policy 'sbom-present': failed to resolve policy: error executing policy request: Get "http://localhost:8002/v1/policies/sbom-present": dial tcp [::1]:8002: connect: connection refused. Available providers: [chainloop]
```

to

```
ERR policy "cyclonedx-freshness" not found
```

and

```
ERR validation error: failed to get policy 'sbom-present': policy "sbom-present" not found
```