### PR TITLE
fix: config field name

### DIFF
--- a/deployment/chainloop/templates/controlplane/configmap.yaml
+++ b/deployment/chainloop/templates/controlplane/configmap.yaml
@@ -65,10 +65,10 @@ data:
     {{- end }}
   {{- if .Values.controlplane.timestampAuthorities }}
   tsa.yaml: |
-    timestampAuthorities:
+    timestamp_authorities:
     {{- range $index, $tsa := .Values.controlplane.timestampAuthorities }}
-      - issuer: {{$tsa.issuer}}
-        url: {{$tsa.url}}
-        cert_chain_path: /tsa_roots/chain-{{$index}}.pem
+      - issuer: {{ $tsa.issuer | default false }}
+        url: {{ $tsa.url }}
+        cert_chain_path: /tsa_roots/chain-{{ $index }}.pem
     {{- end }}
   {{- end }}


### PR DESCRIPTION
Fixes a typo in the config field name "timestamp_authorities"

```diff
580c580
<     timestampAuthorities:
---
>     timestamp_authorities:
595,596c595,596
```
