### PR TITLE
fix(policies): load rego code relative to policy yaml file

### DIFF
--- a/pkg/policies/policies_test.go
+++ b/pkg/policies/policies_test.go
@@ -625,7 +625,7 @@ func (s *testSuite) TestLoadPolicySpec() {
 			expectedRef: &v1.ResourceDescriptor{
 				Name: "file://testdata/sbom_syft.yaml",
 				Digest: map[string]string{
-					"sha256": "24c4bd4f56b470d7436ed0c5a340483fff9ad058033f94b164f5efc59aba5136",
+					"sha256": "81b7fbe4c6ef2182fd042a28fa7f3b3971879d18994147cb812b8fe87a4e04e5",
 				},
 			},
 		},
@@ -633,14 +633,14 @@ func (s *testSuite) TestLoadPolicySpec() {
 			name: "by file ref with valid digest",
 			attachment: &v12.PolicyAttachment{
 				Policy: &v12.PolicyAttachment_Ref{
-					Ref: "file://testdata/sbom_syft.yaml@sha256:24c4bd4f56b470d7436ed0c5a340483fff9ad058033f94b164f5efc59aba5136",
+					Ref: "file://testdata/sbom_syft.yaml@sha256:81b7fbe4c6ef2182fd042a28fa7f3b3971879d18994147cb812b8fe87a4e04e5",
 				},
 			},
 			expectedName: "made-with-syft",
 			expectedRef: &v1.ResourceDescriptor{
 				Name: "file://testdata/sbom_syft.yaml",
 				Digest: map[string]string{
-					"sha256": "24c4bd4f56b470d7436ed0c5a340483fff9ad058033f94b164f5efc59aba5136",
+					"sha256": "81b7fbe4c6ef2182fd042a28fa7f3b3971879d18994147cb812b8fe87a4e04e5",
 				},
 			},
 		},

--- a/pkg/policies/testdata/materials.yaml
+++ b/pkg/policies/testdata/materials.yaml
@@ -4,4 +4,4 @@ metadata:
   name: materials
 spec:
   type: ATTESTATION
-  path: testdata/materials.rego
+  path: materials.rego

--- a/pkg/policies/testdata/multi-kind.yaml
+++ b/pkg/policies/testdata/multi-kind.yaml
@@ -8,6 +8,6 @@ metadata:
 spec:
   policies:
     - kind: SBOM_SPDX_JSON
-      path: testdata/sbom_syft.rego
+      path: sbom_syft.rego
     - kind: ATTESTATION
-      path: testdata/workflow.rego
+      path: workflow.rego

--- a/pkg/policies/testdata/sbom_syft.yaml
+++ b/pkg/policies/testdata/sbom_syft.yaml
@@ -7,4 +7,4 @@ metadata:
     category: SBOM
 spec:
   type: SBOM_SPDX_JSON
-  path: testdata/sbom_syft.rego
+  path: sbom_syft.rego

--- a/pkg/policies/testdata/sbom_syft_not_typed.yaml
+++ b/pkg/policies/testdata/sbom_syft_not_typed.yaml
@@ -3,4 +3,4 @@ kind: Policy
 metadata:
   name: made-with-syft
 spec:
-  path: testdata/sbom_syft.rego
+  path: sbom_syft.rego

--- a/pkg/policies/testdata/with_arguments.yaml
+++ b/pkg/policies/testdata/with_arguments.yaml
@@ -4,4 +4,4 @@ metadata:
   name: workflow
 spec:
   type: ATTESTATION
-  path: testdata/with_arguments.rego
+  path: with_arguments.rego

--- a/pkg/policies/testdata/workflow.yaml
+++ b/pkg/policies/testdata/workflow.yaml
@@ -4,4 +4,4 @@ metadata:
   name: workflow
 spec:
   type: ATTESTATION
-  path: testdata/workflow.rego
+  path: workflow.rego

--- a/pkg/policies/testdata/wrong_policy.yaml
+++ b/pkg/policies/testdata/wrong_policy.yaml
@@ -3,4 +3,4 @@ kind: Policy
 metadata:
   name: wrong_policy
 spec:
-  path: testdata/wrong_policy.rego
+  path: wrong_policy.rego


### PR DESCRIPTION
This PR changes the way that file-based rego policies are loaded. Instead of requiring the full path, rego code will be found releatively to their yaml file. This improves policy portaibility. 
Closes #1411