### PR TITLE
feat(dagger): Allow to bypass policy checks on failures

### DIFF
--- a/extras/dagger/main.go
+++ b/extras/dagger/main.go
@@ -375,7 +375,8 @@ func (att *Attestation) Push(
 	// +optional
 	passphrase *dagger.Secret,
 	// Whether not fail if the policy check fails
-	exceptionBypassPolicyCheck bool,
+	// +optional
+	exceptionBypassPolicyCheck *bool,
 ) (string, error) {
 	container := att.Container(0)
 	args := []string{
@@ -390,7 +391,7 @@ func (att *Attestation) Push(
 	if passphrase != nil {
 		container = container.WithSecretVariable("CHAINLOOP_SIGNING_PASSWORD", passphrase)
 	}
-	if exceptionBypassPolicyCheck {
+	if exceptionBypassPolicyCheck != nil && *exceptionBypassPolicyCheck {
 		args = append(args, "--exception-bypass-policy-check")
 	}
 

--- a/extras/dagger/main.go
+++ b/extras/dagger/main.go
@@ -374,6 +374,8 @@ func (att *Attestation) Push(
 	// The passphrase to decrypt the private key
 	// +optional
 	passphrase *dagger.Secret,
+	// Whether not fail if the policy check fails
+	exceptionBypassPolicyCheck bool,
 ) (string, error) {
 	container := att.Container(0)
 	args := []string{
@@ -387,6 +389,9 @@ func (att *Attestation) Push(
 	}
 	if passphrase != nil {
 		container = container.WithSecretVariable("CHAINLOOP_SIGNING_PASSWORD", passphrase)
+	}
+	if exceptionBypassPolicyCheck {
+		args = append(args, "--exception-bypass-policy-check")
 	}
 
 	return container.WithExec(args, execOpts).Stdout(ctx)


### PR DESCRIPTION
This patch allows the dagger module to receive the `exception-bypass-policy-check` flag to avoid failing the `attestation push` command if any of the policies in the contract hasn't been met.