### PR TITLE
feat(policies): improve attachment validations

### DIFF
--- a/app/controlplane/api/workflowcontract/v1/crafting_schema.proto
+++ b/app/controlplane/api/workflowcontract/v1/crafting_schema.proto
@@ -197,10 +197,18 @@ message PolicySpec {
     string embedded = 2;
 
     option (buf.validate.oneof).required = true;
-  };
+  }
 
   // if set, it will match any material supported by Chainloop
   // except those not having a direct schema (STRING, ARTIFACT, EVIDENCE), since their format cannot be guessed by the crafter.
   // CONTAINER, HELM_CHART are also excluded, but we might implement custom policies for them in the future.
-  CraftingSchema.Material.MaterialType type = 3 [(buf.validate.field).enum = { not_in: [1, 2, 3, 10, 11]}];
+  CraftingSchema.Material.MaterialType type = 3 [(buf.validate.field).enum = {
+    not_in: [
+      1,
+      2,
+      3,
+      10,
+      11
+    ]
+  }];
 }


### PR DESCRIPTION
This PR adds validations to the `ref` property in the policy attachment, including

- making sure the protocol is either empty or one of the supported ones
- if we are using a file, HTTP protocol make sure the file has an extension i.e .yaml
- if we are using provider protocol, make sure that both the provider and the policy name are DNS compatible.
- If we are providing a digest (not used yet), make sure it's a valid formed digest

Errors are exposed now during the contract create/updaet

```sh
# missing extension
ERR validation error: invalid reference "https://raw.githubusercontent.com/chainloop-dev/chainloop/main/docs/examples/policies/sbom/sbom-present": missing extension

# wrong protocol
ERR validation error: invalid reference "unknown:///Users/miguelmartinez/work/chainloop/policies-playground/cyclonedx-licenses.yaml": unsupported protocol: unknown
exit status 1

# invalid digest
ERR validation error: invalid reference "file:///Users/miguelmartinez/work/chainloop/policies-playground/cyclonedx-licenses.yaml@sha256:deadbeef": invalid digest, want policy-ref@sha256:[hex]: wrong number of hex digits for sha256: deadbeef
exit status 1

# invalid policy name
a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')
``` 