### PR TITLE
chore(ci): Upload SBOMs to GitHub release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -115,7 +115,7 @@ jobs:
               chainloop attestation add --name sbom-$material_name --value /tmp/sbom-$material_name.cyclonedx.json --attestation-id ${{ env.ATTESTATION_ID }}
           
               # Upload the SBOM to the release
-              gh release upload ${{ github.ref }} /tmp/sbom-$material_name.cyclonedx.json --clobber
+              gh release upload ${{ github.ref_name }} /tmp/sbom-$material_name.cyclonedx.json --clobber
             fi
           done
 
@@ -185,7 +185,7 @@ jobs:
         if: ${{ success() }}
         run: |
           chainloop_release_url="## Chainloop Attestation"$'\n'"[View the attestation of this release](https://app.chainloop.dev/attestation/${{ needs.finish_attestation.outputs.attestation_hash }})"
-          current_notes=$(gh release view ${{inputs.tag}} --json body -q '.body')
+          current_notes=$(gh release view ${{github.ref_name}} --json body -q '.body')
 
           if echo "$current_notes" | grep -q "## Chainloop Attestation"; then
             # Replace the existing Chainloop Attestation section with the new URL
@@ -196,4 +196,4 @@ jobs:
           fi
 
           # Update the release notes and ignore if it fails since we might be lacking permissions to update the release notes
-          gh release edit ${{inputs.tag}} -n "$modified_notes" || echo -n "Not enough permissions to edit the release notes. Skipping..."
+          gh release edit ${{github.ref_name}} -n "$modified_notes" || echo -n "Not enough permissions to edit the release notes. Skipping..."

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -97,7 +97,7 @@ jobs:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           POSTHOG_ENDPOINT: ${{ secrets.POSTHOG_ENDPOINT }}
 
-      - name: Attest GoReleaser outputs
+      - name: Generate SBOMs, upload to release and attest
         id: attest_goreleaser
         run: |
           # goreleaser output resides in dist/artifacts.json
@@ -110,9 +110,12 @@ jobs:
               repo="${entry%:*}"                    # Remove tag
               repo="${repo##*/}"                    # Extract last segment after the last '/'
               material_name="${repo}-${entry##*-}"  # Construct final name
-              syft -o cyclonedx-json=/tmp/sbom.cyclonedx.json $entry
+              syft -o cyclonedx-json=/tmp/sbom-$material_name.cyclonedx.json $entry
               chainloop attestation add --name $material_name --value $entry --kind CONTAINER_IMAGE --attestation-id ${{ env.ATTESTATION_ID }}
-              chainloop attestation add --name sbom-$material_name --value /tmp/sbom.cyclonedx.json --attestation-id ${{ env.ATTESTATION_ID }}
+              chainloop attestation add --name sbom-$material_name --value /tmp/sbom-$material_name.cyclonedx.json --attestation-id ${{ env.ATTESTATION_ID }}
+          
+              # Upload the SBOM to the release
+              gh release upload ${{ github.ref }} /tmp/sbom-$material_name.cyclonedx.json --clobber
             fi
           done
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -99,6 +99,8 @@ jobs:
 
       - name: Generate SBOMs, upload to release and attest
         id: attest_goreleaser
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # goreleaser output resides in dist/artifacts.json
           # Attest all built containers and manifests


### PR DESCRIPTION
This patch allows to push to the GitHub release the output of the syft command uploading the generated SBOMs of the built artifacts.

It also fixes a reference to the tag being released.