### PR TITLE
fix(deployment): quote app version

### DIFF
--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -7,7 +7,7 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.102.1
+version: 1.102.2
 # Do not update appVersion, this is handled automatically by the release process
 appVersion: v0.96.14
 

--- a/deployment/chainloop/templates/cas/deployment.yaml
+++ b/deployment/chainloop/templates/cas/deployment.yaml
@@ -105,7 +105,7 @@ spec:
           {{- end }}
           env:
             - name: CHART_VERSION
-              value: {{ .Chart.Version }}
+              value: {{ .Chart.Version | quote }}
             {{- if .Values.cas.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.cas.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}

--- a/deployment/chainloop/templates/controlplane/deployment.yaml
+++ b/deployment/chainloop/templates/controlplane/deployment.yaml
@@ -119,7 +119,7 @@ spec:
           {{- end }}
           env:
             - name: CHART_VERSION
-              value: {{ .Chart.Version }}
+              value: {{ .Chart.Version | quote }}
             {{- if .Values.controlplane.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.controlplane.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
Quote version to prevent errors like

```
: json: cannot unmarshal number into Go struct field EnvVar.spec.template.spec.containers.env.value of type string
```