### PR TITLE
chore(policies): remove fallback to file:// when ChainloopLoader fails

### DIFF
--- a/pkg/policies/policies.go
+++ b/pkg/policies/policies.go
@@ -200,18 +200,7 @@ func (pv *PolicyVerifier) loadPolicySpec(ctx context.Context, attachment *v1.Pol
 
 	spec, ref, err := loader.Load(ctx, attachment)
 	if err != nil {
-		// fallback from ChainloopLoader to FileLoader if no scheme is used, to maintain backwards compatibility
-		_, ok := loader.(*ChainloopLoader)
-		scheme, id := refParts(attachment.GetRef())
-		if ok && scheme == "" {
-			// prepend file:// to the ref
-			pv.logger.Debug().Msgf("falling back to FileLoader for %s", attachment.GetRef())
-			attachment.Policy = &v1.PolicyAttachment_Ref{Ref: fmt.Sprintf("%s://%s", fileScheme, id)}
-			spec, ref, err = new(FileLoader).Load(ctx, attachment)
-		}
-	}
-	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("failed to load policy spec: %w", err)
 	}
 
 	// Validate just in case


### PR DESCRIPTION
This fallback was introduced in #1267  for backwards compatibility. It's not needed anymore.
