### PR TITLE
feat(dagger): support workflow creation

### DIFF
--- a/dagger.json
+++ b/dagger.json
@@ -2,5 +2,5 @@
   "name": "chainloop",
   "sdk": "go",
   "source": "extras/dagger",
-  "engineVersion": "v0.12.3"
+  "engineVersion": "v0.13.0"
 }

--- a/extras/dagger/README.md
+++ b/extras/dagger/README.md
@@ -193,7 +193,6 @@ init --token env:CHAINLOOP_TOKEN --workflow-name test-from-dagger-2 attestation-
 
 Please run `dagger call with-instance -h` for more information on the available options.
 
-
 ## Documentation
 
 To learn more, please visit the Chainloop project's documentation website, https://docs.chainloop.dev where you will find a getting started guide, FAQ, examples, and more.

--- a/extras/dagger/README.md
+++ b/extras/dagger/README.md
@@ -165,7 +165,18 @@ dagger call -m github.com/chainloop-dev/chainloop \
   mark-canceled --reason "nothing to see here"
 ```
 
-### Pointing to a different Chainloop Instance
+## CLI operations
+
+This module also provides access to the underlying Chainloop CLI by exposing some of its commands
+
+### Workflow Creation
+
+```sh
+ dagger call -m github.com/chainloop-dev/chainloop \
+   workflow-create --token env:CHAINLOOP_TOKEN --name [your-workflow-name] --project [its-project]
+```
+
+## Pointing to a different Chainloop Instance
 
 By default, this dagger module points to Chainloop's upstream instance, but if you want to point to your own instance, you can do it by running the with-instance command just right after `dagger call`
 
@@ -181,6 +192,7 @@ init --token env:CHAINLOOP_TOKEN --workflow-name test-from-dagger-2 attestation-
 ```
 
 Please run `dagger call with-instance -h` for more information on the available options.
+
 
 ## Documentation
 

--- a/extras/dagger/go.mod
+++ b/extras/dagger/go.mod
@@ -44,3 +44,11 @@ require (
 	golang.org/x/sync v0.7.0
 	google.golang.org/grpc v1.64.1
 )
+
+replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.0.0-20240518090000-14441aefdf88
+
+replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.3.0
+
+replace go.opentelemetry.io/otel/log => go.opentelemetry.io/otel/log v0.3.0
+
+replace go.opentelemetry.io/otel/sdk/log => go.opentelemetry.io/otel/sdk/log v0.3.0

--- a/extras/dagger/main.go
+++ b/extras/dagger/main.go
@@ -428,6 +428,9 @@ func (m *Chainloop) WorkflowCreate(
 	team string,
 	// +optional
 	description string,
+	// name of an existing contract
+	// +optional
+	contractName string,
 	// Set workflow as public so other organizations can see it
 	// +optional
 	public bool,
@@ -442,6 +445,7 @@ func (m *Chainloop) WorkflowCreate(
 			"--project", project,
 			"--team", team,
 			"--description", description,
+			"--contract", contractName,
 			"--public", fmt.Sprintf("%t", public),
 			"--skip-if-exists", fmt.Sprintf("%t", skipIfExists),
 		}, execOpts).

--- a/extras/dagger/main.go
+++ b/extras/dagger/main.go
@@ -415,7 +415,7 @@ func (att *Attestation) reset(ctx context.Context,
 
 /// standalone API calls
 
-// Initialize a new attestation
+// Create a new workflow
 func (m *Chainloop) WorkflowCreate(
 	ctx context.Context,
 	// Chainloop API token


### PR DESCRIPTION
extends our dagger module to support creating workflows

```
Create a new workflow

USAGE
  dagger call workflow-create [arguments]

ARGUMENTS
      --name string          Workflow name [required]
      --project string       Workflow project [required]
      --token Secret         Chainloop API token [required] (default )
      --description string
      --public               Set workflow as public so other organizations can see it
      --skip-if-exists       If the workflow already exists, skip the creation and return success
      --team string
```

closes #1323