### PR TITLE
fix(ci): Remove GitHub release pipeline

### DIFF
--- a/.github/workflows/build_and_package.yaml
+++ b/.github/workflows/build_and_package.yaml
@@ -145,9 +145,3 @@ jobs:
         if: ${{ cancelled() }}
         run: |
           chainloop attestation reset --trigger cancellation
-
-  github-release:
-   if: github.ref_type == 'tag' # Guard to make sure we are releasing once
-   uses: chainloop-dev/chainloop/.github/workflows/release.yaml@main
-   with:
-     tag: ${{ github.ref_name }}


### PR DESCRIPTION
Remove the call to GitHub release reusable workflow altogether.