### PR TITLE
feat: allow passing kind and name at the same time

### DIFF
--- a/app/cli/cmd/attestation_add.go
+++ b/app/cli/cmd/attestation_add.go
@@ -59,13 +59,6 @@ func newAttestationAddCmd() *cobra.Command {
 
   # Add a material to the attestation without specifying neither kind nor name enables automatic detection
   chainloop attestation add --value <material-value>`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if name != "" && kind != "" {
-				return fmt.Errorf("both --name and --kind cannot be set at the same time")
-			}
-
-			return nil
-		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			a, err := action.NewAttestationAdd(
 				&action.AttestationAddOpts{


### PR DESCRIPTION
To support adding contractless materials by providing its name alongside the kind. The underlying code actually supported it.

Closes #1699