### PR TITLE
feat(policies): allow arrays as input for policies

### DIFF
--- a/pkg/policies/engine/rego/rego.go
+++ b/pkg/policies/engine/rego/rego.go
@@ -43,6 +43,7 @@ const (
 	// EnvironmentModePermissive allows all operations on the compiler
 	EnvironmentModePermissive EnvironmentMode = 1
 	inputArgs                                 = "args"
+	inputElements                             = "elements"
 	deprecatedRule                            = "violations"
 	mainRule                                  = "result"
 )
@@ -77,6 +78,13 @@ func (r *Rego) Verify(ctx context.Context, policy *engine.Policy, input []byte, 
 	var decodedInput interface{}
 	if err := decoder.Decode(&decodedInput); err != nil {
 		return nil, fmt.Errorf("failed to parse input: %w", err)
+	}
+
+	// if input is an array, transform it to an object
+	if array, ok := decodedInput.([]interface{}); ok {
+		inputMap := make(map[string]interface{})
+		inputMap[inputElements] = array
+		decodedInput = inputMap
 	}
 
 	// put arguments embedded in the input object

--- a/pkg/policies/engine/rego/rego_test.go
+++ b/pkg/policies/engine/rego/rego_test.go
@@ -67,6 +67,23 @@ func TestRego_VerifyWithValidPolicy(t *testing.T) {
 	})
 }
 
+func TestRego_VerifyWithInputArray(t *testing.T) {
+	regoContent, err := os.ReadFile("testfiles/arrays.rego")
+	require.NoError(t, err)
+
+	r := &Rego{}
+	policy := &engine.Policy{
+		Name:   "foobar",
+		Source: regoContent,
+	}
+
+	t.Run("creates 'elements' field", func(t *testing.T) {
+		result, err := r.Verify(context.TODO(), policy, []byte(`[{"foo": "bar"}, {"foo2":"bar2"}]`), nil)
+		require.NoError(t, err)
+		assert.Equal(t, "2", result.SkipReason)
+	})
+}
+
 func TestRego_VerifyWithArguments(t *testing.T) {
 	regoContent, err := os.ReadFile("testfiles/arguments.rego")
 	require.NoError(t, err)

--- a/pkg/policies/engine/rego/testfiles/arrays.rego
+++ b/pkg/policies/engine/rego/testfiles/arrays.rego
@@ -1,0 +1,9 @@
+package main
+
+import rego.v1
+
+result := {
+  "violations": [],
+  "skipped": true,
+  "skip_reason": sprintf("%d", [count(input.elements)])
+}


### PR DESCRIPTION
This small PR adds the ability to accept arrays as the input for Rego policies.

Related to #1429 