### PR TITLE
feat(ci): Add reusable workflow for GitHub release

### DIFF
--- a/.github/workflows/build_and_package.yaml
+++ b/.github/workflows/build_and_package.yaml
@@ -137,6 +137,11 @@ jobs:
             automated
             helm
 
+      - name: Trigger GitHub Release workflow
+        uses: chainloop-dev/chainloop/.github/workflows/release.yaml@main
+        with:
+          tag: ${{ github.ref_name }}
+
       - name: Mark attestation as failed
         if: ${{ failure() }}
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,11 @@
 name: Release
 
 on:
-  release:
+  workflow_call:
+    inputs:
+      tag:
+        type: string
+        required: true
 
 jobs:
   # This reusable workflow inspects if the given workflow_name exists on Chainloop. If the Workflow does not exist
@@ -9,6 +13,7 @@ jobs:
   # be ignored and the process will continue. For this to work it's using a pre-created API Token
   onboard_workflow:
     name: Onboard Chainloop Workflow
+    if: inputs.tag != null && github.event_name == 'workflow_call'
     uses: chainloop-dev/labs/.github/workflows/chainloop_onboard.yml@64839eb68c20fefda46929c6c6e893cdf0537619
     with:
       project: "chainloop"
@@ -18,6 +23,7 @@ jobs:
 
   release:
     name: Record release from GitHub
+    if: inputs.tag != null && github.event_name == 'workflow_call'
     runs-on: ubuntu-latest
     needs: onboard_workflow
     permissions:
@@ -37,12 +43,12 @@ jobs:
 
       - name: Initialize Attestation
         run: |
-          tag=$(echo -n ${{github.ref}} | cut -d / -f3)
+          tag=$(echo -n ${{inputs.tag}} | cut -d / -f3)
           chainloop attestation init --workflow ${CHAINLOOP_WORKFLOW_NAME} --project ${CHAINLOOP_PROJECT} --version "$tag"
 
       - name: Attest all assets
         run: |
-          tag=$(echo -n ${{github.ref}} | cut -d / -f3)
+          tag=$(echo -n ${{inputs.tag}} | cut -d / -f3)
           gh release download $tag -D /tmp/github-release
           for entry in $(ls /tmp/github-release); do
             # If the name is cas.cyclonedx.json, controlplane.cyclonedx.json or cli.cyclonedx.json, we need to add the attestation with the correct name


### PR DESCRIPTION
This patch changes the definition of the `release` workflow to be a reusable workflow. This workflow will be called once the release process done by Goreleaser is done, so we can attest the whole GitHub release by passing the tag information.