### PR TITLE
fix: do not require nats in dev

### DIFF
--- a/app/controlplane/configs/config.devel.yaml
+++ b/app/controlplane/configs/config.devel.yaml
@@ -16,8 +16,8 @@ server:
     #   certificate: "../../devel/devkeys/selfsigned/controlplane.crt"
     #   private_key: "../../devel/devkeys/selfsigned/controlplane.key"
 
-nats_server:
-  uri: nats://0.0.0.0:4222
+# nats_server:
+#   uri: nats://0.0.0.0:4222
 
 certificate_authority:
   file_ca:


### PR DESCRIPTION
Pushing events to nats is optional but it was not from the dev env POV, this patch changes it.