### PR TITLE
feat(workflowrun): Add index to calculate workflow runs per version

### DIFF
--- a/app/controlplane/pkg/data/ent/migrate/migrations/20241210063348.sql
+++ b/app/controlplane/pkg/data/ent/migrate/migrations/20241210063348.sql
@@ -1,2 +1,2 @@
 -- Create index "workflowrun_version_id_workflow_id" to table: "workflow_runs"
-CREATE INDEX "workflowrun_version_id_workflow_id" ON "workflow_runs" ("version_id", "workflow_id");
+CREATE INDEX CONCURRENTLY "workflowrun_version_id_workflow_id" ON "workflow_runs" ("version_id", "workflow_id");

--- a/app/controlplane/pkg/data/ent/migrate/migrations/20241210063348.sql
+++ b/app/controlplane/pkg/data/ent/migrate/migrations/20241210063348.sql
@@ -1,0 +1,2 @@
+-- Create index "workflowrun_version_id_workflow_id" to table: "workflow_runs"
+CREATE INDEX "workflowrun_version_id_workflow_id" ON "workflow_runs" ("version_id", "workflow_id");

--- a/app/controlplane/pkg/data/ent/migrate/migrations/atlas.sum
+++ b/app/controlplane/pkg/data/ent/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:ACH3XQGY1YmFfR7JixuJlwsyKSz2JiO3d/4zdsEgNDU=
+h1:7r4q6T+a9iHlBKWCC08wKlaxbcZk37RvuklOmTGfZxE=
 20230706165452_init-schema.sql h1:VvqbNFEQnCvUVyj2iDYVQQxDM0+sSXqocpt/5H64k8M=
 20230710111950-cas-backend.sql h1:A8iBuSzZIEbdsv9ipBtscZQuaBp3V5/VMw7eZH6GX+g=
 20230712094107-cas-backends-workflow-runs.sql h1:a5rzxpVGyd56nLRSsKrmCFc9sebg65RWzLghKHh5xvI=
@@ -73,3 +73,4 @@ h1:ACH3XQGY1YmFfR7JixuJlwsyKSz2JiO3d/4zdsEgNDU=
 20241129170353.sql h1:9RmXI0seY855RHiJx1+tfd3iwf9R5HR+3EsWmZdH6nw=
 20241205150625.sql h1:D0Z2lbpsO+65zpt/stpIn4SFmd5M2AcbwXeopKeCeRQ=
 20241209230337.sql h1:u7wrkqqkn1s5CkY4DCeMYMvl9j8ml/eZw7yhM6haf2E=
+20241210063348.sql h1:JxEZsYaGxiszV6gWFJaq4HI8m/CSXFaeANcAssdpqCM=

--- a/app/controlplane/pkg/data/ent/migrate/migrations/atlas.sum
+++ b/app/controlplane/pkg/data/ent/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:7r4q6T+a9iHlBKWCC08wKlaxbcZk37RvuklOmTGfZxE=
+h1:lDWToow1kxvN2zZvDzsFIRxdJyfHDoz5LR+u0WzwGek=
 20230706165452_init-schema.sql h1:VvqbNFEQnCvUVyj2iDYVQQxDM0+sSXqocpt/5H64k8M=
 20230710111950-cas-backend.sql h1:A8iBuSzZIEbdsv9ipBtscZQuaBp3V5/VMw7eZH6GX+g=
 20230712094107-cas-backends-workflow-runs.sql h1:a5rzxpVGyd56nLRSsKrmCFc9sebg65RWzLghKHh5xvI=
@@ -73,4 +73,4 @@ h1:7r4q6T+a9iHlBKWCC08wKlaxbcZk37RvuklOmTGfZxE=
 20241129170353.sql h1:9RmXI0seY855RHiJx1+tfd3iwf9R5HR+3EsWmZdH6nw=
 20241205150625.sql h1:D0Z2lbpsO+65zpt/stpIn4SFmd5M2AcbwXeopKeCeRQ=
 20241209230337.sql h1:u7wrkqqkn1s5CkY4DCeMYMvl9j8ml/eZw7yhM6haf2E=
-20241210063348.sql h1:JxEZsYaGxiszV6gWFJaq4HI8m/CSXFaeANcAssdpqCM=
+20241210063348.sql h1:46Utmkrty36A01obBalGfpIcU5oLpwj8/uhC5YdEcoA=

--- a/app/controlplane/pkg/data/ent/migrate/schema.go
+++ b/app/controlplane/pkg/data/ent/migrate/schema.go
@@ -638,6 +638,11 @@ var (
 				Unique:  false,
 				Columns: []*schema.Column{WorkflowRunsColumns[13]},
 			},
+			{
+				Name:    "workflowrun_version_id_workflow_id",
+				Unique:  false,
+				Columns: []*schema.Column{WorkflowRunsColumns[12], WorkflowRunsColumns[13]},
+			},
 		},
 	}
 	// ReferrerReferencesColumns holds the columns for the "referrer_references" table.

--- a/app/controlplane/pkg/data/ent/schema/workflowrun.go
+++ b/app/controlplane/pkg/data/ent/schema/workflowrun.go
@@ -86,5 +86,7 @@ func (WorkflowRun) Indexes() []ent.Index {
 		// Referrer
 		index.Fields("attestation_digest"),
 		index.Edges("workflow"),
+		// Workflow run counts per project version
+		index.Fields("version_id", "workflow_id"),
 	}
 }


### PR DESCRIPTION
This patch adds an index on the `workflowrun` table to ease the count of number of workflows by version.

The index places the most selective column on the left side, in this case, `version_id`.

From:
```
Aggregate  (cost=12.91..12.92 rows=1 width=8) (actual time=0.060..0.060 rows=1 loops=1)
  ->  Bitmap Heap Scan on workflow_runs  (cost=8.89..12.91 rows=1 width=0) (actual time=0.057..0.057 rows=0 loops=1)
        Recheck Cond: ((workflow_id = 'eebfe9fe-8b2f-43b9-a405-cb99985cba68'::uuid) AND (version_id = 'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1'::uuid))
        ->  BitmapAnd  (cost=8.89..8.89 rows=1 width=0) (actual time=0.045..0.045 rows=0 loops=1)
              ->  Bitmap Index Scan on workflowrun_workflow_id  (cost=0.00..4.32 rows=4 width=0) (actual time=0.044..0.044 rows=0 loops=1)
                    Index Cond: (workflow_id = 'eebfe9fe-8b2f-43b9-a405-cb99985cba68'::uuid)
              ->  Bitmap Index Scan on workflow_run_version_id  (cost=0.00..4.32 rows=4 width=0) (never executed)
                    Index Cond: (version_id = 'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1'::uuid)
Planning Time: 0.481 ms
Execution Time: 0.244 ms
```

To:
```
Aggregate  (cost=8.31..8.32 rows=1 width=8) (actual time=0.027..0.028 rows=1 loops=1)
  ->  Index Only Scan using workflow_runs_version_id_workflow_id_idx on workflow_runs  (cost=0.29..8.31 rows=1 width=0) (actual time=0.024..0.025 rows=0 loops=1)
        Index Cond: ((version_id = 'b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1'::uuid) AND (workflow_id = 'eebfe9fe-8b2f-43b9-a405-cb99985cba68'::uuid))
        Heap Fetches: 0
Planning Time: 0.108 ms
Execution Time: 0.052 ms
```