### PR TITLE
chore(ci): Point to latest version of install.sh

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Chainloop
         if: ${{ github.event_name != 'pull_request' }}
         run: |
-          curl -sfL https://raw.githubusercontent.com/chainloop-dev/chainloop/f7696675cb9b4a4ad1133ec5755225a287f00c0a/docs/static/install.sh | bash -s
+          curl -sfL https://raw.githubusercontent.com/chainloop-dev/chainloop/8a12fce328929abf012c96a07bddfeaf94c74ed4/docs/static/install.sh | bash -s
 
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/github_release.yaml
+++ b/.github/workflows/github_release.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install Chainloop
         run: |
-          curl -sfL https://raw.githubusercontent.com/chainloop-dev/chainloop/f7696675cb9b4a4ad1133ec5755225a287f00c0a/docs/static/install.sh | bash -s
+          curl -sfL https://raw.githubusercontent.com/chainloop-dev/chainloop/8a12fce328929abf012c96a07bddfeaf94c74ed4/docs/static/install.sh | bash -s
 
       - name: Initialize Attestation
         run: |

--- a/.github/workflows/package_chart.yaml
+++ b/.github/workflows/package_chart.yaml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Install Chainloop
         run: |
-          curl -sfL https://raw.githubusercontent.com/chainloop-dev/chainloop/f7696675cb9b4a4ad1133ec5755225a287f00c0a/docs/static/install.sh | bash -s
+          curl -sfL https://raw.githubusercontent.com/chainloop-dev/chainloop/8a12fce328929abf012c96a07bddfeaf94c74ed4/docs/static/install.sh | bash -s
 
       - name: Docker login to Github Packages
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0


### PR DESCRIPTION
This patch points to the latest version available of the `install.sh` at the moment.