### PR TITLE
chore(atlas): Upgrade atlas version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Generate migrations
         if: ${{ matrix.app == 'controlplane' }}
         env:
-          ATLAS_VERSION: v0.30.0
+          ATLAS_VERSION: v0.31.1-647df7a-canary
         run: |
           wget -q https://release.ariga.io/atlas/atlas-linux-amd64-$ATLAS_VERSION -O /tmp/atlas
           sudo install /tmp/atlas /usr/local/bin/atlas

--- a/app/controlplane/Dockerfile.migrations
+++ b/app/controlplane/Dockerfile.migrations
@@ -1,7 +1,8 @@
 # Container image built by go-releaser that's used to run migrations against the database during deployment
 # See https://atlasgo.io/guides/deploying/image
-# Current version v0.31.0
-FROM arigaio/atlas@sha256:05d435f32c7d732abad12e2b4fdb8c952fe695a7fb2aa41a974048c7313ceb1d as base
+# Current version v0.31.1-647df7a-canary
+# Until a v0.31.1 release is available
+FROM arigaio/atlas@sha256:03171af017c334919bb25a22e92390f810db30805de1f5e12460702e45c296ef as base
 
 FROM scratch
 # Update permissions to make it readable by the user

--- a/common.mk
+++ b/common.mk
@@ -7,7 +7,7 @@ init: init-api-tools
 	go install github.com/vektra/mockery/v2@v2.43.2
 	# using binary release for atlas, since ent schema handler is not included
 	# in the community version anymore https://github.com/ariga/atlas/issues/2388#issuecomment-1864287189
-	curl -sSf https://atlasgo.sh | ATLAS_VERSION=v0.27.0 sh -s -- -y
+	curl -sSf https://atlasgo.sh | ATLAS_VERSION=v0.31.1-647df7a-canary sh -s -- -y
 
 # initialize API tooling
 .PHONY: init-api-tools


### PR DESCRIPTION
This patch bumps the version of atlas to `latest` pining its sha. Since there is not a patch version yet, we will wait for version `v0.31.1` to be released to pin to that version fixing CVEs.