### PR TITLE
chore: show timestamp authority in att status

### DIFF
--- a/app/cli/cmd/attestation_status.go
+++ b/app/cli/cmd/attestation_status.go
@@ -115,6 +115,10 @@ func attestationStatusTableOutput(status *action.AttestationStatusResult, full b
 		}
 	}
 
+	if status.TimestampAuthority != "" {
+		gt.AppendRow(table.Row{"Timestamp Authority", status.TimestampAuthority})
+	}
+
 	var blockingColor text.Color
 	var blockingText = action.PolicyViolationBlockingStrategyAdvisory
 	if status.MustBlockOnPolicyViolations {

--- a/app/cli/internal/action/attestation_status.go
+++ b/app/cli/internal/action/attestation_status.go
@@ -56,6 +56,7 @@ type AttestationStatusResult struct {
 	PolicyEvaluations           map[string][]*PolicyEvaluation  `json:"policy_evaluations,omitempty"`
 	HasPolicyViolations         bool                            `json:"has_policy_violations"`
 	MustBlockOnPolicyViolations bool                            `json:"must_block_on_policy_violations"`
+	TimestampAuthority          string                          `json:"timestamp_authority"`
 	// This might only be set if the attestation is pushed
 	Digest string `json:"digest"`
 }
@@ -133,6 +134,7 @@ func (action *AttestationStatus) Run(ctx context.Context, attestationID string, 
 		Annotations:                 pbAnnotationsToAction(c.CraftingState.InputSchema.GetAnnotations()),
 		IsPushed:                    action.isPushed,
 		MustBlockOnPolicyViolations: att.GetBlockOnPolicyViolation(),
+		TimestampAuthority:          att.GetSigningOptions().GetTimestampAuthorityUrl(),
 	}
 
 	if !action.skipPolicyEvaluation {


### PR DESCRIPTION
Add a new row to the status table to show the timestamp authority if configured:
```
INF push completed
┌───────────────────────────┬─────────────────────────────────────────────────────────────────────────┐
│ Initialized At            │ 21 Feb 25 13:04 UTC                                                     │
├───────────────────────────┼─────────────────────────────────────────────────────────────────────────┤
│ Attestation ID            │ ca757e20-2a8d-4632-8761-33a4d8a13b64                                    │
│ Digest                    │ sha256:4b49ac919d9858d47990400e5a9430c0a4a948fda1d8a54496e2b8e589096dd5 │
│ Organization              │ my-org                                                                  │
│ Name                      │ mywf                                                                    │
│ Project                   │ myproject                                                               │
│ Version                   │ v0.172.0 (prerelease)                                                   │
│ Contract                  │ myproject-mywf (revision 95)                                            │
│ Timestamp Authority       │ http://timestamp.digicert.com                                           │
│ Policy violation strategy │ ADVISORY                                                                │
```
Refs #914 