### PR TITLE
fix(chart): Ensure security context is overridden in OpenShift clusters

### DIFF
--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -7,7 +7,7 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.101.1
+version: 1.101.2
 # Do not update appVersion, this is handled automatically by the release process
 appVersion: v0.96.13
 

--- a/deployment/chainloop/templates/cas/deployment.yaml
+++ b/deployment/chainloop/templates/cas/deployment.yaml
@@ -61,7 +61,7 @@ spec:
       topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.cas.topologySpreadConstraints "context" .) | nindent 8 }}
       {{- end }}
       {{- if .Values.cas.podSecurityContext.enabled }}
-      securityContext: {{- omit .Values.cas.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.cas.podSecurityContext "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.cas.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.cas.terminationGracePeriodSeconds }}

--- a/deployment/chainloop/templates/controlplane/deployment.yaml
+++ b/deployment/chainloop/templates/controlplane/deployment.yaml
@@ -62,7 +62,7 @@ spec:
       topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.controlplane.topologySpreadConstraints "context" .) | nindent 8 }}
       {{- end }}
       {{- if .Values.controlplane.podSecurityContext.enabled }}
-      securityContext: {{- omit .Values.controlplane.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.controlplane.podSecurityContext "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.controlplane.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.controlplane.terminationGracePeriodSeconds }}


### PR DESCRIPTION
This patch fixes a regression introduced when migrating to Bitnami Chart guidelines. It was missing a call to a helper method that ensures the deployment compatibility with OpenShift clusters.

```
$ kubectl get pods
NAME                                        READY   STATUS    RESTARTS        AGE
chainloop-cas-f4bdc8b8c-kkvg7               1/1     Running   2 (4m38s ago)   4m46s
chainloop-cas-f4bdc8b8c-rktbv               1/1     Running   2 (4m38s ago)   4m46s
chainloop-controlplane-644c5b487d-9vkt6     1/1     Running   0               4m46s
chainloop-controlplane-644c5b487d-sdpwq     1/1     Running   0               4m46s
chainloop-dex-765df5d877-vxlfc              1/1     Running   0               4m46s
chainloop-postgresql-0                      1/1     Running   0               4m4s
chainloop-vault-injector-7f4b977dbb-5ssfv   1/1     Running   0               4m46s
chainloop-vault-server-0                    1/1     Running   0               4m46s
```

```
$ kubectl config get-clusters
NAME
api-crc-testing:6443
docker-desktop
```

Refs #1353 