### PR TITLE
chore: use user token for attestation commands

### DIFF
--- a/app/cli/cmd/attestation.go
+++ b/app/cli/cmd/attestation.go
@@ -17,14 +17,12 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 )
 
 var (
-	attAPIToken               string
 	useAttestationRemoteState bool
 	attestationLocalStatePath string
 	GracefulExit              bool
@@ -55,14 +53,6 @@ func newAttestationCmd() *cobra.Command {
 
 			return nil
 		},
-	}
-
-	cmd.PersistentFlags().StringVarP(&attAPIToken, "token", "t", "", fmt.Sprintf("auth token. NOTE: You can also use the env variable %s", tokenEnvVarName))
-	// We do not use viper in this case because we do not want this token to be saved in the config file
-	// Instead we load the env variable manually
-	if attAPIToken == "" {
-		// Check first the new env variable
-		attAPIToken = os.Getenv(tokenEnvVarName)
 	}
 
 	cmd.PersistentFlags().Bool("remote-state", false, "Store the attestation state remotely (preview feature)")

--- a/app/cli/cmd/root.go
+++ b/app/cli/cmd/root.go
@@ -335,12 +335,8 @@ func cleanup(conn *grpc.ClientConn) error {
 // 2.3 if they both exist, we default to the user token
 // 2.4 otherwise to the one that's set
 func loadControlplaneAuthToken(cmd *cobra.Command) (string, error) {
-	// If the CMD uses a robot account instead of the regular auth token we override it
-	if _, ok := cmd.Annotations[useAPIToken]; ok {
-		if attAPIToken == "" {
-			return "", newGracefulError(ErrAttestationTokenRequired)
-		}
-
+	// Use the API token if the command can use it and it's provided
+	if _, ok := cmd.Annotations[useAPIToken]; ok && attAPIToken != "" {
 		return attAPIToken, nil
 	}
 

--- a/app/cli/cmd/root.go
+++ b/app/cli/cmd/root.go
@@ -48,6 +48,7 @@ var (
 	defaultCPAPI     = "api.cp.chainloop.dev:443"
 	defaultCASAPI    = "api.cas.chainloop.dev:443"
 	apiToken         string
+	flagYes          bool
 )
 
 const (
@@ -146,7 +147,7 @@ func NewRootCmd(l zerolog.Logger) *cobra.Command {
 			}
 
 			// Warn users when the session is interactive, and the operation is supposed to use an API token instead
-			if v := cmd.Annotations[useAPIToken]; v == "true" && isUserToken {
+			if v := cmd.Annotations[useAPIToken]; v == "true" && isUserToken && !flagYes {
 				if !confirmationPrompt(fmt.Sprintf("This command is will run against the organization %q", orgName)) {
 					return errors.New("command canceled by user")
 				}
@@ -237,6 +238,9 @@ func NewRootCmd(l zerolog.Logger) *cobra.Command {
 
 	rootCmd.PersistentFlags().StringP(confOptions.organization.flagName, "n", "", "organization name")
 	cobra.CheckErr(viper.BindPFlag(confOptions.organization.viperKey, rootCmd.PersistentFlags().Lookup(confOptions.organization.flagName)))
+
+	// Do not ask for confirmation
+	rootCmd.PersistentFlags().BoolVarP(&flagYes, "yes", "y", false, "Skip confirmation")
 
 	rootCmd.AddCommand(newWorkflowCmd(), newAuthCmd(), NewVersionCmd(),
 		newAttestationCmd(), newArtifactCmd(), newConfigCmd(),


### PR DESCRIPTION
This is a follow up of #1003 to pass the user token to the attestation commands if the API token hasn't been provided via env var nor command line.
I've also removed the duplicated `--token` flag.

The affected commands (attestations) will now prompt the user to confirm the operation, since it will be performed against the "current" organization, which might vary depending on the `chainloop org set` command. The confirmation can be bypassed with the `-y` or `--yes` flag

Without CHAINLOOP_TOKEN:

```bash
✗ go run app/cli/main.go att init --workflow mywf --project myproject --replace
WRN API contacted in insecure mode
This command is will run against the organization "my-org"
Please confirm to continue y/N
n
ERR command canceled by user
```

```bash
✗ go run app/cli/main.go att init --workflow mywf --project myproject --replace -y
WRN API contacted in insecure mode
INF Attestation initialized! now you can check its status or add materials to it
┌───────────────────────────┬──────────────────────────────────────┐
│ Initialized At            │ 13 Mar 25 17:55 UTC                  │
├───────────────────────────┼──────────────────────────────────────┤
│ Attestation ID            │ 594dfd11-4aa6-40f2-9539-2903990afea6 │
│ Organization              │ my-org                               │
│ Name                      │ mywf                                 │
│ Project                   │ myproject                            │
│ Version                   │ v0.181.0 (prerelease)                │
│ Contract                  │ myproject-mywf (revision 95)         │
│ Policy violation strategy │ ADVISORY                             │
│ Policies                  │ ------                               │
│                           │ source-commit: Ok                    │
│                           │ sbom-present: missing SBOM material  │
└───────────────────────────┴──────────────────────────────────────┘
```

With CHAINLOOP_TOKEN (no warning is raised):
```
> export CHAINLOOP_TOKEN=xxxxxxxxx
> go run app/cli/main.go att init --workflow mywf --project myproject --replace
WRN API contacted in insecure mode
INF Attestation initialized! now you can check its status or add materials to it
┌───────────────────────────┬──────────────────────────────────────┐
│ Initialized At            │ 13 Mar 25 17:58 UTC                  │
├───────────────────────────┼──────────────────────────────────────┤
│ Attestation ID            │ 4b6bed22-401a-41fe-ad0b-a4013babb36f │
│ Organization              │ my-org                               │
│ Name                      │ mywf                                 │
│ Project                   │ myproject                            │
│ Version                   │ v0.181.0 (prerelease)                │
│ Contract                  │ myproject-mywf (revision 95)         │
│ Policy violation strategy │ ADVISORY                             │
│ Policies                  │ ------                               │
│                           │ source-commit: Ok                    │
│                           │ sbom-present: missing SBOM material  │
└───────────────────────────┴──────────────────────────────────────┘
```

For the rest of commands, the behaviour is the expected:
```bash
> cl wf contract ls
WRN API contacted in insecure mode
WRN Both user credentials and $CHAINLOOP_TOKEN set. Ignoring $CHAINLOOP_TOKEN.
┌───────────────────┬─────────────────┬─────────────────────┬─────────────┐
│ NAME              │ LATEST REVISION │ CREATED AT          │ # WORKFLOWS │
├───────────────────┼─────────────────┼─────────────────────┼─────────────┤
│ default-contract  │               1 │ 17 Dec 24 22:08 UTC │           0 │
│ test-test         │               4 │ 04 Nov 24 12:39 UTC │           1 │
│ myproject-example │               1 │ 21 Oct 24 16:52 UTC │           1 │
│ myproj-mywf       │               1 │ 21 Oct 24 16:42 UTC │           1 │
│ myproject-mywf    │              95 │ 29 Aug 24 17:19 UTC │           1 │
│ test3             │               1 │ 29 Aug 24 17:18 UTC │           0 │
└───────────────────┴─────────────────┴─────────────────────┴─────────────┘
```
