### PR TITLE
fix: optimize workflow runs by returning early if there are no workflows

### DIFF
--- a/app/controlplane/pkg/data/workflowrun.go
+++ b/app/controlplane/pkg/data/workflowrun.go
@@ -25,7 +25,6 @@ import (
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/biz"
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/data/ent"
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/data/ent/attestation"
-	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/data/ent/organization"
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/data/ent/projectversion"
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/data/ent/workflow"
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/data/ent/workflowrun"
@@ -234,10 +233,24 @@ func (r *WorkflowRunRepo) List(ctx context.Context, orgID uuid.UUID, filters *bi
 		return nil, "", errors.New("pagination options is required")
 	}
 
+	// query first for workflows to avoid joining the workflow_runs table
+	wfExist, err := r.data.DB.Workflow.Query().Where(
+		workflow.DeletedAtIsNil(),
+		workflow.OrganizationID(orgID),
+	).Exist(ctx)
+	if err != nil {
+		return nil, "", fmt.Errorf("getting workflows: %w", err)
+	}
+	if !wfExist {
+		// No workflows in the org, no runs
+		return nil, "", nil
+	}
+
+	// Query workflow runs by joining with workflows
 	q := r.data.DB.WorkflowRun.Query().Where(
 		workflowrun.HasWorkflowWith(
+			workflow.OrganizationID(orgID),
 			workflow.DeletedAtIsNil(),
-			workflow.HasOrganizationWith(organization.ID(orgID)),
 		)).
 		Order(ent.Desc(workflowrun.FieldCreatedAt)).
 		WithWorkflowAndProject().WithVersion().


### PR DESCRIPTION
Another follow up on #2070. This time we maintain untouched the original query, but return early if there are no workflows in the organization.
The resulting query plans are (with millions of records):

For the first query (workflows)
```
Limit  (cost=0.16..4.17 rows=1 width=16) (actual time=0.829..0.830 rows=0 loops=1)
  ->  Index Scan using workflow_organization_id on workflows  (cost=0.16..4.17 rows=1 width=16) (actual time=0.828..0.828 rows=0 loops=1)
        Index Cond: (organization_id = '4b1ec0ee-e079-4307-b532-e038cb1fa76a'::uuid)
Planning Time: 0.855 ms
Execution Time: 0.882 ms
```

For the second query (workflow runs)
```
Limit  (cost=0.86..2.47 rows=26 width=236) (actual time=0.079..0.092 rows=26 loops=1)
  ->  Nested Loop  (cost=0.86..124127.02 rows=2000544 width=236) (actual time=0.078..0.090 rows=26 loops=1)
        ->  Index Scan using workflow_runs_created_at_index on workflow_runs  (cost=0.43..74112.59 rows=2000544 width=236) (actual time=0.039..0.046 rows=26 loops=1)
        ->  Memoize  (cost=0.43..0.46 rows=1 width=16) (actual time=0.002..0.002 rows=1 loops=26)
              Cache Key: workflow_runs.workflow_id
              Cache Mode: logical
              Hits: 25  Misses: 1  Evictions: 0  Overflows: 0  Memory Usage: 1kB
              ->  Index Only Scan using workflow_organization_id_id on workflows  (cost=0.42..0.45 rows=1 width=16) (actual time=0.036..0.036 rows=1 loops=1)
                    Index Cond: ((organization_id = '18c3f782-4936-4630-ab8d-20b511366699'::uuid) AND (id = workflow_runs.workflow_id))
                    Heap Fetches: 1
Planning Time: 0.147 ms
Execution Time: 0.116 ms
```
