### PR TITLE
fix: make some Azure pipeline env vars optional

### DIFF
--- a/pkg/attestation/crafter/runners/azurepipeline.go
+++ b/pkg/attestation/crafter/runners/azurepipeline.go
@@ -46,7 +46,7 @@ func (r *AzurePipeline) CheckEnv() bool {
 
 func (r *AzurePipeline) ListEnvVars() []*EnvVarDefinition {
 	return []*EnvVarDefinition{
-		{"BUILD_REQUESTEDFOREMAIL", false},
+		{"BUILD_REQUESTEDFOREMAIL", true},
 		{"BUILD_REQUESTEDFOR", false},
 		{"BUILD_REPOSITORY_URI", false},
 		{"BUILD_REPOSITORY_NAME", false},
@@ -54,8 +54,8 @@ func (r *AzurePipeline) ListEnvVars() []*EnvVarDefinition {
 		{"BUILD_BUILDNUMBER", false},
 		{"BUILD_BUILDURI", false},
 		{"BUILD_REASON", false},
-		{"AGENT_VERSION", false},
-		{"TF_BUILD", false},
+		{"AGENT_VERSION", true},
+		{"TF_BUILD", true},
 	}
 }
 

--- a/pkg/attestation/crafter/runners/azurepipeline.go
+++ b/pkg/attestation/crafter/runners/azurepipeline.go
@@ -48,13 +48,12 @@ func (r *AzurePipeline) ListEnvVars() []*EnvVarDefinition {
 	return []*EnvVarDefinition{
 		{"BUILD_REQUESTEDFOREMAIL", true},
 		{"BUILD_REQUESTEDFOR", false},
-		{"BUILD_REPOSITORY_URI", false},
-		{"BUILD_REPOSITORY_NAME", false},
+		{"BUILD_REPOSITORY_URI", true},
+		{"BUILD_REPOSITORY_NAME", true},
 		{"BUILD_BUILDID", false},
 		{"BUILD_BUILDNUMBER", false},
 		{"BUILD_BUILDURI", false},
-		{"BUILD_REASON", false},
-		{"AGENT_VERSION", true},
+		{"BUILD_REASON", true},
 		{"TF_BUILD", true},
 	}
 }

--- a/pkg/attestation/crafter/runners/azurepipeline_test.go
+++ b/pkg/attestation/crafter/runners/azurepipeline_test.go
@@ -79,7 +79,7 @@ func (s *azurePipelineSuite) TestCheckEnv() {
 
 func (s *azurePipelineSuite) TestListEnvVars() {
 	assert.Equal(s.T(), []*EnvVarDefinition{
-		{"BUILD_REQUESTEDFOREMAIL", false},
+		{"BUILD_REQUESTEDFOREMAIL", true},
 		{"BUILD_REQUESTEDFOR", false},
 		{"BUILD_REPOSITORY_URI", false},
 		{"BUILD_REPOSITORY_NAME", false},
@@ -87,8 +87,8 @@ func (s *azurePipelineSuite) TestListEnvVars() {
 		{"BUILD_BUILDNUMBER", false},
 		{"BUILD_BUILDURI", false},
 		{"BUILD_REASON", false},
-		{"AGENT_VERSION", false},
-		{"TF_BUILD", false},
+		{"AGENT_VERSION", true},
+		{"TF_BUILD", true},
 	}, s.runner.ListEnvVars())
 }
 

--- a/pkg/attestation/crafter/runners/azurepipeline_test.go
+++ b/pkg/attestation/crafter/runners/azurepipeline_test.go
@@ -81,13 +81,12 @@ func (s *azurePipelineSuite) TestListEnvVars() {
 	assert.Equal(s.T(), []*EnvVarDefinition{
 		{"BUILD_REQUESTEDFOREMAIL", true},
 		{"BUILD_REQUESTEDFOR", false},
-		{"BUILD_REPOSITORY_URI", false},
-		{"BUILD_REPOSITORY_NAME", false},
+		{"BUILD_REPOSITORY_URI", true},
+		{"BUILD_REPOSITORY_NAME", true},
 		{"BUILD_BUILDID", false},
 		{"BUILD_BUILDNUMBER", false},
 		{"BUILD_BUILDURI", false},
-		{"BUILD_REASON", false},
-		{"AGENT_VERSION", true},
+		{"BUILD_REASON", true},
 		{"TF_BUILD", true},
 	}, s.runner.ListEnvVars())
 }
@@ -97,7 +96,6 @@ func (s *azurePipelineSuite) TestResolveEnvVars() {
 	s.Empty(errors)
 
 	s.Equal(map[string]string{
-		"AGENT_VERSION":           "3.220.5",
 		"BUILD_BUILDID":           "6",
 		"BUILD_BUILDNUMBER":       "20230726.5",
 		"BUILD_BUILDURI":          "vstfs:///Build/Build/6",


### PR DESCRIPTION
Some of them are not available in classic pipelines, and some of them are only available in classic pipelines. So I'm making them optional to avoid undesired failures.