### PR TITLE
feat: show attestation-level policy evaluations on status

### DIFF
--- a/app/cli/cmd/attestation_init.go
+++ b/app/cli/cmd/attestation_init.go
@@ -115,7 +115,7 @@ func newAttestationInitCmd() *cobra.Command {
 				return newGracefulError(err)
 			}
 
-			res, err := statusAction.Run(cmd.Context(), attestationID)
+			res, err := statusAction.Run(cmd.Context(), attestationID, action.WithSkipPolicyEvaluation())
 			if err != nil {
 				return newGracefulError(err)
 			}

--- a/app/cli/cmd/attestation_status.go
+++ b/app/cli/cmd/attestation_status.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/chainloop-dev/chainloop/app/cli/internal/action"
+	"github.com/chainloop-dev/chainloop/pkg/attestation/renderer/chainloop"
 )
 
 var full bool
@@ -91,7 +92,7 @@ func attestationStatusTableOutput(status *action.AttestationStatusResult, full b
 	}
 
 	gt.AppendRow(table.Row{"Version", projectVersion})
-	gt.AppendRow(table.Row{"Contract Revision", meta.ContractRevision})
+	gt.AppendRow(table.Row{"Contract", fmt.Sprintf("%s (revision %s)", meta.ContractName, meta.ContractRevision)})
 	if status.RunnerContext.JobURL != "" {
 		gt.AppendRow(table.Row{"Runner Type", status.RunnerContext.RunnerType})
 		gt.AppendRow(table.Row{"Runner URL", status.RunnerContext.JobURL})
@@ -108,6 +109,11 @@ func attestationStatusTableOutput(status *action.AttestationStatusResult, full b
 		}
 	}
 
+	evs := status.PolicyEvaluations[chainloop.AttPolicyEvaluation]
+	if len(evs) > 0 {
+		gt.AppendRow(table.Row{"Policies", "------"})
+		policiesTable(evs, gt)
+	}
 	gt.Render()
 
 	if err := materialsTable(status, full); err != nil {

--- a/pkg/attestation/crafter/crafter.go
+++ b/pkg/attestation/crafter/crafter.go
@@ -35,6 +35,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/google/go-containerregistry/pkg/authn"
+	intoto "github.com/in-toto/attestation/go/v1"
 	"github.com/rs/zerolog"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -590,6 +591,24 @@ func (c *Crafter) addMaterial(ctx context.Context, m *schemaapi.CraftingSchema_M
 
 	c.Logger.Debug().Str("key", m.Name).Msg("added to state")
 	return nil
+}
+
+func (c *Crafter) EvaluateAttestationPolicies(ctx context.Context, statement *intoto.Statement) ([]*api.PolicyEvaluation, error) {
+	// evaluate attestation-level policies
+	pv := policies.NewPolicyVerifier(c.CraftingState.InputSchema, c.attClient, c.Logger)
+	policyResults, err := pv.VerifyStatement(ctx, statement)
+	if err != nil {
+		return nil, fmt.Errorf("evaluating policies in statement: %w", err)
+	}
+
+	pgv := policies.NewPolicyGroupVerifier(c.CraftingState.InputSchema, c.attClient, c.Logger)
+	policyGroupResults, err := pgv.VerifyStatement(ctx, statement)
+	if err != nil {
+		return nil, fmt.Errorf("evaluating policy groups in statement: %w", err)
+	}
+
+	policyResults = append(policyResults, policyGroupResults...)
+	return policyResults, nil
 }
 
 func (c *Crafter) ValidateAttestation() error {

--- a/pkg/attestation/renderer/renderer.go
+++ b/pkg/attestation/renderer/renderer.go
@@ -94,6 +94,16 @@ func NewAttestationRenderer(state *crafter.VersionedCraftingState, attClient pb.
 	return r, nil
 }
 
+// Render the in-toto statement without envelope nor validation so it can be used for example for policy evaluation
+func (ab *AttestationRenderer) RenderStatement(ctx context.Context) (*intoto.Statement, error) {
+	statement, err := ab.renderer.Statement(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("generating in-toto statement: %w", err)
+	}
+
+	return statement, nil
+}
+
 // Attestation (dsee envelope) -> { message: { Statement(in-toto): [subject, predicate] }, signature: "sig" }.
 // NOTE: It currently only supports cosign key based signing.
 func (ab *AttestationRenderer) Render(ctx context.Context) (*dsse.Envelope, error) {

--- a/pkg/policies/policies.go
+++ b/pkg/policies/policies.go
@@ -567,12 +567,12 @@ func LogPolicyEvaluations(evaluations []*v12.PolicyEvaluation, logger *zerolog.L
 		}
 
 		if policyEval.Skipped {
-			logger.Warn().Msgf("policy evaluation skipped (%s) for %s. Reasons: %s", policyEval.Name, subject, policyEval.SkipReasons)
+			logger.Debug().Msgf("policy evaluation skipped (%s) for %s. Reasons: %s", policyEval.Name, subject, policyEval.SkipReasons)
 		}
 		if len(policyEval.Violations) > 0 {
-			logger.Warn().Msgf("found policy violations (%s) for %s", policyEval.Name, subject)
+			logger.Debug().Msgf("found policy violations (%s) for %s", policyEval.Name, subject)
 			for _, v := range policyEval.Violations {
-				logger.Warn().Msgf(" - %s", v.Message)
+				logger.Debug().Msgf(" - %s", v.Message)
 			}
 		}
 	}

--- a/pkg/policies/policies.go
+++ b/pkg/policies/policies.go
@@ -129,9 +129,9 @@ func (pv *PolicyVerifier) evaluatePolicyAttachment(ctx context.Context, attachme
 	}
 
 	if opts.name != "" {
-		pv.logger.Info().Msgf("evaluating policy %s against %s", policy.Metadata.Name, opts.name)
+		pv.logger.Debug().Msgf("evaluating policy %s against %s", policy.Metadata.Name, opts.name)
 	} else {
-		pv.logger.Info().Msgf("evaluating policy %s against attestation", policy.Metadata.Name)
+		pv.logger.Debug().Msgf("evaluating policy %s against attestation", policy.Metadata.Name)
 	}
 
 	args, err := ComputeArguments(policy.GetSpec().GetInputs(), attachment.GetWith(), opts.bindings, pv.logger)


### PR DESCRIPTION
Now, when we run `att status` or `att push`, you'll get not only the policy evaluations related to materials but also the attestation-level ones.

I've also lowered the level of some logger entries since now we show the info in the attestation result.

Init has not changed

```sh
$ chainloop att init --workflow test-sbom --project test --replace
INF Attestation initialized! now you can check its status or add materials to it
┌────────────────┬──────────────────────────────────────┐
│ Initialized At │ 19 Dec 24 21:45 UTC                  │
├────────────────┼──────────────────────────────────────┤
│ Attestation ID │ 49632035-10b7-4ff2-bd05-550651825b2f │
│ Organization   │ miguel                               │
│ Name           │ test-sbom                            │
│ Project        │ test                                 │
│ Version        │ v0.147.0 (prerelease)                │
│ Contract       │ test-test-sbom (revision 6)          │
└────────────────┴──────────────────────────────────────┘
```

```sh
$ chainloop att add --name sbom-2 --value ~/Desktop/result.cdx
INF uploading result.cdx - sha256:925ed5a789bad4bc2658ba371530bf3b80639be02d7acd9069c0e52690508132
INF material kind detected kind=SBOM_CYCLONEDX_JSON
INF material added to attestation
```

Status show all the policy information
```
$ chainloop att status
┌────────────────┬─────────────────────────────────────────────────────────────────────────┐
│ Initialized At │ 19 Dec 24 21:45 UTC                                                     │
├────────────────┼─────────────────────────────────────────────────────────────────────────┤
│ Attestation ID │ 49632035-10b7-4ff2-bd05-550651825b2f                                    │
│ Organization   │ miguel                                                                  │
│ Name           │ test-sbom                                                               │
│ Project        │ test                                                                    │
│ Version        │ v0.147.0 (prerelease)                                                   │
│ Contract       │ test-test-sbom (revision 6)                                             │
│ Policies       │ ------                                                                  │
│                │ sbom-present: Ok                                                        │
│                │ material-present: no material found with type CONTAINER_IMAGE (1 times) │
└────────────────┴─────────────────────────────────────────────────────────────────────────┘
┌─────────────────────────────────────────────────────────────────────────┐
│ Materials                                                               │
├──────────┬──────────────────────────────────────────────────────────────┤
│ Name     │ sbom-2                                                       │
│ Type     │ SBOM_CYCLONEDX_JSON                                          │
│ Set      │ Yes                                                          │
│ Required │ No                                                           │
│ Policies │ ------                                                       │
│          │ sbom-ntia:                                                   │
│          │   - missing author                                           │
│          │   - missing supplier for 'alpine'                            │
│          │   - missing unique identifier (PURL, CPE, SWID) for 'alpine' │
│          │ sbom-banned-licenses: Ok                                     │
│          │ sbom-freshness: Ok                                           │
└──────────┴──────────────────────────────────────────────────────────────┘
```

and also push

```
$ chainloop att push
INF push completed
┌────────────────┬─────────────────────────────────────────────────────────────────────────┐
│ Initialized At │ 19 Dec 24 21:45 UTC                                                     │
├────────────────┼─────────────────────────────────────────────────────────────────────────┤
│ Attestation ID │ 49632035-10b7-4ff2-bd05-550651825b2f                                    │
│ Organization   │ miguel                                                                  │
│ Name           │ test-sbom                                                               │
│ Project        │ test                                                                    │
│ Version        │ v0.147.0 (prerelease)                                                   │
│ Contract       │ test-test-sbom (revision 6)                                             │
│ Policies       │ ------                                                                  │
│                │ sbom-present: Ok                                                        │
│                │ material-present: no material found with type CONTAINER_IMAGE (1 times) │
└────────────────┴─────────────────────────────────────────────────────────────────────────┘
┌────────────────────────────────────────────────────────────────────────────────────┐
│ Materials                                                                          │
├──────────┬─────────────────────────────────────────────────────────────────────────┤
│ Name     │ sbom-2                                                                  │
│ Type     │ SBOM_CYCLONEDX_JSON                                                     │
│ Set      │ Yes                                                                     │
│ Required │ No                                                                      │
│ Value    │ result.cdx                                                              │
│ Digest   │ sha256:925ed5a789bad4bc2658ba371530bf3b80639be02d7acd9069c0e52690508132 │
│ Policies │ ------                                                                  │
│          │ sbom-ntia:                                                              │
│          │   - missing author                                                      │
│          │   - missing supplier for 'alpine'                                       │
│          │   - missing unique identifier (PURL, CPE, SWID) for 'alpine'            │
│          │ sbom-banned-licenses: Ok                                                │
│          │ sbom-freshness: Ok                                                      │
└──────────┴─────────────────────────────────────────────────────────────────────────┘
Attestation Digest: sha256:90a3619280b63c3f12301a85dd59d754645982ea4dfa2be22e61209d8d66431c
```