### PR TITLE
fix(ci): remove branch chainloop script

### DIFF
--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -15,7 +15,6 @@ jobs:
     secrets:
       api_token: ${{ secrets.CHAINLOOP_TOKEN }}
     with:
-      chainloop_labs_branch: dfc395be86c9254f42de204584a032d5c1f99706
       workflow_name: "chainloop-docs-release"
       project_name: "chainloop"
 
@@ -93,5 +92,4 @@ jobs:
       signing_key_password: ${{ secrets.COSIGN_PASSWORD }}
     with:
       attestation_name: "docs"
-      chainloop_labs_branch: dfc395be86c9254f42de204584a032d5c1f99706
       workflow_name: "chainloop-docs-release"

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -24,7 +24,6 @@ jobs:
     secrets:
       api_token: ${{ secrets.CHAINLOOP_TOKEN }}
     with:
-      chainloop_labs_branch: dfc395be86c9254f42de204584a032d5c1f99706
       workflow_name: "chainloop-vault-scorecards"
       project_name: "chainloop"
 


### PR DESCRIPTION
Scorecards seems to be fixed to a previous version of the script.

This change I believe will make it load from the latest version in `main`