### PR TITLE
feat(dagger): add support for choosing the contract on init

### DIFF
--- a/extras/dagger/README.md
+++ b/extras/dagger/README.md
@@ -73,7 +73,7 @@ dagger call -m github.com/chainloop-dev/chainloop \
   --workflow-name the-name-of-the-workflow \
   --project-name the-name-of-the-project \
   --repository /path/to/repo \ # optional flag to automatically attest a Git repository \
-  --contract-revision 1 \ # optional flag to specify the revision of the Workflow Contract (default `latest`)
+  --contract-name my-existing-contract \ # optional flag to specify an existing contract that will be used during the creation of a workflow
 ```
 
 #### 2 - Get the status ([docs](https://docs.chainloop.dev/getting-started/attestation-crafting#inspecting-the-crafting-status))

--- a/extras/dagger/main.go
+++ b/extras/dagger/main.go
@@ -76,6 +76,9 @@ func (m *Chainloop) Init(
 	workflowName string,
 	// Project name to be used for the attestation
 	projectName string,
+	// name of an existing contract to attach it to the auto-created workflow
+	// +optional
+	contractName string,
 ) (*Attestation, error) {
 	att := &Attestation{
 		Token:      token,
@@ -90,6 +93,12 @@ func (m *Chainloop) Init(
 	if contractRevision != "" {
 		args = append(args,
 			"--contract-revision", contractRevision,
+		)
+	}
+
+	if contractName != "" {
+		args = append(args,
+			"--contract", contractName,
 		)
 	}
 


### PR DESCRIPTION
Since creating a workflow is no longer mandatory, it will get created automatically on init. We needed a way to indicate what contract to use for the new workflow

ref #1415 