### PR TITLE
feat(signing): do not store old attestation field, and use bundle always

### DIFF
--- a/app/controlplane/pkg/biz/workflowrun.go
+++ b/app/controlplane/pkg/biz/workflowrun.go
@@ -83,7 +83,7 @@ type WorkflowRunRepo interface {
 	FindByAttestationDigest(ctx context.Context, digest string) (*WorkflowRun, error)
 	FindByIDInOrg(ctx context.Context, orgID, ID uuid.UUID) (*WorkflowRun, error)
 	MarkAsFinished(ctx context.Context, ID uuid.UUID, status WorkflowRunStatus, reason string) error
-	SaveAttestation(ctx context.Context, ID uuid.UUID, att *dsse.Envelope, digest string) error
+	SaveAttestation(ctx context.Context, ID uuid.UUID, digest string) error
 	SaveBundle(ctx context.Context, ID uuid.UUID, bundle []byte) error
 	GetBundle(ctx context.Context, wrID uuid.UUID) ([]byte, error)
 	List(ctx context.Context, orgID uuid.UUID, f *RunListFilters, p *pagination.CursorOptions) ([]*WorkflowRun, string, error)
@@ -266,25 +266,19 @@ func (uc *WorkflowRunUseCase) MarkAsFinished(ctx context.Context, id string, sta
 	return uc.wfRunRepo.MarkAsFinished(ctx, runID, status, reason)
 }
 
-func (uc *WorkflowRunUseCase) SaveAttestation(ctx context.Context, id string, envelope, bundle []byte) (*v1.Hash, error) {
+func (uc *WorkflowRunUseCase) SaveAttestation(ctx context.Context, id string, bundle []byte) (*v1.Hash, error) {
 	runID, err := uuid.Parse(id)
 	if err != nil {
 		return nil, NewErrInvalidUUID(err)
 	}
 
-	rawContent := bundle
-	if rawContent == nil {
-		rawContent = envelope
-	}
-
 	// calculate the content digest
-	// Todo: this should be calculated in the use case
-	digest, _, err := v1.SHA256(bytes.NewReader(rawContent))
+	digest, _, err := v1.SHA256(bytes.NewReader(bundle))
 	if err != nil {
 		return nil, fmt.Errorf("failed to calculate SHA256 of attestation: %w", err)
 	}
 
-	dsseEnv, err := attestation.DSSEEnvelopeFromRaw(bundle, envelope)
+	dsseEnv, err := attestation.DSSEEnvelopeFromRaw(bundle)
 	if err != nil {
 		return nil, fmt.Errorf("extracting DSSE envelope: %w", err)
 	}
@@ -317,7 +311,7 @@ func (uc *WorkflowRunUseCase) SaveAttestation(ctx context.Context, id string, en
 		}
 	}
 
-	if err := uc.wfRunRepo.SaveAttestation(ctx, runID, dsseEnv, digest.String()); err != nil {
+	if err := uc.wfRunRepo.SaveAttestation(ctx, runID, digest.String()); err != nil {
 		return nil, fmt.Errorf("saving attestation: %w", err)
 	}
 

--- a/app/controlplane/pkg/data/workflowrun.go
+++ b/app/controlplane/pkg/data/workflowrun.go
@@ -32,7 +32,6 @@ import (
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/pagination"
 	"github.com/go-kratos/kratos/v2/log"
 	"github.com/google/uuid"
-	"github.com/secure-systems-lab/go-securesystemslib/dsse"
 )
 
 type WorkflowRunRepo struct {
@@ -179,10 +178,9 @@ func (r *WorkflowRunRepo) FindByIDInOrg(ctx context.Context, orgID, id uuid.UUID
 	return entWrToBizWr(ctx, run)
 }
 
-// Save the attestation for a workflow run in the database
-func (r *WorkflowRunRepo) SaveAttestation(ctx context.Context, id uuid.UUID, att *dsse.Envelope, digest string) error {
+// SaveAttestation saves the attestation for a workflow run in the database
+func (r *WorkflowRunRepo) SaveAttestation(ctx context.Context, id uuid.UUID, digest string) error {
 	run, err := r.data.DB.WorkflowRun.UpdateOneID(id).
-		SetAttestation(att).
 		SetAttestationDigest(digest).
 		Save(ctx)
 	if err != nil && !ent.IsNotFound(err) {

--- a/pkg/attestation/attestations.go
+++ b/pkg/attestation/attestations.go
@@ -91,18 +91,17 @@ func BundleFromDSSEEnvelope(dsseEnvelope *dsse.Envelope) (*protobundle.Bundle, e
 	}, nil
 }
 
-func DSSEEnvelopeFromRaw(bundle, envelope []byte) (*dsse.Envelope, error) {
+func DSSEEnvelopeFromRaw(bundle []byte) (*dsse.Envelope, error) {
 	var dsseEnv dsse.Envelope
-	if bundle != nil {
-		var attBundle protobundle.Bundle
-		if err := protojson.Unmarshal(bundle, &attBundle); err != nil {
-			return nil, fmt.Errorf("unmarshalling bundle: %w", err)
-		}
-		dsseEnv = *DSSEEnvelopeFromBundle(&attBundle)
-	} else {
-		if err := json.Unmarshal(envelope, &dsseEnv); err != nil {
-			return nil, fmt.Errorf("unmarshalling envelope: %w", err)
-		}
+	if bundle == nil {
+		return nil, fmt.Errorf("empty bundle")
 	}
+
+	var attBundle protobundle.Bundle
+	if err := protojson.Unmarshal(bundle, &attBundle); err != nil {
+		return nil, fmt.Errorf("unmarshalling bundle: %w", err)
+	}
+	dsseEnv = *DSSEEnvelopeFromBundle(&attBundle)
+
 	return &dsseEnv, nil
 }


### PR DESCRIPTION
This PR executes the deprecation of the Attestation field in workflow_runs table, and use the "bundle" field in the Attestation table always.
Note that this change only affects the server, since the CLI should remain compatible with old server installations and keep sending the Envelope.
Refs #914 