### PR TITLE
feat(cli): handle org selection client-side

### DIFF
--- a/app/cli/cmd/config.go
+++ b/app/cli/cmd/config.go
@@ -26,7 +26,7 @@ import (
 
 // Map of all the possible configuration options that we expect viper to handle
 var confOptions = struct {
-	authToken, controlplaneAPI, CASAPI, controlplaneCA, CASCA, insecure *confOpt
+	authToken, controlplaneAPI, CASAPI, controlplaneCA, CASCA, insecure, organization *confOpt
 }{
 	insecure: &confOpt{
 		viperKey: "api-insecure",
@@ -49,6 +49,10 @@ var confOptions = struct {
 	CASCA: &confOpt{
 		viperKey: "artifact-cas.api-ca",
 		flagName: "artifact-cas-ca",
+	},
+	organization: &confOpt{
+		viperKey: "organization",
+		flagName: "org",
 	},
 }
 

--- a/app/cli/cmd/organization_create.go
+++ b/app/cli/cmd/organization_create.go
@@ -17,9 +17,11 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/chainloop-dev/chainloop/app/cli/internal/action"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func newOrganizationCreateCmd() *cobra.Command {
@@ -32,6 +34,12 @@ func newOrganizationCreateCmd() *cobra.Command {
 			org, err := action.NewOrgCreate(actionOpts).Run(context.Background(), name)
 			if err != nil {
 				return err
+			}
+
+			// set the local state
+			viper.Set(confOptions.organization.viperKey, name)
+			if err := viper.WriteConfig(); err != nil {
+				return fmt.Errorf("writing config file: %w", err)
 			}
 
 			logger.Info().Msgf("Organization %q created!", org.Name)

--- a/app/cli/cmd/organization_list.go
+++ b/app/cli/cmd/organization_list.go
@@ -22,6 +22,7 @@ import (
 	"github.com/chainloop-dev/chainloop/app/cli/internal/action"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 const UserWithNoOrganizationMsg = "you are not part of any organization, please run \"chainloop organization create --name ORG_NAME\" to create one"
@@ -50,11 +51,15 @@ func orgMembershipTableOutput(items []*action.MembershipItem) error {
 		return nil
 	}
 
+	// Get the current organization from viper configuration
+	currentOrg := viper.GetString(confOptions.organization.viperKey)
+
 	t := newTableWriter()
-	t.AppendHeader(table.Row{"Name", "Current", "Role", "Joined At"})
+	t.AppendHeader(table.Row{"Name", "Current", "Default", "Role", "Joined At"})
 
 	for _, i := range items {
-		t.AppendRow(table.Row{i.Org.Name, i.Current, i.Role, i.CreatedAt.Format(time.RFC822)})
+		current := i.Org.Name == currentOrg
+		t.AppendRow(table.Row{i.Org.Name, current, i.Default, i.Role, i.CreatedAt.Format(time.RFC822)})
 		t.AppendSeparator()
 	}
 

--- a/app/cli/internal/action/membership_list.go
+++ b/app/cli/internal/action/membership_list.go
@@ -34,7 +34,7 @@ type OrgItem struct {
 
 type MembershipItem struct {
 	ID        string     `json:"id"`
-	Current   bool       `json:"current"`
+	Default   bool       `json:"current"`
 	CreatedAt *time.Time `json:"joinedAt"`
 	UpdatedAt *time.Time `json:"updatedAt"`
 	Org       *OrgItem
@@ -96,7 +96,7 @@ func pbMembershipItemToAction(in *pb.OrgMembershipItem) *MembershipItem {
 		CreatedAt: toTimePtr(in.GetCreatedAt().AsTime()),
 		UpdatedAt: toTimePtr(in.GetCreatedAt().AsTime()),
 		Org:       pbOrgItemToAction(in.Org),
-		Current:   in.Current,
+		Default:   in.Current,
 		Role:      pbRoleToString(in.Role),
 		User:      pbUserItemToAction(in.User),
 	}

--- a/app/cli/main.go
+++ b/app/cli/main.go
@@ -34,10 +34,9 @@ import (
 func main() {
 	// Couldn't find an easier way to disable the timestamp
 	logger := zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr, FormatTimestamp: func(interface{}) string { return "" }})
-	rootCmd := cmd.NewRootCmd(logger)
 
 	// Run the command
-	if err := rootCmd.Execute(); err != nil {
+	if err := cmd.Execute(logger); err != nil {
 		msg, exitCode := errorInfo(err, logger)
 		logger.Error().Msg(msg)
 		os.Exit(exitCode)
@@ -90,8 +89,8 @@ func errorInfo(err error, logger zerolog.Logger) (string, int) {
 		msg = "your authentication token has expired, please run chainloop auth login again"
 	case isWrappedErr(st, jwtMiddleware.ErrMissingJwtToken):
 		msg = "authentication required, please run \"chainloop auth login\""
-	case v1.IsUserWithNoMembershipErrorNotInOrg(err):
-		msg = cmd.UserWithNoOrganizationMsg
+	case v1.IsUserNotMemberOfOrgErrorNotInOrg(err), v1.IsUserWithNoMembershipErrorNotInOrg(err):
+		msg = "the organization you are trying to access does not exist, please run \"chainloop auth login\""
 	case errors.As(err, &cmd.GracefulError{}):
 		// Graceful recovery if the flag is set and the received error is marked as recoverable
 		if cmd.GracefulExit {

--- a/app/controlplane/api/controlplane/v1/response_messages.pb.go
+++ b/app/controlplane/api/controlplane/v1/response_messages.pb.go
@@ -241,6 +241,52 @@ func (UserWithNoMembershipError) EnumDescriptor() ([]byte, []int) {
 	return file_controlplane_v1_response_messages_proto_rawDescGZIP(), []int{3}
 }
 
+type UserNotMemberOfOrgError int32
+
+const (
+	UserNotMemberOfOrgError_USER_NOT_MEMBER_OF_ORG_ERROR_UNSPECIFIED UserNotMemberOfOrgError = 0
+	UserNotMemberOfOrgError_USER_NOT_MEMBER_OF_ORG_ERROR_NOT_IN_ORG  UserNotMemberOfOrgError = 1
+)
+
+// Enum value maps for UserNotMemberOfOrgError.
+var (
+	UserNotMemberOfOrgError_name = map[int32]string{
+		0: "USER_NOT_MEMBER_OF_ORG_ERROR_UNSPECIFIED",
+		1: "USER_NOT_MEMBER_OF_ORG_ERROR_NOT_IN_ORG",
+	}
+	UserNotMemberOfOrgError_value = map[string]int32{
+		"USER_NOT_MEMBER_OF_ORG_ERROR_UNSPECIFIED": 0,
+		"USER_NOT_MEMBER_OF_ORG_ERROR_NOT_IN_ORG":  1,
+	}
+)
+
+func (x UserNotMemberOfOrgError) Enum() *UserNotMemberOfOrgError {
+	p := new(UserNotMemberOfOrgError)
+	*p = x
+	return p
+}
+
+func (x UserNotMemberOfOrgError) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (UserNotMemberOfOrgError) Descriptor() protoreflect.EnumDescriptor {
+	return file_controlplane_v1_response_messages_proto_enumTypes[4].Descriptor()
+}
+
+func (UserNotMemberOfOrgError) Type() protoreflect.EnumType {
+	return &file_controlplane_v1_response_messages_proto_enumTypes[4]
+}
+
+func (x UserNotMemberOfOrgError) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use UserNotMemberOfOrgError.Descriptor instead.
+func (UserNotMemberOfOrgError) EnumDescriptor() ([]byte, []int) {
+	return file_controlplane_v1_response_messages_proto_rawDescGZIP(), []int{4}
+}
+
 type WorkflowContractVersionItem_RawBody_Format int32
 
 const (
@@ -277,11 +323,11 @@ func (x WorkflowContractVersionItem_RawBody_Format) String() string {
 }
 
 func (WorkflowContractVersionItem_RawBody_Format) Descriptor() protoreflect.EnumDescriptor {
-	return file_controlplane_v1_response_messages_proto_enumTypes[4].Descriptor()
+	return file_controlplane_v1_response_messages_proto_enumTypes[5].Descriptor()
 }
 
 func (WorkflowContractVersionItem_RawBody_Format) Type() protoreflect.EnumType {
-	return &file_controlplane_v1_response_messages_proto_enumTypes[4]
+	return &file_controlplane_v1_response_messages_proto_enumTypes[5]
 }
 
 func (x WorkflowContractVersionItem_RawBody_Format) Number() protoreflect.EnumNumber {
@@ -326,11 +372,11 @@ func (x CASBackendItem_ValidationStatus) String() string {
 }
 
 func (CASBackendItem_ValidationStatus) Descriptor() protoreflect.EnumDescriptor {
-	return file_controlplane_v1_response_messages_proto_enumTypes[5].Descriptor()
+	return file_controlplane_v1_response_messages_proto_enumTypes[6].Descriptor()
 }
 
 func (CASBackendItem_ValidationStatus) Type() protoreflect.EnumType {
-	return &file_controlplane_v1_response_messages_proto_enumTypes[5]
+	return &file_controlplane_v1_response_messages_proto_enumTypes[6]
 }
 
 func (x CASBackendItem_ValidationStatus) Number() protoreflect.EnumNumber {
@@ -2494,13 +2540,21 @@ var file_controlplane_v1_response_messages_proto_rawDesc = []byte{
 	0x10, 0x00, 0x12, 0x32, 0x0a, 0x28, 0x55, 0x53, 0x45, 0x52, 0x5f, 0x57, 0x49, 0x54, 0x48, 0x5f,
 	0x4e, 0x4f, 0x5f, 0x4d, 0x45, 0x4d, 0x42, 0x45, 0x52, 0x53, 0x48, 0x49, 0x50, 0x5f, 0x45, 0x52,
 	0x52, 0x4f, 0x52, 0x5f, 0x4e, 0x4f, 0x54, 0x5f, 0x49, 0x4e, 0x5f, 0x4f, 0x52, 0x47, 0x10, 0x01,
-	0x1a, 0x04, 0xa8, 0x45, 0x93, 0x03, 0x1a, 0x04, 0xa0, 0x45, 0xf4, 0x03, 0x42, 0x4c, 0x5a, 0x4a,
-	0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x63, 0x68, 0x61, 0x69, 0x6e,
-	0x6c, 0x6f, 0x6f, 0x70, 0x2d, 0x64, 0x65, 0x76, 0x2f, 0x63, 0x68, 0x61, 0x69, 0x6e, 0x6c, 0x6f,
-	0x6f, 0x70, 0x2f, 0x61, 0x70, 0x70, 0x2f, 0x63, 0x6f, 0x6e, 0x74, 0x72, 0x6f, 0x6c, 0x70, 0x6c,
-	0x61, 0x6e, 0x65, 0x2f, 0x61, 0x70, 0x69, 0x2f, 0x63, 0x6f, 0x6e, 0x74, 0x72, 0x6f, 0x6c, 0x70,
-	0x6c, 0x61, 0x6e, 0x65, 0x2f, 0x76, 0x31, 0x3b, 0x76, 0x31, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74,
-	0x6f, 0x33,
+	0x1a, 0x04, 0xa8, 0x45, 0x93, 0x03, 0x1a, 0x04, 0xa0, 0x45, 0xf4, 0x03, 0x2a, 0x80, 0x01, 0x0a,
+	0x17, 0x55, 0x73, 0x65, 0x72, 0x4e, 0x6f, 0x74, 0x4d, 0x65, 0x6d, 0x62, 0x65, 0x72, 0x4f, 0x66,
+	0x4f, 0x72, 0x67, 0x45, 0x72, 0x72, 0x6f, 0x72, 0x12, 0x2c, 0x0a, 0x28, 0x55, 0x53, 0x45, 0x52,
+	0x5f, 0x4e, 0x4f, 0x54, 0x5f, 0x4d, 0x45, 0x4d, 0x42, 0x45, 0x52, 0x5f, 0x4f, 0x46, 0x5f, 0x4f,
+	0x52, 0x47, 0x5f, 0x45, 0x52, 0x52, 0x4f, 0x52, 0x5f, 0x55, 0x4e, 0x53, 0x50, 0x45, 0x43, 0x49,
+	0x46, 0x49, 0x45, 0x44, 0x10, 0x00, 0x12, 0x31, 0x0a, 0x27, 0x55, 0x53, 0x45, 0x52, 0x5f, 0x4e,
+	0x4f, 0x54, 0x5f, 0x4d, 0x45, 0x4d, 0x42, 0x45, 0x52, 0x5f, 0x4f, 0x46, 0x5f, 0x4f, 0x52, 0x47,
+	0x5f, 0x45, 0x52, 0x52, 0x4f, 0x52, 0x5f, 0x4e, 0x4f, 0x54, 0x5f, 0x49, 0x4e, 0x5f, 0x4f, 0x52,
+	0x47, 0x10, 0x01, 0x1a, 0x04, 0xa8, 0x45, 0x93, 0x03, 0x1a, 0x04, 0xa0, 0x45, 0xf4, 0x03, 0x42,
+	0x4c, 0x5a, 0x4a, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x63, 0x68,
+	0x61, 0x69, 0x6e, 0x6c, 0x6f, 0x6f, 0x70, 0x2d, 0x64, 0x65, 0x76, 0x2f, 0x63, 0x68, 0x61, 0x69,
+	0x6e, 0x6c, 0x6f, 0x6f, 0x70, 0x2f, 0x61, 0x70, 0x70, 0x2f, 0x63, 0x6f, 0x6e, 0x74, 0x72, 0x6f,
+	0x6c, 0x70, 0x6c, 0x61, 0x6e, 0x65, 0x2f, 0x61, 0x70, 0x69, 0x2f, 0x63, 0x6f, 0x6e, 0x74, 0x72,
+	0x6f, 0x6c, 0x70, 0x6c, 0x61, 0x6e, 0x65, 0x2f, 0x76, 0x31, 0x3b, 0x76, 0x31, 0x62, 0x06, 0x70,
+	0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -2515,85 +2569,86 @@ func file_controlplane_v1_response_messages_proto_rawDescGZIP() []byte {
 	return file_controlplane_v1_response_messages_proto_rawDescData
 }
 
-var file_controlplane_v1_response_messages_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
+var file_controlplane_v1_response_messages_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
 var file_controlplane_v1_response_messages_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
 var file_controlplane_v1_response_messages_proto_goTypes = []interface{}{
 	(RunStatus)(0),                                  // 0: controlplane.v1.RunStatus
 	(MembershipRole)(0),                             // 1: controlplane.v1.MembershipRole
 	(AllowListError)(0),                             // 2: controlplane.v1.AllowListError
 	(UserWithNoMembershipError)(0),                  // 3: controlplane.v1.UserWithNoMembershipError
-	(WorkflowContractVersionItem_RawBody_Format)(0), // 4: controlplane.v1.WorkflowContractVersionItem.RawBody.Format
-	(CASBackendItem_ValidationStatus)(0),            // 5: controlplane.v1.CASBackendItem.ValidationStatus
-	(*WorkflowItem)(nil),                            // 6: controlplane.v1.WorkflowItem
-	(*WorkflowRunItem)(nil),                         // 7: controlplane.v1.WorkflowRunItem
-	(*ProjectVersion)(nil),                          // 8: controlplane.v1.ProjectVersion
-	(*AttestationItem)(nil),                         // 9: controlplane.v1.AttestationItem
-	(*PolicyEvaluations)(nil),                       // 10: controlplane.v1.PolicyEvaluations
-	(*PolicyEvaluation)(nil),                        // 11: controlplane.v1.PolicyEvaluation
-	(*PolicyViolation)(nil),                         // 12: controlplane.v1.PolicyViolation
-	(*PolicyReference)(nil),                         // 13: controlplane.v1.PolicyReference
-	(*WorkflowContractItem)(nil),                    // 14: controlplane.v1.WorkflowContractItem
-	(*WorkflowRef)(nil),                             // 15: controlplane.v1.WorkflowRef
-	(*WorkflowContractVersionItem)(nil),             // 16: controlplane.v1.WorkflowContractVersionItem
-	(*User)(nil),                                    // 17: controlplane.v1.User
-	(*OrgMembershipItem)(nil),                       // 18: controlplane.v1.OrgMembershipItem
-	(*OrgItem)(nil),                                 // 19: controlplane.v1.OrgItem
-	(*CASBackendItem)(nil),                          // 20: controlplane.v1.CASBackendItem
-	(*EntityRef)(nil),                               // 21: controlplane.v1.EntityRef
-	nil,                                             // 22: controlplane.v1.AttestationItem.AnnotationsEntry
-	nil,                                             // 23: controlplane.v1.AttestationItem.PolicyEvaluationsEntry
-	(*AttestationItem_EnvVariable)(nil),             // 24: controlplane.v1.AttestationItem.EnvVariable
-	(*AttestationItem_Material)(nil),                // 25: controlplane.v1.AttestationItem.Material
-	nil,                                             // 26: controlplane.v1.AttestationItem.Material.AnnotationsEntry
-	nil,                                             // 27: controlplane.v1.PolicyEvaluation.AnnotationsEntry
-	nil,                                             // 28: controlplane.v1.PolicyEvaluation.WithEntry
-	nil,                                             // 29: controlplane.v1.PolicyReference.DigestEntry
-	(*WorkflowContractVersionItem_RawBody)(nil), // 30: controlplane.v1.WorkflowContractVersionItem.RawBody
-	(*CASBackendItem_Limits)(nil),               // 31: controlplane.v1.CASBackendItem.Limits
-	(*timestamppb.Timestamp)(nil),               // 32: google.protobuf.Timestamp
-	(v1.CraftingSchema_Runner_RunnerType)(0),    // 33: workflowcontract.v1.CraftingSchema.Runner.RunnerType
-	(*v1.CraftingSchema)(nil),                   // 34: workflowcontract.v1.CraftingSchema
+	(UserNotMemberOfOrgError)(0),                    // 4: controlplane.v1.UserNotMemberOfOrgError
+	(WorkflowContractVersionItem_RawBody_Format)(0), // 5: controlplane.v1.WorkflowContractVersionItem.RawBody.Format
+	(CASBackendItem_ValidationStatus)(0),            // 6: controlplane.v1.CASBackendItem.ValidationStatus
+	(*WorkflowItem)(nil),                            // 7: controlplane.v1.WorkflowItem
+	(*WorkflowRunItem)(nil),                         // 8: controlplane.v1.WorkflowRunItem
+	(*ProjectVersion)(nil),                          // 9: controlplane.v1.ProjectVersion
+	(*AttestationItem)(nil),                         // 10: controlplane.v1.AttestationItem
+	(*PolicyEvaluations)(nil),                       // 11: controlplane.v1.PolicyEvaluations
+	(*PolicyEvaluation)(nil),                        // 12: controlplane.v1.PolicyEvaluation
+	(*PolicyViolation)(nil),                         // 13: controlplane.v1.PolicyViolation
+	(*PolicyReference)(nil),                         // 14: controlplane.v1.PolicyReference
+	(*WorkflowContractItem)(nil),                    // 15: controlplane.v1.WorkflowContractItem
+	(*WorkflowRef)(nil),                             // 16: controlplane.v1.WorkflowRef
+	(*WorkflowContractVersionItem)(nil),             // 17: controlplane.v1.WorkflowContractVersionItem
+	(*User)(nil),                                    // 18: controlplane.v1.User
+	(*OrgMembershipItem)(nil),                       // 19: controlplane.v1.OrgMembershipItem
+	(*OrgItem)(nil),                                 // 20: controlplane.v1.OrgItem
+	(*CASBackendItem)(nil),                          // 21: controlplane.v1.CASBackendItem
+	(*EntityRef)(nil),                               // 22: controlplane.v1.EntityRef
+	nil,                                             // 23: controlplane.v1.AttestationItem.AnnotationsEntry
+	nil,                                             // 24: controlplane.v1.AttestationItem.PolicyEvaluationsEntry
+	(*AttestationItem_EnvVariable)(nil),             // 25: controlplane.v1.AttestationItem.EnvVariable
+	(*AttestationItem_Material)(nil),                // 26: controlplane.v1.AttestationItem.Material
+	nil,                                             // 27: controlplane.v1.AttestationItem.Material.AnnotationsEntry
+	nil,                                             // 28: controlplane.v1.PolicyEvaluation.AnnotationsEntry
+	nil,                                             // 29: controlplane.v1.PolicyEvaluation.WithEntry
+	nil,                                             // 30: controlplane.v1.PolicyReference.DigestEntry
+	(*WorkflowContractVersionItem_RawBody)(nil), // 31: controlplane.v1.WorkflowContractVersionItem.RawBody
+	(*CASBackendItem_Limits)(nil),               // 32: controlplane.v1.CASBackendItem.Limits
+	(*timestamppb.Timestamp)(nil),               // 33: google.protobuf.Timestamp
+	(v1.CraftingSchema_Runner_RunnerType)(0),    // 34: workflowcontract.v1.CraftingSchema.Runner.RunnerType
+	(*v1.CraftingSchema)(nil),                   // 35: workflowcontract.v1.CraftingSchema
 }
 var file_controlplane_v1_response_messages_proto_depIdxs = []int32{
-	32, // 0: controlplane.v1.WorkflowItem.created_at:type_name -> google.protobuf.Timestamp
-	7,  // 1: controlplane.v1.WorkflowItem.last_run:type_name -> controlplane.v1.WorkflowRunItem
-	32, // 2: controlplane.v1.WorkflowRunItem.created_at:type_name -> google.protobuf.Timestamp
-	32, // 3: controlplane.v1.WorkflowRunItem.finished_at:type_name -> google.protobuf.Timestamp
+	33, // 0: controlplane.v1.WorkflowItem.created_at:type_name -> google.protobuf.Timestamp
+	8,  // 1: controlplane.v1.WorkflowItem.last_run:type_name -> controlplane.v1.WorkflowRunItem
+	33, // 2: controlplane.v1.WorkflowRunItem.created_at:type_name -> google.protobuf.Timestamp
+	33, // 3: controlplane.v1.WorkflowRunItem.finished_at:type_name -> google.protobuf.Timestamp
 	0,  // 4: controlplane.v1.WorkflowRunItem.status:type_name -> controlplane.v1.RunStatus
-	6,  // 5: controlplane.v1.WorkflowRunItem.workflow:type_name -> controlplane.v1.WorkflowItem
-	33, // 6: controlplane.v1.WorkflowRunItem.runner_type:type_name -> workflowcontract.v1.CraftingSchema.Runner.RunnerType
-	16, // 7: controlplane.v1.WorkflowRunItem.contract_version:type_name -> controlplane.v1.WorkflowContractVersionItem
-	8,  // 8: controlplane.v1.WorkflowRunItem.version:type_name -> controlplane.v1.ProjectVersion
-	24, // 9: controlplane.v1.AttestationItem.env_vars:type_name -> controlplane.v1.AttestationItem.EnvVariable
-	25, // 10: controlplane.v1.AttestationItem.materials:type_name -> controlplane.v1.AttestationItem.Material
-	22, // 11: controlplane.v1.AttestationItem.annotations:type_name -> controlplane.v1.AttestationItem.AnnotationsEntry
-	23, // 12: controlplane.v1.AttestationItem.policy_evaluations:type_name -> controlplane.v1.AttestationItem.PolicyEvaluationsEntry
-	11, // 13: controlplane.v1.PolicyEvaluations.evaluations:type_name -> controlplane.v1.PolicyEvaluation
-	27, // 14: controlplane.v1.PolicyEvaluation.annotations:type_name -> controlplane.v1.PolicyEvaluation.AnnotationsEntry
-	28, // 15: controlplane.v1.PolicyEvaluation.with:type_name -> controlplane.v1.PolicyEvaluation.WithEntry
-	12, // 16: controlplane.v1.PolicyEvaluation.violations:type_name -> controlplane.v1.PolicyViolation
-	13, // 17: controlplane.v1.PolicyEvaluation.policy_reference:type_name -> controlplane.v1.PolicyReference
-	13, // 18: controlplane.v1.PolicyEvaluation.group_reference:type_name -> controlplane.v1.PolicyReference
-	29, // 19: controlplane.v1.PolicyReference.digest:type_name -> controlplane.v1.PolicyReference.DigestEntry
-	32, // 20: controlplane.v1.WorkflowContractItem.created_at:type_name -> google.protobuf.Timestamp
-	15, // 21: controlplane.v1.WorkflowContractItem.workflow_refs:type_name -> controlplane.v1.WorkflowRef
-	32, // 22: controlplane.v1.WorkflowContractVersionItem.created_at:type_name -> google.protobuf.Timestamp
-	34, // 23: controlplane.v1.WorkflowContractVersionItem.v1:type_name -> workflowcontract.v1.CraftingSchema
-	30, // 24: controlplane.v1.WorkflowContractVersionItem.raw_contract:type_name -> controlplane.v1.WorkflowContractVersionItem.RawBody
-	32, // 25: controlplane.v1.User.created_at:type_name -> google.protobuf.Timestamp
-	19, // 26: controlplane.v1.OrgMembershipItem.org:type_name -> controlplane.v1.OrgItem
-	17, // 27: controlplane.v1.OrgMembershipItem.user:type_name -> controlplane.v1.User
-	32, // 28: controlplane.v1.OrgMembershipItem.created_at:type_name -> google.protobuf.Timestamp
-	32, // 29: controlplane.v1.OrgMembershipItem.updated_at:type_name -> google.protobuf.Timestamp
+	7,  // 5: controlplane.v1.WorkflowRunItem.workflow:type_name -> controlplane.v1.WorkflowItem
+	34, // 6: controlplane.v1.WorkflowRunItem.runner_type:type_name -> workflowcontract.v1.CraftingSchema.Runner.RunnerType
+	17, // 7: controlplane.v1.WorkflowRunItem.contract_version:type_name -> controlplane.v1.WorkflowContractVersionItem
+	9,  // 8: controlplane.v1.WorkflowRunItem.version:type_name -> controlplane.v1.ProjectVersion
+	25, // 9: controlplane.v1.AttestationItem.env_vars:type_name -> controlplane.v1.AttestationItem.EnvVariable
+	26, // 10: controlplane.v1.AttestationItem.materials:type_name -> controlplane.v1.AttestationItem.Material
+	23, // 11: controlplane.v1.AttestationItem.annotations:type_name -> controlplane.v1.AttestationItem.AnnotationsEntry
+	24, // 12: controlplane.v1.AttestationItem.policy_evaluations:type_name -> controlplane.v1.AttestationItem.PolicyEvaluationsEntry
+	12, // 13: controlplane.v1.PolicyEvaluations.evaluations:type_name -> controlplane.v1.PolicyEvaluation
+	28, // 14: controlplane.v1.PolicyEvaluation.annotations:type_name -> controlplane.v1.PolicyEvaluation.AnnotationsEntry
+	29, // 15: controlplane.v1.PolicyEvaluation.with:type_name -> controlplane.v1.PolicyEvaluation.WithEntry
+	13, // 16: controlplane.v1.PolicyEvaluation.violations:type_name -> controlplane.v1.PolicyViolation
+	14, // 17: controlplane.v1.PolicyEvaluation.policy_reference:type_name -> controlplane.v1.PolicyReference
+	14, // 18: controlplane.v1.PolicyEvaluation.group_reference:type_name -> controlplane.v1.PolicyReference
+	30, // 19: controlplane.v1.PolicyReference.digest:type_name -> controlplane.v1.PolicyReference.DigestEntry
+	33, // 20: controlplane.v1.WorkflowContractItem.created_at:type_name -> google.protobuf.Timestamp
+	16, // 21: controlplane.v1.WorkflowContractItem.workflow_refs:type_name -> controlplane.v1.WorkflowRef
+	33, // 22: controlplane.v1.WorkflowContractVersionItem.created_at:type_name -> google.protobuf.Timestamp
+	35, // 23: controlplane.v1.WorkflowContractVersionItem.v1:type_name -> workflowcontract.v1.CraftingSchema
+	31, // 24: controlplane.v1.WorkflowContractVersionItem.raw_contract:type_name -> controlplane.v1.WorkflowContractVersionItem.RawBody
+	33, // 25: controlplane.v1.User.created_at:type_name -> google.protobuf.Timestamp
+	20, // 26: controlplane.v1.OrgMembershipItem.org:type_name -> controlplane.v1.OrgItem
+	18, // 27: controlplane.v1.OrgMembershipItem.user:type_name -> controlplane.v1.User
+	33, // 28: controlplane.v1.OrgMembershipItem.created_at:type_name -> google.protobuf.Timestamp
+	33, // 29: controlplane.v1.OrgMembershipItem.updated_at:type_name -> google.protobuf.Timestamp
 	1,  // 30: controlplane.v1.OrgMembershipItem.role:type_name -> controlplane.v1.MembershipRole
-	32, // 31: controlplane.v1.OrgItem.created_at:type_name -> google.protobuf.Timestamp
-	32, // 32: controlplane.v1.CASBackendItem.created_at:type_name -> google.protobuf.Timestamp
-	32, // 33: controlplane.v1.CASBackendItem.validated_at:type_name -> google.protobuf.Timestamp
-	5,  // 34: controlplane.v1.CASBackendItem.validation_status:type_name -> controlplane.v1.CASBackendItem.ValidationStatus
-	31, // 35: controlplane.v1.CASBackendItem.limits:type_name -> controlplane.v1.CASBackendItem.Limits
-	10, // 36: controlplane.v1.AttestationItem.PolicyEvaluationsEntry.value:type_name -> controlplane.v1.PolicyEvaluations
-	26, // 37: controlplane.v1.AttestationItem.Material.annotations:type_name -> controlplane.v1.AttestationItem.Material.AnnotationsEntry
-	4,  // 38: controlplane.v1.WorkflowContractVersionItem.RawBody.format:type_name -> controlplane.v1.WorkflowContractVersionItem.RawBody.Format
+	33, // 31: controlplane.v1.OrgItem.created_at:type_name -> google.protobuf.Timestamp
+	33, // 32: controlplane.v1.CASBackendItem.created_at:type_name -> google.protobuf.Timestamp
+	33, // 33: controlplane.v1.CASBackendItem.validated_at:type_name -> google.protobuf.Timestamp
+	6,  // 34: controlplane.v1.CASBackendItem.validation_status:type_name -> controlplane.v1.CASBackendItem.ValidationStatus
+	32, // 35: controlplane.v1.CASBackendItem.limits:type_name -> controlplane.v1.CASBackendItem.Limits
+	11, // 36: controlplane.v1.AttestationItem.PolicyEvaluationsEntry.value:type_name -> controlplane.v1.PolicyEvaluations
+	27, // 37: controlplane.v1.AttestationItem.Material.annotations:type_name -> controlplane.v1.AttestationItem.Material.AnnotationsEntry
+	5,  // 38: controlplane.v1.WorkflowContractVersionItem.RawBody.format:type_name -> controlplane.v1.WorkflowContractVersionItem.RawBody.Format
 	39, // [39:39] is the sub-list for method output_type
 	39, // [39:39] is the sub-list for method input_type
 	39, // [39:39] is the sub-list for extension type_name
@@ -2860,7 +2915,7 @@ func file_controlplane_v1_response_messages_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_controlplane_v1_response_messages_proto_rawDesc,
-			NumEnums:      6,
+			NumEnums:      7,
 			NumMessages:   26,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/app/controlplane/api/controlplane/v1/response_messages.proto
+++ b/app/controlplane/api/controlplane/v1/response_messages.proto
@@ -274,6 +274,12 @@ enum UserWithNoMembershipError {
   USER_WITH_NO_MEMBERSHIP_ERROR_NOT_IN_ORG = 1 [(errors.code) = 403];
 }
 
+enum UserNotMemberOfOrgError {
+  option (errors.default_code) = 500;
+  USER_NOT_MEMBER_OF_ORG_ERROR_UNSPECIFIED = 0;
+  USER_NOT_MEMBER_OF_ORG_ERROR_NOT_IN_ORG = 1 [(errors.code) = 403];
+}
+
 // EntityRef is a reference to an entity in the system that can be either by name or ID
 message EntityRef {
   oneof ref {

--- a/app/controlplane/api/controlplane/v1/response_messages_errors.pb.go
+++ b/app/controlplane/api/controlplane/v1/response_messages_errors.pb.go
@@ -58,3 +58,27 @@ func IsUserWithNoMembershipErrorNotInOrg(err error) bool {
 func ErrorUserWithNoMembershipErrorNotInOrg(format string, args ...interface{}) *errors.Error {
 	return errors.New(403, UserWithNoMembershipError_USER_WITH_NO_MEMBERSHIP_ERROR_NOT_IN_ORG.String(), fmt.Sprintf(format, args...))
 }
+
+func IsUserNotMemberOfOrgErrorUnspecified(err error) bool {
+	if err == nil {
+		return false
+	}
+	e := errors.FromError(err)
+	return e.Reason == UserNotMemberOfOrgError_USER_NOT_MEMBER_OF_ORG_ERROR_UNSPECIFIED.String() && e.Code == 500
+}
+
+func ErrorUserNotMemberOfOrgErrorUnspecified(format string, args ...interface{}) *errors.Error {
+	return errors.New(500, UserNotMemberOfOrgError_USER_NOT_MEMBER_OF_ORG_ERROR_UNSPECIFIED.String(), fmt.Sprintf(format, args...))
+}
+
+func IsUserNotMemberOfOrgErrorNotInOrg(err error) bool {
+	if err == nil {
+		return false
+	}
+	e := errors.FromError(err)
+	return e.Reason == UserNotMemberOfOrgError_USER_NOT_MEMBER_OF_ORG_ERROR_NOT_IN_ORG.String() && e.Code == 403
+}
+
+func ErrorUserNotMemberOfOrgErrorNotInOrg(format string, args ...interface{}) *errors.Error {
+	return errors.New(403, UserNotMemberOfOrgError_USER_NOT_MEMBER_OF_ORG_ERROR_NOT_IN_ORG.String(), fmt.Sprintf(format, args...))
+}

--- a/app/controlplane/api/gen/frontend/controlplane/v1/response_messages.ts
+++ b/app/controlplane/api/gen/frontend/controlplane/v1/response_messages.ts
@@ -179,6 +179,39 @@ export function userWithNoMembershipErrorToJSON(object: UserWithNoMembershipErro
   }
 }
 
+export enum UserNotMemberOfOrgError {
+  USER_NOT_MEMBER_OF_ORG_ERROR_UNSPECIFIED = 0,
+  USER_NOT_MEMBER_OF_ORG_ERROR_NOT_IN_ORG = 1,
+  UNRECOGNIZED = -1,
+}
+
+export function userNotMemberOfOrgErrorFromJSON(object: any): UserNotMemberOfOrgError {
+  switch (object) {
+    case 0:
+    case "USER_NOT_MEMBER_OF_ORG_ERROR_UNSPECIFIED":
+      return UserNotMemberOfOrgError.USER_NOT_MEMBER_OF_ORG_ERROR_UNSPECIFIED;
+    case 1:
+    case "USER_NOT_MEMBER_OF_ORG_ERROR_NOT_IN_ORG":
+      return UserNotMemberOfOrgError.USER_NOT_MEMBER_OF_ORG_ERROR_NOT_IN_ORG;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return UserNotMemberOfOrgError.UNRECOGNIZED;
+  }
+}
+
+export function userNotMemberOfOrgErrorToJSON(object: UserNotMemberOfOrgError): string {
+  switch (object) {
+    case UserNotMemberOfOrgError.USER_NOT_MEMBER_OF_ORG_ERROR_UNSPECIFIED:
+      return "USER_NOT_MEMBER_OF_ORG_ERROR_UNSPECIFIED";
+    case UserNotMemberOfOrgError.USER_NOT_MEMBER_OF_ORG_ERROR_NOT_IN_ORG:
+      return "USER_NOT_MEMBER_OF_ORG_ERROR_NOT_IN_ORG";
+    case UserNotMemberOfOrgError.UNRECOGNIZED:
+    default:
+      return "UNRECOGNIZED";
+  }
+}
+
 export interface WorkflowItem {
   id: string;
   name: string;

--- a/app/controlplane/internal/service/context.go
+++ b/app/controlplane/internal/service/context.go
@@ -19,6 +19,9 @@ import (
 	"context"
 
 	pb "github.com/chainloop-dev/chainloop/app/controlplane/api/controlplane/v1"
+	v1 "github.com/chainloop-dev/chainloop/app/controlplane/api/controlplane/v1"
+	"github.com/chainloop-dev/chainloop/app/controlplane/internal/usercontext"
+	"github.com/chainloop-dev/chainloop/app/controlplane/internal/usercontext/entities"
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/biz"
 	errors "github.com/go-kratos/kratos/v2/errors"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -52,6 +55,13 @@ func (s *ContextService) Current(ctx context.Context, _ *pb.ContextServiceCurren
 
 	res := &pb.ContextServiceCurrentResponse_Result{}
 
+	// Load current org if available since it can be a user with no org
+	// This is the case for API tokens
+	currentOrg, err := requireCurrentOrg(ctx)
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, err
+	}
+
 	// Load user/API token info
 	if currentAPIToken != nil {
 		res.CurrentUser = &pb.User{
@@ -61,12 +71,36 @@ func (s *ContextService) Current(ctx context.Context, _ *pb.ContextServiceCurren
 		res.CurrentUser = &pb.User{
 			Id: currentUser.ID, Email: currentUser.Email, CreatedAt: timestamppb.New(*currentUser.CreatedAt),
 		}
-	}
 
-	// Load current org if available since it can be a user with no org
-	currentOrg, err := requireCurrentOrg(ctx)
-	if err != nil && !errors.IsNotFound(err) {
-		return nil, err
+		// For regular users, we need to load the membership manually
+		// NOTE that we are not using the middleware here because we want to handle the case
+		// when there is no organization or membership gracefully
+		orgName, err := usercontext.GetOrganizationNameFromHeader(ctx)
+		if err != nil {
+			return nil, handleUseCaseErr(err, s.log)
+		}
+
+		// It might not be set in the header, so we load it from the DB
+		if orgName == "" {
+			membership, err := s.userUC.CurrentMembership(ctx, currentUser.ID)
+			if err != nil && !biz.IsNotFound(err) {
+				return nil, handleUseCaseErr(err, s.log)
+			} else if membership != nil {
+				orgName = membership.Org.Name
+			}
+		}
+
+		if orgName != "" {
+			m, err := s.userUC.MembershipInOrg(ctx, currentUser.ID, orgName)
+			if err != nil && !biz.IsNotFound(err) {
+				return nil, handleUseCaseErr(err, s.log)
+			} else if err != nil {
+				return nil, v1.ErrorUserNotMemberOfOrgErrorNotInOrg("user is not a member of organization %s", orgName)
+			}
+
+			res.CurrentMembership = bizMembershipToPb(m)
+			currentOrg = &entities.Org{Name: m.Org.Name, ID: m.Org.ID, CreatedAt: m.CreatedAt}
+		}
 	}
 
 	if currentOrg != nil {
@@ -78,18 +112,6 @@ func (s *ContextService) Current(ctx context.Context, _ *pb.ContextServiceCurren
 
 		if backend != nil {
 			res.CurrentCasBackend = bizCASBackendToPb(backend)
-		}
-	}
-
-	// Optionally add current membership
-	if currentUser != nil {
-		m, err := s.userUC.CurrentMembership(ctx, currentUser.ID)
-		if err != nil && !biz.IsNotFound(err) {
-			return nil, handleUseCaseErr(err, s.log)
-		}
-
-		if m != nil {
-			res.CurrentMembership = bizMembershipToPb(m)
 		}
 	}
 

--- a/app/controlplane/internal/usercontext/currentorganization_middleware.go
+++ b/app/controlplane/internal/usercontext/currentorganization_middleware.go
@@ -36,7 +36,7 @@ func WithCurrentOrganizationMiddleware(userUseCase biz.UserOrgFinder, logger *lo
 				return handler(ctx, req)
 			}
 
-			orgName, err := getOrganizationName(ctx)
+			orgName, err := GetOrganizationNameFromHeader(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("error getting organization name: %w", err)
 			}
@@ -44,7 +44,7 @@ func WithCurrentOrganizationMiddleware(userUseCase biz.UserOrgFinder, logger *lo
 			if orgName != "" {
 				ctx, err = setCurrentOrganizationFromHeader(ctx, u, orgName, userUseCase)
 				if err != nil {
-					return nil, fmt.Errorf("error setting current org: %w", err)
+					return nil, v1.ErrorUserNotMemberOfOrgErrorNotInOrg("user is not a member of organization %s", orgName)
 				}
 			} else {
 				// If no organization name is provided, we use the DB to find the current organization

--- a/app/controlplane/internal/usercontext/usercontext.go
+++ b/app/controlplane/internal/usercontext/usercontext.go
@@ -37,7 +37,7 @@ func GetRawToken(ctx context.Context) (string, error) {
 	return auths[1], nil
 }
 
-func getOrganizationName(ctx context.Context) (string, error) {
+func GetOrganizationNameFromHeader(ctx context.Context) (string, error) {
 	const OrganizationHeader = "Chainloop-Organization"
 	header, ok := transport.FromServerContext(ctx)
 	if ok {

--- a/app/controlplane/pkg/biz/user.go
+++ b/app/controlplane/pkg/biz/user.go
@@ -163,7 +163,7 @@ func (uc *UserUseCase) FindByID(ctx context.Context, userID string) (*User, erro
 func (uc *UserUseCase) MembershipInOrg(ctx context.Context, userID string, orgName string) (*Membership, error) {
 	m, err := uc.membershipUseCase.FindByOrgNameAndUser(ctx, orgName, userID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find membership: %w", err)
+		return nil, err
 	} else if m == nil {
 		return nil, NewErrNotFound("user does not have this org associated")
 	}


### PR DESCRIPTION
This PR moves the selection of the current organization to the client side configuration file.

This is how it works

The first time you login, or if the config file doesn't exist, or the `organization` entry in the file doesn't exist, the system will retrieve it and do it transparently.

For example, the organization-2 is marked as default server side and it's also marked as current client-side

```
$ cl org ls
┌────────────────┬─────────┬─────────┬───────┬─────────────────────┐
│ NAME           │ CURRENT │ DEFAULT │ ROLE  │ JOINED AT           │
├────────────────┼─────────┼─────────┼───────┼─────────────────────┤
│ organization-1 │ false   │ false   │ owner │ 17 Dec 24 12:40 UTC │
├────────────────┼─────────┼─────────┼───────┼─────────────────────┤
│ organization-2 │ true    │ true    │ owner │ 17 Dec 24 12:40 UTC │
└────────────────┴─────────┴─────────┴───────┴─────────────────────┘
``` 

to switch, you'll use `org set` as before but by default, this one will only affect the local state

```
$ cl org set --name organization-1
$ cl org ls
┌────────────────┬─────────┬─────────┬───────┬─────────────────────┐
│ NAME           │ CURRENT │ DEFAULT │ ROLE  │ JOINED AT           │
├────────────────┼─────────┼─────────┼───────┼─────────────────────┤
│ organization-1 │ true    │ false   │ owner │ 17 Dec 24 12:40 UTC │
├────────────────┼─────────┼─────────┼───────┼─────────────────────┤
│ organization-2 │ false   │ true    │ owner │ 17 Dec 24 12:40 UTC │
└────────────────┴─────────┴─────────┴───────┴─────────────────────┘

$ cl org describe
┌──────────────────────────────────────────────────────────┐
│ Current Context                                          │
├─────────────────────┬────────────────────────────────────┤
│ Logged in as        │ john@chainloop.local               │
├─────────────────────┼────────────────────────────────────┤
│ Organization        │ organization-1 (role=owner)        │
├─────────────────────┼────────────────────────────────────┤
│ Default CAS Backend │  (provider=INLINE, status="valid") │
└─────────────────────┴────────────────────────────────────┘
```
you can set the default value server side by providing a `--default` flag to `cl org set`


You can also select the organization on the fly with the `--org` or `-n` flags.

```
$ cl org describe --org organization-2
┌──────────────────────────────────────────────────────────┐
│ Current Context                                          │
├─────────────────────┬────────────────────────────────────┤
│ Logged in as        │ john@chainloop.local               │
├─────────────────────┼────────────────────────────────────┤
│ Organization        │ organization-2 (role=owner)        │
├─────────────────────┼────────────────────────────────────┤
│ Default CAS Backend │  (provider=INLINE, status="valid") │
└─────────────────────┴────────────────────────────────────┘
```

I've also fixed a bug that prevented the current-context endpoint from returning org information when the client was authenticated as an user.

Fixes #350