### PR TITLE
fix(orgmetrics): Prevent org metrics if org does not exist

### DIFF
--- a/app/controlplane/pkg/biz/orgmetrics.go
+++ b/app/controlplane/pkg/biz/orgmetrics.go
@@ -170,6 +170,11 @@ func (uc *OrgMetricsUseCase) GetLastWorkflowStatusByRun(ctx context.Context, org
 		return nil, fmt.Errorf("finding organization: %w", err)
 	}
 
+	// Check if organization exists, return empty list if not
+	if org == nil {
+		return nil, NewErrNotFound("organization")
+	}
+
 	// Default pagination option
 	paginationOpts, err := pagination.NewOffsetPaginationOpts(pagination.DefaultPage, 100)
 	if err != nil {


### PR DESCRIPTION
This patch fixes an issue provoked by the prometheus collector if the name of the organization changes and that organization has a registered prometheus registry provoking that the fetch of metrics failed because of an unhandled check on organizations.