### PR TITLE
chore: rename policy references in github workflows

### DIFF
--- a/.github/workflows/contracts/chainloop-docs-release.yml
+++ b/.github/workflows/contracts/chainloop-docs-release.yml
@@ -17,9 +17,9 @@ policies:
     - ref: source-commit
   materials:
     - ref: sbom-present
-    - ref: cyclonedx-banned-licenses
+    - ref: sbom-banned-licenses
       with:
         licenses: AGPL-1.0-only, AGPL-1.0-or-later, AGPL-3.0-only, AGPL-3.0-or-later
-    - ref: cyclonedx-banned-components
+    - ref: sbom-banned-components
       with:
         components: log4j@2.14.1

--- a/.github/workflows/contracts/chainloop-vault-codeql.yml
+++ b/.github/workflows/contracts/chainloop-vault-codeql.yml
@@ -9,7 +9,7 @@ policies:
   attestation:
     - ref: source-commit
   materials:
-    - ref: sarif-vulns
+    - ref: vulnerabilities
       with:
         severity: MEDIUM
-    - ref: check-sarif-cves-in-kev
+    - ref: cves-in-kev

--- a/.github/workflows/contracts/chainloop-vault-scorecards.yml
+++ b/.github/workflows/contracts/chainloop-vault-scorecards.yml
@@ -9,7 +9,7 @@ policies:
   attestation:
     - ref: source-commit
   materials:
-    - ref: sarif-vulns
+    - ref: vulnerabilities
       with:
         severity: MEDIUM
-    - ref: check-sarif-cves-in-kev
+    - ref: cves-in-kev


### PR DESCRIPTION
This PR updates all policy references to use the new names.
Fixes #1368
