### PR TITLE
fix(release): Add missing attestation id on attestation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -129,7 +129,7 @@ jobs:
             # Format as chainloop-OS-ARCH
             material_name="chainloop-$os_arch"
 
-            chainloop attestation add --name $material_name --value $entry --kind ARTIFACT
+            chainloop attestation add --name $material_name --value $entry --kind ARTIFACT --attestation-id ${{ env.ATTESTATION_ID }}
           done
 
       - name: Bump Chart and Dagger Version


### PR DESCRIPTION
This patch adds a missing `attestation-id` on the release process.