### PR TITLE
feat: allow to perform attestations with user token

### DIFF
--- a/app/controlplane/internal/server/grpc.go
+++ b/app/controlplane/internal/server/grpc.go
@@ -213,6 +213,8 @@ func craftMiddleware(opts *Opts) []middleware.Middleware {
 				attjwtmiddleware.NewRobotAccountProvider(opts.AuthConfig.GeneratedJwsHmacSecret),
 				// API Token provider
 				attjwtmiddleware.NewAPITokenProvider(opts.AuthConfig.GeneratedJwsHmacSecret),
+				// User Token provider
+				attjwtmiddleware.NewUserTokenProvider(opts.AuthConfig.GeneratedJwsHmacSecret),
 				// Delegated Federated provider
 				attjwtmiddleware.WithFederatedProvider(opts.FederatedConfig),
 			),
@@ -220,7 +222,9 @@ func craftMiddleware(opts *Opts) []middleware.Middleware {
 			usercontext.WithAttestationContextFromRobotAccount(opts.RobotAccountUseCase, opts.OrganizationUseCase, logHelper),
 			// 2.b - Set its API token and Robot Account as alternative to the user
 			usercontext.WithAttestationContextFromAPIToken(opts.APITokenUseCase, opts.OrganizationUseCase, logHelper),
-			// 2.c - Set its robot account from federated delegation
+			// 2.c - Set Attestation context from user token
+			usercontext.WithAttestationContextFromUser(opts.UserUseCase, logHelper),
+			// 2.d - Set its robot account from federated delegation
 			usercontext.WithAttestationContextFromFederatedInfo(opts.OrganizationUseCase, logHelper),
 		).Match(requireRobotAccountMatcher()).Build(),
 	)

--- a/app/controlplane/internal/usercontext/attjwtmiddleware/attmiddleware.go
+++ b/app/controlplane/internal/usercontext/attjwtmiddleware/attmiddleware.go
@@ -52,6 +52,8 @@ const (
 	RobotAccountProviderKey = "robotAccountProvider"
 	// APITokenProviderKey is the key for api token provider
 	APITokenProviderKey = "apiTokenProvider"
+	// UserTokenProviderKey is the key for user token provider
+	UserTokenProviderKey = "userTokenProvider"
 	// FederatedProviderKey is the key for federated token provider
 	FederatedProviderKey = "federatedProvider"
 )
@@ -123,6 +125,24 @@ func NewAPITokenProvider(signingSecret string) JWTOption {
 			}
 
 			return claims.VerifyAudience(apitoken.Audience, true)
+		}),
+		WithSigningMethod(user.SigningMethod),
+		WithKeyFunc(func(_ *jwt.Token) (interface{}, error) {
+			return []byte(signingSecret), nil
+		}),
+	)
+}
+
+func NewUserTokenProvider(signingSecret string) JWTOption {
+	return withTokenProvider(
+		UserTokenProviderKey,
+		WithVerifyAudienceFunc(func(token *jwt.Token) bool {
+			genericClaims, ok := token.Claims.(jwt.MapClaims)
+			if !ok {
+				return false
+			}
+
+			return genericClaims.VerifyAudience(user.Audience, true)
 		}),
 		WithSigningMethod(user.SigningMethod),
 		WithKeyFunc(func(_ *jwt.Token) (interface{}, error) {

--- a/app/controlplane/internal/usercontext/currentuser_middleware.go
+++ b/app/controlplane/internal/usercontext/currentuser_middleware.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2024 The Chainloop Authors.
+// Copyright 2024-2025 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import (
 	"github.com/go-kratos/kratos/v2/log"
 	"github.com/golang-jwt/jwt/v4"
 
+	"github.com/chainloop-dev/chainloop/app/controlplane/internal/usercontext/attjwtmiddleware"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/usercontext/entities"
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/biz"
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/jwt/user"
@@ -81,4 +82,53 @@ func setCurrentUser(ctx context.Context, userUC biz.UserOrgFinder, userID string
 	}
 
 	return entities.WithCurrentUser(ctx, &entities.User{Email: u.Email, ID: u.ID, CreatedAt: u.CreatedAt}), nil
+}
+
+// Middleware that injects the current user + organization to the context during the attestation process
+// it leverages the existing middlewares to set the current user and organization
+// but with a skipping behavior since that's the one required by the attMiddleware multi-selector
+func WithAttestationContextFromUser(userUC *biz.UserUseCase, logger *log.Helper) middleware.Middleware {
+	return func(handler middleware.Handler) middleware.Handler {
+		return func(ctx context.Context, req interface{}) (interface{}, error) {
+			// If the token is not an user token, we don't need to do anything
+			// note that this middleware is called by a multi-middleware that works in cascade mode
+			authInfo, ok := attjwtmiddleware.FromJWTAuthContext(ctx)
+			// If not found means that there is no currentUser set in the context
+			if !ok {
+				logger.Warn("couldn't extract org/user, JWT parser middleware not running before this one?")
+				return nil, errors.New("can't extract JWT info from the context")
+			}
+
+			if authInfo.ProviderKey != attjwtmiddleware.UserTokenProviderKey {
+				return handler(ctx, req)
+			}
+
+			// set the raw claims in the default context field so the user middleware can understand it
+			ctx = jwtMiddleware.NewContext(ctx, authInfo.Claims)
+			// We received a user token during the attestation process
+			// 1 - Set the current user from the user token
+			// 2 - Set the current organization for the user token from the DB, header or default
+			// 3 - Set the robot account
+			// NOTE: we reuse the existing middlewares to set the current user and organization by wrapping the call
+			// Now we can load the organization using the other middleware we have set
+			return WithCurrentUserMiddleware(userUC, logger)(func(ctx context.Context, req any) (any, error) {
+				user := entities.CurrentUser(ctx)
+				if user == nil {
+					return nil, errors.New("user not found")
+				}
+
+				return WithCurrentOrganizationMiddleware(userUC, logger)(func(ctx context.Context, req any) (any, error) {
+					org := entities.CurrentOrg(ctx)
+					if org == nil {
+						return nil, errors.New("organization not found")
+					}
+
+					ctx = withRobotAccount(ctx, &RobotAccount{OrgID: org.ID, ProviderKey: attjwtmiddleware.UserTokenProviderKey})
+					logger.Infow("msg", "[authN] processed credentials", "type", attjwtmiddleware.UserTokenProviderKey)
+
+					return handler(ctx, req)
+				})(ctx, req)
+			})(ctx, req)
+		}
+	}
 }

--- a/app/controlplane/internal/usercontext/currentuser_middleware.go
+++ b/app/controlplane/internal/usercontext/currentuser_middleware.go
@@ -114,23 +114,18 @@ func WithAttestationContextFromUser(userUC *biz.UserUseCase, logger *log.Helper)
 			// NOTE: we reuse the existing middlewares to set the current user and organization by wrapping the call
 			// Now we can load the organization using the other middleware we have set
 			return WithCurrentUserMiddleware(userUC, logger)(func(ctx context.Context, req any) (any, error) {
-				user := entities.CurrentUser(ctx)
-				if user == nil {
-					return nil, errors.New("user not found")
-				}
-
 				return WithCurrentOrganizationMiddleware(userUC, logger)(func(ctx context.Context, req any) (any, error) {
 					org := entities.CurrentOrg(ctx)
 					if org == nil {
 						return nil, errors.New("organization not found")
 					}
 
-					// Load the authorization subject from the context which might be related to a currentUser or an APItoken
 					subject := CurrentAuthzSubject(ctx)
 					if subject == "" {
 						return nil, errors.New("missing authorization subject")
 					}
 
+					// Load the authorization subject from the context which might be related to a currentUser or an APItoken
 					// TODO: move to authz middleware once we add support for all the tokens
 					// for now in that middleware we are not mapping admins nor owners to a specific role
 					if subject != string(authz.RoleAdmin) && subject != string(authz.RoleOwner) {


### PR DESCRIPTION
This PR adds support to perform attestations with an user token, the change basically includes two things

1 - Chain a user-token authenticator to the JWTMulti cascade-based middleware we use during attestations
2 - Add an additional middleware to set the required user and org context required in the service layer.

About 2: I managed to implement it basically reusing the existing middlewares just doing wrap calling, additionally we do an authorization check to make sure read only users can not attest in the org.

### Demo

I have three orgs with organization-2 set as default client-side

```
 go run main.go org ls
WRN API contacted in insecure mode
WRN Both user credentials and $CHAINLOOP_TOKEN set. Ignoring $CHAINLOOP_TOKEN.
┌────────────────┬─────────┬─────────┬───────┬─────────────────────────┬─────────────────────┐
│ NAME           │ CURRENT │ DEFAULT │ ROLE  │ DEFAULT POLICY STRATEGY │ JOINED AT           │
├────────────────┼─────────┼─────────┼───────┼─────────────────────────┼─────────────────────┤
│ new-org        │ false   │ true    │ owner │ ADVISORY                │ 10 Jan 25 11:58 UTC │
├────────────────┼─────────┼─────────┼───────┼─────────────────────────┼─────────────────────┤
│ foobar         │ false   │ false   │ owner │ ENFORCED                │ 22 Dec 24 08:02 UTC │
├────────────────┼─────────┼─────────┼───────┼─────────────────────────┼─────────────────────┤
│ organization-2 │ true    │ false   │ owner │ ADVISORY                │ 17 Dec 24 12:40 UTC │
└────────────────┴─────────┴─────────┴───────┴─────────────────────────┴─────────────────────┘
```

if I perform an attestation, `organization-2` will be picked

```
go run main.go att init --workflow demo --project chainloop-contrib --replace
INF Attestation initialized! now you can check its status or add materials to it
┌───────────────────────────┬──────────────────────────────────────┐
│ Initialized At            │ 10 Mar 25 22:27 UTC                  │
├───────────────────────────┼──────────────────────────────────────┤
│ Attestation ID            │ 7c8f9e8a-24f5-4347-8172-997d04f70648 │
│ Organization              │ organization-2                       │
│ Name                      │ demo                                 │
│ Project                   │ chainloop-contrib                    │
│ Version                   │ v0.178.0 (prerelease)                │
│ Contract                  │ chainloop-contrib-demo (revision 1)  │
│ Policy violation strategy │ ADVISORY                             │
└───────────────────────────┴──────────────────────────────────────┘
```

which can be overridden either manually with the `--org` flag

```
go run main.go att init --workflow demo --project chainloop-contrib --replace --org new-org
WRN API contacted in insecure mode
INF Attestation initialized! now you can check its status or add materials to it
┌───────────────────────────┬──────────────────────────────────────┐
│ Initialized At            │ 10 Mar 25 22:27 UTC                  │
├───────────────────────────┼──────────────────────────────────────┤
│ Attestation ID            │ 91d87fd6-55a8-4516-aa44-45737bb182fd │
│ Organization              │ new-org                              │
│ Name                      │ demo                                 │
│ Project                   │ chainloop-contrib                    │
│ Version                   │ v0.178.0 (prerelease)                │
│ Contract                  │ chainloop-contrib-demo (revision 1)  │
│ Policy violation strategy │ ADVISORY                             │
└───────────────────────────┴──────────────────────────────────────┘
```
closes #1003