### PR TITLE
fix(release): skip file cataloger in syft scans

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -111,7 +111,7 @@ jobs:
             if [[ $entry != *latest ]]; then
               material_name="$(echo $entry | sed 's#.*/##')"
           
-              syft -o cyclonedx-json=/tmp/sbom-$material_name.cyclonedx.json $entry
+              syft -o cyclonedx-json=/tmp/sbom-$material_name.cyclonedx.json --select-catalogers -file $entry
               chainloop attestation add --value $entry --kind CONTAINER_IMAGE --attestation-id ${{ env.ATTESTATION_ID }}
               chainloop attestation add --value /tmp/sbom-$material_name.cyclonedx.json --kind SBOM_CYCLONEDX_JSON --attestation-id ${{ env.ATTESTATION_ID }}
           
@@ -157,9 +157,10 @@ jobs:
         id: attestation_push
         if: ${{ success() }}
         run: |
-          attestation_sha=$(chainloop attestation push --attestation-id ${{ needs.init_attestation.outputs.attestation_id }} -o json | jq -r '.digest')
+          chainloop attestation push --attestation-id ${{ needs.init_attestation.outputs.attestation_id }}
+          attestation_sha=$(chainloop wf run describe --id ${{ needs.init_attestation.outputs.attestation_id }} -o json | jq -r '.digest')
           # check that the command succeeded
-          [ -n "${attestation_sha}" ] || exit 1
+          [ -n "$attestation_sha" ] || exit 1
           echo "attestation_sha=$attestation_sha" >> $GITHUB_OUTPUT
 
       - name: Mark attestation as failed


### PR DESCRIPTION
This PR adds a flag to skip new file catalogers introduced in Syft 1.20.0. Chainloop binaries don't have the required metadata (purl, author ...) for NTIA . While we figure it out, we'll just go back to the behaviour in Syft 1.19.0

I've also made sure that the job fails when there is an error code != 0 in `attestation push`