### PR TITLE
feat: support overriding state path

### DIFF
--- a/app/cli/internal/action/action.go
+++ b/app/cli/internal/action/action.go
@@ -60,7 +60,12 @@ func newCrafter(enableRemoteState bool, conn *grpc.ClientConn, opts ...crafter.N
 	case true:
 		stateManager, err = remote.New(pb.NewAttestationStateServiceClient(conn), c.Logger)
 	case false:
-		stateManager, err = filesystem.New(filepath.Join(os.TempDir(), "chainloop-attestation.tmp.json"))
+		attestationStatePath := filepath.Join(os.TempDir(), "chainloop-attestation.tmp.json")
+		if path := os.Getenv("CHAINLOOP_ATTESTATION_STATE_PATH"); path != "" {
+			attestationStatePath = path
+		}
+
+		stateManager, err = filesystem.New(attestationStatePath)
 	}
 
 	if err != nil {


### PR DESCRIPTION
option to override the default state path for local-based attestation process.

I decided to not to expose it through flags yet since it's a debugging feature for now (will be used for load testing), and I am not sure it's worth exposing