### PR TITLE
fix(integration): Add missing project name

### DIFF
--- a/app/cli/cmd/attached_integration_add.go
+++ b/app/cli/cmd/attached_integration_add.go
@@ -22,7 +22,7 @@ import (
 
 func newAttachedIntegrationAttachCmd() *cobra.Command {
 	var options []string
-	var integrationName, workflowName string
+	var integrationName, workflowName, projectName string
 
 	cmd := &cobra.Command{
 		Use:     "add",
@@ -52,7 +52,7 @@ func newAttachedIntegrationAttachCmd() *cobra.Command {
 				return err
 			}
 
-			res, err := action.NewAttachedIntegrationAdd(actionOpts).Run(integrationName, workflowName, opts)
+			res, err := action.NewAttachedIntegrationAdd(actionOpts).Run(integrationName, workflowName, projectName, opts)
 			if err != nil {
 				return err
 			}
@@ -66,6 +66,9 @@ func newAttachedIntegrationAttachCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&workflowName, "workflow", "", "name of the workflow to attach this integration")
 	cobra.CheckErr(cmd.MarkFlagRequired("workflow"))
+
+	cmd.Flags().StringVar(&workflowName, "project", "", "name of the project the workflow belongs to")
+	cobra.CheckErr(cmd.MarkFlagRequired("project"))
 
 	// StringSlice seems to struggle with comma-separated values such as p12 jsonKeys provided as passwords
 	// So we need to use StringArrayVar instead

--- a/app/cli/cmd/attached_integration_list.go
+++ b/app/cli/cmd/attached_integration_list.go
@@ -27,13 +27,13 @@ import (
 )
 
 func newAttachedIntegrationListCmd() *cobra.Command {
-	var workflowName string
+	var workflowName, projectName string
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List integrations attached to workflows",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			res, err := action.NewAttachedIntegrationList(actionOpts).Run(workflowName)
+			res, err := action.NewAttachedIntegrationList(actionOpts).Run(projectName, workflowName)
 			if err != nil {
 				return err
 			}
@@ -43,6 +43,9 @@ func newAttachedIntegrationListCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&workflowName, "workflow", "", "workflow name")
+	cmd.Flags().StringVar(&projectName, "project", "", "project name")
+	// Add Required flags
+	cobra.CheckErr(cmd.MarkFlagRequired("project"))
 	return cmd
 }
 

--- a/app/cli/internal/action/attached_integration_add.go
+++ b/app/cli/internal/action/attached_integration_add.go
@@ -30,7 +30,7 @@ func NewAttachedIntegrationAdd(cfg *ActionsOpts) *AttachedIntegrationAdd {
 	return &AttachedIntegrationAdd{cfg}
 }
 
-func (action *AttachedIntegrationAdd) Run(integrationName, workflowName string, options map[string]any) (*AttachedIntegrationItem, error) {
+func (action *AttachedIntegrationAdd) Run(integrationName, workflowName, projectName string, options map[string]any) (*AttachedIntegrationItem, error) {
 	client := pb.NewIntegrationsServiceClient(action.cfg.CPConnection)
 
 	requestConfig, err := structpb.NewStruct(options)
@@ -39,7 +39,10 @@ func (action *AttachedIntegrationAdd) Run(integrationName, workflowName string, 
 	}
 
 	resp, err := client.Attach(context.Background(), &pb.IntegrationsServiceAttachRequest{
-		WorkflowName: workflowName, IntegrationName: integrationName, Config: requestConfig,
+		WorkflowName:    workflowName,
+		ProjectName:     projectName,
+		IntegrationName: integrationName,
+		Config:          requestConfig,
 	})
 	if err != nil {
 		return nil, err

--- a/app/cli/internal/action/attached_integration_list.go
+++ b/app/cli/internal/action/attached_integration_list.go
@@ -29,10 +29,13 @@ func NewAttachedIntegrationList(cfg *ActionsOpts) *AttachedIntegrationList {
 	return &AttachedIntegrationList{cfg}
 }
 
-func (action *AttachedIntegrationList) Run(workflowName string) ([]*AttachedIntegrationItem, error) {
+func (action *AttachedIntegrationList) Run(projectName, workflowName string) ([]*AttachedIntegrationItem, error) {
 	client := pb.NewIntegrationsServiceClient(action.cfg.CPConnection)
 
-	resp, err := client.ListAttachments(context.Background(), &pb.ListAttachmentsRequest{WorkflowName: workflowName})
+	resp, err := client.ListAttachments(context.Background(), &pb.ListAttachmentsRequest{
+		ProjectName:  projectName,
+		WorkflowName: workflowName,
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This pull request introduces changes to the CLI commands for attaching and listing integrations, adding support for specifying a project name. The most important changes include modifying the command functions to accept and require a project name, and updating the corresponding action methods to handle the project name.