### PR TITLE
feat(integrations): show default values

### DIFF
--- a/app/cli/cmd/available_integration_describe.go
+++ b/app/cli/cmd/available_integration_describe.go
@@ -122,12 +122,12 @@ func renderSchemaTable(tableTitle string, properties sdk.SchemaPropertiesMap) er
 			color = text.Colors{text.FgHiYellow}
 		}
 
-		required := "no"
-		if v.Required {
-			required = "yes"
+		var requiredInfo = color.Sprint(hBool(v.Required))
+		if v.Default != "" && !v.Required {
+			requiredInfo = fmt.Sprintf("%s (default: %s)", requiredInfo, v.Default)
 		}
 
-		t.AppendRow(table.Row{color.Sprint(v.Name), color.Sprint(propertyType), color.Sprint(required), v.Description})
+		t.AppendRow(table.Row{color.Sprint(v.Name), color.Sprint(propertyType), requiredInfo, v.Description})
 	}
 
 	t.Render()

--- a/app/controlplane/plugins/sdk/v1/fanout.go
+++ b/app/controlplane/plugins/sdk/v1/fanout.go
@@ -443,7 +443,8 @@ type SchemaProperty struct {
 	// If the property is required
 	Required bool
 	// Optional format (email, host)
-	Format string
+	Format  string
+	Default string
 }
 
 func CompileJSONSchema(in []byte) (*schema_validator.Schema, error) {
@@ -493,12 +494,19 @@ func CalculatePropertiesMap(s *schema_validator.Schema, m *SchemaPropertiesMap) 
 			}
 
 			var required = requiredMap[k]
+
+			var defaultVal string
+			if v.Default != nil && !required {
+				defaultVal = fmt.Sprintf("%v", v.Default)
+			}
+
 			(*m)[k] = &SchemaProperty{
 				Name:        k,
 				Type:        v.Types[0],
 				Required:    required,
 				Description: v.Description,
 				Format:      v.Format,
+				Default:     defaultVal,
 			}
 		}
 	}


### PR DESCRIPTION
The latest integration form @aarlint introduced default values. This patch updates the CLI to takes these into account and show it to the user

```
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Attachment inputs                                                                                                        │
├──────────────────┬─────────┬─────────────────────┬───────────────────────────────────────────────────────────────────────┤
│ FIELD            │ TYPE    │ REQUIRED            │ DESCRIPTION                                                           │
├──────────────────┼─────────┼─────────────────────┼───────────────────────────────────────────────────────────────────────┤
│ send_attestation │ boolean │ No (default: true)  │ Send attestation                                                      │
│ send_sbom        │ boolean │ No (default: false) │ Additionally send CycloneDX or SPDX Software Bill Of Materials (SBOM) │
└──────────────────┴─────────┴─────────────────────┴───────────────────────────────────────────────────────────────────────┘
```