### PR TITLE
chore: ignore path not relevant for docs sboms in scanners

### DIFF
--- a/docs/.syft.yaml
+++ b/docs/.syft.yaml
@@ -1,0 +1,2 @@
+exclude:
+  - "./node_modules/rtl-detect/.github"


### PR DESCRIPTION
`rtl-detect` library includes some github workflows not relevant to the release, that are polluting the docs SBOM.
This small change instructs `syft` to ignore such paths.