### PR TITLE
chore(ci): Move env to job level

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,7 +45,7 @@ jobs:
     env:
       CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
       ATTESTATION_ID: ${{ needs.init_attestation.outputs.attestation_id }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     outputs:
       attestation_hash: ${{ steps.attest_goreleaser.outputs.attestation_hash }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,6 +45,7 @@ jobs:
     env:
       CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
       ATTESTATION_ID: ${{ needs.init_attestation.outputs.attestation_id }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     outputs:
       attestation_hash: ${{ steps.attest_goreleaser.outputs.attestation_hash }}
 
@@ -99,8 +100,6 @@ jobs:
 
       - name: Generate SBOMs, upload to release and attest
         id: attest_goreleaser
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # goreleaser output resides in dist/artifacts.json
           # Attest all built containers and manifests


### PR DESCRIPTION
This patch moves the GH_TOKEN to the job level to be able to use the gh cli.