### PR TITLE
chore: set default cobra output to os.Stdout

### DIFF
--- a/app/cli/cmd/root.go
+++ b/app/cli/cmd/root.go
@@ -157,7 +157,6 @@ func NewRootCmd(l zerolog.Logger) *cobra.Command {
 		},
 	}
 
-	rootCmd.SetOut(os.Stdout)
 	rootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
 
 	rootCmd.PersistentFlags().StringVarP(&flagCfgFile, "config", "c", "", "Path to an existing config file (default is $HOME/.config/chainloop/config.toml)")

--- a/app/cli/cmd/root.go
+++ b/app/cli/cmd/root.go
@@ -157,6 +157,7 @@ func NewRootCmd(l zerolog.Logger) *cobra.Command {
 		},
 	}
 
+	rootCmd.SetOut(os.Stdout)
 	rootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
 
 	rootCmd.PersistentFlags().StringVarP(&flagCfgFile, "config", "c", "", "Path to an existing config file (default is $HOME/.config/chainloop/config.toml)")

--- a/app/cli/cmd/version.go
+++ b/app/cli/cmd/version.go
@@ -39,7 +39,7 @@ func NewVersionCmd() *cobra.Command {
 		Use:   "version",
 		Short: "Command line version",
 		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Printf("%s version %s\n", appName, Version)
+			fmt.Printf("%s version %s\n", appName, Version)
 		},
 	}
 }


### PR DESCRIPTION
cobra output is used by `cmd.Printf` family of commands. It was sending its ouput to stderr by default.
This way, `chainloop version` can be used in automations (eg. to check the version is correct after downloading the CLI)

Before:
```shell
> chainloop version > version.txt
> cat version.txt
```
Now:
```shell
> chainloop version > version.txt
> cat version.txt
chainloop version dev
```
