### PR TITLE
feat(docs): document policy inputs

### DIFF
--- a/docs/docs/guides/rego-policies/rego-policies.mdx
+++ b/docs/docs/guides/rego-policies/rego-policies.mdx
@@ -91,6 +91,54 @@ policies:
 ```
 Check our [policies reference](/reference/policies) for more information on how to attach policies to contracts.
 
+## Policy inputs
+As we can see in the above examples, Rego policies will receive and `inputs` variable with all the payload to be evaluated. Chainloop will inject the evidence payload into that variable, for example a CycloneDX JSON document.
+This way, `input.specVersion` will denote the version of the CycloneDX document.
+
+Additionally, Chainloop will inject the following fields:
+* `input.args`: the list of arguments passed to the policy from the contract or the policy group. Each argument becomes a field in the `args` input:
+  ```json
+    // input.args
+    {
+      "severity": "MEDIUM",
+      "foo": "bar",
+      "licenses": ["AGPL-1.0-only", "AGPL-1.0-or-later"]
+    }
+  ```
+    All arguments are passed as `String` type. So if you expect a numeric value you'll need to convert it with the `to_number` Rego builtin.
+
+    Also, for convenience, comma-separated values are parsed and injected as arrays, as in the above example.
+
+* `input.chainloop_metadata`: This is an In-toto descriptor JSON representation of the evidence, which Chainloop generates and stores in the attestation. Developers can create policies that check for specific fields in this payload.
+
+    A typical `chainloop_metadata` field will look like this:
+    ```json
+    {
+      "chainloop_metadata" : {
+        "name" : "registry-1.docker.io/bitnamicharts/chainloop",
+        "digest" : {
+          "sha256" : "2af5745f843476bd781663eea84d3bd6bcd7a9cb9fcd54ce10cf48142bed2151"
+        },
+        "annotations" : {
+          "chainloop.material.image.tag" : "2.0.21",
+          "chainloop.material.name" : "material-1731339792439159000",
+          "chainloop.material.signature" : "eyJzY2hlbWFWZXJzaW9uIjoyLCJtZWRpYVR5cGUiOiJhcHBsaWNhdGlvbi92bmQub2NpLmltYWdlLm1hbmlmZXN0LnYxK2pzb24iLCJjb25maWciOnsibWVkaWFUeXBlIjoiYXBwbGljYXRpb24vdm5kLmNuY2Yubm90YXJ5LnNpZ25hdHVyZSIsImRpZ2VzdCI6InNoYTI1Njo0NDEzNmZhMzU1YjM2NzhhMTE0NmFkMTZmN2U4NjQ5ZTk0ZmI0ZmMyMWZlNzdlODMxMGMwNjBmNjFjYWFmZjhhIiwic2l6ZSI6Mn0sImxheWVycyI6W3sibWVkaWFUeXBlIjoiYXBwbGljYXRpb24vam9zZStqc29uIiwiZGlnZXN0Ijoic2hhMjU2OmMwYWFlMzc5ODE4Zjk2NDQ5Nzk1OGMzNGM4NWZhYzU0MWFiZjgyZDlhMTUxZDBlZDg2MmM4ODE0OWE3ZjQxNmUiLCJzaXplIjo3OTQ3fV0sInN1YmplY3QiOnsibWVkaWFUeXBlIjoiYXBwbGljYXRpb24vdm5kLm9jaS5pbWFnZS5tYW5pZmVzdC52MStqc29uIiwiZGlnZXN0Ijoic2hhMjU2OjJhZjU3NDVmODQzNDc2YmQ3ODE2NjNlZWE4NGQzYmQ2YmNkN2E5Y2I5ZmNkNTRjZTEwY2Y0ODE0MmJlZDIxNTEiLCJzaXplIjo0ODV9LCJhbm5vdGF0aW9ucyI6eyJpby5jbmNmLm5vdGFyeS54NTA5Y2hhaW4udGh1bWJwcmludCNTMjU2IjoiW1wiODM0NDQ2Y2E1ZDk5Mzg2NTYxYjc0OWQ3MjdlNTI1ODU3ZjU3ZDlhNjY3NDRhZjYzZmMxY2I3YzcyNzYyZTA4ZlwiLFwiNzBhMzlkMWQ1Y2Y4ZDVhMWVkNzBiYmM1YWM1NjA5M2JhZDEzYzUyOTdiMzdkOTZiNTFkZDkxZThjYzZiM2IxNlwiLFwiYzQ0MWYzMzBiMzNhYzI2ODc0NWUzYzFkZTcwZjRiYTRjNzY1OTEzNGUwODQyNWY0N2JjOTQ2ZmZiNDgxMjc2NlwiXSIsIm9yZy5vcGVuY29udGFpbmVycy5pbWFnZS5jcmVhdGVkIjoiMjAyNC0xMS0wOFQxMTo0MzoxNVoifX0=",
+          "chainloop.material.signature.digest" : "sha256:2e3aded29ba4266d4c682694c5b45585fa0a3d92bd1ea9bfd52448528c7eb6f5",
+          "chainloop.material.signature.provider" : "notary",
+          "chainloop.material.type" : "HELM_CHART"
+        }
+      }
+    }
+    ```
+    Besides the basic information (name, digest) of the evidence, the `annotations` field will contain some useful metadata gathered by Chainloop during the attestation process.
+    The example above corresponds to an OCI HELM_CHART evidence, for which Chainloop is able to detect the `notary` signature. You can write, for example, a policy that validates that your assets are properly signed, like this:
+    ```go
+    violations contains msg if {
+        not input.chainloop_metadata.annotations["chainloop.material.signature"]
+        msg := sprintf("Signature not found for material '%s'", [input.chainloop_metadata.name])
+    }
+    ```
+
 ## Policy engine constraints (Rego)
 To ensure the policy engine work as pure and as fast as possible, we have deactivated some of the OPA built-in functions. The following functions are not allowed in the policy scripts:
 - `opa.runtime`


### PR DESCRIPTION
New "Policy inputs" section in the Rego policies reference, documenting `inputs`, `args` and `chainloop_metadata` fields.