### PR TITLE
chore: improve performance store attestation

### DIFF
--- a/app/controlplane/configs/config.devel.yaml
+++ b/app/controlplane/configs/config.devel.yaml
@@ -51,9 +51,9 @@ data:
   database:
     driver: pgx
     source: postgresql://postgres:@${DB_HOST:0.0.0.0}/controlplane
-    max_open_conns: 5
-    min_open_conns: 1
-    max_conn_idle_time: 120s
+    # max_open_conns: 5
+    # min_open_conns: 1
+    # max_conn_idle_time: 120s
 
 # Development credentials for the SSO authentication roundtrip
 auth:

--- a/app/controlplane/internal/service/attestation.go
+++ b/app/controlplane/internal/service/attestation.go
@@ -278,7 +278,7 @@ func (s *AttestationService) Store(ctx context.Context, req *cpAPI.AttestationSe
 				}
 			}
 		}
-	}(context.Background()) // reset context
+	}(ctx)
 
 	secretName := casBackend.SecretName
 

--- a/app/controlplane/internal/service/attestation.go
+++ b/app/controlplane/internal/service/attestation.go
@@ -260,21 +260,21 @@ func (s *AttestationService) Store(ctx context.Context, req *cpAPI.AttestationSe
 	if err := s.referrerUseCase.ExtractAndPersist(ctx, envelope, wf.ID.String()); err != nil {
 		return nil, handleUseCaseErr(err, s.log)
 	}
-	//
-	// 	if !casBackend.Inline {
-	// 		// Store the mappings in the DB
-	// 		references, err := s.casMappingUseCase.LookupDigestsInAttestation(envelope)
-	// 		if err != nil {
-	// 			return nil, handleUseCaseErr(err, s.log)
-	// 		}
-	//
-	// 		for _, ref := range references {
-	// 			s.log.Infow("msg", "creating CAS mapping", "name", ref.Name, "digest", ref.Digest, "workflowRun", req.WorkflowRunId, "casBackend", casBackend.ID.String())
-	// 			if _, err := s.casMappingUseCase.Create(ctx, ref.Digest, casBackend.ID.String(), req.WorkflowRunId); err != nil {
-	// 				return nil, handleUseCaseErr(err, s.log)
-	// 			}
-	// 		}
-	// 	}
+
+	if !casBackend.Inline {
+		// Store the mappings in the DB
+		references, err := s.casMappingUseCase.LookupDigestsInAttestation(envelope)
+		if err != nil {
+			return nil, handleUseCaseErr(err, s.log)
+		}
+
+		for _, ref := range references {
+			s.log.Infow("msg", "creating CAS mapping", "name", ref.Name, "digest", ref.Digest, "workflowRun", req.WorkflowRunId, "casBackend", casBackend.ID.String())
+			if _, err := s.casMappingUseCase.Create(ctx, ref.Digest, casBackend.ID.String(), req.WorkflowRunId); err != nil {
+				return nil, handleUseCaseErr(err, s.log)
+			}
+		}
+	}
 
 	secretName := casBackend.SecretName
 

--- a/app/controlplane/internal/service/attestation.go
+++ b/app/controlplane/internal/service/attestation.go
@@ -255,30 +255,26 @@ func (s *AttestationService) Store(ctx context.Context, req *cpAPI.AttestationSe
 	if err != nil {
 		return nil, handleUseCaseErr(err, s.log)
 	}
-	go func(ctx context.Context) {
-		// Store the exploded attestation referrer information in the DB
-		if err := s.referrerUseCase.ExtractAndPersist(ctx, envelope, wf.ID.String()); err != nil {
-			_ = handleUseCaseErr(err, s.log)
-			return
-		}
-
-		if !casBackend.Inline {
-			// Store the mappings in the DB
-			references, err := s.casMappingUseCase.LookupDigestsInAttestation(envelope)
-			if err != nil {
-				_ = handleUseCaseErr(err, s.log)
-				return
-			}
-
-			for _, ref := range references {
-				s.log.Infow("msg", "creating CAS mapping", "name", ref.Name, "digest", ref.Digest, "workflowRun", req.WorkflowRunId, "casBackend", casBackend.ID.String())
-				if _, err := s.casMappingUseCase.Create(ctx, ref.Digest, casBackend.ID.String(), req.WorkflowRunId); err != nil {
-					_ = handleUseCaseErr(err, s.log)
-					return
-				}
-			}
-		}
-	}(ctx)
+	//
+	// 	// Store the exploded attestation referrer information in the DB
+	if err := s.referrerUseCase.ExtractAndPersist(ctx, envelope, wf.ID.String()); err != nil {
+		return nil, handleUseCaseErr(err, s.log)
+	}
+	//
+	// 	if !casBackend.Inline {
+	// 		// Store the mappings in the DB
+	// 		references, err := s.casMappingUseCase.LookupDigestsInAttestation(envelope)
+	// 		if err != nil {
+	// 			return nil, handleUseCaseErr(err, s.log)
+	// 		}
+	//
+	// 		for _, ref := range references {
+	// 			s.log.Infow("msg", "creating CAS mapping", "name", ref.Name, "digest", ref.Digest, "workflowRun", req.WorkflowRunId, "casBackend", casBackend.ID.String())
+	// 			if _, err := s.casMappingUseCase.Create(ctx, ref.Digest, casBackend.ID.String(), req.WorkflowRunId); err != nil {
+	// 				return nil, handleUseCaseErr(err, s.log)
+	// 			}
+	// 		}
+	// 	}
 
 	secretName := casBackend.SecretName
 

--- a/app/controlplane/internal/service/attestation.go
+++ b/app/controlplane/internal/service/attestation.go
@@ -255,8 +255,8 @@ func (s *AttestationService) Store(ctx context.Context, req *cpAPI.AttestationSe
 	if err != nil {
 		return nil, handleUseCaseErr(err, s.log)
 	}
-	//
-	// 	// Store the exploded attestation referrer information in the DB
+
+	// Store the exploded attestation referrer information in the DB
 	if err := s.referrerUseCase.ExtractAndPersist(ctx, envelope, wf.ID.String()); err != nil {
 		return nil, handleUseCaseErr(err, s.log)
 	}

--- a/devel/compose.common.yml
+++ b/devel/compose.common.yml
@@ -11,6 +11,7 @@ services:
       - ALLOW_EMPTY_PASSWORD=yes
       - POSTGRESQL_DATABASE=controlplane
       - POSTGRESQL_USERNAME=postgres
+      - POSTGRESQL_SHARED_PRELOAD_LIBRARIES=pgaudit,pg_stat_statements
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "postgres"]
       interval: 2s


### PR DESCRIPTION
There were a couple of issues with storing attestations

- The go-routine was leaving some open connections, this was a regression introduced a couple of days ago.
- But these open connections were happening because of the referrer storage logic that was runnign a very long transaction. This code removes the transaction and simplifies the code.

before we were getting this

```
SELECT count(*) as total, usename AS username, state, query FROM pg_stat_activity where state = 'idle in transaction' group by (username, state, query);
 total | username  |        state        | query
-------+-----------+---------------------+-------
    50 | chainloop | idle in transaction | begin
```

refs #1533 
