### PR TITLE
feat(policies): validate policy attachments against remote provider

### DIFF
--- a/app/controlplane/pkg/policies/policyprovider.go
+++ b/app/controlplane/pkg/policies/policyprovider.go
@@ -88,6 +88,10 @@ func (p *PolicyProvider) Resolve(policyName, orgName, token string) (*schemaapi.
 	return &policy, createRef(url, policyName, providerDigest, orgName), nil
 }
 
+func (p *PolicyProvider) ValidateAttachment(att *schemaapi.PolicyAttachment, token string) error {
+	panic("sdf")
+}
+
 // ResolveGroup calls remote provider for retrieving a policy group definition
 func (p *PolicyProvider) ResolveGroup(groupName, orgName, token string) (*schemaapi.PolicyGroup, *PolicyReference, error) {
 	if groupName == "" || token == "" {

--- a/app/controlplane/pkg/policies/policyprovider.go
+++ b/app/controlplane/pkg/policies/policyprovider.go
@@ -139,7 +139,8 @@ func (p *PolicyProvider) ValidateAttachment(att *schemaapi.PolicyAttachment, tok
 
 	if resp.StatusCode != http.StatusOK {
 		if resp.StatusCode == http.StatusNotFound {
-			return ErrNotFound
+			// Ignore endpoint not found as it might not be implemented by the provider
+			return nil
 		}
 
 		return fmt.Errorf("expected status code 200 but got %d", resp.StatusCode)


### PR DESCRIPTION
This is an extension of the remote provider feature. Given that they would expose a /policies/validate endpoint that would validate a policy attachment via POST.
```
curl -d '{"policy_attachment":"{\"ref\":\"source-commit\",\"requirements\":[\"foo/bar\"]}"}' -H "Authorization: Bearer $USER_TOKEN" -H "Content-Type: application/json" "localhost:8002/v1/policies/validate"
```

Then it would be used during contract validation to validate any custom metadata in the attachment. For instance, if requirement references were validated:
```shell
> chainloop wf contract update --name myproject-mywf --contract test/my-contract.yaml
ERR validation error: invalid attachment: validation failures: [finding requirement: requirement bar not found]
```

