### PR TITLE
chore(ci): Generate SLSA attestation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,6 +44,8 @@ jobs:
       contents: write # required for goreleaser to upload the release assets
       packages: write # to push container images
       pull-requests: write
+      id-token: write # required for SLSA provenance
+      attestations: write # required for SLSA provenance
     env:
       CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
       ATTESTATION_ID: ${{ needs.init_attestation.outputs.attestation_id }}
@@ -131,6 +133,43 @@ jobs:
 
             chainloop attestation add --name $material_name --value $entry --kind ARTIFACT --attestation-id ${{ env.ATTESTATION_ID }}
           done
+
+      - name: Calculate checksum for SLSA attestation
+        run: |
+          # Create an empty checksum file
+          checksum_file="subjects-checksum.txt"
+          touch "$checksum_file"
+
+          # First the binaries
+          binaries=$(cat dist/artifacts.json | jq -r '.[] | select(.type=="Binary") | select(.name=="chainloop"| not) | "\(.path) \(.name)"')
+          echo "$binaries" | while IFS= read -r entry; do
+            # Extract the path and name from the entry
+            path=$(echo "$entry" | awk '{print $1}')
+            # Calculate the checksum of the file
+            checksum=$(sha256sum "$path" | awk '{print $1}')
+            # Get the name from the entry
+            name=$(echo "$entry" | awk '{print $2}')
+            # Add it to the checksum file
+            echo "$checksum  *$name" >> $checksum_file
+          done
+
+          # Then the docker images
+          images=$(cat dist/artifacts.json | jq -r '.[] | select(.type=="Docker Manifest") | select(.name | endswith(":latest") | not) | "\(.extra.Digest | split("sha256:")[1]) \(.name)"')
+          echo "$images" | while IFS= read -r entry; do
+            # Extract the digest and name from the entry
+            name=$(echo "$entry" | awk '{print $2}')
+            digest=$(echo "$entry" | awk '{print $1}')
+            echo "$digest  $name" >> $checksum_file
+          done
+
+      - uses: actions/attest-build-provenance@v2
+        id: slsa-attest
+        with:
+          subject-checksums: subjects-checksum.txt
+
+      - name: Attest SLSA attestation
+        run: |
+          chainloop attestation --name slsa-attestation add --value ${{ steps.slsa-attest.outputs.bundle-path }} --kind SLSA_PROVENANCE --attestation-id ${{ env.ATTESTATION_ID }}
 
       - name: Bump Chart and Dagger Version
         run: .github/workflows/utils/bump-chart-and-dagger-version.sh deployment/chainloop extras/dagger ${{ github.ref_name }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -150,7 +150,7 @@ jobs:
             # Get the name from the entry
             name=$(echo "$entry" | awk '{print $2}')
             # Add it to the checksum file
-            echo "$checksum  *$name" >> $checksum_file
+            echo "$checksum *$name" >> $checksum_file
           done
 
           # Then the docker images

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -167,7 +167,7 @@ jobs:
             echo "$digest  $name" >> $checksum_file
           done
 
-      - uses: actions/attest-build-provenance@v2
+      - uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
         id: slsa-attest
         with:
           subject-checksums: subjects-checksum.txt

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -136,6 +136,11 @@ jobs:
 
       - name: Calculate checksum for SLSA attestation
         run: |
+          # We're generating a checksum file for the SLSA attestation as a workaround for the current limitations of the SLSA attestation action.
+          # Until it's possible to include multiple container images and binaries in a single attestation, this approach serves as a temporary solution.
+          # An open issue suggests that if pushing the attestation to an OCI registry isn't required, using a checksum file is a valid alternative.
+          # Link: https://github.com/actions/attest-build-provenance/issues/454
+
           # Create an empty checksum file
           checksum_file="subjects-checksum.txt"
           touch "$checksum_file"


### PR DESCRIPTION
This patch generates a SLSA attestation that includes the binaries and Docker images produced by GoReleaser. The final attestation is derived from a checksum file with the following format:

```
984da8d576b3bd9f13bb33dedc29a11bd36752adaf7e1d1ff9d784fd2fba17c8 *chainloop-plugin-discord-webhook
9ecf812d8f462c8efc9b96b2b0dd1431d79e96dbe1b61479b909937902a0ded4 *chainloop-plugin-smtp
75cf34ce56f0299b27bf57bc1aeba78f3a1fb04c03c70365c541bd940a5fc86d *chainloop-plugin-dependency-track
83f69c22625c13b789ee47b93c648d82780b2a45e9a183cf72893f5e83d2fc7c *artifact-cas
39149252e9f42188e7e1d6808992b1b45a74ca0e3b23b7323852e0cd7822b4d5 *control-plane
49c35c45be38cd936b57990fc440f502d49be2c80048ab901eaa48f2178d237d *chainloop-linux-arm64
050fed0589a73c06fc2c868c81ead4526f1d46dd95f4833702a19d7687ceff52 *chainloop-darwin-amd64
30bbf64e7e8652ec595d79f42825ecfd67cad8a128073b0df67a432deb5372ad *chainloop-linux-amd64
3fe1217d0f3e130fed37b100d4c0e93164d661f04c97d138ed2a97e00b473db2 *chainloop-darwin-arm64
16f939e450fcf9d6662699a7be048731604e9203f86a18d3a7499288a1ff5375  ghcr.io/chainloop-dev/chainloop/control-plane:v1.0.0-rc.3
42f758c24da5c7c5fe978157cd3ff7b2ff08b4d134092522b10c43b53a00e57c  ghcr.io/chainloop-dev/chainloop/artifact-cas:v1.0.0-rc.3
a85bb4554298ef862a916466c7f9e0606722bc773fc389002241c2cc6fa40a0f  ghcr.io/chainloop-dev/chainloop/control-plane-migrations:v1.0.0-rc.3
093d3d4ef3eb1f481dc5cff81c2e040de4015174c18609346d86f62e59ad54ef  ghcr.io/chainloop-dev/chainloop/cli:v1.0.0-rc.3
```

Additionally the output from the SLSA attestation output is included in the Chainloop's attestation.