### PR TITLE
feat(releases): exclude latest tag

### DIFF
--- a/.github/workflows/build_and_package.yaml
+++ b/.github/workflows/build_and_package.yaml
@@ -103,10 +103,13 @@ jobs:
           # goreleaser output resides in dist/artifacts.json
           # Attest all built containers and manifests
           images=$(cat dist/artifacts.json | jq -r '.[] | select(.type=="Docker Image" or .type=="Docker Manifest") | .path')
-          for entry in $images; do  
-            syft -o cyclonedx-json=/tmp/sbom.cyclonedx.json $entry
-            chainloop attestation add --value $entry --kind CONTAINER_IMAGE --attestation-id ${{ env.ATTESTATION_ID }}
-            chainloop attestation add --value /tmp/sbom.cyclonedx.json --attestation-id ${{ env.ATTESTATION_ID }}
+          for entry in $images; do
+            # exclude latest tag
+            if [[ $entry != *latest ]]; then
+              syft -o cyclonedx-json=/tmp/sbom.cyclonedx.json $entry
+              chainloop attestation add --value $entry --kind CONTAINER_IMAGE --attestation-id ${{ env.ATTESTATION_ID }}
+              chainloop attestation add --value /tmp/sbom.cyclonedx.json --attestation-id ${{ env.ATTESTATION_ID }}
+            fi
           done
 
       - name: Bump Chart and Dagger Version


### PR DESCRIPTION
They are causing failures when applying some policies, since `latest` is translated to the actual digest.
https://github.com/chainloop-dev/chainloop/actions/runs/12933576750/job/36073698762
Related to https://github.com/chainloop-dev/chainloop/issues/1715