### PR TITLE
fix(github): Move env from top level to steps

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -28,10 +28,6 @@ jobs:
       id-token: write
       contents: read
       actions: read
-    env:
-      CHAINLOOP_WORKFLOW_NAME: "chainloop-vault-scorecards"
-      CHAINLOOP_PROJECT: "chainloop"
-      CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
 
     steps:
       - name: Install Chainloop
@@ -46,6 +42,10 @@ jobs:
       - name: Initialize Attestation
         run: |
           chainloop attestation init --workflow $CHAINLOOP_WORKFLOW_NAME --project $CHAINLOOP_PROJECT
+        env:
+          CHAINLOOP_WORKFLOW_NAME: "chainloop-vault-scorecards"
+          CHAINLOOP_PROJECT: "chainloop"
+          CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
 
       - name: "Run analysis"
         uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
@@ -87,18 +87,26 @@ jobs:
       - name: Attest analysis
         run: |
           chainloop attestation add --name sarif-results --value results.sarif
+        env:
+          CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
 
       - name: Finish and Record Attestation
         if: ${{ success() }}
         run: |
           chainloop attestation push
+        env:
+          CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
 
       - name: Mark attestation as failed
         if: ${{ failure() }}
         run: |
           chainloop attestation reset
+        env:
+          CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
 
       - name: Mark attestation as cancelled
         if: ${{ cancelled() }}
         run: |
           chainloop attestation reset --trigger cancellation
+        env:
+          CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}


### PR DESCRIPTION
This patch moves the environment variables from being a top level on the jobs to individual steps.

It failed in `main` but not in the pull request. Here the job: https://github.com/chainloop-dev/chainloop/actions/runs/12710303333/job/35431292657

Apparently there are restrictions: https://github.com/ossf/scorecard-action#workflow-restrictions

Ref: #1721 