### PR TITLE
fix(policies): fail on required arguments that are empty after applying interpolations

### DIFF
--- a/pkg/policies/policies_test.go
+++ b/pkg/policies/policies_test.go
@@ -932,6 +932,15 @@ func (s *testSuite) TestComputePolicyArguments() {
 			bindings: map[string]string{"foo": "world", "bar": "template"},
 			expected: map[string]string{"arg1": "Hello world template", "arg2": "Bye template"},
 		},
+		{
+			name: "required input with missing binding",
+			inputs: []*v12.PolicyInput{{
+				Name:     "arg1",
+				Required: true,
+			}},
+			args:      map[string]string{"arg1": "{{ inputs.foo }}"},
+			expectErr: true,
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -25,8 +25,12 @@ var inputsPrefixRegexp = regexp.MustCompile(`{{\s*(inputs.)`)
 
 // ApplyBinding renders an input template using bindings in Go templating format
 func ApplyBinding(input string, bindings map[string]string) (string, error) {
-	if bindings == nil || input == "" {
-		return input, nil
+	if input == "" {
+		return "", nil
+	}
+
+	if bindings == nil {
+		bindings = make(map[string]string)
 	}
 
 	// Support both `.inputs.foo` and `inputs.foo`


### PR DESCRIPTION
This PR fixes the case when a required argument gets an interpolated value, and the interpolation variables are not passed. In this case, if it renders to an empty string, should be still considered missing, thus failing the validation.

This one should fail if `foo` value is not provided and `policyfoo` is required by the policy.
```
apiVersion: workflowcontract.chainloop.dev/v1
kind: PolicyGroup
metadata:
  name: my-group
spec:
  inputs:
    - name: foo
policies:
  attestation:
    - ref: my-policy
      with: 
        policyfoo: "{{ inputs.foo }}"
```

Fixes #2012 