### PR TITLE
chore(policies): add missing contract for chainloop-valut-release workflow

### DIFF
--- a/.github/workflows/contracts/chainloop-chainloop-github-release.yaml
+++ b/.github/workflows/contracts/chainloop-chainloop-github-release.yaml
@@ -1,0 +1,14 @@
+schemaVersion: v1
+policies:
+  materials:
+    - ref: sbom-licenses
+    - ref: sbom-freshness
+    - ref: sbom-banned-licenses
+      with:
+        licenses: AGPL-1.0-only, AGPL-1.0-or-later, AGPL-3.0-only, AGPL-3.0-or-later
+    - ref: sbom-banned-components
+      with:
+        components: log4j@2.14.1
+  attestation:
+    - ref: sbom-present
+    - ref: source-commit

--- a/.github/workflows/contracts/chainloop-chainloop-github-release.yaml
+++ b/.github/workflows/contracts/chainloop-chainloop-github-release.yaml
@@ -1,7 +1,7 @@
 schemaVersion: v1
 policies:
   materials:
-    - ref: sbom-licenses
+    - ref: sbom-with-licenses
     - ref: sbom-freshness
     - ref: sbom-banned-licenses
       with:


### PR DESCRIPTION
This is the contract that chainloop-vault-release workflow uses under the hood. Adding here to enable the gitops approach.

Related to #1369 