### PR TITLE
chore(contract): Modify name of contract

### DIFF
--- a/.github/workflows/contracts/chainloop-vault-release.yml
+++ b/.github/workflows/contracts/chainloop-vault-release.yml
@@ -1,4 +1,4 @@
-# Contract for the release.yaml workflow
+# Contract for the release workflow
 schemaVersion: v1
 policies:
   attestation:

--- a/.github/workflows/contracts/chainloop-vault-release.yml
+++ b/.github/workflows/contracts/chainloop-vault-release.yml
@@ -1,4 +1,4 @@
-# Contract for the build-and-package workflow
+# Contract for the release.yaml workflow
 schemaVersion: v1
 policies:
   attestation:


### PR DESCRIPTION
This patch renames the contract from `release` to `chainloop-vault-release`, which is the actual contract used by the `release` workflow in Chainloop. Previously, even though the contract was being updated, it had no effect—because no workflow was actually linked to it.