### PR TITLE
chore: remove cosign for signing attestations

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -73,10 +73,7 @@ jobs:
         if: ${{ success() && github.event_name != 'pull_request' }}
         run: |
           chainloop attestation status --full
-          chainloop attestation push --key env://CHAINLOOP_SIGNING_KEY
-        env:
-          CHAINLOOP_SIGNING_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
-          CHAINLOOP_SIGNING_KEY: ${{ secrets.COSIGN_KEY }}
+          chainloop attestation push
 
       - name: Mark attestation as failed
         if: ${{ failure() && github.event_name != 'pull_request' }}

--- a/.github/workflows/github_release.yaml
+++ b/.github/workflows/github_release.yaml
@@ -9,10 +9,6 @@ on:
     secrets:
       chainloop_token:
         required: true
-      cosign_key:
-        required: true
-      cosign_pass:
-        required: true
 
 permissions: {}
 
@@ -67,13 +63,10 @@ jobs:
         if: ${{ success() }}
         run: |
           chainloop attestation status --full
-          attestation_sha=$(chainloop attestation push --key env://CHAINLOOP_SIGNING_KEY -o json | jq -r '.digest')
+          attestation_sha=$(chainloop attestation push -o json | jq -r '.digest')
           # check that the command succeeded
           [ -n "${attestation_sha}" ] || exit 1
           echo "attestation_sha=$attestation_sha" >> $GITHUB_OUTPUT
-        env:
-          CHAINLOOP_SIGNING_PASSWORD: ${{ secrets.cosign_pass }}
-          CHAINLOOP_SIGNING_KEY: ${{ secrets.cosign_key }}
 
       - name: Mark attestation as failed
         if: ${{ failure() }}


### PR DESCRIPTION
Follow up of https://github.com/chainloop-dev/chainloop/pull/1821 to remove some additional signing keys

Refs #914 