### PR TITLE
feat(policies): Add strict builtin mode

### DIFF
--- a/pkg/policies/engine/rego/testfiles/restrictive_mode_networking.rego
+++ b/pkg/policies/engine/rego/testfiles/restrictive_mode_networking.rego
@@ -1,0 +1,9 @@
+package main
+
+import rego.v1
+
+violations contains msg if {
+    http.send({"method": "GET", "url": "http://example.com"})
+
+    msg := ""
+}


### PR DESCRIPTION
This patch activates the strict mode on errors when the restrictive environment is active so network errors for example, raise an exception and halts the policy evaluation.

Ref #1395 