### PR TITLE
fix(policies): fix provider parsing for pinned policies

### DIFF
--- a/app/controlplane/api/workflowcontract/v1/crafting_schema_test.go
+++ b/app/controlplane/api/workflowcontract/v1/crafting_schema_test.go
@@ -245,8 +245,20 @@ func TestValidateRefs(t *testing.T) {
 			wantErrString: "invalid digest",
 		},
 		{
+			name: "valid digest",
+			ref:  "foobar:policy-name@sha256:133d39edc0f0d32780dd9c940951df0910ef53e6fd64942801ba6fb76494bbf9",
+		},
+		{
 			name: "chainloop provider with valid digest",
 			ref:  "foobar:policy-name@sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c",
+		},
+		{
+			name: "custom policy with valid digest",
+			ref:  "readonly-demo/policy-name@sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c",
+		},
+		{
+			name: "builtin policy with valid digest",
+			ref:  "policy-name@sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c",
 		},
 		{
 			name:          "unsupported protocol",

--- a/pkg/policies/loader.go
+++ b/pkg/policies/loader.go
@@ -205,7 +205,19 @@ type ProviderRef struct {
 }
 
 // ProviderParts returns the provider information for a given reference
-func ProviderParts(ref string) *ProviderRef {
+func ProviderParts(reference string) *ProviderRef {
+	var ref, digest string
+	// first of all, remove the @sha256 suffix to make the parsing easier
+	withDigest := strings.SplitN(reference, "@sha256:", 2)
+
+	if len(withDigest) > 1 {
+		// it has digest
+		ref = withDigest[0]
+		digest = withDigest[1]
+	} else {
+		ref = reference
+	}
+
 	parts := strings.SplitN(ref, "://", 2)
 	var pn []string
 	if len(parts) == 1 {
@@ -230,6 +242,11 @@ func ProviderParts(ref string) *ProviderRef {
 		// the policy is scoped to a specific org
 		orgName = scoped[0]
 		name = scoped[1]
+	}
+
+	// return the digest back
+	if digest != "" {
+		name = fmt.Sprintf("%s@sha256:%s", name, digest)
 	}
 
 	return &ProviderRef{

--- a/pkg/policies/policies_test.go
+++ b/pkg/policies/policies_test.go
@@ -249,10 +249,11 @@ func (s *testSuite) TestVerifyAttestations() {
 
 func (s *testSuite) TestProviderParts() {
 	testCases := []struct {
-		ref  string
-		prov string
-		name string
-		org  string
+		ref    string
+		prov   string
+		name   string
+		org    string
+		digest string
 	}{
 		{
 			ref:  "chainloop://cyclonedx-freshness",
@@ -301,6 +302,29 @@ func (s *testSuite) TestProviderParts() {
 			prov: "",
 			org:  "myorg",
 			name: "cyclonedx-freshness",
+		},
+		{
+			ref:  "myorg/cyclonedx-freshness@sha256:123123123",
+			org:  "myorg",
+			name: "cyclonedx-freshness@sha256:123123123",
+		},
+		{
+			ref:  "builtin:myorg/cyclonedx-freshness@sha256:123123123",
+			prov: "builtin",
+			org:  "myorg",
+			name: "cyclonedx-freshness@sha256:123123123",
+		},
+		{
+			ref:  "chainloop://builtin:myorg/cyclonedx-freshness@sha256:123123123",
+			prov: "builtin",
+			org:  "myorg",
+			name: "cyclonedx-freshness@sha256:123123123",
+		},
+		{
+			ref:  "chainloop://myorg/cyclonedx-freshness@sha256:123123123",
+			prov: "",
+			org:  "myorg",
+			name: "cyclonedx-freshness@sha256:123123123",
 		},
 	}
 


### PR DESCRIPTION
This PR fixes a bug that prevented pinned policies in contracts, after the refactoring to support org-scoped policies.

I've also added some more tests.

```
✗ cldev wf contract update --name myproject-mywf --contract test/my-contract.yaml
WRN API contacted in insecure mode
WRN Both user credentials and $CHAINLOOP_TOKEN set. Ignoring $CHAINLOOP_TOKEN.
INF Contract updated!
┌────────────────────────────────────────────┐
│ Contract                                   │
├──────────────────────┬─────────────────────┤
│ Name                 │ myproject-mywf      │
├──────────────────────┼─────────────────────┤
│ Description          │                     │
├──────────────────────┼─────────────────────┤
│ Associated Workflows │ /                   │
├──────────────────────┼─────────────────────┤
│ Revision number      │ 19                  │
├──────────────────────┼─────────────────────┤
│ Revision Created At  │ 17 Oct 24 16:14 UTC │
└──────────────────────┴─────────────────────┘
┌────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ schemaVersion: v1                                                                                      │
│ materials: []                                                                                          │
│ policies:                                                                                              │
│   materials:                                                                                           │
│     - ref: secrets-detection                                                                           │
│     - ref: vulnerabilities@sha256:badb459c2e310364baf56b6ad64bd9d3da381b0da38d70ffeadbca632343ce2d     │
│     - ref: cyclonedx-licenses@sha256:6a886647b1109869d870aa8bb24cfec5b48a7f3c383bebaac8b55a73bc2d8426  │
│     - ref: sbom-freshness                                                                              │
│     - ref: sbom-ntia                                                                                   │
│     - ref: file://test/result.yaml                                                                     │
│   attestation:                                                                                         │
│     - ref: source-commit                                                                               │
│                                                                                                        │
└────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```
