### PR TITLE
fix: release workflow was missing some secrets

### DIFF
--- a/.github/workflows/build_and_package.yaml
+++ b/.github/workflows/build_and_package.yaml
@@ -154,6 +154,8 @@ jobs:
       tag: ${{ github.ref_name }}
     secrets:
       chainloop_token: ${{ secrets.CHAINLOOP_TOKEN }}
+      cosign_key: ${{ secrets.COSIGN_KEY }}
+      cosign_pass: ${{ secrets.COSIGN_PASSWORD }}
     permissions:
       packages: write
       contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,10 @@ on:
     secrets:
       chainloop_token:
         required: true
+      cosign_key:
+        required: true
+      cosign_pass:
+        required: true
 
 jobs:
   # This reusable workflow inspects if the given workflow_name exists on Chainloop. If the Workflow does not exist
@@ -71,10 +75,12 @@ jobs:
         run: |
           chainloop attestation status --full
           attestation_sha=$(chainloop attestation push --key env://CHAINLOOP_SIGNING_KEY -o json | jq -r '.digest')
+          # check that the command succeeded
+          [ -n "${attestation_sha}" ] || exit 1
           echo "attestation_sha=$attestation_sha" >> $GITHUB_OUTPUT
         env:
-          CHAINLOOP_SIGNING_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
-          CHAINLOOP_SIGNING_KEY: ${{ secrets.COSIGN_KEY }}
+          CHAINLOOP_SIGNING_PASSWORD: ${{ secrets.cosign_pass }}
+          CHAINLOOP_SIGNING_KEY: ${{ secrets.cosign_key }}
 
       - name: Mark attestation as failed
         if: ${{ failure() }}


### PR DESCRIPTION
https://github.com/chainloop-dev/chainloop/actions/runs/12000221724/job/33449294844 is failing because some secrets are not found (since it's a reusable workflow, they need to be passed in).
