### PR TITLE
feat(sentry): Add more information to sentry

### DIFF
--- a/app/controlplane/internal/sentrycontext/sentry_context.go
+++ b/app/controlplane/internal/sentrycontext/sentry_context.go
@@ -1,0 +1,123 @@
+//
+// Copyright 2024 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sentrycontext
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/chainloop-dev/chainloop/app/controlplane/internal/usercontext"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/go-kratos/kratos/v2/middleware"
+	"github.com/go-kratos/kratos/v2/middleware/logging"
+	"github.com/go-kratos/kratos/v2/transport"
+	"google.golang.org/grpc/metadata"
+)
+
+// defaultTracingHeaders is a list of headers that are used to extract tracing information.
+var defaultTracingHeaders = []string{"X-Request-ID", "X-Correlation-ID", "X-Trace-ID"}
+
+// NewSentryContext returns a middleware that adds context to Sentry for the current request
+// that will be sent along with the error if one occurs
+func NewSentryContext() middleware.Middleware {
+	return func(handler middleware.Handler) middleware.Handler {
+		return func(ctx context.Context, req interface{}) (interface{}, error) {
+			addSentryContext(ctx, req)
+			return handler(ctx, req)
+		}
+	}
+}
+
+// addSentryContext adds context to Sentry for the current request
+func addSentryContext(ctx context.Context, req interface{}) {
+	org := usercontext.CurrentOrg(ctx)
+	user := usercontext.CurrentUser(ctx)
+	apiToken := usercontext.CurrentAPIToken(ctx)
+	role := usercontext.CurrentAuthzSubject(ctx)
+
+	sentry.ConfigureScope(func(scope *sentry.Scope) {
+		scope.SetContext("Account", buildAuthContext(user, apiToken, org, role))
+		scope.SetContext("Request", buildRequestContext(ctx, req))
+	})
+}
+
+// buildAuthContext creates a map of the user and membership information
+func buildAuthContext(user *usercontext.User, apiToken *usercontext.APIToken, org *usercontext.Org, role string) map[string]interface{} {
+	if org == nil {
+		return nil
+	}
+
+	val := map[string]interface{}{
+		"orgID":   org.ID,
+		"orgName": org.Name,
+		"role":    role,
+	}
+
+	if user != nil {
+		val["id"] = user.ID
+		val["serviceAccount"] = false
+	} else if apiToken != nil {
+		val["id"] = apiToken.ID
+		val["serviceAccount"] = true
+	}
+
+	return val
+}
+
+// buildRequestContext creates a map of the request information
+func buildRequestContext(ctx context.Context, req interface{}) map[string]interface{} {
+	var protocol, operation string
+
+	if info, ok := transport.FromServerContext(ctx); ok {
+		protocol = info.Kind().String()
+		operation = info.Operation()
+	}
+
+	return map[string]interface{}{
+		"protocol":   protocol,
+		"operation":  operation,
+		"args":       extractArgs(req),
+		"request-id": extractTracingIDFromMetadata(ctx),
+	}
+}
+
+// extractTracingIDFromMetadata extracts the tracing ID from the metadata.
+func extractTracingIDFromMetadata(ctx context.Context) string {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ""
+	}
+
+	for _, header := range defaultTracingHeaders {
+		if val := md.Get(header); len(val) != 0 {
+			return val[0]
+		}
+	}
+
+	return ""
+}
+
+// extractArgs returns the string of the req
+func extractArgs(req interface{}) string {
+	if redacter, ok := req.(logging.Redacter); ok {
+		return redacter.Redact()
+	}
+	if stringer, ok := req.(fmt.Stringer); ok {
+		return stringer.String()
+	}
+	return fmt.Sprintf("%+v", req)
+}

--- a/app/controlplane/internal/sentrycontext/sentry_context.go
+++ b/app/controlplane/internal/sentrycontext/sentry_context.go
@@ -49,6 +49,7 @@ func addSentryContext(ctx context.Context, req interface{}) {
 	apiToken := usercontext.CurrentAPIToken(ctx)
 	role := usercontext.CurrentAuthzSubject(ctx)
 
+	// ConfigureScope allows to set context that will be sent along with the error if one occurs
 	sentry.ConfigureScope(func(scope *sentry.Scope) {
 		scope.SetContext("Account", buildAuthContext(user, apiToken, org, role))
 		scope.SetContext("Request", buildRequestContext(ctx, req))
@@ -112,6 +113,7 @@ func extractTracingIDFromMetadata(ctx context.Context) string {
 }
 
 // extractArgs returns the string of the req
+// Logic extracted from: https://github.com/go-kratos/kratos/blob/f8b97f675b32dfad02edae12d83053c720720b5b/middleware/logging/logging.go#L103
 func extractArgs(req interface{}) string {
 	if redacter, ok := req.(logging.Redacter); ok {
 		return redacter.Redact()

--- a/app/controlplane/internal/sentrycontext/sentry_context_test.go
+++ b/app/controlplane/internal/sentrycontext/sentry_context_test.go
@@ -1,0 +1,146 @@
+//
+// Copyright 2024 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sentrycontext
+
+import (
+	"context"
+	"testing"
+
+	"github.com/chainloop-dev/chainloop/app/controlplane/internal/usercontext"
+
+	"github.com/go-kratos/kratos/v2/transport"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/metadata"
+)
+
+var _ transport.Transporter = (*testingTransport)(nil)
+
+type testingTransport struct {
+	kind      transport.Kind
+	endpoint  string
+	operation string
+}
+
+func (tr *testingTransport) Kind() transport.Kind {
+	return tr.kind
+}
+
+func (tr *testingTransport) Endpoint() string {
+	return tr.endpoint
+}
+
+func (tr *testingTransport) Operation() string {
+	return tr.operation
+}
+
+func (tr *testingTransport) RequestHeader() transport.Header {
+	return nil
+}
+
+func (tr *testingTransport) ReplyHeader() transport.Header {
+	return nil
+}
+
+func TestNewSentryContext(t *testing.T) {
+	handler := func(_ context.Context, _ interface{}) (interface{}, error) {
+		return "response", nil
+	}
+
+	middleware := NewSentryContext()
+	_, err := middleware(handler)(context.Background(), "request")
+	assert.NoError(t, err)
+}
+
+func TestBuildAuthContext(t *testing.T) {
+	org := &usercontext.Org{ID: "org1", Name: "OrgName"}
+	user := &usercontext.User{ID: "user1"}
+	apiToken := &usercontext.APIToken{ID: "token1"}
+	role := "admin"
+
+	t.Run("with user and org", func(t *testing.T) {
+		authContext := buildAuthContext(user, nil, org, role)
+		assert.NotNil(t, authContext)
+		assert.Equal(t, "user1", authContext["id"])
+		assert.Equal(t, false, authContext["serviceAccount"])
+		assert.Equal(t, "org1", authContext["orgID"])
+		assert.Equal(t, "OrgName", authContext["orgName"])
+		assert.Equal(t, "admin", authContext["role"])
+	})
+
+	t.Run("with apiToken and org", func(t *testing.T) {
+		authContext := buildAuthContext(nil, apiToken, org, role)
+		assert.NotNil(t, authContext)
+		assert.Equal(t, "token1", authContext["id"])
+		assert.Equal(t, true, authContext["serviceAccount"])
+		assert.Equal(t, "org1", authContext["orgID"])
+		assert.Equal(t, "OrgName", authContext["orgName"])
+		assert.Equal(t, "admin", authContext["role"])
+	})
+
+	t.Run("with nil org", func(t *testing.T) {
+		authContext := buildAuthContext(user, nil, nil, role)
+		assert.Nil(t, authContext)
+	})
+
+	t.Run("with nil user and apiToken", func(t *testing.T) {
+		authContext := buildAuthContext(nil, nil, org, role)
+		assert.NotNil(t, authContext)
+	})
+}
+
+func TestBuildRequestContext(t *testing.T) {
+	ctx := context.Background()
+	req := "request"
+
+	t.Run("with transport info", func(t *testing.T) {
+		ctx := transport.NewServerContext(ctx, &testingTransport{
+			kind:      transport.KindGRPC,
+			operation: "TestOperation",
+		})
+		requestContext := buildRequestContext(ctx, req)
+		assert.NotNil(t, requestContext)
+		assert.Equal(t, "grpc", requestContext["protocol"])
+		assert.Equal(t, "TestOperation", requestContext["operation"])
+	})
+
+	t.Run("without transport info", func(t *testing.T) {
+		requestContext := buildRequestContext(ctx, req)
+		assert.NotNil(t, requestContext)
+		assert.Equal(t, "", requestContext["protocol"])
+		assert.Equal(t, "", requestContext["operation"])
+	})
+}
+
+func TestExtractTracingIDFromMetadata(t *testing.T) {
+	t.Run("with tracing headers", func(t *testing.T) {
+		md := metadata.New(map[string]string{"X-Request-ID": "request-id"})
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+		tracingID := extractTracingIDFromMetadata(ctx)
+		assert.Equal(t, "request-id", tracingID)
+	})
+
+	t.Run("without tracing headers", func(t *testing.T) {
+		ctx := context.Background()
+		tracingID := extractTracingIDFromMetadata(ctx)
+		assert.Equal(t, "", tracingID)
+	})
+}
+
+func TestExtractArgs(t *testing.T) {
+	req := "request"
+	args := extractArgs(req)
+	assert.Equal(t, "request", args)
+}

--- a/app/controlplane/internal/server/grpc.go
+++ b/app/controlplane/internal/server/grpc.go
@@ -23,6 +23,7 @@ import (
 
 	v1 "github.com/chainloop-dev/chainloop/app/controlplane/api/controlplane/v1"
 	conf "github.com/chainloop-dev/chainloop/app/controlplane/internal/conf/controlplane/config/v1"
+	"github.com/chainloop-dev/chainloop/app/controlplane/internal/sentrycontext"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/usercontext/attjwtmiddleware"
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/authz"
 	authzMiddleware "github.com/chainloop-dev/chainloop/app/controlplane/pkg/authz/middleware"
@@ -215,6 +216,9 @@ func craftMiddleware(opts *Opts) []middleware.Middleware {
 			usercontext.WithAttestationContextFromAPIToken(opts.APITokenUseCase, opts.OrganizationUseCase, logHelper),
 		).Match(requireRobotAccountMatcher()).Build(),
 	)
+
+	// Include the Sentry Context Interceptor
+	middlewares = append(middlewares, sentrycontext.NewSentryContext())
 
 	return middlewares
 }


### PR DESCRIPTION
This patch creates a new Sentry Context interceptor that populates the request context of a possible Sentry exception to include the information about the user and the request.