### PR TITLE
fix(migrations): Update atlas base image sha

### DIFF
--- a/app/controlplane/Dockerfile.migrations
+++ b/app/controlplane/Dockerfile.migrations
@@ -1,7 +1,7 @@
 # Container image built by go-releaser that's used to run migrations against the database during deployment
 # See https://atlasgo.io/guides/deploying/image
 # Current version v0.27.0
-FROM arigaio/atlas@sha256:240e82b144b0055c49500351deaea09358797ec6d039f91cc88a28aa4264f640 as base
+FROM arigaio/atlas@sha256:b2197540d3b1c34513cae8a4b21517978e2fbaa59c0f070f1698cc3205ea4c32 as base
 
 FROM scratch
 # Update permissions to make it readable by the user


### PR DESCRIPTION
It seems we didn't fix all CVEs when upgrading to the latest version of atlas `0.27.0`. In the recent hours they have released a new version that seems to fix all CVEs. Example:
From:
```
$ docker build -f app/controlplane/Dockerfile.migrations -t controlplane-migrations-latest .
[+] Building 0.1s (8/8) FINISHED                                                                                                                                                                          
 => [internal] load build definition from Dockerfile.migrations                                                                                                                                                           
 => => transferring dockerfile: 733B                                                                                                                                                                                      
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 4)                                                                                                                                            
 => [internal] load metadata for docker.io/arigaio/atlas@sha256:240e82b144b0055c49500351deaea09358797ec6d039f91cc88a28aa4264f640                                                                                          
 => [internal] load .dockerignore                                                                                                                                                                                         
 => => transferring context: 2B                                                                                                                                                                                           
 => [base 1/1] FROM docker.io/arigaio/atlas@sha256:240e82b144b0055c49500351deaea09358797ec6d039f91cc88a28aa4264f640                                                                                                       
 => [internal] load build context                                                                                                                                                                                         
 => => transferring context: 31.94kB                                                                                                                                                                                      
 => CACHED [stage-1 1/2] COPY --from=base --chmod=555 /atlas /                                                                                                                                                            
 => [stage-1 2/2] COPY app/controlplane/pkg/data/ent/migrate/migrations /migrations                                                                                                                                       
 => exporting to image                                                                                                                                                                                                    
 => => exporting layers                                                                                                                                                                                                   
 => => writing image sha256:9776f9b2ad3c9dabe8e7aa11a1a1615b9d663517763214f6248212d451f43cfb                                                                                                                              
 => => naming to docker.io/library/controlplane-migrations-latest                                                                                                                                                         

 1 warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 4)

What's next:
    View a summary of image vulnerabilities and recommendations → docker scout quickview

$ trivy image --severity=CRITICAL,HIGH,MEDIUM docker.io/library/controlplane-migrations-latest
2024-09-10T17:02:19+02:00	INFO	[vuln] Vulnerability scanning is enabled
2024-09-10T17:02:19+02:00	INFO	[secret] Secret scanning is enabled
2024-09-10T17:02:19+02:00	INFO	[secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-09-10T17:02:19+02:00	INFO	[secret] Please see also https://aquasecurity.github.io/trivy/v0.54/docs/scanner/secret#recommendation for faster secret detection
2024-09-10T17:02:19+02:00	INFO	Number of language-specific files	num=1
2024-09-10T17:02:19+02:00	INFO	[gobinary] Detecting vulnerabilities...
2024-09-10T17:02:19+02:00	WARN	Using severities from other vendors for some vulnerabilities. Read https://aquasecurity.github.io/trivy/v0.54/docs/scanner/vulnerability#severity-selection for details.

atlas (gobinary)

Total: 3 (MEDIUM: 2, HIGH: 1, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬────────────────┬─────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version  │                            Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼────────────────┼─────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-34156 │ HIGH     │ fixed  │ 1.23.0            │ 1.22.7, 1.23.1 │ encoding/gob: golang: Calling Decoder.Decode on a message   │
│         │                │          │        │                   │                │ which contains deeply nested structures...                  │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2024-34156                  │
│         ├────────────────┼──────────┤        │                   │                ├─────────────────────────────────────────────────────────────┤
│         │ CVE-2024-34155 │ MEDIUM   │        │                   │                │ go/parser: golang: Calling any of the Parse functions       │
│         │                │          │        │                   │                │ containing deeply nested literals...                        │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2024-34155                  │
│         ├────────────────┤          │        │                   │                ├─────────────────────────────────────────────────────────────┤
│         │ CVE-2024-34158 │          │        │                   │                │ go/build/constraint: golang: Calling Parse on a "// +build" │
│         │                │          │        │                   │                │ build tag line with...                                      │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2024-34158                  │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴────────────────┴─────────────────────────────────────────────────────────────┘
```

To:
```
$ docker build -f app/controlplane/Dockerfile.migrations -t controlplane-migrations-latest .
[+] Building 0.1s (8/8) FINISHED
 => [internal] load build definition from Dockerfile.migrations
 => => transferring dockerfile: 733B
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 4)
 => [internal] load metadata for docker.io/arigaio/atlas@sha256:b2197540d3b1c34513cae8a4b21517978e2fbaa59c0f070f1698cc3205ea4c32
 => [internal] load .dockerignore
 => => transferring context: 2B
 => CACHED [base 1/1] FROM docker.io/arigaio/atlas@sha256:b2197540d3b1c34513cae8a4b21517978e2fbaa59c0f070f1698cc3205ea4c32
 => [internal] load build context
 => => transferring context: 4.39kB
 => CACHED [stage-1 1/2] COPY --from=base --chmod=555 /atlas /
 => [stage-1 2/2] COPY app/controlplane/pkg/data/ent/migrate/migrations /migrations
 => exporting to image
 => => exporting layers
 => => writing image sha256:e1356ed776ca3e0f8f8a8fb5318d84efdc293014d4ae3bcb69ecac40b4eb4c05
 => => naming to docker.io/library/controlplane-migrations-latest

 1 warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 4)

What's next:
    View a summary of image vulnerabilities and recommendations → docker scout quickview

$ trivy image --severity=CRITICAL,HIGH,MEDIUM docker.io/library/controlplane-migrations-latest
2024-09-10T17:02:51+02:00	INFO	[vuln] Vulnerability scanning is enabled
2024-09-10T17:02:51+02:00	INFO	[secret] Secret scanning is enabled
2024-09-10T17:02:51+02:00	INFO	[secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-09-10T17:02:51+02:00	INFO	[secret] Please see also https://aquasecurity.github.io/trivy/v0.54/docs/scanner/secret#recommendation for faster secret detection
2024-09-10T17:02:51+02:00	INFO	Number of language-specific files	num=1
2024-09-10T17:02:51+02:00	INFO	[gobinary] Detecting vulnerabilities...
```