### PR TITLE
chore(ci): Include SLSA attestation link on chainloop attestation

### DIFF
--- a/.github/workflows/contracts/chainloop-vault-release.yml
+++ b/.github/workflows/contracts/chainloop-vault-release.yml
@@ -1,5 +1,10 @@
 # Contract for the release workflow
 schemaVersion: v1
+materials:
+  - name: slsa-attestation
+    type: SLSA_PROVENANCE
+    annotations:
+      - name: githubattestation
 policies:
   attestation:
     - ref: source-commit

--- a/.github/workflows/contracts/chainloop-vault-release.yml
+++ b/.github/workflows/contracts/chainloop-vault-release.yml
@@ -4,7 +4,7 @@ materials:
   - name: slsa-attestation
     type: SLSA_PROVENANCE
     annotations:
-      - name: githubattestation
+      - name: github_attestation
 policies:
   attestation:
     - ref: source-commit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -174,7 +174,7 @@ jobs:
 
       - name: Attest SLSA attestation
         run: |
-          chainloop attestation --name slsa-attestation add --value ${{ steps.slsa-attest.outputs.bundle-path }} --kind SLSA_PROVENANCE --attestation-id ${{ env.ATTESTATION_ID }}
+          chainloop attestation --name slsa-attestation add --value ${{ steps.slsa-attest.outputs.bundle-path }} --annotation githubattestation="${{ steps.slsa-attest.outputs.attestation-url }}" --kind SLSA_PROVENANCE --attestation-id ${{ env.ATTESTATION_ID }}
 
       - name: Include source code on attestation
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -174,7 +174,7 @@ jobs:
 
       - name: Attest SLSA attestation
         run: |
-          chainloop attestation --name slsa-attestation add --value ${{ steps.slsa-attest.outputs.bundle-path }} --annotation githubattestation="${{ steps.slsa-attest.outputs.attestation-url }}" --kind SLSA_PROVENANCE --attestation-id ${{ env.ATTESTATION_ID }}
+          chainloop attestation --name slsa-attestation add --value ${{ steps.slsa-attest.outputs.bundle-path }} --annotation github_attestation="${{ steps.slsa-attest.outputs.attestation-url }}" --kind SLSA_PROVENANCE --attestation-id ${{ env.ATTESTATION_ID }}
 
       - name: Include source code on attestation
         run: |


### PR DESCRIPTION
his patch updates the `chainloop-vault-release` contract to include an annotation on the `slsa-attestation` material. The annotation contains a link to the GitHub attestation generated in the previous step.

Defining the material in the contract is necessary because the system does not support adding annotations to materials dynamically—they must be explicitly declared in the contract.