### PR TITLE
fix(docs): Typo on policy engine docs

### DIFF
--- a/docs/docs/reference/policies.mdx
+++ b/docs/docs/reference/policies.mdx
@@ -217,7 +217,7 @@ To ensure the policy engine work as pure and as fast as possible, we have deacti
 - `rego.parse_module`
 - `trace`
 
-Also `http.send` has isolated so only requests to the following domains are allowed:
+Also `http.send` has been isolated so only requests to the following domains are allowed:
 - `chainloop.dev`
 - `cisa.gov`
 


### PR DESCRIPTION
Minor addition to the policy engine documentation.

Ref: #1395 