### PR TITLE
chore: hide compatibility logic

### DIFF
--- a/app/controlplane/internal/service/attestation.go
+++ b/app/controlplane/internal/service/attestation.go
@@ -460,7 +460,7 @@ func extractPolicyEvaluations(in map[string][]*chainloop.PolicyEvaluation) map[s
 
 			eval := &cpAPI.PolicyEvaluation{
 				Name:         ev.Name,
-				MaterialName: ev.GetMaterialName(),
+				MaterialName: ev.MaterialName,
 				Body:         ev.Body,
 				Sources:      ev.Sources,
 				Annotations:  ev.Annotations,
@@ -473,8 +473,8 @@ func extractPolicyEvaluations(in map[string][]*chainloop.PolicyEvaluation) map[s
 				Requirements: ev.Requirements,
 			}
 
-			if ev.GetPolicyReference() != nil {
-				r := ev.GetPolicyReference()
+			if ev.PolicyReference != nil {
+				r := ev.PolicyReference
 				orgName, _ := r.GetAnnotations().AsMap()["organization"].(string)
 				eval.PolicyReference = &cpAPI.PolicyReference{
 					Name:         r.Name,

--- a/pkg/attestation/renderer/chainloop/chainloop.go
+++ b/pkg/attestation/renderer/chainloop/chainloop.go
@@ -199,6 +199,21 @@ func extractPredicate(statement *intoto.Statement, v *ProvenancePredicateV02) er
 		return fmt.Errorf("un-marshaling predicate: %w", err)
 	}
 
+	// Fix compatibility with old versions
+	if v.PolicyEvaluationsFallback != nil {
+		v.PolicyEvaluations = v.PolicyEvaluationsFallback
+	}
+	for _, v := range v.PolicyEvaluations {
+		for _, ev := range v {
+			if ev.MaterialNameFallback != "" {
+				ev.MaterialName = ev.MaterialNameFallback
+			}
+			if ev.PolicyReferenceFallback != nil {
+				ev.PolicyReference = ev.PolicyReferenceFallback
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/attestation/renderer/chainloop/v02.go
+++ b/pkg/attestation/renderer/chainloop/v02.go
@@ -84,22 +84,6 @@ type PolicyEvaluation struct {
 	Requirements            []string                   `json:"requirements,omitempty"`
 }
 
-func (e *PolicyEvaluation) GetPolicyReference() *intoto.ResourceDescriptor {
-	r := e.PolicyReference
-	if r == nil {
-		r = e.PolicyReferenceFallback
-	}
-	return r
-}
-
-func (e *PolicyEvaluation) GetMaterialName() string {
-	n := e.MaterialName
-	if n == "" {
-		n = e.MaterialNameFallback
-	}
-	return n
-}
-
 type PolicyViolation struct {
 	Subject string `json:"subject"`
 	Message string `json:"message"`
@@ -397,11 +381,7 @@ func (p *ProvenancePredicateV02) GetMaterials() []*NormalizedMaterial {
 }
 
 func (p *ProvenancePredicateV02) GetPolicyEvaluations() map[string][]*PolicyEvaluation {
-	evs := p.PolicyEvaluations
-	if len(evs) == 0 && len(p.PolicyEvaluationsFallback) > 0 {
-		evs = p.PolicyEvaluationsFallback
-	}
-	return evs
+	return p.PolicyEvaluations
 }
 
 func (p *ProvenancePredicateV02) HasPolicyViolations() bool {

--- a/pkg/attestation/renderer/chainloop/v02_test.go
+++ b/pkg/attestation/renderer/chainloop/v02_test.go
@@ -291,6 +291,6 @@ func TestPolicyEvaluationsField(t *testing.T) {
 	evs := predicate.GetPolicyEvaluations()["sbom"]
 	assert.Len(t, evs, 1)
 	ev := evs[0]
-	assert.Equal(t, "sbom", ev.GetMaterialName())
-	assert.NotNil(t, ev.GetPolicyReference())
+	assert.Equal(t, "sbom", ev.MaterialName)
+	assert.NotNil(t, ev.PolicyReference)
 }


### PR DESCRIPTION
Follow up for #1756 hiding the compatiblity logic so that callers don't need to use a different interface.
Related to #1755 