### PR TITLE
re-enable: deployment: support nats configuration

### DIFF
--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -7,7 +7,7 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.154.0
+version: 1.154.1
 # Do not update appVersion, this is handled automatically by the release process
 appVersion: v0.136.0
 

--- a/deployment/chainloop/README.md
+++ b/deployment/chainloop/README.md
@@ -529,11 +529,16 @@ chainloop config save \
 | `controlplane.containerPorts.http`             | controlplane HTTP container port                                                                                                                                                                                                                               | `8000`            |
 | `controlplane.containerPorts.grpc`             | controlplane gRPC container port                                                                                                                                                                                                                               | `9000`            |
 | `controlplane.containerPorts.metrics`          | controlplane prometheus metrics container port                                                                                                                                                                                                                 | `5000`            |
+| `controlplane.enableProfiler`                  | Enable pprof profiling on port 6060                                                                                                                                                                                                                            | `false`           |
 | `controlplane.tls.existingSecret`              | Existing secret name containing TLS certificate to be used by the controlplane grpc server. NOTE: When it's set it will disable secret creation. The secret must contains 2 keys: tls.crt and tls.key respectively containing the certificate and private key. | `""`              |
 | `controlplane.pluginsDir`                      | Directory where to look for plugins                                                                                                                                                                                                                            | `/plugins`        |
 | `controlplane.referrerSharedIndex`             | Configure the shared, public index API endpoint that can be used to discover metadata referrers                                                                                                                                                                |                   |
 | `controlplane.referrerSharedIndex.enabled`     | Enable index API endpoint                                                                                                                                                                                                                                      | `false`           |
 | `controlplane.referrerSharedIndex.allowedOrgs` | List of UUIDs of organizations that are allowed to publish to the shared index                                                                                                                                                                                 | `[]`              |
+| `controlplane.nats`                            | optional NATS configuration for events publishing.                                                                                                                                                                                                             |                   |
+| `controlplane.nats.enabled`                    | Enable events publishing through a Nats stream                                                                                                                                                                                                                 | `false`           |
+| `controlplane.nats.host`                       | NATS Host                                                                                                                                                                                                                                                      | `""`              |
+| `controlplane.nats.port`                       | NATS Port                                                                                                                                                                                                                                                      | `4222`            |
 | `controlplane.onboarding.name`                 | Name of the organization to onboard                                                                                                                                                                                                                            |                   |
 | `controlplane.onboarding.role`                 | Role of the organization to onboard                                                                                                                                                                                                                            |                   |
 | `controlplane.prometheus_org_metrics`          | List of organizations to expose metrics for using Prometheus                                                                                                                                                                                                   |                   |
@@ -544,14 +549,17 @@ chainloop config save \
 
 ### Control Plane Database
 
-| Name                                     | Description                                                                                           | Value  |
-| ---------------------------------------- | ----------------------------------------------------------------------------------------------------- | ------ |
-| `controlplane.externalDatabase`          | External PostgreSQL configuration. These values are only used when postgresql.enabled is set to false |        |
-| `controlplane.externalDatabase.host`     | Database host                                                                                         | `""`   |
-| `controlplane.externalDatabase.port`     | Database port number                                                                                  | `5432` |
-| `controlplane.externalDatabase.user`     | Non-root username                                                                                     | `""`   |
-| `controlplane.externalDatabase.database` | Database name                                                                                         | `""`   |
-| `controlplane.externalDatabase.password` | Password for the non-root username                                                                    | `""`   |
+| Name                                         | Description                                                                                           | Value  |
+| -------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ------ |
+| `controlplane.externalDatabase`              | External PostgreSQL configuration. These values are only used when postgresql.enabled is set to false |        |
+| `controlplane.externalDatabase.host`         | Database host                                                                                         | `""`   |
+| `controlplane.externalDatabase.port`         | Database port number                                                                                  | `5432` |
+| `controlplane.externalDatabase.user`         | Non-root username                                                                                     | `""`   |
+| `controlplane.externalDatabase.database`     | Database name                                                                                         | `""`   |
+| `controlplane.externalDatabase.password`     | Password for the non-root username                                                                    | `""`   |
+| `controlplane.externalDatabase.maxOpenConns` | Maximum number of open connections to the database. Default: max(4, num_cpus)                         |        |
+| `controlplane.externalDatabase.minOpenConns` | Min number of connections. Default: 0                                                                 |        |
+| `controlplane.externalDatabase.maxIdleTime`  | Max time a connection may be idle. Default: 30m                                                       |        |
 
 ### Control Plane Authentication
 

--- a/deployment/chainloop/templates/_helpers.tpl
+++ b/deployment/chainloop/templates/_helpers.tpl
@@ -440,3 +440,13 @@ Compile all warning messages into a single one
 {{-   printf "\n\nVALUES VALIDATION:\n%s" $message -}}
 {{- end -}}
 {{- end -}}
+
+
+{{/*
+Return the Nats connection string
+*/}}
+{{- define "controlplane.nats.connection_string" -}}
+{{- $host := required "nats server hostname not set" .Values.controlplane.nats.host }}
+{{- $port := required "nats server port not set" .Values.controlplane.nats.port }}
+{{- printf "nats://%s:%d" $host ($port | int) }}
+{{- end -}}

--- a/deployment/chainloop/templates/controlplane/secret-config.yaml
+++ b/deployment/chainloop/templates/controlplane/secret-config.yaml
@@ -63,6 +63,12 @@ stringData:
         {{- if and .Values.controlplane.externalDatabase.maxIdleTime  }}
         max_conn_idle_time: "{{ .Values.controlplane.externalDatabase.maxIdleTime }}" 
         {{- end }}
+    
+    {{- if and .Values.controlplane.nats.enabled }} }}
+    nats_server: 
+      uri: {{ include "controlplane.nats.connection_string" . | quote }}
+    {{- end }}
+    
 
     credentials_service: {{- include "chainloop.credentials_service_settings" . | indent 6 }}
 

--- a/deployment/chainloop/values.yaml
+++ b/deployment/chainloop/values.yaml
@@ -169,6 +169,15 @@ controlplane:
   referrerSharedIndex:
     enabled: false
     allowedOrgs: []
+  
+  ## @extra controlplane.nats optional NATS configuration for events publishing.
+  ## @param controlplane.nats.enabled Enable events publishing through a Nats stream
+  ## @param controlplane.nats.host NATS Host
+  ## @param controlplane.nats.port NATS Port
+  nats:
+    enabled: false
+    host: ""
+    port: 4222
 
   ## @extra controlplane.onboarding.name Name of the organization to onboard
   ## @extra controlplane.onboarding.role Role of the organization to onboard


### PR DESCRIPTION
re-enable configuring nats through Helm Chart. This was reverted by mistake

This reverts commit 7210202b9ad38fa3d0a3098a3c77b65406ce5f93.