### PR TITLE
feat(.github): Attest container images and generate SBOMs

### DIFF
--- a/.github/workflows/build_and_package.yaml
+++ b/.github/workflows/build_and_package.yaml
@@ -13,9 +13,31 @@ jobs:
   test:
     uses: chainloop-dev/chainloop/.github/workflows/test.yml@main
 
+  init_attestation:
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.ref_type == 'tag' # Guard to make sure we are releasing once
+    outputs:
+      attestation_id: ${{ steps.init_attestation.outputs.attestation_id }}
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Install Chainloop
+        run: |
+          curl -sfL https://docs.chainloop.dev/install.sh | bash -s
+
+      - name: Initialize Attestation
+        id: init_attestation
+        run: |
+          attestation_id=$(chainloop attestation init --workflow ${CHAINLOOP_WORKFLOW_NAME} --project ${CHAINLOOP_PROJECT_NAME} --release --remote-state -o json | jq -r .attestationID)
+          echo "attestation_id=$attestation_id" >> $GITHUB_OUTPUT
+        env:
+          CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
+          CHAINLOOP_WORKFLOW_NAME: "chainloop-vault-build-and-package"
+          CHAINLOOP_PROJECT_NAME: "chainloop"
+
   release:
     name: Release CLI and control-plane/artifact-cas container images
-    needs: test
+    needs: init_attestation
     runs-on: ubuntu-latest
     if: github.ref_type == 'tag' # Guard to make sure we are releasing once
     permissions:
@@ -24,34 +46,15 @@ jobs:
       pull-requests: write
     env:
       CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
-      CONTAINER_IMAGE_CP: ghcr.io/chainloop-dev/chainloop/control-plane:${{ github.ref_name }}
-      CONTAINER_IMAGE_CAS: ghcr.io/chainloop-dev/chainloop/artifact-cas:${{ github.ref_name }}
-      CONTAINER_IMAGE_CLI: ghcr.io/chainloop-dev/chainloop/cli:${{ github.ref_name }}
       GH_TOKEN: ${{ github.token }}
-      CHAINLOOP_WORKFLOW_NAME: "chainloop-vault-build-and-package"
-      CHAINLOOP_PROJECT: "chainloop"
     steps:
       - name: Install Cosign
         uses: sigstore/cosign-installer@ef6a6b364bbad08abd36a5f8af60b595d12702f8 # main
         with:
           cosign-release: "v2.2.3"
 
-      - name: Install Chainloop
-        run: |
-          curl -sfL https://raw.githubusercontent.com/chainloop-dev/chainloop/01ad13af08950b7bfbc83569bea207aeb4e1a285/docs/static/install.sh | bash -s
-
-      - name: Download jq
-        run: |
-          sudo wget -q https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O /usr/local/bin/jq
-          sudo chmod u+x /usr/local/bin/jq
-
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-      # mark this attestation as a release
-      - name: Initialize Attestation
-        run: |
-          chainloop attestation init --workflow $CHAINLOOP_WORKFLOW_NAME --project $CHAINLOOP_PROJECT --release
 
       - name: Docker login to Github Packages
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
@@ -84,32 +87,6 @@ jobs:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           POSTHOG_ENDPOINT: ${{ secrets.POSTHOG_ENDPOINT }}
 
-      - uses: anchore/sbom-action@c6aed38a4323b393d05372c58a74c39ae8386d02 # v0.15.6
-        with:
-          image: ${{ env.CONTAINER_IMAGE_CP }}
-          format: cyclonedx-json
-          artifact-name: controlplane.cyclonedx.json
-          output-file: /tmp/sbom.cp.cyclonedx.json
-
-      - uses: anchore/sbom-action@c6aed38a4323b393d05372c58a74c39ae8386d02 # v0.15.6
-        with:
-          image: ${{ env.CONTAINER_IMAGE_CAS }}
-          format: cyclonedx-json
-          artifact-name: cas.cyclonedx.json
-          output-file: /tmp/sbom.cas.cyclonedx.json
-
-      - uses: anchore/sbom-action@c6aed38a4323b393d05372c58a74c39ae8386d02 # v0.15.6
-        with:
-          image: ${{ env.CONTAINER_IMAGE_CLI }}
-          format: cyclonedx-json
-          artifact-name: cli.cyclonedx.json
-          output-file: /tmp/sbom.cli.cyclonedx.json
-
-      - name: Add Attestation from Goreleaser Output
-        run: |
-          jq -r . <<< '${{ steps.release.outputs.artifacts }}' > /tmp/artifacts.json
-          chainloop attestation add --name goreleaser-output --value /tmp/artifacts.json
-
       - name: Finish and Record Attestation
         if: ${{ success() }}
         run: |
@@ -137,14 +114,112 @@ jobs:
             automated
             helm
 
+  generate_sboms_and_attest:
+    name: ${{ matrix.bundle.image }}
+    permissions:
+      packages: read
+      contents: read
+    needs: release
+    runs-on: ubuntu-latest
+    env:
+      CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
+      ATTESTATION_ID: ${{ needs.init_attestation.outputs.attestation_id }}
+    strategy:
+      matrix:
+        bundle:
+          - image: ghcr.io/chainloop-dev/chainloop/control-plane:latest
+            sbomName: sbom-controlplane-latest
+          - image: ghcr.io/chainloop-dev/chainloop/control-plane:${{ github.ref_name }}
+            sbomName: sbom-controlplane-${{ github.ref_name }}
+            artifactName: controlplane-latest.cyclonedx.json
+          - image: ghcr.io/chainloop-dev/chainloop/control-plane:${{ github.ref_name }}-amd64
+            sbomName: sbom-controlplane-amd64
+            artifactName: controlplane-amd64.cyclonedx.json
+          - image: ghcr.io/chainloop-dev/chainloop/control-plane:${{ github.ref_name }}-arm64
+            sbomName: sbom-controlplane-arm64
+            artifactName: controlplane-arm64.cyclonedx.json
+          - image: ghcr.io/chainloop-dev/chainloop/control-plane-migrations:latest
+            sbomName: sbom-controlplane-migrations-latest
+          - image: ghcr.io/chainloop-dev/chainloop/control-plane-migrations:${{ github.ref_name }}
+            sbomName: sbom-controlplane-migrations-${{ github.ref_name }}
+            artifactName: controlplane-migrations-latest.cyclonedx.json
+          - image: ghcr.io/chainloop-dev/chainloop/control-plane-migrations:${{ github.ref_name }}-amd64
+            sbomName: sbom-controlplane-migrations-amd64
+            artifactName: controlplane-migrations-amd64.cyclonedx.json
+          - image: ghcr.io/chainloop-dev/chainloop/control-plane-migrations:${{ github.ref_name }}-arm64
+            sbomName: sbom-controlplane-migrations-arm64
+            artifactName: controlplane-migrations-arm64.cyclonedx.json
+          - image: ghcr.io/chainloop-dev/chainloop/artifact-cas:latest
+            sbomName: sbom-cas-latest
+          - image: ghcr.io/chainloop-dev/chainloop/artifact-cas:${{ github.ref_name }}
+            sbomName: sbom-cas-${{ github.ref_name }}
+            artifactName: cas-latest.cyclonedx.json
+          - image: ghcr.io/chainloop-dev/chainloop/artifact-cas:${{ github.ref_name }}-amd64
+            sbomName: sbom-cas-amd64
+            artifactName: cas-amd64.cyclonedx.json
+          - image: ghcr.io/chainloop-dev/chainloop/artifact-cas:${{ github.ref_name }}-arm64
+            sbomName: sbom-cas-arm64
+            artifactName: cas-arm64.cyclonedx.json
+          - image: ghcr.io/chainloop-dev/chainloop/cli:latest
+            sbomName: sbom-cli-latest
+          - image: ghcr.io/chainloop-dev/chainloop/cli:${{ github.ref_name }}
+            sbomName: sbom-cli-${{ github.ref_name }}
+            artifactName: cli-latest.cyclonedx.json
+          - image: ghcr.io/chainloop-dev/chainloop/cli:${{ github.ref_name }}-amd64
+            sbomName: sbom-cli-amd64
+            artifactName: cli-amd64.cyclonedx.json
+          - image: ghcr.io/chainloop-dev/chainloop/cli:${{ github.ref_name }}-arm64
+            sbomName: sbom-cli-arm64
+            artifactName: cli-arm64.cyclonedx.json
+    steps:
+      - name: Docker login to Github Packages
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Chainloop
+        run: |
+          curl -sfL https://docs.chainloop.dev/install.sh | bash -s
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: anchore/sbom-action@df80a981bc6edbc4e220a492d3cbe9f5547a6e75 # v0.17.9
+        with:
+          image: ${{ matrix.bundle.image }}
+          format: cyclonedx-json
+          artifact-name: ${{ matrix.bundle.artifactName }}
+          output-file: /tmp/sbom.cyclonedx.json
+
+      - name: Add SBOM and Image to attestation
+        run: |
+          chainloop attestation add --name ${{ matrix.bundle.sbomName }} --value /tmp/sbom.cyclonedx.json --attestation-id ${{ env.ATTESTATION_ID }}
+          chainloop attestation add --value ${{ matrix.bundle.image }} --kind CONTAINER_IMAGE --attestation-id ${{ env.ATTESTATION_ID }}
+
+  finish_attestation:
+    name: Finish Attestation
+    runs-on: ubuntu-latest
+    needs: generate_sboms_and_attest
+    steps:
+      - name: Install Chainloop
+        run: |
+          curl -sfL https://docs.chainloop.dev/install.sh | bash -s
+
+      - name: Finish and Record Attestation
+        if: ${{ success() }}
+        run: |
+          chainloop attestation push --attestation-id ${{ needs.init_attestation.outputs.attestation_id }}
+
       - name: Mark attestation as failed
         if: ${{ failure() }}
         run: |
-          chainloop attestation reset
+          chainloop attestation reset --attestation-id ${{ needs.init_attestation.outputs.attestation_id }}
+
       - name: Mark attestation as cancelled
         if: ${{ cancelled() }}
         run: |
-          chainloop attestation reset --trigger cancellation
+          chainloop attestation reset --trigger cancellation --attestation-id ${{ needs.init_attestation.outputs.attestation_id }}
 
   github-release:
     needs: release

--- a/.github/workflows/contracts/chainloop-chainloop-github-release.yaml
+++ b/.github/workflows/contracts/chainloop-chainloop-github-release.yaml
@@ -3,6 +3,11 @@ schemaVersion: v1
 policies:
   attestation:
     - ref: source-commit
+      with:
+        check_signature: yes
+    - ref: containers-with-sbom
+  materials:
+    - ref: artifact-signed
 policyGroups:
   - ref: sbom-quality
     with:

--- a/.github/workflows/contracts/chainloop-vault-release.yml
+++ b/.github/workflows/contracts/chainloop-vault-release.yml
@@ -1,11 +1,12 @@
 # Contract for the chainloop-vault-build-and-package workflow
 schemaVersion: v1
-runner:
-  type: GITHUB_ACTION
-materials:
-  - type: ARTIFACT
-    name: goreleaser-output
-    output: true
 policies:
   attestation:
     - ref: source-commit
+      with:
+        check_signature: yes
+    - ref: containers-with-sbom
+  materials:
+    - ref: artifact-signed
+runner:
+  type: GITHUB_ACTION


### PR DESCRIPTION
This patch modifies the `build_and_package` workflow so we are able to attest all container images with their different tags and generate a SBOM file for each of them. The result of those operations are being added as part of the attestation.

Ref: #1715 