### PR TITLE
fix(uploads): ignore EOF when sending finish write message

### DIFF
--- a/pkg/casclient/uploader.go
+++ b/pkg/casclient/uploader.go
@@ -103,6 +103,7 @@ doUpload:
 				ResourceName: resource,
 				FinishWrite:  true,
 			}); err != nil {
+				// EOF might be returned when the CAS backend detects a duplicated upload, skipping it in that case
 				if errors.Is(err, io.EOF) {
 					break doUpload
 				}

--- a/pkg/casclient/uploader.go
+++ b/pkg/casclient/uploader.go
@@ -103,6 +103,9 @@ doUpload:
 				ResourceName: resource,
 				FinishWrite:  true,
 			}); err != nil {
+				if errors.Is(err, io.EOF) {
+					break doUpload
+				}
 				return nil, fmt.Errorf("sending the finished upload message %w", err)
 			}
 			break


### PR DESCRIPTION
The CAS backend will close the stream if it detects a duplicated upload (to save resources). In that case, the returned EOF must be ignored. This PR fixes a race condition where that EOF was causing an error.

Related to #1849 