### PR TITLE
fix(policies): ignore http 405 as well as 404 

### DIFF
--- a/app/controlplane/pkg/policies/policyprovider.go
+++ b/app/controlplane/pkg/policies/policyprovider.go
@@ -138,7 +138,7 @@ func (p *PolicyProvider) ValidateAttachment(att *schemaapi.PolicyAttachment, tok
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		if resp.StatusCode == http.StatusNotFound {
+		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusMethodNotAllowed {
 			// Ignore endpoint not found as it might not be implemented by the provider
 			return nil
 		}


### PR DESCRIPTION
When validating attachment, it's possible that the policy provider doesn't implement all endpoints and/org methods. This PR adds an additional exception to ignore those cases.