### PR TITLE
fix(releases): add missing chainloop token to job

### DIFF
--- a/.github/workflows/build_and_package.yaml
+++ b/.github/workflows/build_and_package.yaml
@@ -133,6 +133,8 @@ jobs:
     needs:
       - init_attestation
       - release
+    env:
+      CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
     steps:
       - name: Install Chainloop
         run: |


### PR DESCRIPTION
Fixes the release job by setting a missing env var.
Closes https://github.com/chainloop-dev/chainloop/issues/1715