### PR TITLE
fix: only ask for confirmation on att init

### DIFF
--- a/app/cli/cmd/attestation_init.go
+++ b/app/cli/cmd/attestation_init.go
@@ -25,12 +25,12 @@ import (
 
 func newAttestationInitCmd() *cobra.Command {
 	var (
-		force                   bool
-		contractRevision        int
-		attestationDryRun       bool
-		workflowName            string
-		projectName             string
-		projectVersion          string
+		force                 bool
+		contractRevision      int
+		attestationDryRun     bool
+		workflowName          string
+		projectName           string
+		projectVersion        string
 		projectVersionRelease bool
 		newWorkflowcontract   string
 	)
@@ -39,7 +39,8 @@ func newAttestationInitCmd() *cobra.Command {
 		Use:   "init",
 		Short: "start attestation crafting process",
 		Annotations: map[string]string{
-			useAPIToken: "true",
+			useAPIToken:          trueString,
+			confirmWhenUserToken: trueString,
 		},
 		PreRunE: func(_ *cobra.Command, _ []string) error {
 			if workflowName == "" {

--- a/app/cli/cmd/root.go
+++ b/app/cli/cmd/root.go
@@ -54,7 +54,9 @@ var (
 const (
 	// preference to use an API token if available
 	useAPIToken = "withAPITokenAuth"
-	appName     = "chainloop"
+	// Ask for confirmation when user token is used and API token is preferred
+	confirmWhenUserToken = "confirmWhenUserToken"
+	appName              = "chainloop"
 	//nolint:gosec
 	tokenEnvVarName = "CHAINLOOP_TOKEN"
 	userAudience    = "user-auth.chainloop"
@@ -150,7 +152,7 @@ func NewRootCmd(l zerolog.Logger) *cobra.Command {
 			}
 
 			// Warn users when the session is interactive, and the operation is supposed to use an API token instead
-			if isAPITokenPreferred(cmd) && isUserToken && !flagYes {
+			if shouldAskForConfirmation(cmd) && isUserToken && !flagYes {
 				if !confirmationPrompt(fmt.Sprintf("This command is will run against the organization %q", orgName)) {
 					return errors.New("command canceled by user")
 				}
@@ -516,6 +518,10 @@ func apiInsecure() bool {
 func setLocalOrganization(orgName string) error {
 	viper.Set(confOptions.organization.viperKey, orgName)
 	return viper.WriteConfig()
+}
+
+func shouldAskForConfirmation(cmd *cobra.Command) bool {
+	return isAPITokenPreferred(cmd) && cmd.Annotations[confirmWhenUserToken] == trueString
 }
 
 func isAPITokenPreferred(cmd *cobra.Command) bool {


### PR DESCRIPTION
Follow up on #1003 to only ask for confirmation on `att init` instead of all attestation commands.