### PR TITLE
fix(chart): do not render CAs when merged

### DIFF
--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -7,7 +7,7 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.183.0
+version: 1.183.1
 # Do not update appVersion, this is handled automatically by the release process
 appVersion: v0.165.0
 

--- a/deployment/chainloop/values.yaml
+++ b/deployment/chainloop/values.yaml
@@ -665,43 +665,43 @@ controlplane:
 
   ## Configuration for keyless signing using one of the supported providers
   ## @param controlplane.keylessSigning.enabled Activates or deactivates the feature
-  ## @param controlplane.keylessSigning.backends[0].issuer Whether this backend should be used to issue new certificates. Only one can be set at a time.
-  ## @param controlplane.keylessSigning.backends[0].type backend type. Only "fileCA" and "ejbcaCA" are supported
-  ## @param controlplane.keylessSigning.backends[0].fileCA.cert The PEM-encoded certificate of the file based CA
+  ## @extra controlplane.keylessSigning.backends[0].issuer Whether this backend should be used to issue new certificates. Only one can be set at a time.
+  ## @extra controlplane.keylessSigning.backends[0].type backend type. Only "fileCA" and "ejbcaCA" are supported
+  ## @extra controlplane.keylessSigning.backends[0].fileCA.cert The PEM-encoded certificate of the file based CA
   ##       -----BEGIN CERTIFICATE-----
   ##       ...
   ##       -----END CERTIFICATE-----
-  ## @param controlplane.keylessSigning.backends[0].fileCA.key The PEM-encoded private key of the file based CA
+  ## @extra controlplane.keylessSigning.backends[0].fileCA.key The PEM-encoded private key of the file based CA
   ##       -----BEGIN RSA PRIVATE KEY-----
   ##       ...
   ##       -----END RSA PRIVATE KEY-----
-  ## @param controlplane.keylessSigning.backends[0].fileCA.keyPass The secret key pass
-  ## @param controlplane.keylessSigning.backends[1].type backend type. Only "fileCA" and "ejbcaCA" are supported
-  ## @param controlplane.keylessSigning.backends[1].ejbcaCA.serverURL The url of the EJBCA service ("https://host/ejbca")
-  ## @param controlplane.keylessSigning.backends[1].ejbcaCA.clientKey PEM-encoded the private key for EJBCA cert authentication
-  ## @param controlplane.keylessSigning.backends[1].ejbcaCA.clientCert PEM-encoded certificate for EJBCA cert authentication
-  ## @param controlplane.keylessSigning.backends[1].ejbcaCA.caCert PEM-encoded certificate of the root CA
-  ## @param controlplane.keylessSigning.backends[1].ejbcaCA.certProfileName Name of the certificate profile to use in EJBCA
-  ## @param controlplane.keylessSigning.backends[1].ejbcaCA.endEntityProfileName Name of the Entity Profile to use in EJBCA
-  ## @param controlplane.keylessSigning.backends[1].ejbcaCA.caName Name of the CA issuer to use in EJBCA
+  ## @extra controlplane.keylessSigning.backends[0].fileCA.keyPass The secret key pass
+  ## @extra controlplane.keylessSigning.backends[1].type backend type. Only "fileCA" and "ejbcaCA" are supported
+  ## @extra controlplane.keylessSigning.backends[1].ejbcaCA.serverURL The url of the EJBCA service ("https://host/ejbca")
+  ## @extra controlplane.keylessSigning.backends[1].ejbcaCA.clientKey PEM-encoded the private key for EJBCA cert authentication
+  ## @extra controlplane.keylessSigning.backends[1].ejbcaCA.clientCert PEM-encoded certificate for EJBCA cert authentication
+  ## @extra controlplane.keylessSigning.backends[1].ejbcaCA.caCert PEM-encoded certificate of the root CA
+  ## @extra controlplane.keylessSigning.backends[1].ejbcaCA.certProfileName Name of the certificate profile to use in EJBCA
+  ## @extra controlplane.keylessSigning.backends[1].ejbcaCA.endEntityProfileName Name of the Entity Profile to use in EJBCA
+  ## @extra controlplane.keylessSigning.backends[1].ejbcaCA.caName Name of the CA issuer to use in EJBCA
   keylessSigning:
     enabled: false
-    backends:
-      - type: fileCA
-        fileCA:
-          cert: ""
-          key: ""
-          keyPass: "foo"
-        issuer: true
-      - type: ejbcaCA
-        ejbcaCA:
-          serverURL: ""
-          clientKey: ""
-          clientCert: ""
-          caCert: ""
-          certProfileName: ""
-          endEntityProfileName: ""
-          caName: ""
+  # backends:
+  #   - type: fileCA
+  #     fileCA:
+  #       cert: ""
+  #       key: ""
+  #       keyPass: "foo"
+  #     issuer: true
+  #   - type: ejbcaCA
+  #     ejbcaCA:
+  #       serverURL: ""
+  #       clientKey: ""
+  #       clientCert: ""
+  #       caCert: ""
+  #       certProfileName: ""
+  #       endEntityProfileName: ""
+  #       caName: ""
 
   ## Inject custom CA certificates to the controlplane container
   ## @param controlplane.customCAs List of custom CA certificates content


### PR DESCRIPTION
When using the deprecated format the rendering was failing due to the way the templating in flux merges values entries.

```
helm template foo . --set development=true > /tmp/after.yaml && diff -u /tmp/before.yaml /tmp/after.yaml
Error: execution error at (chainloop/templates/controlplane/secret-config.yaml:75:27): EJBCA server URL is mandatory
```