### PR TITLE
fix(transaction): Allow atlas to run a concurrent index on the DB

### DIFF
--- a/app/controlplane/pkg/data/ent/migrate/migrations/20241210063348.sql
+++ b/app/controlplane/pkg/data/ent/migrate/migrations/20241210063348.sql
@@ -1,2 +1,4 @@
+-- atlas:txmode none
+
 -- Create index "workflowrun_version_id_workflow_id" to table: "workflow_runs"
 CREATE INDEX CONCURRENTLY "workflowrun_version_id_workflow_id" ON "workflow_runs" ("version_id", "workflow_id");

--- a/app/controlplane/pkg/data/ent/migrate/migrations/atlas.sum
+++ b/app/controlplane/pkg/data/ent/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:lDWToow1kxvN2zZvDzsFIRxdJyfHDoz5LR+u0WzwGek=
+h1:APCJw2X658gW+A0bAEHNWy8yTNqRKDf4e0V0SKt8tFU=
 20230706165452_init-schema.sql h1:VvqbNFEQnCvUVyj2iDYVQQxDM0+sSXqocpt/5H64k8M=
 20230710111950-cas-backend.sql h1:A8iBuSzZIEbdsv9ipBtscZQuaBp3V5/VMw7eZH6GX+g=
 20230712094107-cas-backends-workflow-runs.sql h1:a5rzxpVGyd56nLRSsKrmCFc9sebg65RWzLghKHh5xvI=
@@ -73,4 +73,4 @@ h1:lDWToow1kxvN2zZvDzsFIRxdJyfHDoz5LR+u0WzwGek=
 20241129170353.sql h1:9RmXI0seY855RHiJx1+tfd3iwf9R5HR+3EsWmZdH6nw=
 20241205150625.sql h1:D0Z2lbpsO+65zpt/stpIn4SFmd5M2AcbwXeopKeCeRQ=
 20241209230337.sql h1:u7wrkqqkn1s5CkY4DCeMYMvl9j8ml/eZw7yhM6haf2E=
-20241210063348.sql h1:46Utmkrty36A01obBalGfpIcU5oLpwj8/uhC5YdEcoA=
+20241210063348.sql h1:8pCi/LfX9ukdL2xeWoOe7GI+iPLSQoxHTwJfPPzZ1zY=


### PR DESCRIPTION
This patch allows the migration tool to run a concurrent index on a table that cannot happen inside a sql transaction.