### PR TITLE
feat(cmd): add server version to cli

### DIFF
--- a/app/cli/cmd/version.go
+++ b/app/cli/cmd/version.go
@@ -40,7 +40,7 @@ func NewVersionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Command line version",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			var version = struct {
 				Client string `json:"client"`
 				Server string `json:"server"`

--- a/app/cli/cmd/version.go
+++ b/app/cli/cmd/version.go
@@ -16,12 +16,14 @@
 package cmd
 
 import (
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"hash"
 	"io"
 	"os"
 
+	pb "github.com/chainloop-dev/chainloop/app/controlplane/api/controlplane/v1"
 	"github.com/spf13/cobra"
 )
 
@@ -38,8 +40,19 @@ func NewVersionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Command line version",
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("%s version %s\n", appName, Version)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Printf("Client Version: %s\n", Version)
+			if actionOpts.CPConnection != nil {
+				res, err := pb.NewStatusServiceClient(actionOpts.CPConnection).Infoz(context.Background(), &pb.InfozRequest{})
+				var serverVersion = "unknown"
+				if err == nil {
+					serverVersion = res.Version
+				}
+
+				fmt.Printf("Server Version: %s\n", serverVersion)
+			}
+
+			return nil
 		},
 	}
 }

--- a/app/cli/cmd/version.go
+++ b/app/cli/cmd/version.go
@@ -41,16 +41,27 @@ func NewVersionCmd() *cobra.Command {
 		Use:   "version",
 		Short: "Command line version",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Printf("Client Version: %s\n", Version)
+			var version = struct {
+				Client string `json:"client"`
+				Server string `json:"server"`
+			}{
+				Client: Version,
+				Server: "unknown",
+			}
+
 			if actionOpts.CPConnection != nil {
 				res, err := pb.NewStatusServiceClient(actionOpts.CPConnection).Infoz(context.Background(), &pb.InfozRequest{})
-				var serverVersion = "unknown"
 				if err == nil {
-					serverVersion = res.Version
+					version.Server = res.Version
 				}
-
-				fmt.Printf("Server Version: %s\n", serverVersion)
 			}
+
+			if flagOutputFormat == formatJSON {
+				return encodeJSON(version)
+			}
+
+			fmt.Printf("Client Version: %s\n", version.Client)
+			fmt.Printf("Server Version: %s\n", version.Server)
 
 			return nil
 		},


### PR DESCRIPTION
`chainloop version` now returns server version if possible. It also adds `json` output support to the command

```
chainloop version
Client Version: dev
Server Version: dev
```

```
chainloop version -o json
{
   "client": "dev",
   "server": "dev"
}
```

closes #1619 