### PR TITLE
chore: dump attestation bundle for "attestation" output format

### DIFF
--- a/app/cli/cmd/output.go
+++ b/app/cli/cmd/output.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/chainloop-dev/chainloop/app/cli/internal/action"
 	"github.com/jedib0t/go-pretty/v6/table"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
 
 const formatJSON = "json"
@@ -70,6 +72,22 @@ func encodeOutput[messageType tabulatedData, f func(messageType) error](v messag
 
 func encodeJSON(v interface{}) error {
 	return encodeJSONToWriter(v, os.Stdout)
+}
+
+func encodeProtoJSON(v proto.Message) error {
+	options := protojson.MarshalOptions{
+		Multiline: true,
+		Indent:    "   ",
+	}
+	output, err := options.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("failed to encode output: %w", err)
+	}
+	_, err = fmt.Fprint(os.Stdout, string(output))
+	if err != nil {
+		return fmt.Errorf("failed to write output: %w", err)
+	}
+	return nil
 }
 
 func encodeJSONToWriter(v interface{}, w io.Writer) error {

--- a/app/cli/cmd/workflow_workflow_run_describe.go
+++ b/app/cli/cmd/workflow_workflow_run_describe.go
@@ -293,12 +293,16 @@ func encodeAttestationOutput(run *action.WorkflowRunItemFull, writer io.Writer) 
 	case formatStatement:
 		return encodeJSON(run.Attestation.Statement())
 	case formatAttestation:
-		var bundle protobundle.Bundle
-		err = protojson.Unmarshal(run.Attestation.Bundle, &bundle)
-		if err != nil {
-			return fmt.Errorf("unmarshaling attestation: %w", err)
+		if run.Attestation.Bundle != nil {
+			var bundle protobundle.Bundle
+			err = protojson.Unmarshal(run.Attestation.Bundle, &bundle)
+			if err != nil {
+				return fmt.Errorf("unmarshaling attestation: %w", err)
+			}
+			return encodeProtoJSON(&bundle)
+		} else {
+			return encodeJSON(run.Attestation.Envelope)
 		}
-		return encodeProtoJSON(&bundle)
 	case formatPayloadPAE:
 		return encodePAE(run, writer)
 	default:

--- a/app/cli/cmd/workflow_workflow_run_describe.go
+++ b/app/cli/cmd/workflow_workflow_run_describe.go
@@ -30,7 +30,9 @@ import (
 	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/muesli/reflow/wrap"
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
+	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
 	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 const formatStatement = "statement"
@@ -291,7 +293,12 @@ func encodeAttestationOutput(run *action.WorkflowRunItemFull, writer io.Writer) 
 	case formatStatement:
 		return encodeJSON(run.Attestation.Statement())
 	case formatAttestation:
-		return encodeJSON(run.Attestation.Envelope)
+		var bundle protobundle.Bundle
+		err = protojson.Unmarshal(run.Attestation.Bundle, &bundle)
+		if err != nil {
+			return fmt.Errorf("unmarshaling attestation: %w", err)
+		}
+		return encodeProtoJSON(&bundle)
 	case formatPayloadPAE:
 		return encodePAE(run, writer)
 	default:

--- a/app/cli/internal/action/workflow_run_describe.go
+++ b/app/cli/internal/action/workflow_run_describe.go
@@ -49,6 +49,7 @@ type WorkflowRunItemFull struct {
 
 type WorkflowRunAttestationItem struct {
 	Envelope    *dsse.Envelope `json:"envelope"`
+	Bundle      []byte         `json:"bundle"`
 	statement   *intoto.Statement
 	Materials   []*Material   `json:"materials,omitempty"`
 	EnvVars     []*EnvVar     `json:"envvars,omitempty"`
@@ -217,6 +218,7 @@ func (action *WorkflowRunDescribe) Run(ctx context.Context, opts *WorkflowRunDes
 
 	item.Attestation = &WorkflowRunAttestationItem{
 		Envelope:          envelope,
+		Bundle:            attestation.GetBundle(),
 		statement:         statement,
 		EnvVars:           envVars,
 		Materials:         materials,


### PR DESCRIPTION
This PR switches from DSEE envelope to Bundle format when using `--output attestation` option in `workflow run describe` command.