### PR TITLE
fix(release): don't attest archives

### DIFF
--- a/.github/workflows/build_and_package.yaml
+++ b/.github/workflows/build_and_package.yaml
@@ -108,14 +108,6 @@ jobs:
             chainloop attestation add --value $entry --kind CONTAINER_IMAGE --attestation-id ${{ env.ATTESTATION_ID }}
             chainloop attestation add --value /tmp/sbom.cyclonedx.json --attestation-id ${{ env.ATTESTATION_ID }}
           done
-          
-          # Attest CLI archives
-          archives=$(cat dist/artifacts.json | jq -r '.[] | select(.type=="Archive") | .path')
-          for entry in $archives; do
-            syft -o cyclonedx-json=/tmp/sbom.cyclonedx.json $entry
-            chainloop attestation add --value $entry --attestation-id ${{ env.ATTESTATION_ID }}
-            chainloop attestation add --value /tmp/sbom.cyclonedx.json --attestation-id ${{ env.ATTESTATION_ID }}
-          done
 
       - name: Bump Chart and Dagger Version
         run: .github/workflows/utils/bump-chart-and-dagger-version.sh deployment/chainloop extras/dagger ${{ github.ref_name }}


### PR DESCRIPTION
Archives are too large for attesting. All container images are attested anyways.
Closes https://github.com/chainloop-dev/chainloop/issues/1715