### PR TITLE
fix(ci): Remove duplicate attestation push command

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -157,7 +157,6 @@ jobs:
         id: attestation_push
         if: ${{ success() }}
         run: |
-          chainloop attestation push --attestation-id ${{ needs.init_attestation.outputs.attestation_id }}
           attestation_sha=$(chainloop attestation push --attestation-id ${{ needs.init_attestation.outputs.attestation_id }} -o json | jq -r '.digest')
           # check that the command succeeded
           [ -n "${attestation_sha}" ] || exit 1


### PR DESCRIPTION
This patch removes a duplicate `attestation push` command being sent on the release process.