### PR TITLE
fix(metrics): load project

### DIFF
--- a/app/controlplane/pkg/data/orgmetrics.go
+++ b/app/controlplane/pkg/data/orgmetrics.go
@@ -44,7 +44,7 @@ func NewOrgMetricsRepo(data *Data, l log.Logger) biz.OrgMetricsRepo {
 
 func (repo *OrgMetricsRepo) RunsTotal(ctx context.Context, orgID uuid.UUID, tw *biz.TimeWindow) (int32, error) {
 	total, err := orgScopedQuery(repo.data.DB, orgID).
-		QueryWorkflows().
+		QueryWorkflows().WithProject().
 		QueryWorkflowruns().
 		Where(
 			workflowrun.CreatedAtGTE(tw.From),
@@ -66,7 +66,7 @@ func (repo *OrgMetricsRepo) RunsByStatusTotal(ctx context.Context, orgID uuid.UU
 	}
 
 	if err := orgScopedQuery(repo.data.DB, orgID).
-		QueryWorkflows().
+		QueryWorkflows().WithProject().
 		QueryWorkflowruns().
 		Where(
 			workflowrun.CreatedAtGTE(tw.From),
@@ -124,7 +124,6 @@ func (repo *OrgMetricsRepo) TopWorkflowsByRunsCount(ctx context.Context, orgID u
 	if err := orgScopedQuery(repo.data.DB, orgID).
 		QueryWorkflows().
 		QueryWorkflowruns().
-		WithWorkflow().
 		Where(
 			workflowrun.CreatedAtGTE(tw.From),
 			workflowrun.CreatedAtLTE(tw.To),
@@ -146,7 +145,7 @@ func (repo *OrgMetricsRepo) TopWorkflowsByRunsCount(ctx context.Context, orgID u
 				return nil, err
 			}
 
-			wf, err := orgScopedQuery(repo.data.DB, orgID).QueryWorkflows().Where(workflow.ID(workflowID)).First(ctx)
+			wf, err := orgScopedQuery(repo.data.DB, orgID).QueryWorkflows().WithProject().Where(workflow.ID(workflowID)).First(ctx)
 			if err != nil {
 				if ent.IsNotFound(err) {
 					continue


### PR DESCRIPTION
when we removed eager loading by default we added a regression on the topWorkflowsEndpoints. This patch adds the project loading on demand.

See how project name is now returned

```
 grpcurl -H "Authorization: Bearer $API_TOKEN" -d '{"num_workflows": 5, "time_window": "METRICS_TIME_WINDOW_LAST_30_DAYS"}' -plaintext localhost:9000 controlplane.v1.OrgMetricsService/TopWorkflowsByRunsCount
{
  "result": [
    {
      "workflow": {
        "id": "c08f4ffc-2ace-44fe-8939-2c62bf470cd4",
        "name": "was-in-project-2-too",
        "project": "project-www21222",
        "createdAt": "2024-11-29T00:25:58.976858Z",
        "runsCount": 2
      },
      "runsTotalByStatus": [
        {
          "count": 1,
          "status": "RUN_STATUS_EXPIRED"
        },
        {
          "count": 1,
          "status": "RUN_STATUS_SUCCEEDED"
        }
      ]
    }
  ]
}
```