### PR TITLE
fix(cli): Add missing prerelease value to wf run ls command

### DIFF
--- a/app/cli/cmd/workflow_workflow_run_list.go
+++ b/app/cli/cmd/workflow_workflow_run_list.go
@@ -105,7 +105,7 @@ func workflowRunListTableOutput(runs []*action.WorkflowRunItem) error {
 
 	for _, p := range runs {
 		wf := p.Workflow
-		r := table.Row{p.ID, wf.NamespacedName(), versionString(p.ProjectVersion), p.State, p.CreatedAt.Format(time.RFC822), p.RunnerType}
+		r := table.Row{p.ID, wf.NamespacedName(), versionString(p.ProjectVersion), p.ProjectVersion.Prerelease, p.State, p.CreatedAt.Format(time.RFC822), p.RunnerType}
 
 		if full {
 			var finishedAt string

--- a/app/cli/cmd/workflow_workflow_run_list.go
+++ b/app/cli/cmd/workflow_workflow_run_list.go
@@ -105,7 +105,7 @@ func workflowRunListTableOutput(runs []*action.WorkflowRunItem) error {
 
 	for _, p := range runs {
 		wf := p.Workflow
-		r := table.Row{p.ID, wf.NamespacedName(), versionString(p.ProjectVersion), p.ProjectVersion.Prerelease, p.State, p.CreatedAt.Format(time.RFC822), p.RunnerType}
+		r := table.Row{p.ID, wf.NamespacedName(), p.ProjectVersion.Version, p.ProjectVersion.Prerelease, p.State, p.CreatedAt.Format(time.RFC822), p.RunnerType}
 
 		if full {
 			var finishedAt string


### PR DESCRIPTION
This patch fixes and issue with the `wf run ls` command where the columns were not being filled properly due to a missing value regarding the prerelease of a project version.

Before:
```
$ chainloop wf run ls

┌──────────────────────────────────────┬───────────────────────┬───────────────────────┬─────────────┬─────────────────────┬─────────────────┬────────┐
│ ID                                   │ WORKFLOW              │ VERSION               │ PRERELEASE  │ STATE               │ CREATED AT      │ RUNNER │
├──────────────────────────────────────┼───────────────────────┼───────────────────────┼─────────────┼─────────────────────┼─────────────────┼────────┤
│ e903906d-e937-4bf0-828a-5bc6054e7324 │ myproject/mywf        │ v0.0.1                │ success     │ 05 Mar 25 09:49 UTC │ Unspecified     │        │
│ c4dd5471-b07c-4ae1-8bd6-e9642aaff455 │ myproject/mywf        │ v0.0.1                │ initialized │ 05 Mar 25 09:36 UTC │ Unspecified     │        │
```

After:
```
$ chainloop wf run ls

┌──────────────────────────────────────┬───────────────────────┬──────────┬────────────┬─────────────┬─────────────────────┬─────────────────┐
│ ID                                   │ WORKFLOW              │ VERSION  │ PRERELEASE │ STATE       │ CREATED AT          │ RUNNER          │
├──────────────────────────────────────┼───────────────────────┼──────────┼────────────┼─────────────┼─────────────────────┼─────────────────┤
│ e903906d-e937-4bf0-828a-5bc6054e7324 │ myproject/mywf        │ v0.0.1   │ false      │ success     │ 05 Mar 25 09:49 UTC │ Unspecified     │
│ c4dd5471-b07c-4ae1-8bd6-e9642aaff455 │ myproject/mywf        │ v0.0.1   │ false      │ initialized │ 05 Mar 25 09:36 UTC │ Unspecified     │
```
It also removes the `prerelease` from the output of the `Version` column since we have the `Prerelease` one.