### PR TITLE
feat(policies): digest support

### DIFF
--- a/app/controlplane/pkg/biz/workflowcontract.go
+++ b/app/controlplane/pkg/biz/workflowcontract.go
@@ -333,7 +333,7 @@ func (uc *WorkflowContractUseCase) findPolicy(att *schemav1.PolicyAttachment, to
 		provider, name := loader.ProviderParts(att.GetRef())
 		remotePolicy, err := uc.GetPolicy(provider, name, token)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get policy '%s': %w", name, err)
+			return nil, err
 		}
 		return remotePolicy.Policy, nil
 	}

--- a/common.mk
+++ b/common.mk
@@ -14,7 +14,7 @@ init: init-api-tools
 init-api-tools:
 	go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.31.0
 	go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3.0
-	go install github.com/bufbuild/buf/cmd/buf@v1.10.0
+	go install github.com/bufbuild/buf/cmd/buf@v1.40.1
 	go install github.com/envoyproxy/protoc-gen-validate@v1.0.1
 	# Tools fixed to a specific version via its commit since they are not released standalone
 	go install github.com/go-kratos/kratos/cmd/protoc-gen-go-errors/v2@v2.0.0-20231102162905-3fc8fb7a0a0b

--- a/pkg/policies/loader_test.go
+++ b/pkg/policies/loader_test.go
@@ -104,3 +104,29 @@ func TestPolicyReferenceResourceDescriptor(t *testing.T) {
 		assert.Equal(t, tc.want, got)
 	}
 }
+
+func TestExtractNameAndDigestFromRef(t *testing.T) {
+	testCases := []struct {
+		ref  string
+		want []string
+	}{
+		{
+			ref:  "chainloop://policy.json@sha256:1234",
+			want: []string{"chainloop://policy.json", "sha256:1234"},
+		},
+		{
+			ref:  "chainloop://policy.json",
+			want: []string{"chainloop://policy.json", ""},
+		},
+		{
+			ref:  "",
+			want: []string{"", ""},
+		},
+	}
+
+	for _, tc := range testCases {
+		gotName, gotDigest := ExtractDigest(tc.ref)
+		assert.Equal(t, tc.want[0], gotName)
+		assert.Equal(t, tc.want[1], gotDigest)
+	}
+}

--- a/pkg/policies/policies.go
+++ b/pkg/policies/policies.go
@@ -47,7 +47,7 @@ func NewPolicyError(err error) *PolicyError {
 }
 
 func (e *PolicyError) Error() string {
-	return fmt.Sprintf("policy error: %s", e.err.Error())
+	return e.err.Error()
 }
 
 func (e *PolicyError) Unwrap() error {
@@ -200,12 +200,12 @@ func (pv *PolicyVerifier) loadPolicySpec(ctx context.Context, attachment *v1.Pol
 		}
 	}
 	if err != nil {
-		return nil, nil, fmt.Errorf("loading policy spec: %w", err)
+		return nil, nil, err
 	}
 
 	// Validate just in case
 	if err = validatePolicy(spec); err != nil {
-		return nil, nil, fmt.Errorf("invalid policy: %w", err)
+		return nil, nil, err
 	}
 
 	return spec, ref, nil
@@ -360,7 +360,7 @@ func (pv *PolicyVerifier) requiredPoliciesForMaterial(ctx context.Context, mater
 		// load the policy spec
 		spec, _, err := pv.loadPolicySpec(ctx, policyAtt)
 		if err != nil {
-			return nil, fmt.Errorf("failed to load policy spec: %w", err)
+			return nil, fmt.Errorf("failed to load policy attachment %q: %w", policyAtt.GetRef(), err)
 		}
 
 		specType := spec.GetSpec().GetType()

--- a/pkg/policies/policies_test.go
+++ b/pkg/policies/policies_test.go
@@ -548,6 +548,30 @@ func (s *testSuite) TestLoadPolicySpec() {
 			},
 		},
 		{
+			name: "by file ref with valid digest",
+			attachment: &v12.PolicyAttachment{
+				Policy: &v12.PolicyAttachment_Ref{
+					Ref: "file://testdata/sbom_syft.yaml@sha256:24c4bd4f56b470d7436ed0c5a340483fff9ad058033f94b164f5efc59aba5136",
+				},
+			},
+			expectedName: "made-with-syft",
+			expectedRef: &v1.ResourceDescriptor{
+				Name: "file://testdata/sbom_syft.yaml",
+				Digest: map[string]string{
+					"sha256": "24c4bd4f56b470d7436ed0c5a340483fff9ad058033f94b164f5efc59aba5136",
+				},
+			},
+		},
+		{
+			name: "by file ref with invalid digest",
+			attachment: &v12.PolicyAttachment{
+				Policy: &v12.PolicyAttachment_Ref{
+					Ref: "file://testdata/sbom_syft.yaml@sha256:deadbeef",
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "embedded invalid",
 			attachment: &v12.PolicyAttachment{
 				Policy: &v12.PolicyAttachment_Embedded{


### PR DESCRIPTION
This patch allows setting `@sha256:digest` in the policy reference which will be used for

- pull the right policy version in the case of a policy from a chainloop provider.
- client-side validate other providers such as file or HTTP

This patch also includes some minor updates on error handling to cleanup a little bit the message, I know @jiparis you were asking for this, and I think you are right.

This is now an example of a policy that digest mismatches

```
failed to load policy attachment "file:///Users/miguelmartinez/work/chainloop/policies-playground/cyclonedx-licenses.yaml@sha256:12b7d023ea5410cb4f35804f8a6cd66a6e1bdc0bedb12c65a04e6b4b4c15f352": digest mismatch: got sha256:4f07666ec9c464885bb3ec65d400a63dca2c47b4c8ac278a9365146137265093, want sha256:12b7d023ea5410cb4f35804f8a6cd66a6e1bdc0bedb12c65a04e6b4b4c15f352
```

closes #1111 