### PR TITLE
chore(.chainloop): Prepare for v1.0.0

### DIFF
--- a/.chainloop.yml
+++ b/.chainloop.yml
@@ -1,5 +1,5 @@
 # This can indicate the next version and by default it will be marked as pre-release
-projectVersion: v1.0.0-rc.14
+projectVersion: v1.0.0
 
 # Experimental feature used by Chainloop labs shared workflow https://github.com/chainloop-dev/labs
 # It maps the material names with location in disk so they get automatically attested


### PR DESCRIPTION
This patch modifies the version on `.chainloop.yaml` file to prepare for `v1.0.0`.