### PR TITLE
feat(.github): Generate Chainloop CLI SBOM

### DIFF
--- a/.github/workflows/build_and_package.yaml
+++ b/.github/workflows/build_and_package.yaml
@@ -26,6 +26,7 @@ jobs:
       CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
       CONTAINER_IMAGE_CP: ghcr.io/chainloop-dev/chainloop/control-plane:${{ github.ref_name }}
       CONTAINER_IMAGE_CAS: ghcr.io/chainloop-dev/chainloop/artifact-cas:${{ github.ref_name }}
+      CONTAINER_IMAGE_CLI: ghcr.io/chainloop-dev/chainloop/cli:${{ github.ref_name }}
       GH_TOKEN: ${{ github.token }}
       CHAINLOOP_WORKFLOW_NAME: "chainloop-vault-build-and-package"
     steps:
@@ -94,6 +95,13 @@ jobs:
           format: cyclonedx-json
           artifact-name: cas.cyclonedx.json
           output-file: /tmp/sbom.cas.cyclonedx.json
+
+      - uses: anchore/sbom-action@c6aed38a4323b393d05372c58a74c39ae8386d02 # v0.15.6
+        with:
+          image: ${{ env.CONTAINER_IMAGE_CLI }}
+          format: cyclonedx-json
+          artifact-name: cli.cyclonedx.json
+          output-file: /tmp/sbom.cli.cyclonedx.json
 
       - name: Add Attestation from Goreleaser Output
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,6 +43,12 @@ jobs:
           tag=$(echo -n ${{github.ref}} | cut -d / -f3)
           gh release download $tag -D /tmp/github-release
           for entry in $(ls /tmp/github-release); do
+            # If the name is cas.cyclonedx.json, controlplane.cyclonedx.json or cli.cyclonedx.json, we need to add the attestation with the correct name
+            if [[ $entry =~ ^(cas|controlplane|cli)\.cyclonedx\.json$ ]]; then
+              name=$(echo -n "${entry%.json}" | sed 's/\./-/g')
+              chainloop attestation add --value "/tmp/github-release/$entry" --name "$name"
+              continue
+            fi
             chainloop attestation add --value "/tmp/github-release/$entry"
           done
           


### PR DESCRIPTION
This patch generate a CycloneDX SBOM for the CLI which was not generated and add it to the release attestation.

It additionally changes the names of the materials being added when it comes to CycloneDX for a better identification.