### PR TITLE
fix(policies): Support file:// URLs with no path

### DIFF
--- a/app/controlplane/api/workflowcontract/v1/crafting_schema_test.go
+++ b/app/controlplane/api/workflowcontract/v1/crafting_schema_test.go
@@ -191,6 +191,11 @@ func TestValidateRefs(t *testing.T) {
 			wantErrString: "missing extension",
 		},
 		{
+			name:          "file with no path nor host",
+			ref:           "file://",
+			wantErrString: "invalid file reference",
+		},
+		{
 			name: "valid http URL",
 			ref:  "http://example.com/path/to/file.yaml",
 		},

--- a/app/controlplane/api/workflowcontract/v1/crafting_schema_test.go
+++ b/app/controlplane/api/workflowcontract/v1/crafting_schema_test.go
@@ -182,6 +182,15 @@ func TestValidateRefs(t *testing.T) {
 			wantErrString: "missing extension",
 		},
 		{
+			name: "file with no path",
+			ref:  "file://file.yaml",
+		},
+		{
+			name:          "file with no path and no extension",
+			ref:           "file://file",
+			wantErrString: "missing extension",
+		},
+		{
 			name: "valid http URL",
 			ref:  "http://example.com/path/to/file.yaml",
 		},

--- a/app/controlplane/api/workflowcontract/v1/crafting_schema_validations.go
+++ b/app/controlplane/api/workflowcontract/v1/crafting_schema_validations.go
@@ -110,7 +110,19 @@ func ValidatePolicyAttachmentRef(ref string) error {
 	}
 
 	switch u.Scheme {
-	case "http", "https", "file":
+	case "file":
+		// file URLs like file://my-policy.yaml are parsed as only Host with empty path
+		path := u.Path
+		if path == "" {
+			path = u.Host
+		}
+		if path == "" {
+			return fmt.Errorf("invalid file reference %q", u.String())
+		}
+		if filepath.Ext(path) == "" {
+			return fmt.Errorf("missing extension")
+		}
+	case "http", "https":
 		if u.Path == "" {
 			return fmt.Errorf("path is empty")
 		} else if filepath.Ext(u.Path) == "" {


### PR DESCRIPTION
this PR adds support to local file URLs with no path like: `file://my-policy.yaml`

Fixes #1307 