### PR TITLE
feat(signserver): support encrypted PEM in TLS connection with SignServer

### DIFF
--- a/app/cli/cmd/attestation_push.go
+++ b/app/cli/cmd/attestation_push.go
@@ -31,8 +31,9 @@ func newAttestationPushCmd() *cobra.Command {
 		pkPath, bundle   string
 		annotationsFlag  []string
 		signServerCAPath string
-		// Client certificate for SignServer auth
+		// Client certificate and passphrase for SignServer auth
 		signServerAuthCertPath string
+		signServerAuthCertPass string
 		bypassPolicyCheck      bool
 	)
 
@@ -71,6 +72,7 @@ func newAttestationPushCmd() *cobra.Command {
 				SignServerOpts: &action.SignServerOpts{
 					CAPath:             signServerCAPath,
 					AuthClientCertPath: signServerAuthCertPath,
+					AuthClientCertPass: signServerAuthCertPass,
 				},
 			})
 			if err != nil {
@@ -131,6 +133,7 @@ func newAttestationPushCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&signServerCAPath, "signserver-ca-path", "", "custom CA to be used for SignServer TLS connection")
 	cmd.Flags().StringVar(&signServerAuthCertPath, "signserver-client-cert", "", "path to client certificate in PEM format for authenticated SignServer TLS connection")
+	cmd.Flags().StringVar(&signServerAuthCertPass, "signserver-client-pass", "", "certificate passphrase for authenticated SignServer TLS connection")
 	cmd.Flags().BoolVar(&bypassPolicyCheck, exceptionFlagName, false, "do not fail this command on policy violations enforcement")
 
 	return cmd

--- a/app/cli/internal/action/attestation_push.go
+++ b/app/cli/internal/action/attestation_push.go
@@ -44,8 +44,8 @@ type AttestationPushOpts struct {
 type SignServerOpts struct {
 	// CA certificate for TLS connection
 	CAPath string
-	// (optional) Client cert for mutual TLS authentication
-	AuthClientCertPath string
+	// (optional) Client cert and passphrase for mutual TLS authentication
+	AuthClientCertPath, AuthClientCertPass string
 }
 
 type AttestationResult struct {
@@ -161,6 +161,7 @@ func (action *AttestationPush) Run(ctx context.Context, attestationID string, ru
 		signerOpts.SignServerOpts = &signer.SignServerOpts{
 			CAPath:             action.signServerOpts.CAPath,
 			AuthClientCertPath: action.signServerOpts.AuthClientCertPath,
+			AuthClientCertPass: action.signServerOpts.AuthClientCertPass,
 		}
 	}
 	sig, err := signer.GetSigner(action.keyPath, action.Logger, signerOpts)

--- a/go.mod
+++ b/go.mod
@@ -91,6 +91,7 @@ require (
 	github.com/sigstore/sigstore/pkg/signature/kms/azure v1.8.8
 	github.com/sigstore/sigstore/pkg/signature/kms/gcp v1.8.8
 	github.com/sigstore/sigstore/pkg/signature/kms/hashivault v1.8.8
+	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78
 	gitlab.com/gitlab-org/security-products/analyzers/report/v5 v5.3.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20240827150818-7e3bb234dfed
 	google.golang.org/genproto/googleapis/bytestream v0.0.0-20240903143218-8af14fe29dc1

--- a/go.sum
+++ b/go.sum
@@ -1419,6 +1419,8 @@ github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQ
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/yashtewari/glob-intersection v0.2.0 h1:8iuHdN88yYuCzCdjt0gDe+6bAhUwBeEWqThExu54RFg=
 github.com/yashtewari/glob-intersection v0.2.0/go.mod h1:LK7pIC3piUjovexikBbJ26Yml7g8xa5bsjfx2v1fwok=
+github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 h1:ilQV1hzziu+LLM3zUTJ0trRztfwgjqKnBWNtSRkbmwM=
+github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78/go.mod h1:aL8wCCfTfSfmXjznFBSZNN13rSJjlIOI1fUNAtF7rmI=
 github.com/ysmood/fetchup v0.2.3 h1:ulX+SonA0Vma5zUFXtv52Kzip/xe7aj4vqT5AJwQ+ZQ=
 github.com/ysmood/fetchup v0.2.3/go.mod h1:xhibcRKziSvol0H1/pj33dnKrYyI2ebIvz5cOOkYGns=
 github.com/ysmood/goob v0.4.0 h1:HsxXhyLBeGzWXnqVKtmT9qM7EuVs/XOgkX7T6r1o1AQ=

--- a/pkg/attestation/signer/signer.go
+++ b/pkg/attestation/signer/signer.go
@@ -35,8 +35,8 @@ type Opts struct {
 type SignServerOpts struct {
 	// CA certificate for TLS connection
 	CAPath string
-	// (optional) Client cert for mutual TLS authentication
-	AuthClientCertPath string
+	// (optional) Client cert and passphrase for mutual TLS authentication
+	AuthClientCertPath, AuthClientCertPass string
 }
 
 // GetSigner creates a new Signer based on input parameters
@@ -54,7 +54,8 @@ func GetSigner(keyPath string, logger zerolog.Logger, opts *Opts) (sigstoresigne
 			}
 			signer = signserver.NewSigner(host, worker,
 				signserver.WithCAPath(opts.SignServerOpts.CAPath),
-				signserver.WithClientCertPath(opts.SignServerOpts.AuthClientCertPath))
+				signserver.WithClientCertPath(opts.SignServerOpts.AuthClientCertPath),
+				signserver.WithClientCertPass(opts.SignServerOpts.AuthClientCertPass))
 		} else {
 			signer = cosign.NewSigner(keyPath, logger)
 		}


### PR DESCRIPTION
This PR adds a `--signserver-client-pass` flag to optionally provide a passphrase for the SignServer client certificate. It supports RFC 1423 and PKCS#8 encryption methods.
When not used, the provided PEM is assumed not encrypted.

Full command:
```
> chainloop att push --key signserver://localhost:8443/PlainSigner --signserver-ca-path localhost-chain.pem --signserver-client-cert client-user.pem --signserver-client-pass $SIGNSERVER_PASS
```

