### PR TITLE
chore(vex): Include VEX files for projects

### DIFF
--- a/.vex/artifact-cas.vex.json
+++ b/.vex/artifact-cas.vex.json
@@ -1,0 +1,8 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-c378dbd5f883c58616eedad8f5a659f23d29acc9f869e555cdeff41f2de74ed5",
+  "author": "Chainloop Inc.",
+  "timestamp": "2025-02-11T09:19:15.738778+01:00",
+  "version": 1,
+  "statements": []
+}

--- a/.vex/cli.vex.json
+++ b/.vex/cli.vex.json
@@ -1,0 +1,8 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-c378dbd5f883c58616eedad8f5a659f23d29acc9f869e555cdeff41f2de74ed5",
+  "author": "Chainloop Inc.",
+  "timestamp": "2025-02-11T09:19:15.738778+01:00",
+  "version": 1,
+  "statements": []
+}

--- a/.vex/controlplane.vex.json
+++ b/.vex/controlplane.vex.json
@@ -1,0 +1,8 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-c378dbd5f883c58616eedad8f5a659f23d29acc9f869e555cdeff41f2de74ed5",
+  "author": "Chainloop Inc.",
+  "timestamp": "2025-02-11T09:19:15.738778+01:00",
+  "version": 1,
+  "statements": []
+}


### PR DESCRIPTION
This patch includes three VEX files for the individual projects in the repository: artifacts-cas, cli, and controlplane. These files provide the current status of any CVEs that may affect Chainloop, allowing us to keep the end users informed.