### PR TITLE
fix: Remove sbom-spdx from policy check

### DIFF
--- a/.github/workflows/contracts/chainloop-docs-release.yml
+++ b/.github/workflows/contracts/chainloop-docs-release.yml
@@ -16,8 +16,3 @@ policyGroups:
       sbom_name: sbom-cdx
       bannedLicenses: AGPL-1.0-only, AGPL-1.0-or-later, AGPL-3.0-only, AGPL-3.0-or-later
       bannedComponents: log4j@2.14.1
-  - ref: sbom-quality
-    with:
-      sbom_name: sbom-spdx
-      bannedLicenses: AGPL-1.0-only, AGPL-1.0-or-later, AGPL-3.0-only, AGPL-3.0-or-later
-      bannedComponents: log4j@2.14.1


### PR DESCRIPTION
Our current policy group doesn't support SPDX right away. Let's remove this check until it's resolved.
