### PR TITLE
refactor: run attestation-level policy evaluations in crafting layer

### DIFF
--- a/app/cli/internal/action/attestation_status.go
+++ b/app/cli/internal/action/attestation_status.go
@@ -146,7 +146,7 @@ func (action *AttestationStatus) Run(ctx context.Context, attestationID string, 
 			return nil, fmt.Errorf("rendering statement: %w", err)
 		}
 
-		res.PolicyEvaluations, err = action.getPolicyEvaluations(ctx, c, statement)
+		res.PolicyEvaluations, err = action.getPolicyEvaluations(ctx, c, attestationID, statement)
 		if err != nil {
 			return nil, fmt.Errorf("getting policy evaluations: %w", err)
 		}
@@ -201,30 +201,27 @@ func (action *AttestationStatus) Run(ctx context.Context, attestationID string, 
 }
 
 // getPolicyEvaluations retrieves both material-level and attestation-level policy evaluations
-func (action *AttestationStatus) getPolicyEvaluations(ctx context.Context, c *crafter.Crafter, statement *intoto.Statement) (map[string][]*PolicyEvaluation, error) {
+func (action *AttestationStatus) getPolicyEvaluations(ctx context.Context, c *crafter.Crafter, attestationID string, statement *intoto.Statement) (map[string][]*PolicyEvaluation, error) {
 	// grouped by material name
 	evaluations := make(map[string][]*PolicyEvaluation)
 
-	// Add material-level policy evaluations
-	for _, v := range c.CraftingState.Attestation.GetPolicyEvaluations() {
-		if existing, ok := evaluations[v.MaterialName]; ok {
-			evaluations[v.MaterialName] = append(existing, policyEvaluationStateToActionForStatus(v))
-		} else {
-			evaluations[v.MaterialName] = []*PolicyEvaluation{policyEvaluationStateToActionForStatus(v)}
-		}
-	}
-
 	// Add attestation-level policy evaluations
-	attestationEvaluations, err := c.EvaluateAttestationPolicies(ctx, statement)
-	if err != nil {
+	// TODO: run somewhere else
+	if err := c.EvaluateAttestationPolicies(ctx, attestationID, statement); err != nil {
 		return nil, fmt.Errorf("evaluating attestation policies: %w", err)
 	}
 
-	for _, v := range attestationEvaluations {
-		if existing, ok := evaluations[chainloop.AttPolicyEvaluation]; ok {
-			evaluations[chainloop.AttPolicyEvaluation] = append(existing, policyEvaluationStateToActionForStatus(v))
+	// map evaluations
+	for _, v := range c.CraftingState.Attestation.GetPolicyEvaluations() {
+		keyName := v.MaterialName
+		if keyName == "" {
+			keyName = chainloop.AttPolicyEvaluation
+		}
+
+		if existing, ok := evaluations[keyName]; ok {
+			evaluations[keyName] = append(existing, policyEvaluationStateToActionForStatus(v))
 		} else {
-			evaluations[chainloop.AttPolicyEvaluation] = []*PolicyEvaluation{policyEvaluationStateToActionForStatus(v)}
+			evaluations[keyName] = []*PolicyEvaluation{policyEvaluationStateToActionForStatus(v)}
 		}
 	}
 

--- a/app/cli/internal/action/attestation_status.go
+++ b/app/cli/internal/action/attestation_status.go
@@ -141,7 +141,7 @@ func (action *AttestationStatus) Run(ctx context.Context, attestationID string, 
 		}
 
 		// We do not want to evaluate policies here during render since we want to do it in a separate step
-		statement, err := renderer.RenderStatement(ctx, chainloop.WithSkipPolicyEvaluation(true))
+		statement, err := renderer.RenderStatement(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("rendering statement: %w", err)
 		}
@@ -206,7 +206,6 @@ func (action *AttestationStatus) getPolicyEvaluations(ctx context.Context, c *cr
 	evaluations := make(map[string][]*PolicyEvaluation)
 
 	// Add attestation-level policy evaluations
-	// TODO: run somewhere else
 	if err := c.EvaluateAttestationPolicies(ctx, attestationID, statement); err != nil {
 		return nil, fmt.Errorf("evaluating attestation policies: %w", err)
 	}

--- a/pkg/attestation/renderer/renderer.go
+++ b/pkg/attestation/renderer/renderer.go
@@ -54,7 +54,7 @@ type AttestationRenderer struct {
 }
 
 type r interface {
-	Statement(ctx context.Context, opts ...chainloop.RenderOpt) (*intoto.Statement, error)
+	Statement(ctx context.Context) (*intoto.Statement, error)
 }
 
 type Opt func(*AttestationRenderer)
@@ -95,8 +95,8 @@ func NewAttestationRenderer(state *crafter.VersionedCraftingState, attClient pb.
 }
 
 // Render the in-toto statement skipping validations, dsse envelope wrapping nor signing
-func (ab *AttestationRenderer) RenderStatement(ctx context.Context, opts ...chainloop.RenderOpt) (*intoto.Statement, error) {
-	statement, err := ab.renderer.Statement(ctx, opts...)
+func (ab *AttestationRenderer) RenderStatement(ctx context.Context) (*intoto.Statement, error) {
+	statement, err := ab.renderer.Statement(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("generating in-toto statement: %w", err)
 	}


### PR DESCRIPTION
Runs the attestation-related policy evaluations in the crafting layer storing it in the state.

This is a pre-requisite for #1685.

In practice nothing changes except that policy-level evaluations happen in `status` and `push` and then the renderer layer just takes the info in the state. 