### PR TITLE
feat(users): Make field HasRestrictedAccess nillable

### DIFF
--- a/app/controlplane/pkg/biz/user.go
+++ b/app/controlplane/pkg/biz/user.go
@@ -36,7 +36,7 @@ type User struct {
 	ID                  string
 	Email               string
 	CreatedAt           *time.Time
-	HasRestrictedAccess bool
+	HasRestrictedAccess *bool
 }
 
 type UserRepo interface {

--- a/app/controlplane/pkg/data/ent/mutation.go
+++ b/app/controlplane/pkg/data/ent/mutation.go
@@ -10349,7 +10349,7 @@ func (m *UserMutation) HasRestrictedAccess() (r bool, exists bool) {
 // OldHasRestrictedAccess returns the old "has_restricted_access" field's value of the User entity.
 // If the User object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *UserMutation) OldHasRestrictedAccess(ctx context.Context) (v bool, err error) {
+func (m *UserMutation) OldHasRestrictedAccess(ctx context.Context) (v *bool, err error) {
 	if !m.op.Is(OpUpdateOne) {
 		return v, errors.New("OldHasRestrictedAccess is only allowed on UpdateOne operations")
 	}

--- a/app/controlplane/pkg/data/ent/schema/user.go
+++ b/app/controlplane/pkg/data/ent/schema/user.go
@@ -49,7 +49,7 @@ func (User) Fields() []ent.Field {
 			Annotations(&entsql.Annotation{
 				Default: "CURRENT_TIMESTAMP",
 			}),
-		field.Bool("has_restricted_access").Optional(),
+		field.Bool("has_restricted_access").Optional().Nillable(),
 	}
 }
 

--- a/app/controlplane/pkg/data/ent/user.go
+++ b/app/controlplane/pkg/data/ent/user.go
@@ -23,7 +23,7 @@ type User struct {
 	// CreatedAt holds the value of the "created_at" field.
 	CreatedAt time.Time `json:"created_at,omitempty"`
 	// HasRestrictedAccess holds the value of the "has_restricted_access" field.
-	HasRestrictedAccess bool `json:"has_restricted_access,omitempty"`
+	HasRestrictedAccess *bool `json:"has_restricted_access,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the UserQuery when eager-loading is set.
 	Edges        UserEdges `json:"edges"`
@@ -98,7 +98,8 @@ func (u *User) assignValues(columns []string, values []any) error {
 			if value, ok := values[i].(*sql.NullBool); !ok {
 				return fmt.Errorf("unexpected type %T for field has_restricted_access", values[i])
 			} else if value.Valid {
-				u.HasRestrictedAccess = value.Bool
+				u.HasRestrictedAccess = new(bool)
+				*u.HasRestrictedAccess = value.Bool
 			}
 		default:
 			u.selectValues.Set(columns[i], values[i])
@@ -147,8 +148,10 @@ func (u *User) String() string {
 	builder.WriteString("created_at=")
 	builder.WriteString(u.CreatedAt.Format(time.ANSIC))
 	builder.WriteString(", ")
-	builder.WriteString("has_restricted_access=")
-	builder.WriteString(fmt.Sprintf("%v", u.HasRestrictedAccess))
+	if v := u.HasRestrictedAccess; v != nil {
+		builder.WriteString("has_restricted_access=")
+		builder.WriteString(fmt.Sprintf("%v", *v))
+	}
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/app/controlplane/pkg/data/ent/user_create.go
+++ b/app/controlplane/pkg/data/ent/user_create.go
@@ -192,7 +192,7 @@ func (uc *UserCreate) createSpec() (*User, *sqlgraph.CreateSpec) {
 	}
 	if value, ok := uc.mutation.HasRestrictedAccess(); ok {
 		_spec.SetField(user.FieldHasRestrictedAccess, field.TypeBool, value)
-		_node.HasRestrictedAccess = value
+		_node.HasRestrictedAccess = &value
 	}
 	if nodes := uc.mutation.MembershipsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{

--- a/app/controlplane/pkg/data/user.go
+++ b/app/controlplane/pkg/data/user.go
@@ -133,10 +133,15 @@ func (r *userRepo) CountUsersWithRestrictedOrUnsetAccess(ctx context.Context) (i
 }
 
 func entUserToBizUser(eu *ent.User) *biz.User {
-	return &biz.User{
-		Email:               eu.Email,
-		ID:                  eu.ID.String(),
-		CreatedAt:           toTimePtr(eu.CreatedAt),
-		HasRestrictedAccess: eu.HasRestrictedAccess,
+	base := &biz.User{
+		Email:     eu.Email,
+		ID:        eu.ID.String(),
+		CreatedAt: toTimePtr(eu.CreatedAt),
 	}
+
+	if eu.HasRestrictedAccess != nil {
+		base.HasRestrictedAccess = eu.HasRestrictedAccess
+	}
+
+	return base
 }


### PR DESCRIPTION
This change allows the HasRestrictedAccess field to represent three states: true, false, and nil.

A missing value (nil) is fundamentally different from false, which is why the Nillable option was added.

This change only produces modification in the generated code, the SQL remains unchanged.