### PR TITLE
chore(ci): Change pinned version of labs

### DIFF
--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -13,7 +13,7 @@ permissions: {}
 jobs:
   chainloop_init:
     name: Chainloop Init
-    uses: chainloop-dev/labs/.github/workflows/chainloop_init.yml@64839eb68c20fefda46929c6c6e893cdf0537619
+    uses: chainloop-dev/labs/.github/workflows/chainloop_init.yml@6bbd1c2b3022e48ae60afa0c2b90f3b6d31bcf11
     secrets:
       api_token: ${{ secrets.CHAINLOOP_TOKEN }}
     with:
@@ -79,7 +79,7 @@ jobs:
 
   chainloop_push:
     name: Chainloop Push
-    uses: chainloop-dev/labs/.github/workflows/chainloop_push.yml@25c77318e739c60e86d3dfe7e864f51c665972dd
+    uses: chainloop-dev/labs/.github/workflows/chainloop_push.yml@6bbd1c2b3022e48ae60afa0c2b90f3b6d31bcf11
     needs:
       - deploy_docs
     secrets:

--- a/.github/workflows/package_chart.yaml
+++ b/.github/workflows/package_chart.yaml
@@ -17,7 +17,7 @@ jobs:
   # be ignored and the process will continue. For this to work it's using a pre-created API Token
   onboard_workflow:
     name: Onboard Chainloop Workflow
-    uses: chainloop-dev/labs/.github/workflows/chainloop_onboard.yml@64839eb68c20fefda46929c6c6e893cdf0537619
+    uses: chainloop-dev/labs/.github/workflows/chainloop_onboard.yml@6bbd1c2b3022e48ae60afa0c2b90f3b6d31bcf11
     with:
       project: "chainloop"
       workflow_name: "helm-package"

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -20,7 +20,7 @@ permissions: read-all
 jobs:
   chainloop_init:
     name: Chainloop Init
-    uses: chainloop-dev/labs/.github/workflows/chainloop_init.yml@64839eb68c20fefda46929c6c6e893cdf0537619
+    uses: chainloop-dev/labs/.github/workflows/chainloop_init.yml@6bbd1c2b3022e48ae60afa0c2b90f3b6d31bcf11
     secrets:
       api_token: ${{ secrets.CHAINLOOP_TOKEN }}
     with:
@@ -85,7 +85,7 @@ jobs:
 
   chainloop_push:
     name: Chainloop Push
-    uses: chainloop-dev/labs/.github/workflows/chainloop_push.yml@25c77318e739c60e86d3dfe7e864f51c665972dd
+    uses: chainloop-dev/labs/.github/workflows/chainloop_push.yml@6bbd1c2b3022e48ae60afa0c2b90f3b6d31bcf11
     needs:
       - analysis
     secrets:

--- a/.github/workflows/sync_contracts.yml
+++ b/.github/workflows/sync_contracts.yml
@@ -17,6 +17,6 @@ permissions: read-all
 jobs:
   chainloop_contract_sync:
     name: Chainloop Contract Sync
-    uses: chainloop-dev/labs/.github/workflows/chainloop_contract_sync.yml@0d6e9ca1190aecc9048729de0cce8e96f314e2bb
+    uses: chainloop-dev/labs/.github/workflows/chainloop_contract_sync.yml@6bbd1c2b3022e48ae60afa0c2b90f3b6d31bcf11
     secrets:
       api_token: ${{ secrets.CHAINLOOP_TOKEN }}


### PR DESCRIPTION
This patch changes the pinned version of labs so it includes the latest changes regarding the install.sh before a new release of Chainloop goes out.
