### PR TITLE
chore: upgrade go to 1.23.6

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
-          go-version: "1.23.5"
+          go-version: "1.23.6"
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
-          go-version: "1.23.5"
+          go-version: "1.23.6"
 
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
@@ -66,7 +66,7 @@ jobs:
 
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
-          go-version: "1.23.5"
+          go-version: "1.23.6"
 
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
-          go-version: "1.23.5"
+          go-version: "1.23.6"
 
       # install qemu binaries for multiarch builds (needed by goreleaser/buildx)
       - name: Setup qemu

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
-          go-version: "1.23.5"
+          go-version: "1.23.6"
           cache: true
           cache-dependency-path: go.sum
 

--- a/app/artifact-cas/Dockerfile
+++ b/app/artifact-cas/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23@sha256:8c10f21bec412f08f73aa7b97ca5ac5f28a39d8a88030ad8a339fd0a781d72b4 AS builder
+FROM golang:1.23@sha256:927112936d6b496ed95f55f362cc09da6e3e624ef868814c56d55bd7323e0959 AS builder
 
 # Not linked libraries since it will be injected into a scratch container
 ENV CGO_ENABLED=0

--- a/app/artifact-cas/Dockerfile.goreleaser
+++ b/app/artifact-cas/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-FROM golang:1.23@sha256:8c10f21bec412f08f73aa7b97ca5ac5f28a39d8a88030ad8a339fd0a781d72b4 AS builder
+FROM golang:1.23@sha256:927112936d6b496ed95f55f362cc09da6e3e624ef868814c56d55bd7323e0959 AS builder
 
 FROM scratch
 

--- a/app/cli/Dockerfile.goreleaser
+++ b/app/cli/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-FROM golang:1.23@sha256:8c10f21bec412f08f73aa7b97ca5ac5f28a39d8a88030ad8a339fd0a781d72b4 AS builder
+FROM golang:1.23@sha256:927112936d6b496ed95f55f362cc09da6e3e624ef868814c56d55bd7323e0959 AS builder
 RUN mkdir -p /.config/chainloop
 
 FROM scratch

--- a/app/controlplane/Dockerfile
+++ b/app/controlplane/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23@sha256:8c10f21bec412f08f73aa7b97ca5ac5f28a39d8a88030ad8a339fd0a781d72b4 AS builder
+FROM golang:1.23@sha256:927112936d6b496ed95f55f362cc09da6e3e624ef868814c56d55bd7323e0959 AS builder
 
 # Not linked libraries since it will be injected into a scratch container
 ENV CGO_ENABLED=0

--- a/app/controlplane/Dockerfile.goreleaser
+++ b/app/controlplane/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-FROM golang:1.23@sha256:8c10f21bec412f08f73aa7b97ca5ac5f28a39d8a88030ad8a339fd0a781d72b4 AS builder
+FROM golang:1.23@sha256:927112936d6b496ed95f55f362cc09da6e3e624ef868814c56d55bd7323e0959 AS builder
 
 FROM scratch
 

--- a/docs/docs/getting-started/attestation-crafting.md
+++ b/docs/docs/getting-started/attestation-crafting.md
@@ -291,7 +291,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.23.5"
+          go-version: "1.23.6"
 
       - name: Configure AWS credentials to push container images
         uses: aws-actions/configure-aws-credentials@v1

--- a/docs/examples/ci-workflows/github.yaml
+++ b/docs/examples/ci-workflows/github.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.23.5"
+          go-version: "1.23.6"
 
       # Generate SBOM using syft in cycloneDX format
       - uses: anchore/sbom-action@v0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chainloop-dev/chainloop
 
-go 1.23.5
+go 1.23.6
 
 require (
 	cloud.google.com/go/secretmanager v1.14.0


### PR DESCRIPTION
There is no newer image for `atlas` yet.
Fixes #1798 