### PR TITLE
fix: return validation error

### DIFF
--- a/app/controlplane/pkg/biz/workflowcontract.go
+++ b/app/controlplane/pkg/biz/workflowcontract.go
@@ -292,7 +292,7 @@ func (uc *WorkflowContractUseCase) ValidateContractPolicies(rawSchema []byte, to
 	// Validate that externally provided policies exist
 	c, err := identifyUnMarshalAndValidateRawContract(rawSchema)
 	if err != nil {
-		return err
+		return NewErrValidation(err)
 	}
 
 	for _, att := range c.Schema.GetPolicies().GetAttestation() {


### PR DESCRIPTION
If we can't detect the format, we want to return a validation error instead of an internal error.