### PR TITLE
feat(cli): show digest for string material

### DIFF
--- a/app/cli/internal/action/attestation_status.go
+++ b/app/cli/internal/action/attestation_status.go
@@ -335,6 +335,7 @@ func setMaterialValue(w *v1.Attestation_Material, o *AttestationStatusResultMate
 	switch m := w.GetM().(type) {
 	case *v1.Attestation_Material_String_:
 		o.Value = m.String_.GetValue()
+		o.Hash = m.String_.GetDigest()
 	case *v1.Attestation_Material_ContainerImage_:
 		o.Value = m.ContainerImage.GetName()
 		o.Hash = m.ContainerImage.GetDigest()


### PR DESCRIPTION
String material includes digest but it was not shown in the status/push CLI output, this PR changes that.

```
┌────────────────────────────────────────────────────────────────────────────────────┐
│ Materials                                                                          │
├──────────┬─────────────────────────────────────────────────────────────────────────┤
│ Name     │ material-1736347748127656000                                            │
│ Type     │ STRING                                                                  │
│ Set      │ Yes                                                                     │
│ Required │ No                                                                      │
│ Value    │ 1023544                                                                 │
│ Digest   │ sha256:e7926bc60251a56dfc2285db31f46c29a2cfd58c53a8ab5bcfcbc6234afa5e88 │
└──────────┴─────────────────────────────────────────────────────────────────────────┘
```