### PR TITLE
fix(policies): report rendered args in evaluations

### DIFF
--- a/pkg/policies/policies.go
+++ b/pkg/policies/policies.go
@@ -180,7 +180,7 @@ func (pv *PolicyVerifier) evaluatePolicyAttachment(ctx context.Context, attachme
 		Violations:      engineEvaluationsToAPIViolations(evalResults),
 		Annotations:     policy.GetMetadata().GetAnnotations(),
 		Description:     policy.GetMetadata().GetDescription(),
-		With:            attachment.GetWith(),
+		With:            args,
 		Type:            opts.kind,
 		ReferenceName:   ref.GetURI(),
 		ReferenceDigest: ref.GetDigest(),


### PR DESCRIPTION
This small PR fixes args in policy evaluations when they have placeholders, rendering the final computed value.
```
            {
               "annotations": {
                  "category": "sbom, security"
               },
...
               "skipped": false,
               "type": "SBOM_CYCLONEDX_JSON",
               "with": {
                  "components": "log4j@2.14.1"
               }
```
Fixes #1509 