### PR TITLE
feat(gitlab): try to parse token from provided creds

### DIFF
--- a/app/cli/cmd/root.go
+++ b/app/cli/cmd/root.go
@@ -137,7 +137,7 @@ func NewRootCmd(l zerolog.Logger) *cobra.Command {
 					return err
 				}
 
-				currentContext, err := action.NewConfigCurrentContext(newActionOpts(logger, conn)).Run()
+				currentContext, err := action.NewConfigCurrentContext(newActionOpts(logger, conn, token)).Run()
 				if err == nil && currentContext.CurrentMembership != nil {
 					if err := setLocalOrganization(currentContext.CurrentMembership.Org.Name); err != nil {
 						return fmt.Errorf("writing config file: %w", err)
@@ -162,7 +162,7 @@ func NewRootCmd(l zerolog.Logger) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			actionOpts = newActionOpts(logger, conn)
+			actionOpts = newActionOpts(logger, conn, token)
 
 			if !isTelemetryDisabled() {
 				logger.Debug().Msg("Telemetry enabled, to disable it use DO_NOT_TRACK=1")
@@ -332,8 +332,8 @@ func initConfigFile() {
 	cobra.CheckErr(viper.ReadInConfig())
 }
 
-func newActionOpts(logger zerolog.Logger, conn *grpc.ClientConn) *action.ActionsOpts {
-	return &action.ActionsOpts{CPConnection: conn, Logger: logger}
+func newActionOpts(logger zerolog.Logger, conn *grpc.ClientConn, token string) *action.ActionsOpts {
+	return &action.ActionsOpts{CPConnection: conn, Logger: logger, AuthTokenRaw: token}
 }
 
 func cleanup(conn *grpc.ClientConn) error {

--- a/app/cli/internal/action/action.go
+++ b/app/cli/internal/action/action.go
@@ -37,6 +37,7 @@ const (
 type ActionsOpts struct {
 	CPConnection *grpc.ClientConn
 	Logger       zerolog.Logger
+	AuthTokenRaw string
 }
 
 type OffsetPagination struct {

--- a/app/cli/internal/action/attestation_init.go
+++ b/app/cli/internal/action/attestation_init.go
@@ -168,7 +168,7 @@ func (action *AttestationInit) Run(ctx context.Context, opts *AttestationInitRun
 	}
 
 	// Auto discover the runner context and enforce against the one in the contract if needed
-	discoveredRunner, err := crafter.DiscoverAndEnforceRunner(contractVersion.GetV1().GetRunner().GetType(), action.dryRun, action.Logger)
+	discoveredRunner, err := crafter.DiscoverAndEnforceRunner(contractVersion.GetV1().GetRunner().GetType(), action.dryRun, action.AuthTokenRaw, action.Logger)
 	if err != nil {
 		return "", ErrRunnerContextNotFound{err.Error()}
 	}

--- a/app/cli/internal/telemetry/telemetry.go
+++ b/app/cli/internal/telemetry/telemetry.go
@@ -116,7 +116,7 @@ func (tg Tags) WithRuntimeInfo() Tags {
 
 // WithEnvironmentInfo adds environment information to the Tags.
 func (tg Tags) WithEnvironmentInfo() Tags {
-	runner := crafter.DiscoverRunner(zerolog.Nop())
+	runner := crafter.DiscoverRunner("", zerolog.Nop())
 	tg["ci"] = "false"
 	// Check if the ID of the runner matches the unspecified one, meaning it's the Generic Runner
 	if runner.ID() != schemaapi.CraftingSchema_Runner_RUNNER_TYPE_UNSPECIFIED {

--- a/pkg/attestation/crafter/runners/gitlabpipeline.go
+++ b/pkg/attestation/crafter/runners/gitlabpipeline.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 The Chainloop Authors.
+// Copyright 2023-2025 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,8 +28,9 @@ type GitlabPipeline struct {
 	gitlabToken *oidc.GitlabToken
 }
 
-func NewGitlabPipeline(ctx context.Context, logger *zerolog.Logger) *GitlabPipeline {
-	client, err := oidc.NewGitlabClient(ctx, logger)
+// authtoken is a possible oidc token that could be used to authenticate the runner
+func NewGitlabPipeline(ctx context.Context, authToken string, logger *zerolog.Logger) *GitlabPipeline {
+	client, err := oidc.NewGitlabClient(ctx, authToken, logger)
 	if err != nil {
 		logger.Debug().Err(err).Msgf("failed to create Gitlab OIDC client: %v", err)
 		return &GitlabPipeline{
@@ -61,6 +62,7 @@ func (r *GitlabPipeline) ListEnvVars() []*EnvVarDefinition {
 	return []*EnvVarDefinition{
 		{"GITLAB_USER_EMAIL", false},
 		{"GITLAB_USER_LOGIN", false},
+		{"CI_SERVER_URL", false},
 		{"CI_PROJECT_URL", false},
 		{"CI_COMMIT_SHA", false},
 		{"CI_JOB_URL", false},

--- a/pkg/attestation/crafter/runners/gitlabpipeline_test.go
+++ b/pkg/attestation/crafter/runners/gitlabpipeline_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 The Chainloop Authors.
+// Copyright 2023-2025 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -83,6 +83,7 @@ func (s *gitlabPipelineSuite) TestListEnvVars() {
 	assert.Equal(s.T(), []*EnvVarDefinition{
 		{"GITLAB_USER_EMAIL", false},
 		{"GITLAB_USER_LOGIN", false},
+		{"CI_SERVER_URL", false},
 		{"CI_PROJECT_URL", false},
 		{"CI_COMMIT_SHA", false},
 		{"CI_JOB_URL", false},
@@ -106,6 +107,7 @@ func (s *gitlabPipelineSuite) TestResolveEnvVars() {
 		"CI_RUNNER_VERSION":     "13.10.0",
 		"CI_RUNNER_DESCRIPTION": "chainloop-runner",
 		"CI_COMMIT_REF_NAME":    "main",
+		"CI_SERVER_URL":         "https://gitlab.com",
 	}, resolvedEnvVars)
 }
 
@@ -120,7 +122,7 @@ func (s *gitlabPipelineSuite) TestRunnerName() {
 // Run before each test
 func (s *gitlabPipelineSuite) SetupTest() {
 	logger := zerolog.New(zerolog.Nop()).Level(zerolog.Disabled)
-	s.runner = NewGitlabPipeline(context.Background(), &logger)
+	s.runner = NewGitlabPipeline(context.Background(), "test-token", &logger)
 	t := s.T()
 	t.Setenv("GITLAB_CI", "true")
 	t.Setenv("GITLAB_USER_EMAIL", "foo@foo.com")
@@ -132,6 +134,7 @@ func (s *gitlabPipelineSuite) SetupTest() {
 	t.Setenv("CI_RUNNER_VERSION", "13.10.0")
 	t.Setenv("CI_RUNNER_DESCRIPTION", "chainloop-runner")
 	t.Setenv("CI_COMMIT_REF_NAME", "main")
+	t.Setenv("CI_SERVER_URL", "https://gitlab.com")
 }
 
 // Run the tests

--- a/pkg/attestation/crafter/runners/oidc/gitlab.go
+++ b/pkg/attestation/crafter/runners/oidc/gitlab.go
@@ -49,7 +49,7 @@ type GitlabOIDCClient struct {
 	Token *GitlabToken
 }
 
-func NewGitlabClient(ctx context.Context, logger *zerolog.Logger) (*GitlabOIDCClient, error) {
+func NewGitlabClient(ctx context.Context, authToken string, logger *zerolog.Logger) (*GitlabOIDCClient, error) {
 	var c GitlabOIDCClient
 
 	// retrieve the Gitlab server on which the pipeline is running, which is the provider URL
@@ -59,16 +59,12 @@ func NewGitlabClient(ctx context.Context, logger *zerolog.Logger) (*GitlabOIDCCl
 		return nil, fmt.Errorf("%s environment variable not set", CIServerURLEnv)
 	}
 
-	tokenContent := os.Getenv(GitlabTokenEnv)
-	logger.Debug().Msg("retrieved token content")
-	if tokenContent == "" {
-		return nil, fmt.Errorf("%s environment variable not set", GitlabTokenEnv)
+	token, err := loadTokenFromEnvOrRawToken(ctx, authToken, providerURL, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load token: %w", err)
 	}
 
-	token, err := parseToken(ctx, providerURL, tokenContent)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse token: %w", err)
-	}
+	logger.Debug().Msg("OIDC token loaded successfully")
 
 	c.Token = token
 	return &c, nil
@@ -113,4 +109,27 @@ func parseToken(ctx context.Context, providerURL string, tokenString string) (*G
 	}
 
 	return token, nil
+}
+
+// To load the auth token we do it in two steps:
+// 1 - check if it's explicitly set as an environment variable GITLAB_OIDC
+// 2 - if not, try to parse it from the input token string
+func loadTokenFromEnvOrRawToken(ctx context.Context, authToken string, providerURL string, logger *zerolog.Logger) (*GitlabToken, error) {
+	tokenContent := os.Getenv(GitlabTokenEnv)
+	if tokenContent == "" && authToken == "" {
+		return nil, fmt.Errorf("no token provided, neither explicitly nor as an environment variable %s", GitlabTokenEnv)
+	}
+
+	if tokenContent != "" {
+		logger.Debug().Msgf("retrieved token content from environment variable %s", GitlabTokenEnv)
+		return parseToken(ctx, providerURL, tokenContent)
+	}
+
+	logger.Debug().Msg("no token content in environment variable, trying to parse from raw token")
+	parsedToken, err := parseToken(ctx, providerURL, authToken)
+	if err != nil {
+		return nil, fmt.Errorf("Invalid authentication token provided, %w", err)
+	}
+
+	return parsedToken, nil
 }

--- a/pkg/attestation/crafter/runners/oidc/gitlab_test.go
+++ b/pkg/attestation/crafter/runners/oidc/gitlab_test.go
@@ -40,6 +40,7 @@ func TestNewGitlabClient(t *testing.T) {
 	tests := []struct {
 		name              string
 		setupEnv          func(t *testing.T)
+		explicitToken     string
 		expectErr         bool
 		expectErrContains string
 	}{
@@ -59,14 +60,24 @@ func TestNewGitlabClient(t *testing.T) {
 				t.Setenv(oidc.GitlabTokenEnv, "")
 			},
 			expectErr:         true,
-			expectErrContains: "environment variable not set",
+			expectErrContains: "no token provided",
+		},
+		{
+			name: "explicit wrong token",
+			setupEnv: func(t *testing.T) {
+				t.Setenv(oidc.CIServerURLEnv, "https://gitlab.example.com")
+				t.Setenv(oidc.GitlabTokenEnv, "")
+			},
+			expectErr:         true,
+			explicitToken:     "wrong-token",
+			expectErrContains: "Invalid authentication token provided",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.setupEnv(t)
-			client, err := oidc.NewGitlabClient(ctx, &testLogger)
+			client, err := oidc.NewGitlabClient(ctx, tt.explicitToken, &testLogger)
 
 			if tt.expectErr {
 				assert.Error(t, err)


### PR DESCRIPTION
Extends the current authenticated runner feature for gitLab to also use the authentication token provided during attestation process.

This means that you'll not need to craft another OIDC token but just use whatever you are using for the attestation process, which might already be a GitLab OIDC token