### PR TITLE
feat(cli): Allow to load materials from external sources

### DIFF
--- a/app/cli/cmd/attestation_add.go
+++ b/app/cli/cmd/attestation_add.go
@@ -60,7 +60,10 @@ func newAttestationAddCmd() *cobra.Command {
   chainloop attestation add --kind <material-kind> --value <material-value>
 
   # Add a material to the attestation without specifying neither kind nor name enables automatic detection
-  chainloop attestation add --value <material-value>`,
+  chainloop attestation add --value <material-value>
+
+  # Add a material by also providing a URL pointing to the material. It will be downloaded to a temporary folder first
+  chainloop attestation add --value https://example.com/sbom.json`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			a, err := action.NewAttestationAdd(
 				&action.AttestationAddOpts{

--- a/app/cli/cmd/attestation_add.go
+++ b/app/cli/cmd/attestation_add.go
@@ -259,6 +259,8 @@ func loadResource(resourcePath string) ([]byte, error) {
 
 // loadFromURL loads the content of a URL and returns it as a byte slice.
 func loadFromURL(url string) ([]byte, error) {
+	// As cosign does: https://github.com/sigstore/cosign/blob/beb9cf21bc6741bc6e6b9736bdf57abfb91599c0/pkg/blob/load.go#L47
+	// #nosec G107
 	resp, err := http.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("requesting URL: %w", err)

--- a/app/cli/cmd/attestation_add.go
+++ b/app/cli/cmd/attestation_add.go
@@ -94,11 +94,7 @@ func newAttestationAddCmd() *cobra.Command {
 					// Try to load the value from a file or URL
 					// If the value is a URL, it will be downloaded and stored in a temporary file
 					// otherwise, it will be used as is
-					var (
-						rawValuePath string
-						err          error
-					)
-					rawValuePath, err = getPathForResource(value)
+					rawValuePath, err := getPathForResource(value)
 					if err != nil {
 						// If the error is an unrecognized scheme error, it means the path is not a URL
 						// and we should take the value as is

--- a/app/cli/cmd/attestation_add.go
+++ b/app/cli/cmd/attestation_add.go
@@ -16,8 +16,13 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/muesli/reflow/wrap"
@@ -86,8 +91,15 @@ func newAttestationAddCmd() *cobra.Command {
 			// optimistic locking. We retry the operation if the state has changed since we last read it.
 			return runWithBackoffRetry(
 				func() error {
+					// Try to load the value from a file or URL
+					// If the value is a URL, it will be downloaded and stored in a temporary file
+					// otherwise, it will be used as is
+					rawValuePath, err := loadFileOrURL(value)
+					if err != nil {
+						return fmt.Errorf("loading resource: %w", err)
+					}
 					// TODO: take the material output and show render it
-					resp, err := a.Run(cmd.Context(), attestationID, name, value, kind, annotations)
+					resp, err := a.Run(cmd.Context(), attestationID, name, rawValuePath, kind, annotations)
 					if err != nil {
 						return err
 					}
@@ -191,4 +203,102 @@ func displayMaterialInfo(status *action.AttestationStatusMaterial, policyEvaluat
 	mt.Style().Options.SeparateRows = true
 	mt.Render()
 	return nil
+}
+
+// unrecognizedSchemeError is an error type for when a URL scheme is not recognized out of
+// the supported ones.
+type unrecognizedSchemeError struct {
+	Scheme string
+}
+
+func (e *unrecognizedSchemeError) Error() string {
+	return fmt.Sprintf("loading URL: unrecognized scheme: %s", e.Scheme)
+}
+
+// loadFileOrURL tries to load a file or URL from the given path.
+// If the path starts with "http://" or "https://", it will try to load the file from the URL and save it
+// in a temporary file. It will return the path to the temporary file.
+// If the path is an actual file path, it will return the filepath
+func loadFileOrURL(resourcePath string) (string, error) {
+	if _, err := os.Stat(resourcePath); err == nil {
+		return resourcePath, nil
+	}
+
+	// Try to load the resource from a URL
+	raw, err := loadResource(resourcePath)
+	if err != nil {
+		// If the error is an unrecognized scheme error, it means the path is not a URL
+		// and we should return the path as is
+		var uerr *unrecognizedSchemeError
+		if errors.As(err, &uerr) {
+			return resourcePath, nil
+		}
+		return "", fmt.Errorf("loading resource: %w", err)
+	}
+
+	// If the resource is loaded from a URL, save it in a temporary file
+	return createTempFile(resourcePath, raw)
+}
+
+func loadResource(resourcePath string) ([]byte, error) {
+	parts := strings.SplitAfterN(resourcePath, "://", 2)
+	// If the path does not contain a scheme, it is considered a file path
+	if len(parts) != 2 {
+		return nil, &unrecognizedSchemeError{Scheme: parts[0]}
+	}
+
+	switch parts[0] {
+	case "http://", "https://":
+		return loadFromURL(resourcePath)
+	case "env://":
+		return loadFromEnv(parts[1])
+	default:
+		return nil, &unrecognizedSchemeError{Scheme: parts[0]}
+	}
+}
+
+// loadFromURL loads the content of a URL and returns it as a byte slice.
+func loadFromURL(url string) ([]byte, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("requesting URL: %w", err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("loading URL response: %w", err)
+	}
+	return raw, nil
+}
+
+// loadFromEnv loads the content of an environment variable and returns it as a byte slice.
+func loadFromEnv(envVar string) ([]byte, error) {
+	value, found := os.LookupEnv(envVar)
+	if !found {
+		return nil, fmt.Errorf("loading URL: env var $%s not found", envVar)
+	}
+	return []byte(value), nil
+}
+
+// createTempFile creates a temporary file with the given filename and writes the given data to it.
+func createTempFile(filename string, rawData []byte) (string, error) {
+	// Create a temporary directory with a random name to avoid collisions
+	tempDir, err := os.MkdirTemp("", "chainloop-inflight-dir-*")
+	if err != nil {
+		return "", fmt.Errorf("creating temporary directory: %w", err)
+	}
+
+	// Create a temporary file with the same name as the original file
+	tempFile, err := os.Create(filepath.Join(tempDir, filepath.Base(filename)))
+	if err != nil {
+		return "", fmt.Errorf("creating temporary file: %w", err)
+	}
+
+	// Write the data to the temporary file
+	if _, err := tempFile.Write(rawData); err != nil {
+		return "", fmt.Errorf("writing to temporary file: %w", err)
+	}
+
+	return tempFile.Name(), nil
 }

--- a/app/cli/cmd/attestation_add.go
+++ b/app/cli/cmd/attestation_add.go
@@ -18,11 +18,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/muesli/reflow/wrap"
@@ -32,6 +28,7 @@ import (
 
 	"github.com/chainloop-dev/chainloop/app/cli/internal/action"
 	schemaapi "github.com/chainloop-dev/chainloop/app/controlplane/api/workflowcontract/v1"
+	"github.com/chainloop-dev/chainloop/pkg/resourceloader"
 )
 
 const NotSet = "[NOT SET]"
@@ -94,11 +91,11 @@ func newAttestationAddCmd() *cobra.Command {
 					// Try to load the value from a file or URL
 					// If the value is a URL, it will be downloaded and stored in a temporary file
 					// otherwise, it will be used as is
-					rawValuePath, err := getPathForResource(value)
+					rawValuePath, err := resourceloader.GetPathForResource(value)
 					if err != nil {
 						// If the error is an unrecognized scheme error, it means the path is not a URL
 						// and we should take the value as is
-						var uerr *unrecognizedSchemeError
+						var uerr *resourceloader.UnrecognizedSchemeError
 						if errors.As(err, &uerr) {
 							rawValuePath = value
 						} else {
@@ -210,98 +207,4 @@ func displayMaterialInfo(status *action.AttestationStatusMaterial, policyEvaluat
 	mt.Style().Options.SeparateRows = true
 	mt.Render()
 	return nil
-}
-
-// unrecognizedSchemeError is an error type for when a URL scheme is not recognized out of
-// the supported ones.
-type unrecognizedSchemeError struct {
-	Scheme string
-}
-
-func (e *unrecognizedSchemeError) Error() string {
-	return fmt.Sprintf("loading URL: unrecognized scheme: %s", e.Scheme)
-}
-
-// getPathForResource tries to load a file or URL from the given path.
-// If the path starts with "http://" or "https://", it will try to load the file from the URL and save it
-// in a temporary file. It will return the path to the temporary file.
-// If the path is an actual file path, it will return the filepath
-func getPathForResource(resourcePath string) (string, error) {
-	if _, err := os.Stat(resourcePath); err == nil {
-		return resourcePath, nil
-	}
-
-	// Try to load the resource from a URL
-	raw, err := loadResourceFromURLOrEnv(resourcePath)
-	if err != nil {
-		return "", fmt.Errorf("loading resource: %w", err)
-	}
-
-	// If the resource is loaded from a URL, save it in a temporary file
-	return createTempFile(resourcePath, raw)
-}
-
-func loadResourceFromURLOrEnv(resourcePath string) ([]byte, error) {
-	parts := strings.SplitAfterN(resourcePath, "://", 2)
-	// If the path does not contain a scheme, it is considered a file path
-	if len(parts) != 2 {
-		return nil, &unrecognizedSchemeError{Scheme: parts[0]}
-	}
-
-	switch parts[0] {
-	case "http://", "https://":
-		return loadFromURL(resourcePath)
-	case "env://":
-		return loadFromEnv(parts[1])
-	default:
-		return nil, &unrecognizedSchemeError{Scheme: parts[0]}
-	}
-}
-
-// loadFromURL loads the content of a URL and returns it as a byte slice.
-func loadFromURL(url string) ([]byte, error) {
-	// As cosign does: https://github.com/sigstore/cosign/blob/beb9cf21bc6741bc6e6b9736bdf57abfb91599c0/pkg/blob/load.go#L47
-	// #nosec G107
-	resp, err := http.Get(url)
-	if err != nil {
-		return nil, fmt.Errorf("requesting URL: %w", err)
-	}
-	defer resp.Body.Close()
-
-	raw, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("loading URL response: %w", err)
-	}
-	return raw, nil
-}
-
-// loadFromEnv loads the content of an environment variable and returns it as a byte slice.
-func loadFromEnv(envVar string) ([]byte, error) {
-	value, found := os.LookupEnv(envVar)
-	if !found {
-		return nil, fmt.Errorf("loading URL: env var $%s not found", envVar)
-	}
-	return []byte(value), nil
-}
-
-// createTempFile creates a temporary file with the given filename and writes the given data to it.
-func createTempFile(filename string, rawData []byte) (string, error) {
-	// Create a temporary directory with a random name to avoid collisions
-	tempDir, err := os.MkdirTemp("", "chainloop-inflight-dir-*")
-	if err != nil {
-		return "", fmt.Errorf("creating temporary directory: %w", err)
-	}
-
-	// Create a temporary file with the same name as the original file
-	tempFile, err := os.Create(filepath.Join(tempDir, filepath.Base(filename)))
-	if err != nil {
-		return "", fmt.Errorf("creating temporary file: %w", err)
-	}
-
-	// Write the data to the temporary file
-	if _, err := tempFile.Write(rawData); err != nil {
-		return "", fmt.Errorf("writing to temporary file: %w", err)
-	}
-
-	return tempFile.Name(), nil
 }

--- a/pkg/resourceloader/resourceloader.go
+++ b/pkg/resourceloader/resourceloader.go
@@ -1,0 +1,121 @@
+//
+// Copyright 20245 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourceloader
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// UnrecognizedSchemeError is an error type for when a URL scheme is not recognized out of
+// the supported ones.
+type UnrecognizedSchemeError struct {
+	Scheme string
+}
+
+func (e *UnrecognizedSchemeError) Error() string {
+	return fmt.Sprintf("loading URL: unrecognized scheme: %s", e.Scheme)
+}
+
+// GetPathForResource tries to load a file or URL from the given path.
+// If the path starts with "http://" or "https://", it will try to load the file from the URL and save it
+// in a temporary file. It will return the path to the temporary file.
+// If the path is an actual file path, it will return the filepath
+func GetPathForResource(resourcePath string) (string, error) {
+	if _, err := os.Stat(resourcePath); err == nil {
+		return resourcePath, nil
+	}
+
+	// Try to load the resource from a URL
+	raw, err := loadResourceFromURLOrEnv(resourcePath)
+	if err != nil {
+		return "", fmt.Errorf("loading resource: %w", err)
+	}
+
+	// If the resource is loaded from a URL, save it in a temporary file
+	return createTempFile(resourcePath, raw)
+}
+
+func loadResourceFromURLOrEnv(resourcePath string) ([]byte, error) {
+	parts := strings.SplitAfterN(resourcePath, "://", 2)
+	// If the path does not contain a scheme, it is considered a file path
+	if len(parts) != 2 {
+		return nil, &UnrecognizedSchemeError{Scheme: parts[0]}
+	}
+
+	switch parts[0] {
+	case "http://", "https://":
+		return loadFromURL(resourcePath)
+	case "env://":
+		return loadFromEnv(parts[1])
+	default:
+		return nil, &UnrecognizedSchemeError{Scheme: parts[0]}
+	}
+}
+
+// loadFromURL loads the content of a URL and returns it as a byte slice.
+func loadFromURL(url string) ([]byte, error) {
+	// As cosign does: https://github.com/sigstore/cosign/blob/beb9cf21bc6741bc6e6b9736bdf57abfb91599c0/pkg/blob/load.go#L47
+	// #nosec G107
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("requesting URL: %w", err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("loading URL response: %w", err)
+	}
+	return raw, nil
+}
+
+// loadFromEnv loads the content of an environment variable and returns it as a byte slice.
+func loadFromEnv(envVar string) ([]byte, error) {
+	value, found := os.LookupEnv(envVar)
+	if !found {
+		return nil, fmt.Errorf("loading URL: env var $%s not found", envVar)
+	}
+	return []byte(value), nil
+}
+
+// createTempFile creates a temporary file with the given filename and writes the given data to it.
+func createTempFile(filename string, rawData []byte) (string, error) {
+	// Create a temporary directory with a random name to avoid collisions
+	tempDir, err := os.MkdirTemp("", "chainloop-inflight-dir-*")
+	if err != nil {
+		return "", fmt.Errorf("creating temporary directory: %w", err)
+	}
+
+	// Create a temporary file with the same name as the original file
+	tempFile, err := os.Create(filepath.Join(tempDir, filepath.Base(filename)))
+	if err != nil {
+		return "", fmt.Errorf("creating temporary file: %w", err)
+	}
+	// Close the file when we are done
+	defer tempFile.Close()
+
+	// Write the data to the temporary file
+	if _, err := tempFile.Write(rawData); err != nil {
+		return "", fmt.Errorf("writing to temporary file: %w", err)
+	}
+
+	return tempFile.Name(), nil
+}

--- a/pkg/resourceloader/resourceloader.go
+++ b/pkg/resourceloader/resourceloader.go
@@ -1,5 +1,5 @@
 //
-// Copyright 20245 The Chainloop Authors.
+// Copyright 2025 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
This patch enhances the `attestation add` command by allowing it to accept HTTP(S) URLs. When a URL is provided, the CLI downloads the file and uses it for attestation, eliminating the need for users to have the file locally. Internally, the CLI stores the downloaded file in a temporary directory, preserving its base name for material verification before pushing it to the configured CAS.

The existing behavior of loading files from the local file system remains unchanged.

A few examples:

Loading a GitLab Security Report from the file system:
```
$ chainloop attestation add --value ./pkg/attestation/crafter/materials/testdata/gl-secret-detection-report.json
INF material kind detected kind=GITLAB_SECURITY_REPORT
INF material added to attestation
┌──────────┬─────────────────────────────────────────────────────────────────────────┐
│ Name     │ material-1740665350182267000                                            │
├──────────┼─────────────────────────────────────────────────────────────────────────┤
│ Type     │ GITLAB_SECURITY_REPORT                                                  │
├──────────┼─────────────────────────────────────────────────────────────────────────┤
│ Required │ No                                                                      │
├──────────┼─────────────────────────────────────────────────────────────────────────┤
│ Value    │ gl-secret-detection-report.json                                         │
├──────────┼─────────────────────────────────────────────────────────────────────────┤
│ Digest   │ sha256:1e542c962a0f26eb0a5a6bf504335407d62548525bdb2cab1667936e5da4933f │
└──────────┴─────────────────────────────────────────────────────────────────────────┘
```
Loading another material from an URL:
```
$ chainloop attestation add --value https://raw.githubusercontent.com/chainloop-dev/chainloop/refs/heads/main/pkg/attestation/crafter/materials/testdata/zap_scan.zip
INF material kind detected kind=ZAP_DAST_ZIP
INF material added to attestation
┌──────────┬─────────────────────────────────────────────────────────────────────────┐
│ Name     │ material-1740665230173345000                                            │
├──────────┼─────────────────────────────────────────────────────────────────────────┤
│ Type     │ ZAP_DAST_ZIP                                                            │
├──────────┼─────────────────────────────────────────────────────────────────────────┤
│ Required │ No                                                                      │
├──────────┼─────────────────────────────────────────────────────────────────────────┤
│ Value    │ zap_scan.zip                                                            │
├──────────┼─────────────────────────────────────────────────────────────────────────┤
│ Digest   │ sha256:7aa1273cbc367cd13cc7be0e97a939df47f9b35e1fc45b4b81b6152569b3565c │
└──────────┴─────────────────────────────────────────────────────────────────────────┘
```
Special cases such as container images remain the same as before:
```
$ chainloop attestation add --value ghcr.io/chainloop-dev/chainloop/control-plane:latest
INF material kind detected kind=CONTAINER_IMAGE
INF material added to attestation
┌──────────┬─────────────────────────────────────────────────────────────────────────┐
│ Name     │ material-1740666161405005000                                            │
├──────────┼─────────────────────────────────────────────────────────────────────────┤
│ Type     │ CONTAINER_IMAGE                                                         │
├──────────┼─────────────────────────────────────────────────────────────────────────┤
│ Required │ No                                                                      │
├──────────┼─────────────────────────────────────────────────────────────────────────┤
│ Value    │ ghcr.io/chainloop-dev/chainloop/control-plane:latest                    │
├──────────┼─────────────────────────────────────────────────────────────────────────┤
│ Digest   │ sha256:c8994629227d0482defd16585b851f676b1515f5b6cd59e214be2fa4ef39c76b │
└──────────┴─────────────────────────────────────────────────────────────────────────┘
```