### PR TITLE
feat: do not swallow run error

### DIFF
--- a/app/controlplane/pkg/data/workflow.go
+++ b/app/controlplane/pkg/data/workflow.go
@@ -318,7 +318,12 @@ func entWFToBizWF(ctx context.Context, w *ent.Workflow, r *ent.WorkflowRun) (*bi
 	}
 
 	if r != nil {
-		wf.LastRun = entWrToBizWr(ctx, r)
+		lastRun, err := entWrToBizWr(ctx, r)
+		if err != nil {
+			return nil, fmt.Errorf("converting workflow run: %w", err)
+		}
+
+		wf.LastRun = lastRun
 	}
 
 	return wf, nil


### PR DESCRIPTION
context errors were being swallowed during the workflow run. This change makes error handling more explicit