### PR TITLE
fix(github-release): Add job dependency

### DIFF
--- a/.github/workflows/build_and_package.yaml
+++ b/.github/workflows/build_and_package.yaml
@@ -147,6 +147,7 @@ jobs:
           chainloop attestation reset --trigger cancellation
 
   github-release:
+    needs: release
     if: github.ref_type == 'tag' # Guard to make sure we are releasing once
     uses: chainloop-dev/chainloop/.github/workflows/release.yaml@main
     with:


### PR DESCRIPTION
This patch adds a job dependency to the previous job so it waits until it's done to proceed.