### PR TITLE
fix(release-notes): Add missing path to get attestation digest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -170,7 +170,7 @@ jobs:
         if: ${{ success() }}
         run: |
           chainloop attestation push --attestation-id ${{ needs.init_attestation.outputs.attestation_id }}
-          attestation_sha=$(chainloop wf run describe --id ${{ needs.init_attestation.outputs.attestation_id }} -o json | jq -r '.digest')
+          attestation_sha=$(chainloop wf run describe --id ${{ needs.init_attestation.outputs.attestation_id }} -o json | jq -r '.attestation.digest')
           # check that the command succeeded
           [ -n "$attestation_sha" ] || exit 1
           echo "attestation_sha=$attestation_sha" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This patch corrects the path to the attestation digest, ensuring it is properly propagated for inclusion in the GitHub release notes.