### PR TITLE
feat(contract): Update chainloop release contract

### DIFF
--- a/.github/workflows/contracts/release.yml
+++ b/.github/workflows/contracts/release.yml
@@ -17,5 +17,10 @@ policyGroups:
     with:
       bannedLicenses: AGPL-1.0-only, AGPL-1.0-or-later, AGPL-3.0-only, AGPL-3.0-or-later
       bannedComponents: log4j@2.14.1
+  - ref: slsa-checks
+    with:
+      provenance_material_name: slsa-attestation
+      runner: GITHUB_ACTION
+      federated_identity: "true"
 runner:
   type: GITHUB_ACTION


### PR DESCRIPTION
This patch modifies the chainloop release contract so it includes the policy group that maps the SLSA framework.