### PR TITLE
chore(contract): Use builtin policy group

### DIFF
--- a/.github/workflows/contracts/release.yml
+++ b/.github/workflows/contracts/release.yml
@@ -13,7 +13,7 @@ policies:
       requirements:
         - chainloop-best-practices/container-signed
 policyGroups:
-  - ref: read-only-demo/sbom-quality
+  - ref: sbom-quality
     with:
       bannedLicenses: AGPL-1.0-only, AGPL-1.0-or-later, AGPL-3.0-only, AGPL-3.0-or-later
       bannedComponents: log4j@2.14.1


### PR DESCRIPTION
This patch replaces the custom policy `sbom-quality` for the builtin one.