### PR TITLE
feat(events): org created/invited

### DIFF
--- a/app/controlplane/internal/usercontext/apitoken_middleware_test.go
+++ b/app/controlplane/internal/usercontext/apitoken_middleware_test.go
@@ -102,7 +102,7 @@ func TestWithCurrentAPITokenAndOrgMiddleware(t *testing.T) {
 			orgRepo := bizMocks.NewOrganizationRepo(t)
 			apiTokenUC, err := biz.NewAPITokenUseCase(apiTokenRepo, &conf.Auth{GeneratedJwsHmacSecret: "test"}, nil, nil, nil)
 			require.NoError(t, err)
-			orgUC := biz.NewOrganizationUseCase(orgRepo, nil, nil, nil, nil, nil)
+			orgUC := biz.NewOrganizationUseCase(orgRepo, nil, nil, nil, nil, nil, nil)
 			require.NoError(t, err)
 
 			ctx := context.Background()

--- a/app/controlplane/pkg/auditor/events/organization.go
+++ b/app/controlplane/pkg/auditor/events/organization.go
@@ -114,7 +114,7 @@ func (p *OrgUserInvited) ActionType() string {
 }
 
 func (p *OrgUserInvited) Description() string {
-	return fmt.Sprintf("{{ .ActorEmail }} has invited the user %s to the organization %s with role %s", p.ReceiverEmail, p.OrgName, p.Role)
+	return fmt.Sprintf("{{ .ActorEmail }} has invited %s to the organization %s with role %s", p.ReceiverEmail, p.OrgName, p.Role)
 }
 
 func (p *OrgUserInvited) ActionInfo() (json.RawMessage, error) {

--- a/app/controlplane/pkg/auditor/events/organization.go
+++ b/app/controlplane/pkg/auditor/events/organization.go
@@ -1,0 +1,126 @@
+//
+// Copyright 2024 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/auditor"
+	"github.com/google/uuid"
+)
+
+var (
+	_ auditor.LogEntry = (*OrgUserJoined)(nil)
+	_ auditor.LogEntry = (*OrgUserLeft)(nil)
+	_ auditor.LogEntry = (*OrgCreated)(nil)
+)
+
+const (
+	OrgType                    auditor.TargetType = "Organization"
+	userJoinedOrgActionType    string             = "UserJoined"
+	userLeftOrgActionType      string             = "UserLeft"
+	userInvitedToOrgActionType string             = "UserInvited"
+	orgCreatedActionType       string             = "OrgCreated"
+)
+
+type OrgBase struct {
+	OrgID   *uuid.UUID `json:"org_id,omitempty"`
+	OrgName string     `json:"org_name,omitempty"`
+}
+
+func (p *OrgBase) RequiresActor() bool {
+	return true
+}
+
+func (p *OrgBase) TargetType() auditor.TargetType {
+	return OrgType
+}
+
+func (p *OrgBase) TargetID() *uuid.UUID {
+	return p.OrgID
+}
+
+func (p *OrgBase) ActionInfo() (json.RawMessage, error) {
+	if p.OrgName == "" || p.OrgID == nil {
+		return nil, errors.New("user id and org name are required")
+	}
+
+	return json.Marshal(&p)
+}
+
+// Org created
+type OrgCreated struct {
+	*OrgBase
+}
+
+func (p *OrgCreated) ActionType() string {
+	return orgCreatedActionType
+}
+
+func (p *OrgCreated) Description() string {
+	return fmt.Sprintf("{{ .ActorEmail }} has created the organization %s", p.OrgName)
+}
+
+// user joined the organization
+type OrgUserJoined struct {
+	*OrgBase
+}
+
+func (p *OrgUserJoined) ActionType() string {
+	return userJoinedOrgActionType
+}
+
+func (p *OrgUserJoined) Description() string {
+	return fmt.Sprintf("{{ .ActorEmail }} has joined the organization %s", p.OrgName)
+}
+
+// user left the organization
+type OrgUserLeft struct {
+	*OrgBase
+}
+
+func (p *OrgUserLeft) ActionType() string {
+	return userLeftOrgActionType
+}
+
+func (p *OrgUserLeft) Description() string {
+	return fmt.Sprintf("{{ .ActorEmail }} has left the organization %s", p.OrgName)
+}
+
+// user got invited to the organization
+type OrgUserInvited struct {
+	*OrgBase
+	ReceiverEmail string
+	Role          string
+}
+
+func (p *OrgUserInvited) ActionType() string {
+	return userInvitedToOrgActionType
+}
+
+func (p *OrgUserInvited) Description() string {
+	return fmt.Sprintf("{{ .ActorEmail }} has invited the user %s to the organization %s with role %s", p.ReceiverEmail, p.OrgName, p.Role)
+}
+
+func (p *OrgUserInvited) ActionInfo() (json.RawMessage, error) {
+	if p.OrgName == "" || p.ReceiverEmail == "" {
+		return nil, errors.New("org name and receiver emails are required")
+	}
+
+	return json.Marshal(&p)
+}

--- a/app/controlplane/pkg/auditor/events/organization.go
+++ b/app/controlplane/pkg/auditor/events/organization.go
@@ -34,8 +34,8 @@ const (
 	OrgType                    auditor.TargetType = "Organization"
 	userJoinedOrgActionType    string             = "UserJoined"
 	userLeftOrgActionType      string             = "UserLeft"
-	userInvitedToOrgActionType string             = "UserInvited"
-	orgCreatedActionType       string             = "OrgCreated"
+	userInvitedToOrgActionType string             = "InvitationCreated"
+	orgCreatedActionType       string             = "OrganizationCreated"
 )
 
 type OrgBase struct {

--- a/app/controlplane/pkg/auditor/events/user.go
+++ b/app/controlplane/pkg/auditor/events/user.go
@@ -30,17 +30,20 @@ var (
 	_ auditor.LogEntry = (*UserLoggedIn)(nil)
 )
 
-const UserType auditor.TargetType = "User"
-
 const (
-	userSignedUpActionType = "SignedUp"
-	userLoggedInActionType = "LoggedIn"
+	UserType               auditor.TargetType = "User"
+	UserSignedUpActionType string             = "SignedUp"
+	UserLoggedInActionType string             = "LoggedIn"
 )
 
 // UserBase is the base struct for policy events
 type UserBase struct {
 	UserID *uuid.UUID `json:"user_id,omitempty"`
 	Email  string     `json:"email,omitempty"`
+}
+
+func (p *UserBase) RequiresActor() bool {
+	return true
 }
 
 func (p *UserBase) TargetType() auditor.TargetType {
@@ -64,7 +67,7 @@ type UserSignedUp struct {
 }
 
 func (p *UserSignedUp) ActionType() string {
-	return userSignedUpActionType
+	return UserSignedUpActionType
 }
 
 func (p *UserSignedUp) Description() string {
@@ -78,7 +81,7 @@ type UserLoggedIn struct {
 }
 
 func (p *UserLoggedIn) ActionType() string {
-	return userLoggedInActionType
+	return UserLoggedInActionType
 }
 
 func (p *UserLoggedIn) Description() string {

--- a/app/controlplane/pkg/auditor/logentry.go
+++ b/app/controlplane/pkg/auditor/logentry.go
@@ -55,6 +55,7 @@ type LogEntry interface {
 	TargetID() *uuid.UUID
 	// Description returns a templatable string, see the DescriptionVariables struct.
 	Description() string
+	RequiresActor() bool
 }
 
 type DescriptionVariables struct {

--- a/app/controlplane/pkg/biz/organization_test.go
+++ b/app/controlplane/pkg/biz/organization_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/biz"
 	repoM "github.com/chainloop-dev/chainloop/app/controlplane/pkg/biz/mocks"
 	"github.com/go-kratos/kratos/v2/log"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
@@ -33,14 +34,15 @@ type organizationTestSuite struct {
 
 func (s *organizationTestSuite) TestCreateWithRandomName() {
 	repo := repoM.NewOrganizationRepo(s.T())
-	uc := biz.NewOrganizationUseCase(repo, nil, nil, nil, nil, nil, log.NewStdLogger(io.Discard))
+	l := log.NewStdLogger(io.Discard)
+	uc := biz.NewOrganizationUseCase(repo, nil, biz.NewAuditorUseCase(nil, l), nil, nil, nil, l)
 
 	s.Run("the org exists, we retry", func() {
 		ctx := context.Background()
 		// the first one fails because it already exists
 		repo.On("Create", ctx, mock.Anything).Once().Return(nil, biz.NewErrAlreadyExistsStr("it already exists"))
 		// but the second call creates the org
-		repo.On("Create", ctx, mock.Anything).Once().Return(&biz.Organization{Name: "foobar"}, nil)
+		repo.On("Create", ctx, mock.Anything).Once().Return(&biz.Organization{Name: "foobar", ID: uuid.NewString()}, nil)
 		got, err := uc.CreateWithRandomName(ctx)
 		s.NoError(err)
 		s.Equal("foobar", got.Name)

--- a/app/controlplane/pkg/biz/organization_test.go
+++ b/app/controlplane/pkg/biz/organization_test.go
@@ -33,7 +33,7 @@ type organizationTestSuite struct {
 
 func (s *organizationTestSuite) TestCreateWithRandomName() {
 	repo := repoM.NewOrganizationRepo(s.T())
-	uc := biz.NewOrganizationUseCase(repo, nil, nil, nil, nil, log.NewStdLogger(io.Discard))
+	uc := biz.NewOrganizationUseCase(repo, nil, nil, nil, nil, nil, log.NewStdLogger(io.Discard))
 
 	s.Run("the org exists, we retry", func() {
 		ctx := context.Background()


### PR DESCRIPTION
new set of events for org management

- orgCreate
- orgInvite
- OrgJoined
- OrgLeft

![image](https://github.com/user-attachments/assets/4d300bc9-4b56-4888-8ae3-316c02285382)

This PR also adds some logic to allow `event publishers` to define if the event must contain actor or not. That way the system will not send events that do not have the full context

refs #1628