### PR TITLE
fix secret names

### DIFF
--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -7,7 +7,7 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.184.0
+version: 1.184.1
 # Do not update appVersion, this is handled automatically by the release process
 appVersion: v0.166.0
 

--- a/deployment/chainloop/templates/controlplane/deployment.yaml
+++ b/deployment/chainloop/templates/controlplane/deployment.yaml
@@ -160,8 +160,8 @@ spec:
             {{- end }}
             {{- if .Values.controlplane.keylessSigning.enabled }}
             {{- range $index, $backend := .Values.controlplane.keylessSigning.backends }}
-            - name: sign-backend-{{$backend.type}}-{{$index}}
-              mountPath: /sign_secrets_{{$backend.type}}_{{$index}}
+            - name: sign-backend-{{$backend.type | lower}}-{{$index}}
+              mountPath: /sign_secrets_{{$backend.type | lower}}_{{$index}}
             {{- end }}
             {{- end }}
             {{- if include "controlplane.tls-secret-name" . }}
@@ -230,9 +230,9 @@ spec:
         {{- end }}
         {{- if and .Values.controlplane.keylessSigning.enabled }}
         {{- range $index, $backend := .Values.controlplane.keylessSigning.backends }}
-        - name: sign-backend-{{$backend.type}}-{{$index}}
+        - name: sign-backend-{{$backend.type | lower}}-{{$index}}
           secrets:
-            secretName: {{ include "chainloop.controlplane.fullname" $ }}-keyless-{{$backend.type}}-{{$index}}
+            secretName: {{ include "chainloop.controlplane.fullname" $ }}-keyless-{{$backend.type | lower}}-{{$index}}
         {{- end }}
         {{- end }}
         {{- if .Values.controlplane.extraVolumes }}

--- a/deployment/chainloop/templates/controlplane/secret-config.yaml
+++ b/deployment/chainloop/templates/controlplane/secret-config.yaml
@@ -61,17 +61,17 @@ stringData:
     {{- with $backend.fileCA }}
       - issuer: {{default false $backend.issuer }}
         file_ca:
-          cert_path: "/sign_secrets_{{$backend.type}}_{{$index}}/file_ca.cert"
-          key_path:  "/sign_secrets_{{$backend.type}}_{{$index}}/file_ca.key"
+          cert_path: "/sign_secrets_{{$backend.type | lower}}_{{$index}}/file_ca.cert"
+          key_path:  "/sign_secrets_{{$backend.type | lower}}_{{$index}}/file_ca.key"
           key_pass: "{{- required "FileCA keyPass is mandatory" .keyPass }}"
     {{- end }}
   {{- else if eq "ejbcaCA" $backend.type }}
     {{- with $backend.ejbcaCA }}
       - issuer: {{default false $backend.issuer}}
         ejbca_ca:
-          cert_path: "/sign_secrets_{{$backend.type}}_{{$index}}/ejbca_client.cert"
-          key_path:  "/sign_secrets_{{$backend.type}}_{{$index}}/ejbca_client.key"
-          root_ca_path: "/sign_secrets_{{$backend.type}}_{{$index}}/ejbca_ca.cert"
+          cert_path: "/sign_secrets_{{$backend.type | lower}}_{{$index}}/ejbca_client.cert"
+          key_path:  "/sign_secrets_{{$backend.type | lower}}_{{$index}}/ejbca_client.key"
+          root_ca_path: "/sign_secrets_{{$backend.type | lower}}_{{$index}}/ejbca_ca.cert"
           server_url: "{{- required "EJBCA server URL is mandatory" .serverURL }}"
           certificate_profile_name: "{{- required "EJBCA certificate profile name is mandatory" .certProfileName }}"
           end_entity_profile_name: "{{- required "EJBCA end entity profile name is mandatory" .endEntityProfileName }}"

--- a/deployment/chainloop/templates/controlplane/secrets-signer-ca.yaml
+++ b/deployment/chainloop/templates/controlplane/secrets-signer-ca.yaml
@@ -10,7 +10,7 @@ SPDX-License-Identifier: APACHE-2.0
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "chainloop.controlplane.fullname" $ }}-keyless-{{$backend.type}}-{{$index}}
+  name: {{ include "chainloop.controlplane.fullname" $ }}-keyless-{{$backend.type | lower}}-{{$index}}
   labels:
     {{- include "chainloop.controlplane.labels" $ | nindent 4 }}
 type: Opaque


### PR DESCRIPTION
This PR fixes secret names in deployment to be RFC 1123 compatible.
Refs #1822 

```diff
445c445
<   generated_jws_hmac_secret: "S1BlTkNvekdxSA=="
---
>   generated_jws_hmac_secret: "MzJRemN5RFlIdg=="
452,453c452,453
<           cert_path: "/sign_secrets_fileCA_0/file_ca.cert"
<           key_path:  "/sign_secrets_fileCA_0/file_ca.key"
---
>           cert_path: "/sign_secrets_fileca_0/file_ca.cert"
>           key_path:  "/sign_secrets_fileca_0/file_ca.key"
477c477
<       generated_jws_hmac_secret: "KPeNCozGqH"
---
>       generated_jws_hmac_secret: "32QzcyDYHv"
502c502
<   name: test-chainloop-controlplane-keyless-fileCA-0
---
>   name: test-chainloop-controlplane-keyless-fileca-0
1614c1614
<         checksum/secret-config: b1dee35ccd0a15f584e519cb49cfd035ff7789f938f0a2b88a79956e364ff0d1
---
>         checksum/secret-config: 12d88e1b082e6ccff0db1e41c8ff0b9e4452eba5113b34a78916171682209fad
1728,1729c1728,1729
<             - name: sign-backend-fileCA-0
<               mountPath: /sign_secrets_fileCA_0
---
>             - name: sign-backend-fileca-0
>               mountPath: /sign_secrets_fileca_0
1744c1744
<         - name: sign-backend-fileCA-0
---
>         - name: sign-backend-fileca-0
1746c1746
<             secretName: test-chainloop-controlplane-keyless-fileCA-0
---
>             secretName: test-chainloop-controlplane-keyless-fileca-0

```