### PR TITLE
fix(chart): render in Helm 3.18

### DIFF
--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -7,7 +7,7 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.227.0
+version: 1.227.1
 # Do not update appVersion, this is handled automatically by the release process
 appVersion: v1.4.2
 

--- a/deployment/chainloop/templates/controlplane/configmap.yaml
+++ b/deployment/chainloop/templates/controlplane/configmap.yaml
@@ -38,7 +38,7 @@ data:
         {{- end }}
     cas_server:
       grpc:
-        addr: {{ printf "%s-api:%.0f" (include "chainloop.cas.fullname" .) (coalesce .Values.cas.serviceAPI.port .Values.cas.serviceAPI.ports.http) }}
+        addr: {{ printf "%s-api:%s" (include "chainloop.cas.fullname" .) (coalesce .Values.cas.serviceAPI.port .Values.cas.serviceAPI.ports.http) }}
       insecure: {{ empty (include "controlplane.tls-secret-name" .) }}
       download_url: {{ include "chainloop.cas.external_url" . }}/download
       {{- if .Values.cas.defaultMaxEntrySize }}


### PR DESCRIPTION
Before

```
helm template foo ./chainloop --set development=true | grep cas_server -A 3
    cas_server:
      grpc:
        addr: foo-chainloop-cas-api:%!f(json.Number=)
      insecure: true
```

after

```
 helm template foo ./chainloop --set development=true | grep cas_server -A 3
    cas_server:
      grpc:
        addr: foo-chainloop-cas-api:80
      insecure: true
```
Fixes #2067