### PR TITLE
fix: remote state with no version

### DIFF
--- a/app/cli/cmd/attestation_status.go
+++ b/app/cli/cmd/attestation_status.go
@@ -210,7 +210,7 @@ func hBool(b bool) string {
 // Version information to be shown during the attestation process
 // both during the process and at the end
 func versionStringAttestation(p *action.ProjectVersion, isPushed bool) string {
-	if p.Version == "" {
+	if p == nil || p.Version == "" {
 		return ""
 	}
 

--- a/app/cli/internal/action/attestation_init.go
+++ b/app/cli/internal/action/attestation_init.go
@@ -125,10 +125,13 @@ func (action *AttestationInit) Run(ctx context.Context, opts *AttestationInitRun
 		Project:        workflow.GetProject(),
 		Team:           workflow.GetTeam(),
 		SchemaRevision: strconv.Itoa(int(contractVersion.GetRevision())),
-		Version: &clientAPI.ProjectVersion{
+	}
+
+	if opts.ProjectVersion != "" {
+		workflowMeta.Version = &clientAPI.ProjectVersion{
 			Version:        opts.ProjectVersion,
 			MarkAsReleased: opts.ProjectVersionMarkAsReleased,
-		},
+		}
 	}
 
 	action.Logger.Debug().Msg("workflow contract and metadata retrieved from the control plane")
@@ -169,7 +172,11 @@ func (action *AttestationInit) Run(ctx context.Context, opts *AttestationInitRun
 		workflowRun := runResp.GetResult().GetWorkflowRun()
 		workflowMeta.WorkflowRunId = workflowRun.GetId()
 		workflowMeta.Organization = runResp.GetResult().GetOrganization()
-		workflowMeta.Version.Prerelease = runResp.GetResult().GetWorkflowRun().Version.GetPrerelease()
+
+		if v := workflowMeta.Version; v != nil {
+			workflowMeta.Version.Prerelease = runResp.GetResult().GetWorkflowRun().Version.GetPrerelease()
+		}
+
 		action.Logger.Debug().Str("workflow-run-id", workflowRun.GetId()).Msg("attestation initialized in the control plane")
 		attestationID = workflowRun.GetId()
 	}

--- a/app/cli/internal/action/attestation_status.go
+++ b/app/cli/internal/action/attestation_status.go
@@ -104,16 +104,19 @@ func (action *AttestationStatus) Run(ctx context.Context, attestationID string) 
 			Project:          workflowMeta.GetProject(),
 			Team:             workflowMeta.GetTeam(),
 			ContractRevision: workflowMeta.GetSchemaRevision(),
-			ProjectVersion: &ProjectVersion{
-				Version:        workflowMeta.GetVersion().GetVersion(),
-				Prerelease:     workflowMeta.Version.Prerelease,
-				MarkAsReleased: workflowMeta.Version.MarkAsReleased,
-			},
 		},
 		InitializedAt: toTimePtr(att.InitializedAt.AsTime()),
 		DryRun:        c.CraftingState.DryRun,
 		Annotations:   pbAnnotationsToAction(c.CraftingState.InputSchema.GetAnnotations()),
 		IsPushed:      action.isPushed,
+	}
+
+	if v := workflowMeta.GetVersion(); v != nil {
+		res.WorkflowMeta.ProjectVersion = &ProjectVersion{
+			Version:        v.GetVersion(),
+			Prerelease:     v.GetPrerelease(),
+			MarkAsReleased: v.GetMarkAsReleased(),
+		}
 	}
 
 	// Let's perform the following steps in order to show all possible materials:


### PR DESCRIPTION
If no version was provided during attestation and you were using a remote state, you would get a validation error.

This makes sure to store the version object, if only if, the version number exists.