### PR TITLE
chore(cli): Remove Prerelease column on wf run ls

### DIFF
--- a/app/cli/cmd/workflow_workflow_run_list.go
+++ b/app/cli/cmd/workflow_workflow_run_list.go
@@ -95,7 +95,7 @@ func workflowRunListTableOutput(runs []*action.WorkflowRunItem) error {
 		return nil
 	}
 
-	header := table.Row{"ID", "Workflow", "Version", "Prerelease", "State", "Created At", "Runner"}
+	header := table.Row{"ID", "Workflow", "Version", "State", "Created At", "Runner"}
 	if full {
 		header = append(header, "Finished At", "Failure reason")
 	}
@@ -105,7 +105,7 @@ func workflowRunListTableOutput(runs []*action.WorkflowRunItem) error {
 
 	for _, p := range runs {
 		wf := p.Workflow
-		r := table.Row{p.ID, wf.NamespacedName(), p.ProjectVersion.Version, p.ProjectVersion.Prerelease, p.State, p.CreatedAt.Format(time.RFC822), p.RunnerType}
+		r := table.Row{p.ID, wf.NamespacedName(), versionString(p.ProjectVersion), p.State, p.CreatedAt.Format(time.RFC822), p.RunnerType}
 
 		if full {
 			var finishedAt string


### PR DESCRIPTION
This patch removes the `Prerelease` column from the `wf run ls` command to make it consistent with the rest of commands.

Follow up of comment: https://github.com/chainloop-dev/chainloop/pull/1879#discussion_r1981265887