### PR TITLE
chore(install): Modify install.sh to support new GitHub release artifacts

### DIFF
--- a/docs/static/install.sh
+++ b/docs/static/install.sh
@@ -139,6 +139,7 @@ post_install_message() {
 
 download_and_install_legacy() {
   local TMP_DIR=$1
+  local VERSION=$2
   FILENAME="chainloop-cli-${VERSION}-${OS}-${ARC}.tar.gz"
   # Constructing download FILE and URL
   FILE="$TMP_DIR/${FILENAME}"
@@ -173,6 +174,7 @@ download_and_install_legacy() {
 
 download_and_install() {
     local TMP_DIR=$1
+    local VERSION=$2
     BASE_URL="${GITHUB_BASE_URL}/v${VERSION}"
 
     FILENAME="chainloop-${OS}-${ARC}"
@@ -286,7 +288,7 @@ TMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
 
 # Decide which method to use to install Chainloop
 if [[ $(check_if_legacy_installation "$TMP_DIR") == "true" ]]; then
-    download_and_install_legacy "$TMP_DIR"
+    download_and_install_legacy "$TMP_DIR" "$VERSION"
 else
-    download_and_install "$TMP_DIR"
+    download_and_install "$TMP_DIR" "$VERSION"
 fi

--- a/docs/static/install.sh
+++ b/docs/static/install.sh
@@ -15,6 +15,7 @@ PUBLIC_KEY_URL="https://raw.githubusercontent.com/chainloop-dev/chainloop/01ad13
 
 # Constants
 GITHUB_BASE_URL="https://github.com/chainloop-dev/chainloop/releases/download"
+GITHUB_LATEST_RELEASE_URL="https://github.com/chainloop-dev/chainloop/releases/latest"
 
 # Print in colors - 0=green, 1=red, 2=neutral
 # e.g. fancy_print 0 "All is great"
@@ -84,13 +85,12 @@ check_if_legacy_installation() {
     CHECKSUM_FILE="$TMP_DIR/${CHECKSUM_FILENAME}"
     curl -fsL "$URL" -o "${CHECKSUM_FILE}" || (fancy_print 1 "The requested file does not exist: ${URL}"; exit 1)
 
-   grep -q "chainloop-cli-${VERSION}-${OS}-${ARC}.tar.gz" "$CHECKSUM_FILE" && echo "true" || echo "false"
+    grep -q "chainloop-cli-${VERSION}-${OS}-${ARC}.tar.gz" "$CHECKSUM_FILE" && echo "true" || echo "false"
 }
 
 # Get the latest version from the GitHub releases page
 get_latest_version() {
-    local latest_url="https://github.com/chainloop-dev/chainloop/releases/latest"
-    curl -sI -o /dev/null -w '%{redirect_url}' "$latest_url" | sed -n 's#.*/tag/\(v.*\)#\1#p'
+    curl -sI -o /dev/null -w '%{redirect_url}' "$GITHUB_LATEST_RELEASE_URL" | sed -n 's#.*/tag/\(v.*\)#\1#p'
 }
 
 # Download the checksum file and verify it


### PR DESCRIPTION
This patch updates the `install.sh` script to support both legacy and modern GitHub release formats for the Chainloop CLI.

In newer releases (starting from version `v1.0.0-rc.3`), the CLI is distributed as a plain binary without a version in the filename and without a `.tar.gz` archive. The script now detects whether a given release is legacy or modern and downloads the appropriate artifact accordingly—either the `.tar.gz` archive for older versions or the standalone binary for newer ones.

For modern releases, the latest version can be downloaded using the following URL:

```
https://github.com/chainloop-dev/chainloop/releases/latest/download/chainloop-OS-ARCH
```

Please note that legacy and modern GitHub releases referrers to the way Chainloop pushes artifacts to GitHub's releases.

Examples:

Regular installation (legacy)
```shell
$ /usr/bin/env bash docs/static/install.sh                   
Step 1: Downloading: chainloop-cli-1.0.0-rc.3-darwin-arm64.tar.gz
Done...

Step 1.2: Verifying checksum
chainloop-cli-1.0.0-rc.3-darwin-arm64.tar.gz: OK
Checksum OK

Step 1.3: Verifying signature
Verified OK
Step 2: Decompressing: /var/folders/ct/h8h0pjcd6q180cnxqhykjv3c0000gn/T/tmp.1yk9hixiAU/chainloop-cli-1.0.0-rc.3-darwin-arm64.tar.gz
Done...

Step 3: Installing: chainloop in path /usr/local/bin
Password:
Step 4: Cleanup
Done...

Client Version: 1.0.0-rc.3
Server Version: 1.0.0-rc.3
Check here for the next steps: https://docs.chainloop.dev

Run 'chainloop auth login' to get started
```

New installations (being force by modifying the code since there are not new releases yet):
```
$ /usr/bin/env bash docs/static/install.sh
Step 1: Downloading: chainloop-darwin-arm64, Version: 1.0.0-rc.3
Done...

Step 1.2: Verifying checksum
chainloop-darwin-arm64: OK
Checksum OK

Step 1.3: Verifying signature
Verified OK
Step 2: Installing: chainloop to /usr/local/bin
Step 3: Cleanup
Done...

Client Version: 1.0.0-rc.3
Server Version: 1.0.0-rc.3
Check here for the next steps: https://docs.chainloop.dev

Run 'chainloop auth login' to get started
```

Forcing a specific version of the CLI:

Legacy
```
$ /usr/bin/env bash docs/static/install.sh --version v1.0.0-rc.3
Step 1: Downloading: chainloop-cli-1.0.0-rc.3-darwin-arm64.tar.gz
Done...

Step 1.2: Verifying checksum
chainloop-cli-1.0.0-rc.3-darwin-arm64.tar.gz: OK
Checksum OK

Step 1.3: Verifying signature
Verified OK
Step 2: Decompressing: /var/folders/ct/h8h0pjcd6q180cnxqhykjv3c0000gn/T/tmp.QXyJjjSWac/chainloop-cli-1.0.0-rc.3-darwin-arm64.tar.gz
Done...

Step 3: Installing: chainloop in path /usr/local/bin
Step 4: Cleanup
Done...

Client Version: 1.0.0-rc.3
Server Version: 1.0.0-rc.3
Check here for the next steps: https://docs.chainloop.dev

Run 'chainloop auth login' to get started
```

New installations (being force by modifying the code since there are not new releases yet) forcing a version:
```
$ /usr/bin/env bash docs/static/install.sh --version v1.0.0-rc.3
Step 1: Downloading: chainloop-darwin-arm64, Version: 1.0.0-rc.3
Done...

Step 1.2: Verifying checksum
chainloop-darwin-arm64: OK
Checksum OK

Step 1.3: Verifying signature
Verified OK
Step 2: Installing: chainloop to /usr/local/bin
Step 3: Cleanup
Done...

Client Version: 1.0.0-rc.3
Server Version: 1.0.0-rc.3
Check here for the next steps: https://docs.chainloop.dev

Run 'chainloop auth login' to get started
```