### PR TITLE
fix(chart): Remove duplicated key from deployment

### DIFF
--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -7,7 +7,7 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.146.0
+version: 1.146.1
 # Do not update appVersion, this is handled automatically by the release process
 appVersion: v0.128.0
 

--- a/deployment/chainloop/templates/controlplane/deployment.yaml
+++ b/deployment/chainloop/templates/controlplane/deployment.yaml
@@ -103,7 +103,6 @@ spec:
             httpGet:
               path: /statusz
               port: http
-            periodSeconds: 5
             failureThreshold: 10
             periodSeconds: 5
             initialDelaySeconds: 10


### PR DESCRIPTION
This patch removes a duplicated key on the controlplane manifest that was preventing the chart from being deployed.