### PR TITLE
chore(dagger): downgrade dagger engine

### DIFF
--- a/dagger.json
+++ b/dagger.json
@@ -2,5 +2,5 @@
   "name": "chainloop",
   "sdk": "go",
   "source": "extras/dagger",
-  "engineVersion": "v0.13.0"
+  "engineVersion": "v0.12.3"
 }


### PR DESCRIPTION
https://github.com/chainloop-dev/chainloop/pull/1324 introduced by mistake a dagger engine upgrade. We should do this upgrade separately to allow clients that do not have this version to stick to this commit hash.