### PR TITLE
Remove GitHub attestation to use Chainloop native capabilities

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,7 @@ on:
 # https://github.com/ossf/scorecard/blob/7ed886f1bd917d19cb9d6ce6c10e80e81fa31c39/docs/checks.md#token-permissions
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   test:
@@ -133,48 +134,6 @@ jobs:
 
             chainloop attestation add --name $material_name --value $entry --kind ARTIFACT --attestation-id ${{ env.ATTESTATION_ID }}
           done
-
-      - name: Calculate checksum for SLSA attestation
-        run: |
-          # We're generating a checksum file for the SLSA attestation as a workaround for the current limitations of the SLSA attestation action.
-          # Until it's possible to include multiple container images and binaries in a single attestation, this approach serves as a temporary solution.
-          # An open issue suggests that if pushing the attestation to an OCI registry isn't required, using a checksum file is a valid alternative.
-          # Link: https://github.com/actions/attest-build-provenance/issues/454
-
-          # Create an empty checksum file
-          checksum_file="/tmp/subjects-checksum.txt"
-          touch "$checksum_file"
-
-          # First the binaries
-          binaries=$(cat dist/artifacts.json | jq -r '.[] | select(.type=="Binary") | select(.name=="chainloop"| not) | "\(.path) \(.name)"')
-          echo "$binaries" | while IFS= read -r entry; do
-            # Extract the path and name from the entry
-            path=$(echo "$entry" | awk '{print $1}')
-            # Calculate the checksum of the file
-            checksum=$(sha256sum "$path" | awk '{print $1}')
-            # Get the name from the entry
-            name=$(echo "$entry" | awk '{print $2}')
-            # Add it to the checksum file
-            echo "$checksum *$name" >> $checksum_file
-          done
-
-          # Then the docker images
-          images=$(cat dist/artifacts.json | jq -r '.[] | select(.type=="Docker Manifest") | select(.name | endswith(":latest") | not) | "\(.extra.Digest | split("sha256:")[1]) \(.name)"')
-          echo "$images" | while IFS= read -r entry; do
-            # Extract the digest and name from the entry
-            name=$(echo "$entry" | awk '{print $2}')
-            digest=$(echo "$entry" | awk '{print $1}')
-            echo "$digest  $name" >> $checksum_file
-          done
-
-      - uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
-        id: slsa-attest
-        with:
-          subject-checksums: /tmp/subjects-checksum.txt
-
-      - name: Attest SLSA attestation
-        run: |
-          chainloop attestation --name slsa-attestation add --value ${{ steps.slsa-attest.outputs.bundle-path }} --annotation github_attestation="${{ steps.slsa-attest.outputs.attestation-url }}" --kind SLSA_PROVENANCE --attestation-id ${{ env.ATTESTATION_ID }}
 
       - name: Include source code on attestation
         run: |


### PR DESCRIPTION
This PR removes GitHub native SLSA attestation and adds the `id_token: write` permission. 