### PR TITLE
fix(ci): Include GitHub release workflow with proper permissions

### DIFF
--- a/.github/workflows/build_and_package.yaml
+++ b/.github/workflows/build_and_package.yaml
@@ -145,3 +145,12 @@ jobs:
         if: ${{ cancelled() }}
         run: |
           chainloop attestation reset --trigger cancellation
+
+  github-release:
+    if: github.ref_type == 'tag' # Guard to make sure we are releasing once
+    uses: chainloop-dev/chainloop/.github/workflows/release.yaml@main
+    with:
+      tag: ${{ github.ref_name }}
+    permissions:
+      packages: write
+      contents: write


### PR DESCRIPTION
This pull request includes an important change to the GitHub Actions workflow configuration to automate the release process when a tag is pushed.

Changes to GitHub Actions workflow:

* [`.github/workflows/build_and_package.yaml`](diffhunk://#diff-6da07ad9f67c905cf311036b9b3ae522ff5a7af74dab5c6d91f2aa00f154ef40R148-R156): Added a `github-release` job that triggers when a tag is pushed. This job uses the `chainloop-dev/chainloop/.github/workflows/release.yaml` workflow to handle the release process, including setting permissions to write packages and contents.