### PR TITLE
chore(pkg): Only download material if 200

### DIFF
--- a/pkg/resourceloader/resourceloader.go
+++ b/pkg/resourceloader/resourceloader.go
@@ -73,12 +73,18 @@ func loadResourceFromURLOrEnv(resourcePath string) ([]byte, error) {
 // loadFromURL loads the content of a URL and returns it as a byte slice.
 func loadFromURL(url string) ([]byte, error) {
 	// As cosign does: https://github.com/sigstore/cosign/blob/beb9cf21bc6741bc6e6b9736bdf57abfb91599c0/pkg/blob/load.go#L47
+	// By default it will attempt a maximum 10 redirects
 	// #nosec G107
 	resp, err := http.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("requesting URL: %w", err)
 	}
 	defer resp.Body.Close()
+
+	// Check if the response is OK
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("loading URL: %s", resp.Status)
+	}
 
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
This pull request includes an improvement to the `loadFromURL` function in the `pkg/resourceloader/resourceloader.go` file. The change ensures better error handling when loading content from a URL.

Improvements to error handling:

* [`pkg/resourceloader/resourceloader.go`](diffhunk://#diff-6844a78ff7547fa02662f82d0df7c827e08f5a513eb4e4cf4f9b07c3c766c0b9R76-R88): Added a check to ensure the HTTP response status is OK before attempting to read the response body. If the status is not OK, an error is returned with the status message.