### PR TITLE
feat(policygroups): allow empty strings in material templates

### DIFF
--- a/app/cli/internal/action/attestation_init.go
+++ b/app/cli/internal/action/attestation_init.go
@@ -251,6 +251,10 @@ func getGroupMaterialsToAdd(group *v1.PolicyGroup, pgAtt *v1.PolicyGroupAttachme
 		if err != nil {
 			return nil, err
 		}
+		// skip if interpolated material name is still empty
+		if csm.GetName() == "" {
+			continue
+		}
 
 		// check if material already exists in the contract and skip it in that case
 		ignore := false


### PR DESCRIPTION
This simple PR allows empty strings to be passed to arguments whose purpose is material name interpolation.
For example, having this group definition
```yaml
apiVersion: workflowcontract.chainloop.dev/v1
kind: PolicyGroup
metadata:
  name: my-group
spec:
  inputs:
    - name: sbom_name
      default: "sbom"
  policies:
    materials:
      - name: "{{ inputs.sbom_name }}"
        type: SBOM_SPDX_JSON
        policies:
          - ref: my-policy
```
When attaching it, there are three possible outcomes:
* Attaching with `sbom_name: mysbom`. It will enforce the material `mysbom` to be present
* Attaching with no arguments. It will enforce the material `sbom` to be present
* Attaching with `sbom_name: ""`. It will behave like a generic policy group, applying the policies to ANY SPDX material.

```bash
➜  chainloop att init --name mywf --project myproject --replace
INF Attestation initialized! now you can check its status or add materials to it
...
DBG loading policy group "sbom-quality" using *policies.ChainloopGroupLoader
DBG loading policy spec "sbom-present" using *policies.ChainloopLoader
DBG evaluating policy sbom-present against attestation
┌───────────────────────────┬──────────────────────────────────────┐
│ Initialized At            │ 03 Feb 25 18:07 UTC                  │
├───────────────────────────┼──────────────────────────────────────┤
│ Attestation ID            │ 3044047c-1470-43f3-9265-d4259d9c4ba6 │
│ Organization              │ my-org                               │
│ Name                      │ mywf                                 │
│ Project                   │ myproject                            │
│ Version                   │ v0.159.0 (prerelease)                │
│ Contract                  │ myproject-mywf (revision 90)         │
│ Policy violation strategy │ ADVISORY                             │
│ Policies                  │ ------                               │
│                           │ sbom-present: missing SBOM material  │
└───────────────────────────┴──────────────────────────────────────┘
➜  chainloop att add --value test/cyclonedx.json
INF uploading cyclonedx.json - sha256:7502f43a5f4c312006d2cbbbd2d6b555121b7e21cc03ef6d86808db73725d930
DBG loading policy group "sbom-quality" using *policies.ChainloopGroupLoader
DBG loading policy spec "sbom-banned-licenses" using *policies.ChainloopLoader
DBG loading policy spec "sbom-banned-components" using *policies.ChainloopLoader
DBG loading policy spec "sbom-freshness" using *policies.ChainloopLoader
DBG loading policy spec "sbom-ntia" using *policies.ChainloopLoader
DBG loading policy spec "sbom-with-licenses" using *policies.ChainloopLoader
DBG loading policy spec "sbom-banned-licenses" using *policies.ChainloopLoader
DBG evaluating policy sbom-banned-licenses against material-1738606074694157000
DBG loading policy spec "sbom-banned-components" using *policies.ChainloopLoader
DBG evaluating policy sbom-banned-components against material-1738606074694157000
DBG loading policy spec "sbom-freshness" using *policies.ChainloopLoader
DBG evaluating policy sbom-freshness against material-1738606074694157000
DBG loading policy spec "sbom-ntia" using *policies.ChainloopLoader
DBG evaluating policy sbom-ntia against material-1738606074694157000
DBG loading policy spec "sbom-with-licenses" using *policies.ChainloopLoader
DBG evaluating policy sbom-with-licenses against material-1738606074694157000
DBG found policy violations (sbom-freshness) for material-1738606074694157000
DBG  - SBOM created at: 2024-07-23T15:58:37+00:00 which is too old (freshness limit set to 5 days)
DBG found policy violations (sbom-ntia) for material-1738606074694157000
DBG  - missing author
DBG  - missing supplier for 'app/node_modules/@esbuild/linux-x64/bin/esbuild'
DBG  - missing supplier for 'wolfi'
DBG  - missing unique identifier (PURL, CPE, SWID) for 'app/node_modules/@esbuild/linux-x64/bin/esbuild'
DBG  - missing unique identifier (PURL, CPE, SWID) for 'wolfi'
DBG  - missing version for 'app/node_modules/@esbuild/linux-x64/bin/esbuild'
INF material kind detected kind=SBOM_CYCLONEDX_JSON
INF material added to attestation
┌────────────────────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Name               │ material-1738606074694157000                                                                                │
├────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Type               │ SBOM_CYCLONEDX_JSON                                                                                         │
├────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Required           │ No                                                                                                          │
├────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Value              │ cyclonedx.json                                                                                              │
├────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Digest             │ sha256:7502f43a5f4c312006d2cbbbd2d6b555121b7e21cc03ef6d86808db73725d930                                     │
├────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Policy evaluations │ ------                                                                                                      │
├────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│                    │ sbom-banned-licenses: Ok                                                                                    │
├────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│                    │ sbom-banned-components: Ok                                                                                  │
├────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│                    │ sbom-freshness: SBOM created at: 2024-07-23T15:58:37+00:00 which is too old (freshness limit set to 5 days) │
├────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│                    │ sbom-ntia: missing author                                                                                   │
│                    │   - missing supplier for 'app/node_modules/@esbuild/linux-x64/bin/esbuild'                                  │
│                    │   - missing supplier for 'wolfi'                                                                            │
│                    │   - missing unique identifier (PURL, CPE, SWID) for 'app/node_modules/@esbuild/linux-x64/bin/esbuild'       │
│                    │   - missing unique identifier (PURL, CPE, SWID) for 'wolfi'                                                 │
│                    │   - missing version for 'app/node_modules/@esbuild/linux-x64/bin/esbuild'                                   │
├────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│                    │ sbom-with-licenses: Ok                                                                                      │
└────────────────────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
➜ chainloop att push
INF push completed
┌───────────────────────────┬─────────────────────────────────────────────────────────────────────────┐
│ Initialized At            │ 03 Feb 25 18:07 UTC                                                     │
├───────────────────────────┼─────────────────────────────────────────────────────────────────────────┤
│ Attestation ID            │ 3044047c-1470-43f3-9265-d4259d9c4ba6                                    │
│ Digest                    │ sha256:fd00e8fcecb5ea1f0ee7a46d473bf66ecd05d1098204b9af4e6fd31012ae0474 │
│ Organization              │ my-org                                                                  │
│ Name                      │ mywf                                                                    │
│ Project                   │ myproject                                                               │
│ Version                   │ v0.159.0 (prerelease)                                                   │
│ Contract                  │ myproject-mywf (revision 90)                                            │
│ Policy violation strategy │ ADVISORY                                                                │
│ Policies                  │ ------                                                                  │
│                           │ sbom-present: Ok                                                        │
└───────────────────────────┴─────────────────────────────────────────────────────────────────────────┘
┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Materials                                                                                                              │
├──────────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Name     │ material-1738606074694157000                                                                                │
│ Type     │ SBOM_CYCLONEDX_JSON                                                                                         │
│ Set      │ Yes                                                                                                         │
│ Required │ No                                                                                                          │
│ Value    │ cyclonedx.json                                                                                              │
│ Digest   │ sha256:7502f43a5f4c312006d2cbbbd2d6b555121b7e21cc03ef6d86808db73725d930                                     │
│ Policies │ ------                                                                                                      │
│          │ sbom-banned-licenses: Ok                                                                                    │
│          │ sbom-banned-components: Ok                                                                                  │
│          │ sbom-freshness: SBOM created at: 2024-07-23T15:58:37+00:00 which is too old (freshness limit set to 5 days) │
│          │ sbom-ntia: missing author                                                                                   │
│          │   - missing supplier for 'app/node_modules/@esbuild/linux-x64/bin/esbuild'                                  │
│          │   - missing supplier for 'wolfi'                                                                            │
│          │   - missing unique identifier (PURL, CPE, SWID) for 'app/node_modules/@esbuild/linux-x64/bin/esbuild'       │
│          │   - missing unique identifier (PURL, CPE, SWID) for 'wolfi'                                                 │
│          │   - missing version for 'app/node_modules/@esbuild/linux-x64/bin/esbuild'                                   │
│          │ sbom-with-licenses: Ok                                                                                      │
└──────────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

```
