### PR TITLE
feat: stop signing attestations with cosign

### DIFF
--- a/.github/workflows/package_chart.yaml
+++ b/.github/workflows/package_chart.yaml
@@ -91,10 +91,7 @@ jobs:
       - name: Finish and Record Attestation
         if: ${{ success() }}
         run: |
-          chainloop attestation push --key env://CHAINLOOP_SIGNING_KEY
-        env:
-          CHAINLOOP_SIGNING_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
-          CHAINLOOP_SIGNING_KEY: ${{ secrets.COSIGN_KEY }}
+          chainloop attestation push
 
       - name: Mark attestation as failed
         if: ${{ failure() }}


### PR DESCRIPTION
We will use Chainloop key-less format instead.