### PR TITLE
feat(ci): Modify version bumper script to allow release candidates

### DIFF
--- a/.github/workflows/utils/bump-chart-and-dagger-version.sh
+++ b/.github/workflows/utils/bump-chart-and-dagger-version.sh
@@ -45,11 +45,11 @@ fi
 # AppVersion represents the container version
 sed -i "s#^appVersion:.*#appVersion: ${semVer}#g" "${chart_yaml}"
 # We want to also replace the images annotation tags
-sed -i "s/:v[0-9\.]*/:${semVer}/g" "${chart_yaml}"
+sed -i "s/:v.*/:${semVer}/g" "${chart_yaml}"
 
 ## Changes images in Values.yaml
 sed -i "s/tag: .*/tag: \"${semVer}\"/g" "${values_yaml}"
 
 ## Update Dagger version
-sed -i "s/chainloopVersion = \"v[0-9\.]*\"/chainloopVersion = \"${semVer}\"/" "${dagger_main}"
+sed -i "s/chainloopVersion = v.*\"/chainloopVersion = \"${semVer}\"/" "${dagger_main}"
 

--- a/.github/workflows/utils/bump-project-version.sh
+++ b/.github/workflows/utils/bump-project-version.sh
@@ -21,8 +21,24 @@ if [[ -n "${1}" ]]; then
    project_yaml="${1}"
 fi
 
-# load the previous version and BUMP THE MINOR
-version=$(cat ${project_yaml} | awk -F'[ .]' '/^projectVersion:/ {print $2"."$3+1"."0}')
+# Load the previous version and bump appropriately
+version=$(cat "${project_yaml}" | awk '/^projectVersion:/ {
+    version = $2;
+    if (version ~ /-rc/) {
+        # Handle release candidate versions (e.g., v1.0.0-rc.1 -> v1.0.0-rc.2)
+        split(version, parts, /-rc\./);
+        rc_num = parts[2] + 1;
+        print parts[1] "-rc." rc_num;
+    }
+    else {
+        # Load the previous version and BUMP THE MINOR
+        # Handle minor version bumps (e.g., v1.0.0 -> v1.1.0)
+        split(version, ver_parts, /\./);
+        ver_parts[2] = ver_parts[2] + 1;
+        print ver_parts[1] "." ver_parts[2] "." ver_parts[3];
+    }
+}')
 
-## Changes in .chainloop.yml
+# Update the project yaml file
 sed -i "s#^projectVersion:.*#projectVersion: ${version}#g" "${project_yaml}"
+


### PR DESCRIPTION
This patch updates the version bumper scripts for both the Chainloop project version and the Chart version. It adds support for release candidates (-rc prefix) and minor versions.

Note: Major versions are NOT supported by this script—we’ll need a different solution for those.