### PR TITLE
chore: do not generate spdx in docs

### DIFF
--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -66,13 +66,6 @@ jobs:
           config: docs/.syft.yaml
           output-file: docs/reports/sbom.cyclonedx.json
 
-      - uses: anchore/sbom-action@a5afbb185c4d9799c758f05e496032af75ae9128
-        with:
-          path: .
-          format: spdx-json
-          upload-artifact: false
-          output-file: docs/reports/sbom.spdx.json
-
       # Upload artifacts so they are shared with the chainloop job
       - uses: actions/upload-artifact@ef09cdac3e2d3e60d8ccadda691f4f1cec5035cb
         with:


### PR DESCRIPTION
Docs workflow is already generating a CycloneDX report. SPDX is not needed.