### PR TITLE
chore(conf): Refactor configuration of use case

### DIFF
--- a/app/controlplane/cmd/wire.go
+++ b/app/controlplane/cmd/wire.go
@@ -61,6 +61,7 @@ func wireApp(*conf.Bootstrap, credentials.ReaderWriter, log.Logger, sdk.Availabl
 			newPolicyProviderConfig,
 			newNatsConnection,
 			auditor.NewAuditLogPublisher,
+			newCASServerOptions,
 		),
 	)
 }
@@ -84,5 +85,14 @@ func newPolicyProviderConfig(in []*conf.PolicyProvider) []*policies.NewRegistryC
 func serviceOpts(l log.Logger) []service.NewOpt {
 	return []service.NewOpt{
 		service.WithLogger(l),
+	}
+}
+
+func newCASServerOptions(in *conf.Bootstrap_CASServer) *biz.CASServerDefaultOpts {
+	if in == nil {
+		return &biz.CASServerDefaultOpts{}
+	}
+	return &biz.CASServerDefaultOpts{
+		DefaultEntryMaxSize: in.GetDefaultEntryMaxSize(),
 	}
 }

--- a/app/controlplane/cmd/wire_gen.go
+++ b/app/controlplane/cmd/wire_gen.go
@@ -43,7 +43,8 @@ func wireApp(bootstrap *conf.Bootstrap, readerWriter credentials.ReaderWriter, l
 	casBackendRepo := data.NewCASBackendRepo(dataData, logger)
 	providers := loader.LoadProviders(readerWriter)
 	bootstrap_CASServer := bootstrap.CasServer
-	casBackendUseCase, err := biz.NewCASBackendUseCase(casBackendRepo, readerWriter, providers, bootstrap_CASServer, logger)
+	casServerDefaultOpts := newCASServerOptions(bootstrap_CASServer)
+	casBackendUseCase, err := biz.NewCASBackendUseCase(casBackendRepo, readerWriter, providers, casServerDefaultOpts, logger)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
@@ -310,4 +311,13 @@ func newPolicyProviderConfig(in []*conf.PolicyProvider) []*policies.NewRegistryC
 
 func serviceOpts(l log.Logger) []service.NewOpt {
 	return []service.NewOpt{service.WithLogger(l)}
+}
+
+func newCASServerOptions(in *conf.Bootstrap_CASServer) *biz.CASServerDefaultOpts {
+	if in == nil {
+		return &biz.CASServerDefaultOpts{}
+	}
+	return &biz.CASServerDefaultOpts{
+		DefaultEntryMaxSize: in.GetDefaultEntryMaxSize(),
+	}
 }

--- a/app/controlplane/pkg/biz/casbackend.go
+++ b/app/controlplane/pkg/biz/casbackend.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/bytefmt"
-	conf "github.com/chainloop-dev/chainloop/app/controlplane/internal/conf/controlplane/config/v1"
 	backend "github.com/chainloop-dev/chainloop/pkg/blobmanager"
 	"github.com/chainloop-dev/chainloop/pkg/blobmanager/azureblob"
 	"github.com/chainloop-dev/chainloop/pkg/blobmanager/oci"
@@ -119,13 +118,18 @@ type CASBackendUseCase struct {
 	MaxBytesDefault int64
 }
 
-func NewCASBackendUseCase(repo CASBackendRepo, credsRW credentials.ReaderWriter, providers backend.Providers, c *conf.Bootstrap_CASServer, l log.Logger) (*CASBackendUseCase, error) {
+// CASServerDefaultOpts holds the default options for the CAS server
+type CASServerDefaultOpts struct {
+	DefaultEntryMaxSize string
+}
+
+func NewCASBackendUseCase(repo CASBackendRepo, credsRW credentials.ReaderWriter, providers backend.Providers, c *CASServerDefaultOpts, l log.Logger) (*CASBackendUseCase, error) {
 	if l == nil {
 		l = log.NewStdLogger(io.Discard)
 	}
 
 	var maxBytesDefault uint64 = 100 * 1024 * 1024 // 100MB
-	if c.GetDefaultEntryMaxSize() != "" {
+	if c != nil && c.DefaultEntryMaxSize != "" {
 		var err error
 		maxBytesDefault, err = bytefmt.ToBytes(c.DefaultEntryMaxSize)
 		if err != nil {

--- a/app/controlplane/pkg/biz/casbackend_test.go
+++ b/app/controlplane/pkg/biz/casbackend_test.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"testing"
 
-	conf "github.com/chainloop-dev/chainloop/app/controlplane/internal/conf/controlplane/config/v1"
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/biz"
 	bizMocks "github.com/chainloop-dev/chainloop/app/controlplane/pkg/biz/mocks"
 	backends "github.com/chainloop-dev/chainloop/pkg/blobmanager"
@@ -178,7 +177,7 @@ func (s *casBackendTestSuite) TestNewCASBackendUseCase() {
 
 	tests := []struct {
 		name        string
-		config      *conf.Bootstrap_CASServer
+		config      *biz.CASServerDefaultOpts
 		expectError bool
 		errorMsg    string
 		wantSize    int64 // Expected size in bytes after parsing
@@ -191,7 +190,7 @@ func (s *casBackendTestSuite) TestNewCASBackendUseCase() {
 		},
 		{
 			name: "valid size - megabytes",
-			config: &conf.Bootstrap_CASServer{
+			config: &biz.CASServerDefaultOpts{
 				DefaultEntryMaxSize: "100MB",
 			},
 			expectError: false,
@@ -199,7 +198,7 @@ func (s *casBackendTestSuite) TestNewCASBackendUseCase() {
 		},
 		{
 			name: "valid size - gigabytes",
-			config: &conf.Bootstrap_CASServer{
+			config: &biz.CASServerDefaultOpts{
 				DefaultEntryMaxSize: "2GB",
 			},
 			expectError: false,
@@ -207,7 +206,7 @@ func (s *casBackendTestSuite) TestNewCASBackendUseCase() {
 		},
 		{
 			name: "invalid size format",
-			config: &conf.Bootstrap_CASServer{
+			config: &biz.CASServerDefaultOpts{
 				DefaultEntryMaxSize: "invalid",
 			},
 			expectError: true,
@@ -216,7 +215,7 @@ func (s *casBackendTestSuite) TestNewCASBackendUseCase() {
 		},
 		{
 			name: "negative size",
-			config: &conf.Bootstrap_CASServer{
+			config: &biz.CASServerDefaultOpts{
 				DefaultEntryMaxSize: "-100MB",
 			},
 			expectError: true,
@@ -225,7 +224,7 @@ func (s *casBackendTestSuite) TestNewCASBackendUseCase() {
 		},
 		{
 			name: "zero size",
-			config: &conf.Bootstrap_CASServer{
+			config: &biz.CASServerDefaultOpts{
 				DefaultEntryMaxSize: "0",
 			},
 			expectError: true,
@@ -234,7 +233,7 @@ func (s *casBackendTestSuite) TestNewCASBackendUseCase() {
 		},
 		{
 			name: "missing unit",
-			config: &conf.Bootstrap_CASServer{
+			config: &biz.CASServerDefaultOpts{
 				DefaultEntryMaxSize: "100",
 			},
 			expectError: true,

--- a/app/controlplane/pkg/biz/testhelpers/database.go
+++ b/app/controlplane/pkg/biz/testhelpers/database.go
@@ -207,6 +207,12 @@ func NewCASBackendConfig() *conf.Bootstrap_CASServer {
 	}
 }
 
+func NewCASServerOptions(in *conf.Bootstrap_CASServer) *biz.CASServerDefaultOpts {
+	return &biz.CASServerDefaultOpts{
+		DefaultEntryMaxSize: in.GetDefaultEntryMaxSize(),
+	}
+}
+
 func NewPromSpec() []*conf.PrometheusIntegrationSpec {
 	return []*conf.PrometheusIntegrationSpec{}
 }

--- a/app/controlplane/pkg/biz/testhelpers/wire.go
+++ b/app/controlplane/pkg/biz/testhelpers/wire.go
@@ -58,6 +58,7 @@ func WireTestData(*TestDatabase, *testing.T, log.Logger, credentials.ReaderWrite
 			newNatsConnection,
 			auditor.NewAuditLogPublisher,
 			NewCASBackendConfig,
+			NewCASServerOptions,
 		),
 	)
 }

--- a/app/controlplane/pkg/biz/testhelpers/wire_gen.go
+++ b/app/controlplane/pkg/biz/testhelpers/wire_gen.go
@@ -41,7 +41,8 @@ func WireTestData(testDatabase *TestDatabase, t *testing.T, logger log.Logger, r
 	organizationRepo := data.NewOrganizationRepo(dataData, logger)
 	casBackendRepo := data.NewCASBackendRepo(dataData, logger)
 	bootstrap_CASServer := NewCASBackendConfig()
-	casBackendUseCase, err := biz.NewCASBackendUseCase(casBackendRepo, readerWriter, providers, bootstrap_CASServer, logger)
+	casServerDefaultOpts := NewCASServerOptions(bootstrap_CASServer)
+	casBackendUseCase, err := biz.NewCASBackendUseCase(casBackendRepo, readerWriter, providers, casServerDefaultOpts, logger)
 	if err != nil {
 		cleanup()
 		return nil, nil, err


### PR DESCRIPTION
This patch refactors the dependencies of `CASBackendUseCase` to use an intermediate structure and avoid using the internal configuration object.

Close #1675 