### PR TITLE
chore(golang): Upgrade Golang version to 1.23.1

### DIFF
--- a/.github/workflows/build_and_package.yaml
+++ b/.github/workflows/build_and_package.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
-          go-version: "1.22.5"
+          go-version: "1.23.1"
 
       # install qemu binaries for multiarch builds (needed by goreleaser/buildx)
       - name: Setup qemu

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
-          go-version: "1.22.5"
+          go-version: "1.23.1"
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,14 +31,14 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Lint main module
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
         if: ${{ matrix.app == 'main-module' }}
         with:
           version: v1.60.3
           only-new-issues: 'true'
 
       - name: Lint ${{ matrix.app }}
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
         if: ${{ matrix.app != 'main-module' }}
         with:
           working-directory: app/${{ matrix.app }}
@@ -75,7 +75,7 @@ jobs:
           make -C extras/dagger module-init
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
         with:
           working-directory: extras/dagger
           version: v1.60.3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,22 +26,24 @@ jobs:
     steps:
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
-          go-version: "1.22.5"
+          go-version: "1.23.1"
 
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Lint main module
-        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
+        uses: golangci/golangci-lint-action@v6
         if: ${{ matrix.app == 'main-module' }}
         with:
-          version: v1.54
+          version: v1.60.3
+          only-new-issues: 'true'
 
       - name: Lint ${{ matrix.app }}
-        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
+        uses: golangci/golangci-lint-action@v6
         if: ${{ matrix.app != 'main-module' }}
         with:
           working-directory: app/${{ matrix.app }}
-          version: v1.54
+          version: v1.60.3
+          only-new-issues: 'true'
 
   lint-protos:
     runs-on: ubuntu-latest
@@ -64,7 +66,7 @@ jobs:
 
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
-          go-version: "1.22.5"
+          go-version: "1.23.1"
 
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
@@ -73,7 +75,8 @@ jobs:
           make -C extras/dagger module-init
 
       - name: Lint
-        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
+        uses: golangci/golangci-lint-action@v6
         with:
           working-directory: extras/dagger
-          version: v1.54
+          version: v1.60.3
+          only-new-issues: 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Generate migrations
         if: ${{ matrix.app == 'controlplane' }}
         env:
-          ATLAS_VERSION: v0.25.0
+          ATLAS_VERSION: v0.27.0
         run: |
           wget -q https://release.ariga.io/atlas/atlas-linux-amd64-$ATLAS_VERSION -O /tmp/atlas
           sudo install /tmp/atlas /usr/local/bin/atlas

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
-          go-version: "1.22.5"
+          go-version: "1.23.1"
           cache: true
           cache-dependency-path: go.sum
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,7 +23,7 @@ linters:
     - unconvert
     - dogsled
     - goconst
-    - exportloopref
+    - copyloopvar
     - gocyclo
     - goprintffuncname
     # Can't enable it for now, it crashes https://github.com/ent/ent/pull/3315

--- a/app/controlplane/Dockerfile.migrations
+++ b/app/controlplane/Dockerfile.migrations
@@ -1,6 +1,7 @@
 # Container image built by go-releaser that's used to run migrations against the database during deployment
 # See https://atlasgo.io/guides/deploying/image
-FROM arigaio/atlas@sha256:dc0f6b545320fc0be1bd28d122c98c2a96ef8e7019d75bcd5e8eec3e1d93f267 as base
+# Current version v0.27.0
+FROM arigaio/atlas@sha256:240e82b144b0055c49500351deaea09358797ec6d039f91cc88a28aa4264f640 as base
 
 FROM scratch
 # Update permissions to make it readable by the user

--- a/common.mk
+++ b/common.mk
@@ -7,7 +7,7 @@ init: init-api-tools
 	go install github.com/vektra/mockery/v2@v2.43.2
 	# using binary release for atlas, since ent schema handler is not included
 	# in the community version anymore https://github.com/ariga/atlas/issues/2388#issuecomment-1864287189
-	curl -sSf https://atlasgo.sh | ATLAS_VERSION=v0.25.0 sh -s -- -y
+	curl -sSf https://atlasgo.sh | ATLAS_VERSION=v0.27.0 sh -s -- -y
 
 # initialize API tooling
 .PHONY: init-api-tools

--- a/docs/docs/getting-started/attestation-crafting.md
+++ b/docs/docs/getting-started/attestation-crafting.md
@@ -284,7 +284,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "1.23.1"
 
       - name: Configure AWS credentials to push container images
         uses: aws-actions/configure-aws-credentials@v1

--- a/docs/examples/ci-workflows/github.yaml
+++ b/docs/examples/ci-workflows/github.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "1.23.1"
 
       # Generate SBOM using syft in cycloneDX format
       - uses: anchore/sbom-action@v0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chainloop-dev/chainloop
 
-go 1.22.5
+go 1.23.1
 
 require (
 	cloud.google.com/go/secretmanager v1.11.5


### PR DESCRIPTION
This patch upgrades the Golang version to latest at the moment, 1.23.1.

Refs: https://github.com/chainloop-dev/chainloop/issues/1299