### PR TITLE
chore(gen): Run code generation

### DIFF
--- a/app/controlplane/api/buf.gen.yaml
+++ b/app/controlplane/api/buf.gen.yaml
@@ -19,5 +19,5 @@ plugins:
       - outputClientImpl=grpc-web # client implementation it generates
       - esModuleInterop=true # use imports as required in modern ts setups
       - useOptionals=messages # use optional TypeScript properties instead of undefined
-  - plugin: buf.build/bufbuild/protoschema-jsonschema
+  - plugin: buf.build/bufbuild/protoschema-jsonschema:v0.2.0
     out: ./gen/jsonschema


### PR DESCRIPTION
~Apparently there was a lot of changes regarding code generation. Probably because of a lack of rebase in the most recent PR.~

Last night, the JSON schema plugin generator was upgraded to v0.3.0, introducing changes that altered our current generation process. For now, I’ve pinned it to the previous version v0.2.0 until we assess the impact.