### PR TITLE
chore: improve performance project creation

### DIFF
--- a/app/controlplane/pkg/data/workflowrun.go
+++ b/app/controlplane/pkg/data/workflowrun.go
@@ -49,7 +49,7 @@ func NewWorkflowRunRepo(data *Data, logger log.Logger) biz.WorkflowRunRepo {
 
 func (r *WorkflowRunRepo) Create(ctx context.Context, opts *biz.WorkflowRunRepoCreateOpts) (run *biz.WorkflowRun, err error) {
 	// Create version and workflow in a transaction
-	tx, err := r.data.DB.Debug().Tx(ctx)
+	tx, err := r.data.DB.Tx(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("starting transaction: %w", err)
 	}


### PR DESCRIPTION
the following query has a locking issue when performing an attestation on the same run with the same version.

```
INSERT INTO "project_versions" ("version", "created_at", "prerelease", "project_id", "id") VALUES ($1, $2, $3, $4, $5) ON CONFLICT ("version", "project_id") WHERE "deleted_at" IS NULL DO UPDATE SET "version" = "project_versions"."version", "created_at" = "project_versions"."created_at", "prerelease" = "project_versions"."prerelease", "project_id" = "project_versions"."project_id", "id" = "project_versions"."id" RETURNING "id"
```
![image](https://github.com/user-attachments/assets/d34f825f-2dcb-4c2a-941a-9b885f8bd64c)


This PR adds a guard to the method that queries in advance the version instead of relying on the upsert mechanism always.
 
ref #1533 