### PR TITLE
fix: re-add validations for policy groups

### DIFF
--- a/app/cli/internal/action/attestation_init.go
+++ b/app/cli/internal/action/attestation_init.go
@@ -218,10 +218,7 @@ func enrichContractMaterials(ctx context.Context, schema *v1.CraftingSchema, cli
 			Logger: logger,
 		})
 		if err != nil {
-			// Temporarily skip if policy groups still use old schema
-			// TODO: remove this check in next release
-			logger.Warn().Msgf("policy group '%s' skipped since it's not found or it might use an old schema version", pgAtt.GetRef())
-			return nil
+			return fmt.Errorf("failed to load policy group: %w", err)
 		}
 		logger.Debug().Msgf("adding materials from policy group '%s'", group.GetMetadata().GetName())
 

--- a/app/cli/internal/action/attestation_init_test.go
+++ b/app/cli/internal/action/attestation_init_test.go
@@ -67,8 +67,7 @@ func TestEnrichMaterials(t *testing.T) {
 			name:        "wrong policy group",
 			materials:   []*v1.CraftingSchema_Material{},
 			policyGroup: "file://testdata/idontexist.yaml",
-			// TODO: Fix this condition in next release
-			expectErr: false,
+			expectErr:   true,
 		},
 		{
 			name:        "name-less materials are not added",

--- a/app/controlplane/pkg/biz/workflowcontract.go
+++ b/app/controlplane/pkg/biz/workflowcontract.go
@@ -366,10 +366,7 @@ func (uc *WorkflowContractUseCase) findPolicyGroup(att *schemav1.PolicyGroupAtta
 		pr := loader.ProviderParts(att.GetRef())
 		remoteGroup, err := uc.GetPolicyGroup(pr.Provider, pr.Name, pr.OrgName, token)
 		if err != nil {
-			// Temporarily skip if policy groups still use old schema
-			// TODO: remove this check in next release
-			uc.logger.Warnf("policy group '%s' skipped since it's not found or it might use an old schema version", att.GetRef())
-			return nil, nil
+			return nil, NewErrValidation(fmt.Errorf("failed to get policy group: %w", err))
 		}
 		if remoteGroup.PolicyGroup != nil {
 			// validate group arguments

--- a/pkg/policies/policy_groups.go
+++ b/pkg/policies/policy_groups.go
@@ -58,10 +58,7 @@ func (pgv *PolicyGroupVerifier) VerifyMaterial(ctx context.Context, material *ap
 			Logger: pgv.logger,
 		})
 		if err != nil {
-			// Temporarily skip if policy groups still use old schema
-			// TODO: remove this check in next release
-			pgv.logger.Warn().Msgf("policy group '%s' skipped since it's not found or it might use an old schema version", groupAtt.GetRef())
-			return result, nil
+			return nil, NewPolicyError(err)
 		}
 
 		// matches group arguments against spec and apply defaults


### PR DESCRIPTION
These validations were skipped when schema changed at #1351 . Now it's safe to take them back.