### PR TITLE
feat(verification): attestation verify command

### DIFF
--- a/app/cli/cmd/attestation.go
+++ b/app/cli/cmd/attestation.go
@@ -72,7 +72,8 @@ func newAttestationCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&GracefulExit, "graceful-exit", false, "exit 0 in case of error. NOTE: this flag will be removed once Chainloop reaches 1.0")
 	cmd.PersistentFlags().StringVar(&attestationLocalStatePath, "local-state-path", "", "path to store the attestation state locally, default: [tmpDir]/chainloop_attestation.tmp.json")
 
-	cmd.AddCommand(newAttestationInitCmd(), newAttestationAddCmd(), newAttestationStatusCmd(), newAttestationPushCmd(), newAttestationResetCmd())
+	cmd.AddCommand(newAttestationInitCmd(), newAttestationAddCmd(), newAttestationStatusCmd(), newAttestationPushCmd(),
+		newAttestationResetCmd(), newAttestationVerifyCmd())
 
 	return cmd
 }

--- a/app/cli/cmd/attestation_verify.go
+++ b/app/cli/cmd/attestation_verify.go
@@ -1,0 +1,53 @@
+//
+// Copyright 22025 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/chainloop-dev/chainloop/app/cli/internal/action"
+	"github.com/spf13/cobra"
+)
+
+func newAttestationVerifyCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "verify file-or-url",
+		Short:                 "verify an attestation",
+		Long:                  "Verify an attestation by validating its validation material against the configured trusted root",
+		DisableFlagsInUseLine: true,
+		Example: `  # verify local attestation
+  chainloop attestation verify attestation.json
+
+  # verify an attestation stored in an https endpoint
+  chainloop attestation verify https://myrepository/attestation.json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			res, err := action.NewAttestationVerifyAction(actionOpts).Run(cmd.Context(), args[0])
+			if err != nil {
+				return fmt.Errorf("verifying attestation: %w", err)
+			}
+			if res {
+				actionOpts.Logger.Info().Msg("attestation verified successfully")
+			} else {
+				actionOpts.Logger.Warn().Msg("attestation couldn't be verified")
+			}
+
+			return nil
+		},
+		Args: cobra.ExactArgs(1),
+	}
+
+	return cmd
+}

--- a/app/cli/internal/action/attestation_verify.go
+++ b/app/cli/internal/action/attestation_verify.go
@@ -1,0 +1,73 @@
+//
+// Copyright 2024-2025 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package action
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	pb "github.com/chainloop-dev/chainloop/app/controlplane/api/controlplane/v1"
+	"github.com/chainloop-dev/chainloop/pkg/attestation/verifier"
+	"github.com/sigstore/cosign/v2/pkg/blob"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type AttestationVerifyAction struct {
+	cfg *ActionsOpts
+}
+
+func NewAttestationVerifyAction(cfg *ActionsOpts) *AttestationVerifyAction {
+	return &AttestationVerifyAction{cfg}
+}
+
+func (action *AttestationVerifyAction) Run(ctx context.Context, fileOrUrl string) (bool, error) {
+	content, err := blob.LoadFileOrURL(fileOrUrl)
+	if err != nil {
+		return false, fmt.Errorf("loading attestation: %w", err)
+	}
+
+	return verifyBundle(ctx, content, action.cfg)
+}
+
+func verifyBundle(ctx context.Context, content []byte, opts *ActionsOpts) (bool, error) {
+	sc := pb.NewSigningServiceClient(opts.CPConnection)
+	trResp, err := sc.GetTrustedRoot(ctx, &pb.GetTrustedRootRequest{})
+	if err != nil {
+		// if trusted root is not implemented, skip verification
+		if status.Code(err) != codes.Unimplemented {
+			return false, fmt.Errorf("failed getting trusted root: %w", err)
+		}
+	}
+
+	if trResp != nil {
+		tr, err := trustedRootPbToVerifier(trResp)
+		if err != nil {
+			return false, fmt.Errorf("getting roots: %w", err)
+		}
+		if err = verifier.VerifyBundle(ctx, content, tr); err != nil {
+			if !errors.Is(err, verifier.ErrMissingVerificationMaterial) {
+				opts.Logger.Debug().Err(err).Msg("bundle verification failed")
+				return false, errors.New("bundle verification failed")
+			}
+		} else {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}


### PR DESCRIPTION
This PR adds a new subcommand to the attestation command to verify a downloaded attestation bundle.
```shell
➜  chainloop wf run describe --digest sha256:0c432b7de0dde8c1aea926086e9346980c03abecd3461e00bb87413f50466037 --output attestation > att.json

➜  chainloop att verify att.json
INF attestation verified successfully
```

It also supports http(s) endpoints.
```shell
➜ chainloop att verify https://gist.githubusercontent.com/jiparis/fac2dbc4488503b14779ac590618d525/raw/d577442adec89221201c4403102dd5603eb0c803/gistfile1.txt
INF attestation verified successfully
```