### PR TITLE
chore: downgrade pgx

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0
 	github.com/in-toto/attestation v0.1.1-0.20231010121940-09a03152c04a
 	github.com/invopop/jsonschema v0.7.0
-	github.com/jackc/pgx/v5 v5.7.1
+	github.com/jackc/pgx/v5 v5.5.4
 	github.com/muesli/reflow v0.3.0
 	github.com/open-policy-agent/opa v0.68.0
 	github.com/openvex/go-vex v0.2.5

--- a/go.sum
+++ b/go.sum
@@ -903,8 +903,8 @@ github.com/jackc/pgx/v4 v4.12.1-0.20210724153913-640aa07df17c/go.mod h1:1QD0+tgS
 github.com/jackc/pgx/v4 v4.18.1/go.mod h1:FydWkUyadDmdNH/mHnGob881GawxeEm7TcMCzkb+qQE=
 github.com/jackc/pgx/v4 v4.18.2 h1:xVpYkNR5pk5bMCZGfClbO962UIqVABcAGt7ha1s/FeU=
 github.com/jackc/pgx/v4 v4.18.2/go.mod h1:Ey4Oru5tH5sB6tV7hDmfWFahwF15Eb7DNXlRKx2CkVw=
-github.com/jackc/pgx/v5 v5.7.1 h1:x7SYsPBYDkHDksogeSmZZ5xzThcTgRz++I5E+ePFUcs=
-github.com/jackc/pgx/v5 v5.7.1/go.mod h1:e7O26IywZZ+naJtWWos6i6fvWK+29etgITqrqHLfoZA=
+github.com/jackc/pgx/v5 v5.5.4 h1:Xp2aQS8uXButQdnCMWNmvx6UysWQQC+u1EoizjguY+8=
+github.com/jackc/pgx/v5 v5.5.4/go.mod h1:ez9gk+OAat140fv9ErkZDYFWmXLfV+++K0uAOiwgm1A=
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=

--- a/go.sum
+++ b/go.sum
@@ -908,7 +908,6 @@ github.com/jackc/pgx/v5 v5.5.4/go.mod h1:ez9gk+OAat140fv9ErkZDYFWmXLfV+++K0uAOiw
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
-github.com/jackc/puddle v1.3.0 h1:eHK/5clGOatcjX3oWGBO/MpxpbHzSwud5EWTSCI+MX0=
 github.com/jackc/puddle v1.3.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=

--- a/go.sum
+++ b/go.sum
@@ -908,6 +908,7 @@ github.com/jackc/pgx/v5 v5.5.4/go.mod h1:ez9gk+OAat140fv9ErkZDYFWmXLfV+++K0uAOiw
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
+github.com/jackc/puddle v1.3.0 h1:eHK/5clGOatcjX3oWGBO/MpxpbHzSwud5EWTSCI+MX0=
 github.com/jackc/puddle v1.3.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=


### PR DESCRIPTION
We've having some issues lately at boot and I want to make sure if it was related to the upgrade I made here https://github.com/chainloop-dev/chainloop/issues/1562

```
github.com/go-kratos/kratos/v2.(*App).Run.func2()
	/home/runner/go/pkg/mod/github.com/go-kratos/kratos/v2@v2.7.0/app.go:112 +0x62
golang.org/x/sync/errgroup.(*Group).Go.func1()
	/home/runner/go/pkg/mod/golang.org/x/sync@v0.9.0/errgroup/errgroup.go:78 +0x50
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 1
	/home/runner/go/pkg/mod/golang.org/x/sync@v0.9.0/errgroup/errgroup.go:75 +0x96

goroutine 840 [IO wait]:
internal/poll.runtime_pollWait(0x7f7ffe8c6120, 0x72)
	/opt/hostedtoolcache/go/1.23.1/x64/src/runtime/netpoll.go:351 +0x85
internal/poll.(*pollDesc).wait(0xc000f10480?, 0xc0002be600?, 0x0)
	/opt/hostedtoolcache/go/1.23.1/x64/src/internal/poll/fd_poll_runtime.go:84 +0x27
internal/poll.(*pollDesc).waitRead(...)
	/opt/hostedtoolcache/go/1.23.1/x64/src/internal/poll/fd_poll_runtime.go:89
internal/poll.(*FD).Read(0xc000f10480, {0xc0002be600, 0x1300, 0x1300})
	/opt/hostedtoolcache/go/1.23.1/x64/src/internal/poll/fd_unix.go:165 +0x27a
net.(*netFD).Read(0xc000f10480, {0xc0002be600?, 0x410b5e?, 0xc00137b9a0?})
	/opt/hostedtoolcache/go/1.23.1/x64/src/net/fd_posix.go:55 +0x25
net.(*conn).Read(0xc00014bc88, {0xc0002be600?, 0xc000fea0a0?, 0xc0002be83e?})
	/opt/hostedtoolcache/go/1.23.1/x64/src/net/net.go:189 +0x45
crypto/tls.(*atLeastReader).Read(0xc00191e0f0, {0xc0002be600?, 0x0?, 0xc00191e0f0?})
	/opt/hostedtoolcache/go/1.23.1/x64/src/crypto/tls/conn.go:809 +0x3b
bytes.(*Buffer).ReadFrom(0xc0010b9438, {0x319f120, 0xc00191e0f0})
	/opt/hostedtoolcache/go/1.23.1/x64/src/bytes/buffer.go:211 +0x98
crypto/tls.(*Conn).readFromUntil(0xc0010b9188, {0x319fbc0, 0xc00014bc88}, 0xc00137ba10?)
	/opt/hostedtoolcache/go/1.23.1/x64/src/crypto/tls/conn.go:831 +0xde
crypto/tls.(*Conn).readRecordOrCCS(0xc0010b9188, 0x0)
	/opt/hostedtoolcache/go/1.23.1/x64/src/crypto/tls/conn.go:629 +0x3cf
crypto/tls.(*Conn).readRecord(...)
	/opt/hostedtoolcache/go/1.23.1/x64/src/crypto/tls/conn.go:591
crypto/tls.(*Conn).Read(0xc0010b9188, {0xc001374000, 0x1000, 0xc001043c00?})
	/opt/hostedtoolcache/go/1.23.1/x64/src/crypto/tls/conn.go:1385 +0x150
bufio.(*Reader).Read(0xc000b64f60, {0xc0007a2740, 0x9, 0x4955e50?})
	/opt/hostedtoolcache/go/1.23.1/x64/src/bufio/bufio.go:241 +0x197
io.ReadAtLeast({0x319d220, 0xc000b64f60}, {0xc0007a2740, 0x9, 0x9}, 0x9)
	/opt/hostedtoolcache/go/1.23.1/x64/src/io/io.go:335 +0x90
io.ReadFull(...)
	/opt/hostedtoolcache/go/1.23.1/x64/src/io/io.go:354
net/http.http2readFrameHeader({0xc0007a2740, 0x9, 0xc000b90360?}, {0x319d220?, 0xc000b64f60?})
	/opt/hostedtoolcache/go/1.23.1/x64/src/net/http/h2_bundle.go:1642 +0x65
net/http.(*http2Framer).ReadFrame(0xc0007a2700)
	/opt/hostedtoolcache/go/1.23.1/x64/src/net/http/h2_bundle.go:1909 +0x85
net/http.(*http2clientConnReadLoop).run(0xc00137bfa8)
	/opt/hostedtoolcache/go/1.23.1/x64/src/net/http/h2_bundle.go:9496 +0xda
net/http.(*http2ClientConn).readLoop(0xc000597200)
	/opt/hostedtoolcache/go/1.23.1/x64/src/net/http/h2_bundle.go:9392 +0x7c
created by net/http.(*http2Transport).newClientConn in goroutine 839
	/opt/hostedtoolcache/go/1.23.1/x64/src/net/http/h2_bundle.go:8006 +0xd1b

goroutine 856 [runnable]:
syscall.Syscall(0x1, 0x1c, 0xc001046000, 0x13d)
	/opt/hostedtoolcache/go/1.23.1/x64/src/syscall/syscall_linux.go:73 +0x25
syscall.write(0xc001562700?, {0xc001046000?, 0xc001a7e000?, 0x9a01dc?})
	/opt/hostedtoolcache/go/1.23.1/x64/src/syscall/zsyscall_linux_amd64.go:964 +0x3b
syscall.Write(...)
	/opt/hostedtoolcache/go/1.23.1/x64/src/syscall/syscall_unix.go:211
internal/poll.ignoringEINTRIO(...)
	/opt/hostedtoolcache/go/1.23.1/x64/src/internal/poll/fd_unix.go:745
internal/poll.(*FD).Write(0xc001562700, {0xc001046000, 0x13d, 0x140})
	/opt/hostedtoolcache/go/1.23.1/x64/src/internal/poll/fd_unix.go:381 +0x394
net.(*netFD).Write(0xc001562700, {0xc001046000?, 0xc000100008?, 0x7f804538ff18?})
	/opt/hostedtoolcache/go/1.23.1/x64/src/net/fd_posix.go:96 +0x25
net.(*conn).Write(0xc000188018, {0xc001046000?, 0x416601?, 0xc0016c5580?})
	/opt/hostedtoolcache/go/1.23.1/x64/src/net/net.go:201 +0x45
crypto/tls.(*Conn).write(0xc0010b8a88, {0xc001046000?, 0x5?, 0x5?})
	/opt/hostedtoolcache/go/1.23.1/x64/src/crypto/tls/conn.go:948 +0x109
crypto/tls.(*Conn).writeRecordLocked(0xc0010b8a88, 0x17, {0xc0010cec00, 0x127, 0x200})
	/opt/hostedtoolcache/go/1.23.1/x64/src/crypto/tls/conn.go:1029 +0x67f
crypto/tls.(*Conn).Write(0x0?, {0xc0010cec00, 0x127, 0x200})
	/opt/hostedtoolcache/go/1.23.1/x64/src/crypto/tls/conn.go:1248 +0x37e
github.com/jackc/pgx/v5/pgproto3.(*Frontend).Flush(0xc000d24d88)
	/home/runner/go/pkg/mod/github.com/jackc/pgx/v5@v5.7.1/pgproto3/frontend.go:105 +0xd4
github.com/jackc/pgx/v5/pgconn.(*PgConn).flushWithPotentialWriteReadDeadlock(0xc000d24908)
	/home/runner/go/pkg/mod/github.com/jackc/pgx/v5@v5.7.1/pgconn/pgconn.go:1877 +0x6d
github.com/jackc/pgx/v5/pgconn.(*PgConn).execExtendedSuffix(0xc000d24908, 0xc000d249a0)
	/home/runner/go/pkg/mod/github.com/jackc/pgx/v5@v5.7.1/pgconn/pgconn.go:1210 +0x97
github.com/jackc/pgx/v5/pgconn.(*PgConn).ExecPrepared(0xc000d24908, {0x31c7950?, 0x4a22360?}, {0xc001b06f00, 0x3a}, {0xc001545aa0, 0x1, 0x1}, {0xc001b04710, 0x1, ...}, ...)
	/home/runner/go/pkg/mod/github.com/jackc/pgx/v5@v5.7.1/pgconn/pgconn.go:1165 +0x165
github.com/jackc/pgx/v5.(*Conn).execPrepared(0xc000d88360, {0x31c7950, 0x4a22360}, 0xc0013028c0, {0xc001ac64d0?, 0xc0016c5a18?, 0xf4c73b?})
	/home/runner/go/pkg/mod/github.com/jackc/pgx/v5@v5.7.1/conn.go:586 +0xf4
github.com/jackc/pgx/v5.(*Conn).exec(0xc000d88360, {0x31c7950, 0x4a22360}, {0xc001d24060, 0x2b}, {0xc001ac64d0?, 0xc0016c5a28?, 0x0?})
	/home/runner/go/pkg/mod/github.com/jackc/pgx/v5@v5.7.1/conn.go:523 +0x370
github.com/jackc/pgx/v5.(*Conn).Exec(0xc000d88360, {0x31c7950?, 0x4a22360?}, {0xc001d24060, 0x2b}, {0xc001ac64d0, 0x1, 0x1})
	/home/runner/go/pkg/mod/github.com/jackc/pgx/v5@v5.7.1/conn.go:466 +0x117
github.com/jackc/pgx/v5/pgxpool.(*Conn).Exec(0xc000e026c0?, {0x31c7950?, 0x4a22360?}, {0xc001d24060?, 0xc0010eeb60?}, {0xc001ac64d0?, 0xc000100008?, 0xc001ac64e0?})
	/home/runner/go/pkg/mod/github.com/jackc/pgx/v5@v5.7.1/pgxpool/conn.go:87 +0x3c
github.com/jackc/pgx/v5/pgxpool.(*Pool).Exec(0xc001d260d0?, {0x31c7950, 0x4a22360}, {0xc001d24060, 0x2b}, {0xc001ac64d0, 0x1, 0x1})
	/home/runner/go/pkg/mod/github.com/jackc/pgx/v5@v5.7.1/pgxpool/pool.go:611 +0xf7
github.com/IguteChung/casbin-psql-watcher.(*Watcher).notifyMessage(0xc0007813e0, 0xc0012a05a0)
	/home/runner/go/pkg/mod/github.com/!igute!chung/casbin-psql-watcher@v1.0.0/watcher.go:263 +0x1da
github.com/IguteChung/casbin-psql-watcher.(*Watcher).UpdateForAddPolicy(0xc0007813e0, {0x2b73f38, 0x1}, {0x2b73f38, 0x1}, {0xc001621dd0, 0x3, 0x3})
	/home/runner/go/pkg/mod/github.com/!igute!chung/casbin-psql-watcher@v1.0.0/watcher.go:161 +0x13f
github.com/casbin/casbin/v2.(*Enforcer).addPolicy(0xc0009d5550, {0x2b73f38, 0x1}, {0x2b73f38, 0x1}, {0xc001621dd0, 0x3, 0x3})
	/home/runner/go/pkg/mod/github.com/casbin/casbin/v2@v2.81.0/internal_api.go:320 +0xd7
github.com/casbin/casbin/v2.(*Enforcer).AddNamedPolicy(0xc0009d5550, {0x2b73f38, 0x1}, {0xc0016c5eb0?, 0x1?, 0xc000c32bb0?})
	/home/runner/go/pkg/mod/github.com/casbin/casbin/v2@v2.81.0/management_api.go:223 +0xe5
github.com/casbin/casbin/v2.(*Enforcer).AddPolicy(...)
	/home/runner/go/pkg/mod/github.com/casbin/casbin/v2@v2.81.0/management_api.go:200
github.com/chainloop-dev/chainloop/app/controlplane/pkg/authz.(*Enforcer).AddPolicies(0xc00014b998, 0xc0016c5f58, {0xc0012a0750, 0x12, 0xc000e0a800?})
	/home/runner/work/chainloop/chainloop/app/controlplane/pkg/authz/authz.go:242 +0x225
github.com/chainloop-dev/chainloop/app/controlplane/pkg/biz.(*APITokenSyncerUseCase).SyncPolicies(0xc00014ada0)
	/home/runner/work/chainloop/chainloop/app/controlplane/pkg/biz/apitoken.go:247 +0x18a
main.main.func1()
	/home/runner/work/chainloop/chainloop/app/controlplane/cmd/main.go:162 +0x31
created by main.main in goroutine 1
	/home/runner/work/chainloop/chainloop/app/controlplane/cmd/main.go:161 +0x616
```