### PR TITLE
chore: only redirect if login URL is overridden

### DIFF
--- a/app/controlplane/internal/service/auth.go
+++ b/app/controlplane/internal/service/auth.go
@@ -294,7 +294,7 @@ func callbackHandler(svc *AuthService, w http.ResponseWriter, r *http.Request) *
 		q.Set(oidcErrorParam, desc)
 		redirectURL.RawQuery = q.Encode()
 
-		return &oauthResp{http.StatusUnauthorized, errors.New(desc), true, redirectURL}
+		return &oauthResp{http.StatusUnauthorized, nil, true, redirectURL}
 	}
 
 	// Get information from google OIDC token

--- a/app/controlplane/internal/service/auth_test.go
+++ b/app/controlplane/internal/service/auth_test.go
@@ -65,13 +65,13 @@ func TestGetAuthURLs(t *testing.T) {
 			name:             "external with override",
 			config:           &conf.Server_HTTP{Addr: "1.2.3.4", ExternalUrl: "https://foo.com"},
 			loginURLOverride: "https://foo.override.com/auth/login",
-			want:             &AuthURLs{callback: "https://foo.com/auth/callback", Login: "https://foo.override.com/auth/login"},
+			want:             &AuthURLs{callback: "https://foo.com/auth/callback", Login: "https://foo.override.com/auth/login", loginIsOverridden: true},
 		},
 		{
 			name:             "internal with override",
 			config:           internalServer,
 			loginURLOverride: "https://foo.override.com/auth/login",
-			want:             &AuthURLs{callback: "http://1.2.3.4/auth/callback", Login: "https://foo.override.com/auth/login"},
+			want:             &AuthURLs{callback: "http://1.2.3.4/auth/callback", Login: "https://foo.override.com/auth/login", loginIsOverridden: true},
 		},
 	}
 


### PR DESCRIPTION
We want to redirect only in case there is a dedicated login page, otherwise we can incur in login loops.