### PR TITLE
feat: add policies to chainloop github release workflows

### DIFF
--- a/.github/workflows/contracts/chainloop-chainloop-github-release.yaml
+++ b/.github/workflows/contracts/chainloop-chainloop-github-release.yaml
@@ -3,6 +3,11 @@ schemaVersion: v1
 policies:
   attestation:
     - ref: source-commit
+      with:
+        check_signature: yes
+    - ref: containers-with-sbom
+  materials:
+    - ref: artifact-signed
 policyGroups:
   - ref: sbom-quality
     with:

--- a/.github/workflows/contracts/chainloop-vault-release.yml
+++ b/.github/workflows/contracts/chainloop-vault-release.yml
@@ -9,3 +9,5 @@ materials:
 policies:
   attestation:
     - ref: source-commit
+      with:
+        check_signature: yes


### PR DESCRIPTION
This PR adds some chainloop builtin policies to the OSS release workflows, in particular: container signatures and container sboms.
