### PR TITLE
fix(jenkins): use WORKSPACE instead of AGENT_WORKDIR

### DIFF
--- a/pkg/attestation/crafter/crafter_test.go
+++ b/pkg/attestation/crafter/crafter_test.go
@@ -280,12 +280,12 @@ func (s *crafterSuite) TestResolveEnvVars() {
 			},
 			expectedEnvVars: map[string]string{
 				// Missing var: GIT_BRANCH
-				"CUSTOM_VAR_1":  "custom_value_1",
-				"CUSTOM_VAR_2":  "custom_value_2",
-				"JOB_NAME":      "some-job",
-				"BUILD_URL":     "http://some-url",
-				"AGENT_WORKDIR": "/some/home/dir",
-				"NODE_NAME":     "some-node",
+				"CUSTOM_VAR_1": "custom_value_1",
+				"CUSTOM_VAR_2": "custom_value_2",
+				"JOB_NAME":     "some-job",
+				"BUILD_URL":    "http://some-url",
+				"WORKSPACE":    "/some/home/dir",
+				"NODE_NAME":    "some-node",
 			},
 		}, {
 			name:          "all optional jenkins variable with no error",
@@ -298,14 +298,14 @@ func (s *crafterSuite) TestResolveEnvVars() {
 				"CUSTOM_VAR_2": "custom_value_2",
 			},
 			expectedEnvVars: map[string]string{
-				"GIT_BRANCH":    "some-branch", // optional var 1
-				"GIT_COMMIT":    "some-commit", // optional var 2
-				"CUSTOM_VAR_1":  "custom_value_1",
-				"CUSTOM_VAR_2":  "custom_value_2",
-				"JOB_NAME":      "some-job",
-				"BUILD_URL":     "http://some-url",
-				"AGENT_WORKDIR": "/some/home/dir",
-				"NODE_NAME":     "some-node",
+				"GIT_BRANCH":   "some-branch", // optional var 1
+				"GIT_COMMIT":   "some-commit", // optional var 2
+				"CUSTOM_VAR_1": "custom_value_1",
+				"CUSTOM_VAR_2": "custom_value_2",
+				"JOB_NAME":     "some-job",
+				"BUILD_URL":    "http://some-url",
+				"WORKSPACE":    "/some/home/dir",
+				"NODE_NAME":    "some-node",
 			},
 		},
 	}
@@ -324,7 +324,7 @@ func (s *crafterSuite) TestResolveEnvVars() {
 				contract = "testdata/contracts/jenkins_with_env_vars.yaml"
 				s.T().Setenv("JOB_NAME", "some-job")
 				s.T().Setenv("BUILD_URL", "http://some-url")
-				s.T().Setenv("AGENT_WORKDIR", "/some/home/dir")
+				s.T().Setenv("WORKSPACE", "/some/home/dir")
 				s.T().Setenv("NODE_NAME", "some-node")
 				s.T().Setenv("JENKINS_HOME", "/some/home/dir")
 				runner = runners.NewJenkinsJob()

--- a/pkg/attestation/crafter/runners/jenkinsjob.go
+++ b/pkg/attestation/crafter/runners/jenkinsjob.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 The Chainloop Authors.
+// Copyright 2024 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -55,7 +55,10 @@ func (r *JenkinsJob) ListEnvVars() []*EnvVarDefinition {
 		{"GIT_COMMIT", true},
 
 		// Some info about the agent
-		{"AGENT_WORKDIR", false},
+		// We've found this one to be optional
+		{"AGENT_WORKDIR", true},
+		// Workspace is required as long as the jobs run inside a `node` block
+		{"WORKSPACE", false},
 		{"NODE_NAME", false},
 	}
 }

--- a/pkg/attestation/crafter/runners/jenkinsjob_test.go
+++ b/pkg/attestation/crafter/runners/jenkinsjob_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 The Chainloop Authors.
+// Copyright 2024 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -82,7 +82,8 @@ func (s *jenkinsJobSuite) TestListEnvVars() {
 		{"BUILD_URL", false},
 		{"GIT_BRANCH", true},
 		{"GIT_COMMIT", true},
-		{"AGENT_WORKDIR", false},
+		{"AGENT_WORKDIR", true},
+		{"WORKSPACE", false},
 		{"NODE_NAME", false},
 	}, s.runner.ListEnvVars())
 }
@@ -98,7 +99,7 @@ func (s *jenkinsJobSuite) TestResolveEnvVars() {
 	os.Unsetenv("GIT_COMMIT")
 	resolvedEnvVars, errors = s.runner.ResolveEnvVars()
 	s.Empty(errors)
-	s.Equal(reuiredJenkinsJobTestingEnvVars, resolvedEnvVars)
+	s.Equal(requiredJenkinsJobTestingEnvVars, resolvedEnvVars)
 }
 
 func (s *jenkinsJobSuite) TestRunURI() {
@@ -119,19 +120,19 @@ func (s *jenkinsJobSuite) SetupTest() {
 }
 
 var jenkinsJobTestingEnvVars = map[string]string{
-	"JOB_NAME":      "some-jenkins-job",
-	"BUILD_URL":     "http://some-build-url/",
-	"AGENT_WORKDIR": "/home/sample/agent",
-	"NODE_NAME":     "some-node",
-	"GIT_BRANCH":    "somebranch",
-	"GIT_COMMIT":    "somecommit",
+	"JOB_NAME":   "some-jenkins-job",
+	"BUILD_URL":  "http://some-build-url/",
+	"WORKSPACE":  "/home/sample/agent",
+	"NODE_NAME":  "some-node",
+	"GIT_BRANCH": "somebranch",
+	"GIT_COMMIT": "somecommit",
 }
 
-var reuiredJenkinsJobTestingEnvVars = map[string]string{
-	"JOB_NAME":      "some-jenkins-job",
-	"BUILD_URL":     "http://some-build-url/",
-	"AGENT_WORKDIR": "/home/sample/agent",
-	"NODE_NAME":     "some-node",
+var requiredJenkinsJobTestingEnvVars = map[string]string{
+	"JOB_NAME":  "some-jenkins-job",
+	"BUILD_URL": "http://some-build-url/",
+	"WORKSPACE": "/home/sample/agent",
+	"NODE_NAME": "some-node",
 }
 
 // Run the tests


### PR DESCRIPTION
Fixes #1347 