### PR TITLE
fix(chart): Map server-certs to correct secret name

### DIFF
--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -7,7 +7,7 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.101.0
+version: 1.101.1
 # Do not update appVersion, this is handled automatically by the release process
 appVersion: v0.96.13
 

--- a/deployment/chainloop/README.md
+++ b/deployment/chainloop/README.md
@@ -521,26 +521,26 @@ chainloop config save \
 
 ### Control Plane
 
-| Name                                           | Description                                                                                     | Value             |
-| ---------------------------------------------- | ----------------------------------------------------------------------------------------------- | ----------------- |
-| `controlplane.replicaCount`                    | Number of replicas                                                                              | `2`               |
-| `controlplane.image.registry`                  | Image registry                                                                                  | `REGISTRY_NAME`   |
-| `controlplane.image.repository`                | Image repository                                                                                | `REPOSITORY_NAME` |
-| `controlplane.containerPorts.http`             | controlplane HTTP container port                                                                | `8000`            |
-| `controlplane.containerPorts.grpc`             | controlplane gRPC container port                                                                | `9000`            |
-| `controlplane.containerPorts.metrics`          | controlplane prometheus metrics container port                                                  | `5000`            |
-| `controlplane.tls.existingSecret`              | Existing secret name containing TLS certificate to be used by the controlplane grpc server      | `""`              |
-| `controlplane.pluginsDir`                      | Directory where to look for plugins                                                             | `/plugins`        |
-| `controlplane.referrerSharedIndex`             | Configure the shared, public index API endpoint that can be used to discover metadata referrers |                   |
-| `controlplane.referrerSharedIndex.enabled`     | Enable index API endpoint                                                                       | `false`           |
-| `controlplane.referrerSharedIndex.allowedOrgs` | List of UUIDs of organizations that are allowed to publish to the shared index                  | `[]`              |
-| `controlplane.onboarding.name`                 | Name of the organization to onboard                                                             |                   |
-| `controlplane.onboarding.role`                 | Role of the organization to onboard                                                             |                   |
-| `controlplane.prometheus_org_metrics`          | List of organizations to expose metrics for using Prometheus                                    |                   |
-| `controlplane.policy_providers`                | List of endpoints providing external policies                                                   |                   |
-| `controlplane.migration.image.registry`        | Image registry                                                                                  | `REGISTRY_NAME`   |
-| `controlplane.migration.image.repository`      | Image repository                                                                                | `REPOSITORY_NAME` |
-| `controlplane.migration.ssl`                   | Connect to the database using SSL (required fro AWS RDS, etc)                                   | `false`           |
+| Name                                           | Description                                                                                                                                                                                                                                                    | Value             |
+| ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `controlplane.replicaCount`                    | Number of replicas                                                                                                                                                                                                                                             | `2`               |
+| `controlplane.image.registry`                  | Image registry                                                                                                                                                                                                                                                 | `REGISTRY_NAME`   |
+| `controlplane.image.repository`                | Image repository                                                                                                                                                                                                                                               | `REPOSITORY_NAME` |
+| `controlplane.containerPorts.http`             | controlplane HTTP container port                                                                                                                                                                                                                               | `8000`            |
+| `controlplane.containerPorts.grpc`             | controlplane gRPC container port                                                                                                                                                                                                                               | `9000`            |
+| `controlplane.containerPorts.metrics`          | controlplane prometheus metrics container port                                                                                                                                                                                                                 | `5000`            |
+| `controlplane.tls.existingSecret`              | Existing secret name containing TLS certificate to be used by the controlplane grpc server. NOTE: When it's set it will disable secret creation. The secret must contains 2 keys: tls.crt and tls.key respectively containing the certificate and private key. | `""`              |
+| `controlplane.pluginsDir`                      | Directory where to look for plugins                                                                                                                                                                                                                            | `/plugins`        |
+| `controlplane.referrerSharedIndex`             | Configure the shared, public index API endpoint that can be used to discover metadata referrers                                                                                                                                                                |                   |
+| `controlplane.referrerSharedIndex.enabled`     | Enable index API endpoint                                                                                                                                                                                                                                      | `false`           |
+| `controlplane.referrerSharedIndex.allowedOrgs` | List of UUIDs of organizations that are allowed to publish to the shared index                                                                                                                                                                                 | `[]`              |
+| `controlplane.onboarding.name`                 | Name of the organization to onboard                                                                                                                                                                                                                            |                   |
+| `controlplane.onboarding.role`                 | Role of the organization to onboard                                                                                                                                                                                                                            |                   |
+| `controlplane.prometheus_org_metrics`          | List of organizations to expose metrics for using Prometheus                                                                                                                                                                                                   |                   |
+| `controlplane.policy_providers`                | List of endpoints providing external policies                                                                                                                                                                                                                  |                   |
+| `controlplane.migration.image.registry`        | Image registry                                                                                                                                                                                                                                                 | `REGISTRY_NAME`   |
+| `controlplane.migration.image.repository`      | Image repository                                                                                                                                                                                                                                               | `REPOSITORY_NAME` |
+| `controlplane.migration.ssl`                   | Connect to the database using SSL (required fro AWS RDS, etc)                                                                                                                                                                                                  | `false`           |
 
 ### Control Plane Database
 
@@ -714,15 +714,15 @@ chainloop config save \
 
 ### Artifact Content Addressable (CAS) API
 
-| Name                         | Description                                                                       | Value             |
-| ---------------------------- | --------------------------------------------------------------------------------- | ----------------- |
-| `cas.replicaCount`           | Number of replicas                                                                | `2`               |
-| `cas.image.registry`         | Image registry                                                                    | `REGISTRY_NAME`   |
-| `cas.image.repository`       | Image repository                                                                  | `REPOSITORY_NAME` |
-| `cas.containerPorts.http`    | controlplane HTTP container port                                                  | `8000`            |
-| `cas.containerPorts.grpc`    | controlplane gRPC container port                                                  | `9000`            |
-| `cas.containerPorts.metrics` | controlplane prometheus metrics container port                                    | `5000`            |
-| `cas.tls.existingSecret`     | Existing secret name containing TLS certificate to be used by the cas grpc server | `""`              |
+| Name                         | Description                                                                                                                                                                                                                                           | Value             |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `cas.replicaCount`           | Number of replicas                                                                                                                                                                                                                                    | `2`               |
+| `cas.image.registry`         | Image registry                                                                                                                                                                                                                                        | `REGISTRY_NAME`   |
+| `cas.image.repository`       | Image repository                                                                                                                                                                                                                                      | `REPOSITORY_NAME` |
+| `cas.containerPorts.http`    | controlplane HTTP container port                                                                                                                                                                                                                      | `8000`            |
+| `cas.containerPorts.grpc`    | controlplane gRPC container port                                                                                                                                                                                                                      | `9000`            |
+| `cas.containerPorts.metrics` | controlplane prometheus metrics container port                                                                                                                                                                                                        | `5000`            |
+| `cas.tls.existingSecret`     | Existing secret name containing TLS certificate to be used by the cas grpc server. NOTE: When it's set it will disable secret creation. The secret must contains 2 keys: tls.crt and tls.key respectively containing the certificate and private key. | `""`              |
 
 ### CAS Networking
 

--- a/deployment/chainloop/templates/cas/deployment.yaml
+++ b/deployment/chainloop/templates/cas/deployment.yaml
@@ -156,7 +156,7 @@ spec:
         {{- if include "cas.tls-secret-name" .  }}
         - name: server-certs
           secret:
-            secretName: {{ .Values.cas.tls.existingSecret  }}
+            secretName: {{ include "cas.tls-secret-name" .  }}
         {{- end }}
         {{- if eq "gcpSecretManager" .Values.secretsBackend.backend  }}
         - name: gcp-secretmanager-serviceaccountkey

--- a/deployment/chainloop/values.yaml
+++ b/deployment/chainloop/values.yaml
@@ -154,9 +154,7 @@ controlplane:
   ## TLS configuration
   ##
   tls:
-    ## @param controlplane.tls.existingSecret Existing secret name containing TLS certificate to be used by the controlplane grpc server
-    ## NOTE: When it's set it will disable secret creation. The secret must contains 2 keys: tls.crt and tls.key respectively containing the certificate and private key.
-    ##
+    ## @param controlplane.tls.existingSecret Existing secret name containing TLS certificate to be used by the controlplane grpc server. NOTE: When it's set it will disable secret creation. The secret must contains 2 keys: tls.crt and tls.key respectively containing the certificate and private key.
     existingSecret: ""
 
   ## @param controlplane.pluginsDir Directory where to look for plugins
@@ -932,9 +930,7 @@ cas:
   ## TLS configuration
   ##
   tls:
-    ## @param cas.tls.existingSecret Existing secret name containing TLS certificate to be used by the cas grpc server
-    ## NOTE: When it's set it will disable secret creation. The secret must contains 2 keys: tls.crt and tls.key respectively containing the certificate and private key.
-    ##
+    ## @param cas.tls.existingSecret Existing secret name containing TLS certificate to be used by the cas grpc server. NOTE: When it's set it will disable secret creation. The secret must contains 2 keys: tls.crt and tls.key respectively containing the certificate and private key.
     existingSecret: ""
 
   ## @skip cas.serviceAccount


### PR DESCRIPTION
This patch fixes a regression introduced in the chart that was taking only into account the legacy option for TLS configuration and not the new one.

Refs: #1353 