### PR TITLE
Add support to organization repos with GitHub OIDC token

### DIFF
--- a/pkg/attestation/crafter/runners/githubaction.go
+++ b/pkg/attestation/crafter/runners/githubaction.go
@@ -32,9 +32,8 @@ func NewGithubAction(ctx context.Context) *GitHubAction {
 	// In order to ensure that we are running in a non-falsifiable environment we get the OIDC
 	// from Github. That allows us to read the workflow file path and runnner type. If that can't
 	// be done we fallback to reading the env vars directly.
-	actorPersonal := fmt.Sprintf("https://github.com/%s", os.Getenv("GITHUB_ACTOR"))
-	actorOrganization := fmt.Sprintf("https://github.com/%s", os.Getenv("GITHUB_REPOSITORY_OWNER"))
-	client, err := oidc.NewGitHubClient(oidc.WithActor(actorPersonal), oidc.WithActor(actorOrganization))
+	actor := fmt.Sprintf("https://github.com/%s", os.Getenv("GITHUB_ACTOR"))
+	client, err := oidc.NewGitHubClient(oidc.WithActor(actor))
 	if err != nil {
 		return &GitHubAction{
 			githubToken: nil,

--- a/pkg/attestation/crafter/runners/githubaction.go
+++ b/pkg/attestation/crafter/runners/githubaction.go
@@ -32,8 +32,9 @@ func NewGithubAction(ctx context.Context) *GitHubAction {
 	// In order to ensure that we are running in a non-falsifiable environment we get the OIDC
 	// from Github. That allows us to read the workflow file path and runnner type. If that can't
 	// be done we fallback to reading the env vars directly.
-	actor := fmt.Sprintf("https://github.com/%s", os.Getenv("GITHUB_ACTOR"))
-	client, err := oidc.NewGitHubClient(oidc.WithActor(actor))
+	actorPersonal := fmt.Sprintf("https://github.com/%s", os.Getenv("GITHUB_ACTOR"))
+	actorOrganization := fmt.Sprintf("https://github.com/%s", os.Getenv("GITHUB_REPOSITORY_OWNER"))
+	client, err := oidc.NewGitHubClient(oidc.WithActor(actorPersonal), oidc.WithActor(actorOrganization))
 	if err != nil {
 		return &GitHubAction{
 			githubToken: nil,

--- a/pkg/attestation/crafter/runners/oidc/github.go
+++ b/pkg/attestation/crafter/runners/oidc/github.go
@@ -50,7 +50,7 @@ type GitHubOIDCClient struct {
 	requestURL   *url.URL
 	verifierFunc func(context.Context) (*oidc.IDTokenVerifier, error)
 	bearerToken  string
-	actor        string
+	actor        []string
 	audience     []string
 	token        *Token
 }
@@ -79,10 +79,10 @@ func WithAudience(audience []string) Option {
 	}
 }
 
-// WithAudience sets the audience for the OIDC token.
+// WithActor sets the audience for the OIDC token.
 func WithActor(actor string) Option {
 	return func(c *GitHubOIDCClient) {
-		c.actor = actor
+		c.actor = append(c.actor, actor)
 	}
 }
 
@@ -113,6 +113,7 @@ func NewGitHubClient(opts ...Option) (*GitHubOIDCClient, error) {
 	c = GitHubOIDCClient{
 		requestURL:  parsedURL,
 		bearerToken: bearerToken,
+		actor:       []string{},
 	}
 	for _, opt := range opts {
 		opt(&c)
@@ -220,7 +221,7 @@ func (c *GitHubOIDCClient) decodePayload(b []byte) (string, error) {
 }
 
 // verifyToken verifies the token contents and signature.
-func (c *GitHubOIDCClient) verifyToken(ctx context.Context, audience []string, actor string, rawIDToken string) (*oidc.IDToken, error) {
+func (c *GitHubOIDCClient) verifyToken(ctx context.Context, audience []string, actor []string, rawIDToken string) (*oidc.IDToken, error) {
 	// Verify the token.
 	verifier, err := c.verifierFunc(ctx)
 	if err != nil {
@@ -232,9 +233,20 @@ func (c *GitHubOIDCClient) verifyToken(ctx context.Context, audience []string, a
 		return nil, fmt.Errorf("verify: could not verify token: %w", err)
 	}
 
-	// Verify the audience received is the one we requested or is equal to the actor
-	if slices.Compare(audience, idToken.Audience) != 0 && slices.Compare([]string{actor}, idToken.Audience) != 0 {
-		return nil, fmt.Errorf("%w: audience not equal %q != %q or not equal to actor %q", errVerify, audience, idToken.Audience, []string{actor})
+	// Verify the audience received is the one we requested or is equal to any of the actors
+	if slices.Compare(audience, idToken.Audience) != 0 {
+		// Check if any of the actors matches the idToken.Audience
+		actorMatch := false
+		for _, a := range actor {
+			if slices.Compare([]string{a}, idToken.Audience) == 0 {
+				actorMatch = true
+				break
+			}
+		}
+
+		if !actorMatch {
+			return nil, fmt.Errorf("%w: audience not equal %q != %q and none of the actors %q match the audience", errVerify, audience, idToken.Audience, actor)
+		}
 	}
 
 	return idToken, nil

--- a/pkg/attestation/crafter/runners/oidc/github.go
+++ b/pkg/attestation/crafter/runners/oidc/github.go
@@ -50,7 +50,7 @@ type GitHubOIDCClient struct {
 	requestURL   *url.URL
 	verifierFunc func(context.Context) (*oidc.IDTokenVerifier, error)
 	bearerToken  string
-	actor        []string
+	actor        string
 	audience     []string
 	token        *Token
 }
@@ -79,10 +79,10 @@ func WithAudience(audience []string) Option {
 	}
 }
 
-// WithActor sets the audience for the OIDC token.
+// WithAudience sets the audience for the OIDC token.
 func WithActor(actor string) Option {
 	return func(c *GitHubOIDCClient) {
-		c.actor = append(c.actor, actor)
+		c.actor = actor
 	}
 }
 
@@ -113,7 +113,6 @@ func NewGitHubClient(opts ...Option) (*GitHubOIDCClient, error) {
 	c = GitHubOIDCClient{
 		requestURL:  parsedURL,
 		bearerToken: bearerToken,
-		actor:       []string{},
 	}
 	for _, opt := range opts {
 		opt(&c)
@@ -221,7 +220,7 @@ func (c *GitHubOIDCClient) decodePayload(b []byte) (string, error) {
 }
 
 // verifyToken verifies the token contents and signature.
-func (c *GitHubOIDCClient) verifyToken(ctx context.Context, audience []string, actor []string, rawIDToken string) (*oidc.IDToken, error) {
+func (c *GitHubOIDCClient) verifyToken(ctx context.Context, audience []string, actor string, rawIDToken string) (*oidc.IDToken, error) {
 	// Verify the token.
 	verifier, err := c.verifierFunc(ctx)
 	if err != nil {
@@ -233,20 +232,9 @@ func (c *GitHubOIDCClient) verifyToken(ctx context.Context, audience []string, a
 		return nil, fmt.Errorf("verify: could not verify token: %w", err)
 	}
 
-	// Verify the audience received is the one we requested or is equal to any of the actors
-	if slices.Compare(audience, idToken.Audience) != 0 {
-		// Check if any of the actors matches the idToken.Audience
-		actorMatch := false
-		for _, a := range actor {
-			if slices.Compare([]string{a}, idToken.Audience) == 0 {
-				actorMatch = true
-				break
-			}
-		}
-
-		if !actorMatch {
-			return nil, fmt.Errorf("%w: audience not equal %q != %q and none of the actors %q match the audience", errVerify, audience, idToken.Audience, actor)
-		}
+	// Verify the audience received is the one we requested or is equal to the actor
+	if slices.Compare(audience, idToken.Audience) != 0 && slices.Compare([]string{actor}, idToken.Audience) != 0 {
+		return nil, fmt.Errorf("%w: audience not equal %q != %q or not equal to actor %q", errVerify, audience, idToken.Audience, []string{actor})
 	}
 
 	return idToken, nil


### PR DESCRIPTION
In order to support organization repositories OIDC token on GitHub we need to check for different actor - this PR introduces the change allowing specifying multiple expected audiences. 