### PR TITLE
fix(controlplane): make email case insensitive

### DIFF
--- a/app/controlplane/pkg/biz/membership_integration_test.go
+++ b/app/controlplane/pkg/biz/membership_integration_test.go
@@ -46,7 +46,7 @@ func (s *membershipIntegrationTestSuite) TestByOrg() {
 	_, err = s.Membership.Create(ctx, sharedOrg.ID, user2.ID, biz.WithCurrentMembership())
 	s.NoError(err)
 
-	s.T().Run("org 1", func(t *testing.T) {
+	s.Run("org 1", func() {
 		memberships, err := s.Membership.ByOrg(ctx, userOrg.ID)
 		s.NoError(err)
 		s.Len(memberships, 1)
@@ -55,7 +55,7 @@ func (s *membershipIntegrationTestSuite) TestByOrg() {
 		s.Equal(memberships[0].Role, authz.RoleViewer)
 	})
 
-	s.T().Run("shared org", func(t *testing.T) {
+	s.Run("shared org", func() {
 		memberships, err := s.Membership.ByOrg(ctx, sharedOrg.ID)
 		s.NoError(err)
 		s.Len(memberships, 2)

--- a/app/controlplane/pkg/biz/orginvitation.go
+++ b/app/controlplane/pkg/biz/orginvitation.go
@@ -18,6 +18,7 @@ package biz
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/authz"
@@ -73,6 +74,8 @@ func WithInvitationRole(r authz.Role) InvitationCreateOpt {
 }
 
 func (uc *OrgInvitationUseCase) Create(ctx context.Context, orgID, senderID, receiverEmail string, createOpts ...InvitationCreateOpt) (*OrgInvitation, error) {
+	receiverEmail = strings.ToLower(receiverEmail)
+
 	// 1 - Static Validation
 	if receiverEmail == "" {
 		return nil, NewErrValidationStr("receiver email is required")

--- a/app/controlplane/pkg/biz/orginvitation_integration_test.go
+++ b/app/controlplane/pkg/biz/orginvitation_integration_test.go
@@ -176,7 +176,7 @@ func (s *OrgInvitationIntegrationTestSuite) TestCreate() {
 		}
 	})
 
-	s.T().Run("and the email address is downcased", func(t *testing.T) {
+	s.Run("and the email address is downcased", func() {
 		invite, err := s.OrgInvitation.Create(ctx, s.org1.ID, s.user.ID, "WasCamelCase@cyberdyne.io")
 		s.NoError(err)
 		s.Equal("wascamelcase@cyberdyne.io", invite.ReceiverEmail)

--- a/app/controlplane/pkg/biz/orginvitation_integration_test.go
+++ b/app/controlplane/pkg/biz/orginvitation_integration_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 The Chainloop Authors.
+// Copyright 2024 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -174,6 +174,12 @@ func (s *OrgInvitationIntegrationTestSuite) TestCreate() {
 			s.NoError(err)
 			s.Equal(r, invite.Role)
 		}
+	})
+
+	s.T().Run("and the email address is downcased", func(t *testing.T) {
+		invite, err := s.OrgInvitation.Create(ctx, s.org1.ID, s.user.ID, "WasCamelCase@cyberdyne.io")
+		s.NoError(err)
+		s.Equal("wascamelcase@cyberdyne.io", invite.ReceiverEmail)
 	})
 }
 

--- a/app/controlplane/pkg/biz/user.go
+++ b/app/controlplane/pkg/biz/user.go
@@ -18,6 +18,7 @@ package biz
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	pb "github.com/chainloop-dev/chainloop/app/controlplane/api/controlplane/v1"
@@ -99,6 +100,9 @@ func (uc *UserUseCase) DeleteUser(ctx context.Context, userID string) error {
 // to the organizations defined in the configuration. If disableAutoOnboarding is set to true, it will
 // skip the auto-onboarding process.
 func (uc *UserUseCase) FindOrCreateByEmail(ctx context.Context, email string, disableAutoOnboarding ...bool) (*User, error) {
+	// emails are case-insensitive
+	email = strings.ToLower(email)
+
 	u, err := uc.userRepo.FindByEmail(ctx, email)
 	if err != nil {
 		return nil, err

--- a/app/controlplane/pkg/biz/user_integration_test.go
+++ b/app/controlplane/pkg/biz/user_integration_test.go
@@ -29,6 +29,24 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+func (s *userIntegrationTestSuite) TestFindOrCreateByEmail() {
+	// It will create a new user
+	u, err := s.User.FindOrCreateByEmail(context.Background(), "user1@user.com")
+	s.NoError(err)
+	s.Equal("user1@user.com", u.Email)
+
+	// running it again has the same ID
+	u2, err := s.User.FindOrCreateByEmail(context.Background(), "user1@user.com")
+	s.NoError(err)
+	s.Equal(u2.ID, u.ID)
+
+	// It will downcase the email
+	// running it again has the same ID
+	u3, err := s.User.FindOrCreateByEmail(context.Background(), "WAS-UPPERCASE@user.com")
+	s.NoError(err)
+	s.Equal("was-uppercase@user.com", u3.Email)
+}
+
 /*
 User mapping:
 - userOne -> userOne org

--- a/app/controlplane/pkg/data/ent/migrate/migrations/20240920193509.sql
+++ b/app/controlplane/pkg/data/ent/migrate/migrations/20240920193509.sql
@@ -1,0 +1,2 @@
+-- set all email addresses to lowercase
+UPDATE users SET email = LOWER(email);

--- a/app/controlplane/pkg/data/ent/migrate/migrations/atlas.sum
+++ b/app/controlplane/pkg/data/ent/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:3t9rfP6n9TkogTDvCGpnZvdVjpgRnb5eeXjA753TFvg=
+h1:/GVJXP6pdXbjL89PpRrAKyL9sg5T8mS0Vnrb6QjoQNg=
 20230706165452_init-schema.sql h1:VvqbNFEQnCvUVyj2iDYVQQxDM0+sSXqocpt/5H64k8M=
 20230710111950-cas-backend.sql h1:A8iBuSzZIEbdsv9ipBtscZQuaBp3V5/VMw7eZH6GX+g=
 20230712094107-cas-backends-workflow-runs.sql h1:a5rzxpVGyd56nLRSsKrmCFc9sebg65RWzLghKHh5xvI=
@@ -42,3 +42,4 @@ h1:3t9rfP6n9TkogTDvCGpnZvdVjpgRnb5eeXjA753TFvg=
 20240817110515.sql h1:TpKcnvfG41SUC4rNMQ9YFNuVsDB0A408hCI5qaoRzQo=
 20240819104758.sql h1:bpAwdQakxcXNy5ZfmA/tAzx+lIQBPs2LWs6wk2QCPTw=
 20240827110459.sql h1:opB+0UvGuYIyi1B3BEyh06HNzon3V867QHsc8yrsTuE=
+20240920193509.sql h1:FREEMo5oD//cf+6iq72YgbVJgXN/fuy7DB/jvx6NgKM=


### PR DESCRIPTION
- stores email addresses for users and invitations in lowercase
- updates all email addresses in the DB to be lowercase

Fixes #1344 