### PR TITLE
fix(bundles): do not store full chain

### DIFF
--- a/pkg/attestation/renderer/renderer.go
+++ b/pkg/attestation/renderer/renderer.go
@@ -183,12 +183,13 @@ func (ab *AttestationRenderer) envelopeToBundle(dsseEnvelope dsse.Envelope) (*pr
 		if len(chain) == 0 {
 			return nil, errors.New("certificate chain is empty")
 		}
+
 		// Store generated cert, ignoring the chain
 		block, _ := pem.Decode([]byte(chain[0]))
-
 		if block == nil {
 			return nil, fmt.Errorf("failed to decode PEM block")
 		}
+		
 		cert := &v12.X509Certificate{RawBytes: block.Bytes}
 		bundle.VerificationMaterial.Content = &protobundle.VerificationMaterial_Certificate{
 			Certificate: cert,

--- a/pkg/attestation/renderer/renderer.go
+++ b/pkg/attestation/renderer/renderer.go
@@ -180,19 +180,18 @@ func (ab *AttestationRenderer) envelopeToBundle(dsseEnvelope dsse.Envelope) (*pr
 	//       public keys.
 	if v, ok := ab.signer.(*chainloopsigner.Signer); ok {
 		chain := v.Chain
-		certs := make([]*v12.X509Certificate, 0)
-		// Store cert chain except root certificate, as it's required to be provided separately
-		for _, c := range chain[0 : len(chain)-1] {
-			block, _ := pem.Decode([]byte(c))
-			if block == nil {
-				return nil, fmt.Errorf("failed to decode PEM block")
-			}
-			certs = append(certs, &v12.X509Certificate{RawBytes: block.Bytes})
+		if len(chain) == 0 {
+			return nil, errors.New("certificate chain is empty")
 		}
-		bundle.VerificationMaterial.Content = &protobundle.VerificationMaterial_X509CertificateChain{
-			X509CertificateChain: &v12.X509CertificateChain{
-				Certificates: certs,
-			},
+		// Store generated cert, ignoring the chain
+		block, _ := pem.Decode([]byte(chain[0]))
+
+		if block == nil {
+			return nil, fmt.Errorf("failed to decode PEM block")
+		}
+		cert := &v12.X509Certificate{RawBytes: block.Bytes}
+		bundle.VerificationMaterial.Content = &protobundle.VerificationMaterial_Certificate{
+			Certificate: cert,
 		}
 	}
 

--- a/pkg/attestation/renderer/renderer.go
+++ b/pkg/attestation/renderer/renderer.go
@@ -189,7 +189,7 @@ func (ab *AttestationRenderer) envelopeToBundle(dsseEnvelope dsse.Envelope) (*pr
 		if block == nil {
 			return nil, fmt.Errorf("failed to decode PEM block")
 		}
-		
+
 		cert := &v12.X509Certificate{RawBytes: block.Bytes}
 		bundle.VerificationMaterial.Content = &protobundle.VerificationMaterial_Certificate{
 			Certificate: cert,

--- a/pkg/attestation/renderer/renderer_test.go
+++ b/pkg/attestation/renderer/renderer_test.go
@@ -123,7 +123,7 @@ func (s *rendererSuite) TestEnvelopeToBundle() {
 		s.Nil(bundle.GetVerificationMaterial().GetContent())
 	})
 
-	s.Run("from keyless signer, it adds intermediate certificates, but not the root CA", func() {
+	s.Run("from keyless signer, it doesn't add intermediate certificates nor root CA", func() {
 		envelope, err := testEnvelope("chainloop/testdata/valid.envelope.v2.json")
 		s.Require().NoError(err)
 
@@ -145,12 +145,12 @@ func (s *rendererSuite) TestEnvelopeToBundle() {
 		s.Equal("application/vnd.in-toto+json", bundle.GetDsseEnvelope().GetPayloadType())
 
 		// only 1 cert is added
-		s.Equal(1, len(bundle.GetVerificationMaterial().GetX509CertificateChain().GetCertificates()))
+		s.NotNil(bundle.GetVerificationMaterial().GetCertificate())
 
 		// and it's the leaf certificate
 		s.Equal(cert, string(pem.EncodeToMemory(&pem.Block{
 			Type:  "CERTIFICATE",
-			Bytes: bundle.GetVerificationMaterial().GetX509CertificateChain().GetCertificates()[0].RawBytes}),
+			Bytes: bundle.GetVerificationMaterial().GetCertificate().RawBytes}),
 		))
 	})
 }


### PR DESCRIPTION
Sigstore bundles v3.0 should only contain the leaf certificate used for signing. Intermediates and root certificates must be trusted and provided out-of-band.

https://github.com/sigstore/protobuf-specs/blob/main/protos/sigstore_bundle.proto#L91
