### PR TITLE
feat(ci): Release binaries without version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -62,6 +62,15 @@ archives:
     # Override default to not to include the readme nor license file
     files:
       - none*
+  # Include the plain binaries of the CLI for the release without version
+  - format: binary
+    id: binaries-cli
+    name_template: "{{ .Binary }}-{{ .Os }}-{{ .Arch }}"
+    builds:
+      - cli
+    # Override default to not to include the readme nor license file
+    files:
+      - none*
 
 checksum:
   name_template: "checksums.txt"


### PR DESCRIPTION
To simplify the installation of Chainloop’s CLI, we want to include a generic binary in GitHub releases that can be downloaded using `latest`. To achieve this, we must expose the binaries to the GitHub release without the version.

The checksums are updated, from this:
```
a0b4760007e44d64dc44afa56829e1a108088078fb495217db3ad8f0ba830864  chainloop-cli-1.0.0-rc.2-SNAPSHOT-82578394-darwin-amd64.tar.gz
b80d265f182d331236b214a1527119e6a4cb13fbd67580950ad1f45fd9fc09e7  chainloop-cli-1.0.0-rc.2-SNAPSHOT-82578394-darwin-arm64.tar.gz
47dbb136cbd589c0e5f69625d819f2e0369d6a3b3bae433b40769c35ed8c100e  chainloop-cli-1.0.0-rc.2-SNAPSHOT-82578394-linux-amd64.tar.gz
3e1f3beea847a7c50eabd158de576c8ebc07e4f140084ba285a62ffe7f822546  chainloop-cli-1.0.0-rc.2-SNAPSHOT-82578394-linux-arm64.tar.gz
```

To this:
```
0f0ceafdca9ae8a29253777b9f23500ddcd8f1d9ff0e2089f0abf397606fb0fb  chainloop-cli-1.0.0-rc.2-SNAPSHOT-d564e66c-darwin-amd64.tar.gz
5c309810634d87f2aeeb85f63235b5fa87c71397ccfce2f34ecbfbba385333b3  chainloop-cli-1.0.0-rc.2-SNAPSHOT-d564e66c-darwin-arm64.tar.gz
3a1442a9d7a0526096f250d2a47645b08ffc9f79595080050cd7d8e3bcd8d91b  chainloop-cli-1.0.0-rc.2-SNAPSHOT-d564e66c-linux-amd64.tar.gz
2043cb67edd3df723f7b3543edc684a8dc1e2c352103282efe509091bae51eae  chainloop-cli-1.0.0-rc.2-SNAPSHOT-d564e66c-linux-arm64.tar.gz
1262f4149260de256a5b1b0d12f549f756fcf6bd77c642c264c1b1624264d91c  chainloop-darwin-amd64
1aca5de1caebcc19cdf5aafd3aa2af865575e3e9b0ffc64a1df9cc31f14d09cb  chainloop-darwin-arm64
6712d2696e9eae1351e94af5a8a1ad5f10b9491dc23f50c92b82b9873fecb70d  chainloop-linux-amd64
9e2c2e0805163759bb3f5dc62b1af8483b19ec27b7ebf21683fa9f6c9d032d7d  chainloop-linux-arm64

```

Please note the tar.gz are called `chainloop-cli-{{ .Version }}-{{ .Os }}-{{ .Arch }}.tar.gz` wheras the binaries are `{{ .Binary }}-{{ .Os }}-{{ .Arch }}`.

We can even generate the binaries with the version and remove the tar.gz at all if we wanted.