### PR TITLE
chore(migrations): Update atlas to latest version

### DIFF
--- a/app/controlplane/Dockerfile.migrations
+++ b/app/controlplane/Dockerfile.migrations
@@ -1,9 +1,9 @@
 # Container image built by go-releaser that's used to run migrations against the database during deployment
 # See https://atlasgo.io/guides/deploying/image
 # from: arigaio/atlas:latest
-# docker run arigaio/atlas@sha256:4c8d44f1b9a3dbafc72ea00792b2c5235862934414b732944b8500f35d064ea0 version
-# atlas version v0.32.1-bef8a97-canary
-FROM arigaio/atlas@sha256:4c8d44f1b9a3dbafc72ea00792b2c5235862934414b732944b8500f35d064ea0 as base
+# docker run arigaio/atlas@sha256:4fec3f3e76f6e0b6505c2515527024a5bd683a32edb5936d50c35fc633911470 version
+# atlas version v0.32.1-7468df3-canary
+FROM arigaio/atlas@sha256:4fec3f3e76f6e0b6505c2515527024a5bd683a32edb5936d50c35fc633911470
 
 FROM scratch
 # Update permissions to make it readable by the user


### PR DESCRIPTION
This patch updates atlas to its latest version: `v0.32.1-7468df3-canary`

No CVEs are found for this version:
```
$ grype arigaio/atlas@sha256:4fec3f3e76f6e0b6505c2515527024a5bd683a32edb5936d50c35fc633911470
 ✔ Loaded image                                                                                                          arigaio/atlas@sha256:4fec3f3e76f6e0b6505c2515527024a5bd683a32edb5936d50c35fc633911470
 ✔ Parsed image                                                                                                                        sha256:0f27452e904a5eb8fbbe074810611cec082fd4013ea659817f14c30cea03d86d
 ✔ Cataloged contents                                                                                                                         98fc418b38220ee30549261972745d3e23e93175262192992a35194083764731
   ├── ✔ Packages                        [146 packages]
   ├── ✔ Executables                     [1 executables]
   ├── ✔ File metadata                   [942 locations]
   └── ✔ File digests                    [942 files]
 ✔ Scanned for vulnerabilities     [0 vulnerability matches]
   ├── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
   └── by status:   0 fixed, 0 not-fixed, 0 ignored
No vulnerabilities found
```

```
$  trivy image arigaio/atlas@sha256:4fec3f3e76f6e0b6505c2515527024a5bd683a32edb5936d50c35fc633911470
2025-04-15T10:50:11+02:00	INFO	[vulndb] Need to update DB
2025-04-15T10:50:11+02:00	INFO	[vulndb] Downloading vulnerability DB...
2025-04-15T10:50:11+02:00	INFO	[vulndb] Downloading artifact...	repo="ghcr.io/aquasecurity/trivy-db:2"
62.20 MiB / 62.20 MiB [--------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 20.48 MiB p/s 3.2s
2025-04-15T10:50:18+02:00	INFO	[vulndb] Artifact successfully downloaded	repo="ghcr.io/aquasecurity/trivy-db:2"
2025-04-15T10:50:18+02:00	INFO	[vuln] Vulnerability scanning is enabled
2025-04-15T10:50:18+02:00	INFO	[secret] Secret scanning is enabled
2025-04-15T10:50:18+02:00	INFO	[secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2025-04-15T10:50:18+02:00	INFO	[secret] Please see also https://aquasecurity.github.io/trivy/v0.57/docs/scanner/secret#recommendation for faster secret detection
2025-04-15T10:50:18+02:00	INFO	Detected OS	family="debian" version="12.10"
2025-04-15T10:50:18+02:00	INFO	[debian] Detecting vulnerabilities...	os_version="12" pkg_num=3
2025-04-15T10:50:18+02:00	INFO	Number of language-specific files	num=1
2025-04-15T10:50:18+02:00	INFO	[gobinary] Detecting vulnerabilities...

arigaio/atlas@sha256:4fec3f3e76f6e0b6505c2515527024a5bd683a32edb5936d50c35fc633911470 (debian 12.10)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

```