### PR TITLE
fix: remove duplicated tests in GH workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,4 +76,6 @@ jobs:
 
       - name: Test top level modules
         if: ${{ matrix.app == 'main-module' }}
-        run: make test
+        run: |
+          go test ./pkg/...
+          go test ./internal/...


### PR DESCRIPTION
This PR makes sure that only top level packages are tested in the `main-module` target. The rest of the code is already covered by `controlplane`, `artifact-cas` and `cli`.

This should also mitigate those flaky tests that fail from time to time.

Closes #1746 