### PR TITLE
fix(attestation-result): Include material annotations to attestation results

### DIFF
--- a/app/cli/internal/action/attestation_status.go
+++ b/app/cli/internal/action/attestation_status.go
@@ -269,12 +269,31 @@ func populateContractMaterials(inputSchemaMaterials []*pbc.CraftingSchema_Materi
 			if err := setMaterialValue(cm, materialResult); err != nil {
 				return fmt.Errorf("setting material value: %w", err)
 			}
+
+			// Update the expected annotations of the material stated on the contract with the ones in the attestation
+			updateMaterialAnnotations(cm, materialResult)
 		}
 
 		res.Materials = append(res.Materials, *materialResult)
 		visitedMaterials[m.Name] = struct{}{}
 	}
 	return nil
+}
+
+// updateMaterialAnnotations iterates through all expected annotations for the material
+// and attempts to find their corresponding values in the incoming attestation result.
+func updateMaterialAnnotations(cm *v1.Attestation_Material, attsMaterial *AttestationStatusMaterial) {
+	// Loop through the expected annotations in the attestation material
+	for k := range cm.Annotations {
+		// Check if the annotation exists in the provided attestation material
+		for _, a := range attsMaterial.Annotations {
+			// If the annotation name matches, update its value
+			if a.Name == k {
+				a.Value = cm.Annotations[k]
+				break
+			}
+		}
+	}
 }
 
 // populateAdditionalMaterials populates the materials that are not defined in the contract schema


### PR DESCRIPTION
This patch fixes the attestation result logic to include annotations from the attestation materials. Previously, although the annotations were present in the final attestation, they were not reflected in the attestation result, causing it to display NOT SET.

Before:
```
INF push completed
┌───────────────────────────┬─────────────────────────────────────────────────────────────────────────┐
│ Initialized At            │ 11 Apr 25 09:49 UTC                                                     │
├───────────────────────────┼─────────────────────────────────────────────────────────────────────────┤
│ Attestation ID            │ 4f177397-a8f8-4ca8-9ad8-82d141c8dd2c                                    │
│ Digest                    │ sha256:fffc6326efc1503972c36686c5f4a9ed587faab3ba05f08c86659b7363a99d7d │
│ Organization              │ testing                                                                 │
│ Name                      │ goreleaser                                                              │
│ Project                   │ core                                                                    │
│ Version                   │ 1.0 (prerelease)                                                        │
│ Contract                  │ core-goreleaser (revision 2)                                            │
│ Policy violation strategy │ ADVISORY                                                                │
└───────────────────────────┴─────────────────────────────────────────────────────────────────────────┘
┌───────────────────────────────────────────────────────────────────────────────────────┐
│ Materials                                                                             │
├─────────────┬─────────────────────────────────────────────────────────────────────────┤
│ Name        │ slsa-attestation                                                        │
│ Type        │ SLSA_PROVENANCE                                                         │
│ Set         │ Yes                                                                     │
│ Required    │ Yes                                                                     │
│ Value       │ chainloop-dev-chainloop-attestation-6231042.sigstore.json               │
│ Digest      │ sha256:dd80c34cadd25107f2b68f9bfd7acf0cc65d1c00ff1c4de52ae78610eb28a29f │
│ Annotations │ ------                                                                  │
│             │ github_attestation: [NOT SET]                                           │
└─────────────┴─────────────────────────────────────────────────────────────────────────┘
```

After:
```
INF push completed
┌───────────────────────────┬─────────────────────────────────────────────────────────────────────────┐
│ Initialized At            │ 11 Apr 25 09:43 UTC                                                     │
├───────────────────────────┼─────────────────────────────────────────────────────────────────────────┤
│ Attestation ID            │ fb120b3d-a014-48e2-98dc-144a58250b5d                                    │
│ Digest                    │ sha256:8297e6c3759290837a6b9d0b0e3cb15e465a8a25ddf8ccedf3bf83ed6d451ae2 │
│ Organization              │ testing                                                                 │
│ Name                      │ goreleaser                                                              │
│ Project                   │ core                                                                    │
│ Version                   │ 1.0 (prerelease)                                                        │
│ Contract                  │ core-goreleaser (revision 2)                                            │
│ Policy violation strategy │ ADVISORY                                                                │
└───────────────────────────┴─────────────────────────────────────────────────────────────────────────┘
┌───────────────────────────────────────────────────────────────────────────────────────┐
│ Materials                                                                             │
├─────────────┬─────────────────────────────────────────────────────────────────────────┤
│ Name        │ slsa-attestation                                                        │
│ Type        │ SLSA_PROVENANCE                                                         │
│ Set         │ Yes                                                                     │
│ Required    │ Yes                                                                     │
│ Value       │ chainloop-dev-chainloop-attestation-6231042.sigstore.json               │
│ Digest      │ sha256:dd80c34cadd25107f2b68f9bfd7acf0cc65d1c00ff1c4de52ae78610eb28a29f │
│ Annotations │ ------                                                                  │
│             │ github_attestation: https://example.com                                 │
└─────────────┴─────────────────────────────────────────────────────────────────────────┘
```