### PR TITLE
fix: add contract without policies for getting started

### DIFF
--- a/app/controlplane/configs/config.devel.yaml
+++ b/app/controlplane/configs/config.devel.yaml
@@ -94,10 +94,11 @@ auth:
 prometheus_integration:
   - org_name: "development"
 
-policy_providers:
-  - name: chainloop
-    default: true
-    url: http://localhost:8002/v1
+# Policy providers configuration
+# policy_providers:
+#   - name: chainloop
+#     default: true
+#     url: http://localhost:8002/v1
 
 enable_profiler: true
 

--- a/docs/examples/quickstart/quickstart-contract-oss.yaml
+++ b/docs/examples/quickstart/quickstart-contract-oss.yaml
@@ -1,0 +1,12 @@
+# This is an example contract that expects a container, an SBOM, and a vulnerabilities report.
+schemaVersion: v1
+materials:
+  - name: container
+    type: CONTAINER_IMAGE
+  - name: sbom
+    type: SBOM_CYCLONEDX_JSON
+    optional: true
+  - name: vulnerabilities-report
+    type: SARIF
+    optional: true
+

--- a/docs/examples/quickstart/quickstart-contract.yaml
+++ b/docs/examples/quickstart/quickstart-contract.yaml
@@ -11,22 +11,3 @@ materials:
   - name: vulnerabilities-report
     type: SARIF
     optional: true
-policies:
-  attestation:
-    # Container with sbom checks that all containers added to the attestation
-    # have a valid SBOM also present in the attestation
-    - ref: containers-with-sbom
-  materials:
-    # Artifact signed checks that all artifacts such as Container Images and Charts are signed
-    - ref: artifact-signed
-    # Vulnerabilities checks the vulnerabilities reports if present in the attestation
-    # does not contain any vulnerabilities with severity higher than the specified
-    - ref: vulnerabilities
-      with:
-        severity: "MEDIUM"
-policyGroups:
-  # This policy group applies a number of SBOM-related policies
-  - ref: sbom-quality
-    with:
-      bannedLicenses: AGPL-1.0-only, AGPL-1.0-or-later, AGPL-3.0-only, AGPL-3.0-or-later
-      bannedComponents: log4j@2.14.1

--- a/docs/examples/quickstart/quickstart-contract.yaml
+++ b/docs/examples/quickstart/quickstart-contract.yaml
@@ -11,3 +11,22 @@ materials:
   - name: vulnerabilities-report
     type: SARIF
     optional: true
+policies:
+  attestation:
+    # Container with sbom checks that all containers added to the attestation
+    # have a valid SBOM also present in the attestation
+    - ref: containers-with-sbom
+  materials:
+    # Artifact signed checks that all artifacts such as Container Images and Charts are signed
+    - ref: artifact-signed
+    # Vulnerabilities checks the vulnerabilities reports if present in the attestation
+    # does not contain any vulnerabilities with severity higher than the specified
+    - ref: vulnerabilities
+      with:
+        severity: "MEDIUM"
+policyGroups:
+  # This policy group applies a number of SBOM-related policies
+  - ref: sbom-quality
+    with:
+      bannedLicenses: AGPL-1.0-only, AGPL-1.0-or-later, AGPL-3.0-only, AGPL-3.0-or-later
+      bannedComponents: log4j@2.14.1


### PR DESCRIPTION
The contract shouldn't have any non-local policy, since policy provider is not configured by default. 
Closes #2076 