### PR TITLE
feat(.github): Bump Dagger version on new releases

### DIFF
--- a/.github/workflows/build_and_package.yaml
+++ b/.github/workflows/build_and_package.yaml
@@ -117,18 +117,18 @@ jobs:
           CHAINLOOP_SIGNING_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
           CHAINLOOP_SIGNING_KEY: ${{ secrets.COSIGN_KEY }}
 
-      - name: Bump Chart Version
-        run: .github/workflows/utils/bump-chart-version.sh deployment/chainloop ${{ github.ref_name }}
+      - name: Bump Chart and Dagger Version
+        run: .github/workflows/utils/bump-chart-and-dagger-version.sh deployment/chainloop extras/dagger ${{ github.ref_name }}
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5.0.2
         with:
-          commit-message: Bump Chart Version ${{ github.ref_name }}
+          commit-message: Bump Chart and Dagger Version ${{ github.ref_name }}
           signoff: true
           base: main
-          title: Bump Helm Chart Version => ${{ github.ref_name }}
+          title: Bump Helm Chart and Dagger Version => ${{ github.ref_name }}
           body: |
-            A new Chainloop release is available! Bumping Helm Chart reference to ${{ github.ref_name }}
+            A new Chainloop release is available! Bumping Helm Chart reference and Dagger version to ${{ github.ref_name }}
           labels: |
             automated
             helm

--- a/.github/workflows/utils/bump-chart-and-dagger-version.sh
+++ b/.github/workflows/utils/bump-chart-and-dagger-version.sh
@@ -6,7 +6,7 @@ set -e
 
 die () {
     echo >&2 "$@"
-    echo "usage: bump.sh [chartPath] [version] [isCanary]"
+    echo "usage: bump.sh [chartPath] [daggerPath] [version] [isCanary]"
     exit 1
 }
 
@@ -15,10 +15,11 @@ if [[ -n "${DEBUG}" ]]; then
     set -x
 fi
 
-[ "$#" -ge 2 ] || die "At least 2 arguments required, $# provided"
+[ "$#" -ge 3 ] || die "At least 3 arguments required, $# provided"
 
 chart_yaml="${1}/Chart.yaml"
 values_yaml="${1}/values.yaml"
+dagger_main="${2}/main.go"
 semVer="${2}"
 
 ## Changes in Chart.yaml
@@ -48,3 +49,7 @@ sed -i "s/:v[0-9\.]*/:${semVer}/g" "${chart_yaml}"
 
 ## Changes images in Values.yaml
 sed -i "s/tag: .*/tag: \"${semVer}\"/g" "${values_yaml}"
+
+## Update Dagger version
+sed -i "s/chainloopVersion = \"v[0-9\.]*\"/chainloopVersion = \"${semVer}\"/" "${dagger_main}"
+


### PR DESCRIPTION
This patch modifies the bump chart version to also upgrade the version of dagger in every release.


Refs: #1330 