### PR TITLE
fix(workflows): remove status command

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -155,7 +155,6 @@ jobs:
         id: attestation_push
         if: ${{ success() }}
         run: |
-          chainloop attestation status --full
           chainloop attestation push --attestation-id ${{ needs.init_attestation.outputs.attestation_id }}
           attestation_sha=$(chainloop attestation push --attestation-id ${{ needs.init_attestation.outputs.attestation_id }} -o json | jq -r '.digest')
           # check that the command succeeded


### PR DESCRIPTION
Remove not needed status command, since `att push` already shows the status. The command was lacking the `--attestation-id` field for remote attestations.