### PR TITLE
fix(ci): Restore push of sbom to GitHub release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -112,8 +112,8 @@ jobs:
               material_name="$(echo $entry | sed 's#.*/##')"
           
               syft -o cyclonedx-json=/tmp/sbom-$material_name.cyclonedx.json $entry
-              chainloop attestation add --value $entry --attestation-id ${{ env.ATTESTATION_ID }}
-              chainloop attestation add --value /tmp/sbom-$material_name.cyclonedx.json --attestation-id ${{ env.ATTESTATION_ID }}
+              chainloop attestation add --value $entry --kind CONTAINER_IMAGE --attestation-id ${{ env.ATTESTATION_ID }}
+              chainloop attestation add --value /tmp/sbom-$material_name.cyclonedx.json --kind SBOM_CYCLONEDX_JSON --attestation-id ${{ env.ATTESTATION_ID }}
           
               # Upload the SBOM to the release
               gh release upload ${{ github.ref_name }} /tmp/sbom-$material_name.cyclonedx.json --clobber

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -109,12 +109,14 @@ jobs:
           for entry in $images; do
             # exclude latest tag
             if [[ $entry != *latest ]]; then
-              syft -o cyclonedx-json=/tmp/sbom.cyclonedx.json $entry
-              chainloop attestation add --value $entry --kind CONTAINER_IMAGE --attestation-id ${{ env.ATTESTATION_ID }}
-              chainloop attestation add --value /tmp/sbom.cyclonedx.json --attestation-id ${{ env.ATTESTATION_ID }}
+              material_name="$(echo $entry | sed 's#.*/##')"
+          
+              syft -o cyclonedx-json=/tmp/sbom-$material_name.cyclonedx.json $entry
+              chainloop attestation add --value $entry --attestation-id ${{ env.ATTESTATION_ID }}
+              chainloop attestation add --value /tmp/sbom-$material_name.cyclonedx.json --attestation-id ${{ env.ATTESTATION_ID }}
           
               # Upload the SBOM to the release
-              # gh release upload ${{ github.ref_name }} /tmp/sbom-$material_name.cyclonedx.json --clobber
+              gh release upload ${{ github.ref_name }} /tmp/sbom-$material_name.cyclonedx.json --clobber
             fi
           done
 


### PR DESCRIPTION
This patch restore the push of sbom materials to GitHub release.