### PR TITLE
chore(atlas): Upgrade atlas to version 0.30

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Generate migrations
         if: ${{ matrix.app == 'controlplane' }}
         env:
-          ATLAS_VERSION: v0.27.0
+          ATLAS_VERSION: v0.30.0
         run: |
           wget -q https://release.ariga.io/atlas/atlas-linux-amd64-$ATLAS_VERSION -O /tmp/atlas
           sudo install /tmp/atlas /usr/local/bin/atlas

--- a/app/controlplane/Dockerfile.migrations
+++ b/app/controlplane/Dockerfile.migrations
@@ -1,7 +1,7 @@
 # Container image built by go-releaser that's used to run migrations against the database during deployment
 # See https://atlasgo.io/guides/deploying/image
-# Current version v0.27.0
-FROM arigaio/atlas@sha256:b2197540d3b1c34513cae8a4b21517978e2fbaa59c0f070f1698cc3205ea4c32 as base
+# Current version v0.30.0
+FROM arigaio/atlas@sha256:4e70ea7e8fe69817168109db4084ca12425a1b157dce4696954f5d9af37f5b47 as base
 
 FROM scratch
 # Update permissions to make it readable by the user


### PR DESCRIPTION
This patch upgrades the version of atlas to version 0.30 since it's the only that is no reporting CVEs.

This will fix: CVE-2024-45338 and CVE-2024-45337 on Chainloop migration image.