### PR TITLE
chore(migrations): Bump atlas migration container image

### DIFF
--- a/app/controlplane/Dockerfile.migrations
+++ b/app/controlplane/Dockerfile.migrations
@@ -1,9 +1,9 @@
 # Container image built by go-releaser that's used to run migrations against the database during deployment
 # See https://atlasgo.io/guides/deploying/image
 # from: arigaio/atlas:latest
-# docker run arigaio/atlas@sha256:4fec3f3e76f6e0b6505c2515527024a5bd683a32edb5936d50c35fc633911470 version
-# atlas version v0.32.1-7468df3-canary
-FROM arigaio/atlas@sha256:4fec3f3e76f6e0b6505c2515527024a5bd683a32edb5936d50c35fc633911470 as base
+# docker run arigaio/atlas@sha256:5b52e74c938e2e32df081be435501d0de8f7a019840d7cc844997e6af0061bc1 version
+# atlas version v0.32.1-819f32c-canary
+FROM arigaio/atlas@sha256:5b52e74c938e2e32df081be435501d0de8f7a019840d7cc844997e6af0061bc1 as base
 
 FROM scratch
 # Update permissions to make it readable by the user

--- a/common.mk
+++ b/common.mk
@@ -7,7 +7,7 @@ init: init-api-tools
 	go install github.com/vektra/mockery/v2@v2.43.2
 	# using binary release for atlas, since ent schema handler is not included
 	# in the community version anymore https://github.com/ariga/atlas/issues/2388#issuecomment-1864287189
-	curl -sSf https://atlasgo.sh | ATLAS_VERSION=v0.32.1 sh -s -- -y
+	curl -sSf https://atlasgo.sh | ATLAS_VERSION=v0.32.0 sh -s -- -y
 
 # initialize API tooling
 .PHONY: init-api-tools


### PR DESCRIPTION
This patch upgrades Atlas to `v0.32.1-819f32c-canary` to address the CVE GHSA-vvgc-356p-c3xw

It also reverts the Atlas version in the common script to the previously working one, as the updated version caused issues in that context.

New version of Atlas does not show any CVE at this moment:
```
$ grype arigaio/atlas@sha256:5b52e74c938e2e32df081be435501d0de8f7a019840d7cc844997e6af0061bc1
 ✔ Loaded image                                                                                                                        arigaio/atlas@sha256:5b52e74c938e2e32df081be435501d0de8f7a019840d7cc844997e6af0061bc1
 ✔ Parsed image                                                                                                                                      sha256:8742ad5b19d0fb9803c95496d8f88eea812f4625f4c50ff1e68bb330f812fc34
 ✔ Cataloged contents                                                                                                                                       a737a875af700b62d5af7fe402566ca511b344128a22d4c79225d763819b627f
   ├── ✔ Packages                        [146 packages]
   ├── ✔ Executables                     [1 executables]
   ├── ✔ File metadata                   [942 locations]
   └── ✔ File digests                    [942 files]
 ✔ Scanned for vulnerabilities     [0 vulnerability matches]
   ├── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
   └── by status:   0 fixed, 0 not-fixed, 0 ignored
No vulnerabilities found
```
```
$ trivy image arigaio/atlas@sha256:5b52e74c938e2e32df081be435501d0de8f7a019840d7cc844997e6af0061bc1
2025-04-22T09:47:30+02:00	INFO	[vuln] Vulnerability scanning is enabled
2025-04-22T09:47:30+02:00	INFO	[secret] Secret scanning is enabled
2025-04-22T09:47:30+02:00	INFO	[secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2025-04-22T09:47:30+02:00	INFO	[secret] Please see also https://aquasecurity.github.io/trivy/v0.57/docs/scanner/secret#recommendation for faster secret detection
2025-04-22T09:47:30+02:00	INFO	Detected OS	family="debian" version="12.10"
2025-04-22T09:47:30+02:00	INFO	[debian] Detecting vulnerabilities...	os_version="12" pkg_num=3
2025-04-22T09:47:30+02:00	INFO	Number of language-specific files	num=1
2025-04-22T09:47:30+02:00	INFO	[gobinary] Detecting vulnerabilities...

arigaio/atlas@sha256:5b52e74c938e2e32df081be435501d0de8f7a019840d7cc844997e6af0061bc1 (debian 12.10)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```