### PR TITLE
chore(ci): Rename workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
       security-events: write
     env:
       CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
-      CHAINLOOP_WORKFLOW_NAME: "chainloop-vault-codeql"
+      CHAINLOOP_WORKFLOW_NAME: "codeql"
       CHAINLOOP_PROJECT: "chainloop"
 
     strategy:

--- a/.github/workflows/contracts/chainloop-chainloop-github-release.yaml
+++ b/.github/workflows/contracts/chainloop-chainloop-github-release.yaml
@@ -1,4 +1,4 @@
-# contract used in chainloop-vault-release workflow
+# contract used in release workflow
 schemaVersion: v1
 policies:
   attestation:

--- a/.github/workflows/contracts/chainloop-docs-release.yml
+++ b/.github/workflows/contracts/chainloop-docs-release.yml
@@ -1,4 +1,4 @@
-# Contract used in chainloop-docs-release workflow
+# Contract used in docs-release workflow
 schemaVersion: v1
 runner:
   type: GITHUB_ACTION

--- a/.github/workflows/contracts/chainloop-vault-codeql.yml
+++ b/.github/workflows/contracts/chainloop-vault-codeql.yml
@@ -1,4 +1,4 @@
-# Contract for chainloop-vault-codeql workflow
+# Contract for codeql workflow
 schemaVersion: v1
 runner:
   type: GITHUB_ACTION

--- a/.github/workflows/contracts/chainloop-vault-helm-package.yml
+++ b/.github/workflows/contracts/chainloop-vault-helm-package.yml
@@ -1,4 +1,4 @@
-# Contract for chainloop-vault-helm-package workflow
+# Contract for helm-package workflow
 schemaVersion: v1
 runner:
   type: GITHUB_ACTION

--- a/.github/workflows/contracts/chainloop-vault-scorecards.yml
+++ b/.github/workflows/contracts/chainloop-vault-scorecards.yml
@@ -1,4 +1,4 @@
-# Contract for chainloop-vault-scorecards workflow
+# Contract for scorecards workflow
 schemaVersion: v1
 runner:
   type: GITHUB_ACTION

--- a/.github/workflows/contracts/release.yml
+++ b/.github/workflows/contracts/release.yml
@@ -1,4 +1,4 @@
-# Contract for the chainloop-vault-build-and-package workflow
+# Contract for the build-and-package workflow
 schemaVersion: v1
 policies:
   attestation:

--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -17,7 +17,7 @@ jobs:
     secrets:
       api_token: ${{ secrets.CHAINLOOP_TOKEN }}
     with:
-      workflow_name: "chainloop-docs-release"
+      workflow_name: "docs-release"
       project_name: "chainloop"
 
   deploy_docs:
@@ -86,4 +86,4 @@ jobs:
       api_token: ${{ secrets.CHAINLOOP_TOKEN }}
     with:
       attestation_name: "docs"
-      workflow_name: "chainloop-docs-release"
+      workflow_name: "docs-release"

--- a/.github/workflows/package_chart.yaml
+++ b/.github/workflows/package_chart.yaml
@@ -20,7 +20,7 @@ jobs:
     uses: chainloop-dev/labs/.github/workflows/chainloop_onboard.yml@64839eb68c20fefda46929c6c6e893cdf0537619
     with:
       project: "chainloop"
-      workflow_name: "chainloop-vault-helm-package"
+      workflow_name: "helm-package"
     secrets:
       api_token: ${{ secrets.CHAINLOOP_TOKEN }}
 

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -24,7 +24,7 @@ jobs:
     secrets:
       api_token: ${{ secrets.CHAINLOOP_TOKEN }}
     with:
-      workflow_name: "chainloop-vault-scorecards"
+      workflow_name: "scorecards"
       project_name: "chainloop"
 
   analysis:
@@ -92,4 +92,4 @@ jobs:
       api_token: ${{ secrets.CHAINLOOP_TOKEN }}
     with:
       attestation_name: "scorecards"
-      workflow_name: "chainloop-vault-scorecards"
+      workflow_name: "scorecards"


### PR DESCRIPTION
This patch removes the `chainloop-vault` and `chainloop-docs` as prefix from the workflow names.