### PR TITLE
fix(contract): Add missing parameter to contracts

### DIFF
--- a/.github/workflows/contracts/chainloop-docs-release.yml
+++ b/.github/workflows/contracts/chainloop-docs-release.yml
@@ -17,3 +17,9 @@ policies:
     - ref: source-commit
   materials:
     - ref: sbom-present
+    - ref: cyclonedx-banned-licenses
+      with:
+        licenses: AGPL-1.0-only, AGPL-1.0-or-later, AGPL-3.0-only, AGPL-3.0-or-later
+    - ref: cyclonedx-banned-components
+      with:
+        components: log4j@2.14.1

--- a/.github/workflows/contracts/chainloop-vault-codeql.yml
+++ b/.github/workflows/contracts/chainloop-vault-codeql.yml
@@ -10,4 +10,6 @@ policies:
     - ref: source-commit
   materials:
     - ref: sarif-vulns
+      with:
+        severity: MEDIUM
     - ref: check-sarif-cves-in-kev

--- a/.github/workflows/contracts/chainloop-vault-scorecards.yml
+++ b/.github/workflows/contracts/chainloop-vault-scorecards.yml
@@ -10,4 +10,6 @@ policies:
     - ref: source-commit
   materials:
     - ref: sarif-vulns
+      with:
+        severity: MEDIUM
     - ref: check-sarif-cves-in-kev


### PR DESCRIPTION
This patch adds a missing parameter for the `sarif-vulns` and `cyclonedx` policies. 

Ref #1312 