### PR TITLE
chore(workflows): Include attestation name on release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -114,10 +114,20 @@ jobs:
             # exclude latest tag
             if [[ $entry != *latest ]]; then
               material_name="$(echo $entry | sed 's#.*/##')"
+    
+              # Extract repo name (component after last slash, before colon)
+              repo_name="$(echo $entry | sed 's#.*/##' | sed 's#:.*##')"
+              
+              # Extract just the architecture (after the last dash)
+              arch="$(echo $material_name | sed 's#.*-##')"
+              
+              # Create attestation names (without version)
+              container_name="${repo_name}-${arch}"
+              sbom_name="${repo_name}-sbom-${arch}"
 
               syft -o cyclonedx-json=/tmp/sbom-$material_name.cyclonedx.json $entry
-              chainloop attestation add --value $entry --kind CONTAINER_IMAGE --attestation-id ${{ env.ATTESTATION_ID }}
-              chainloop attestation add --value /tmp/sbom-$material_name.cyclonedx.json --kind SBOM_CYCLONEDX_JSON --attestation-id ${{ env.ATTESTATION_ID }}
+              chainloop attestation add --name $container_name --value $entry --kind CONTAINER_IMAGE --attestation-id ${{ env.ATTESTATION_ID }}
+              chainloop attestation add --name $sbom_name --value /tmp/sbom-$material_name.cyclonedx.json --kind SBOM_CYCLONEDX_JSON --attestation-id ${{ env.ATTESTATION_ID }}
 
               # Upload the SBOM to the release
               gh release upload ${{ github.ref_name }} /tmp/sbom-$material_name.cyclonedx.json --clobber


### PR DESCRIPTION
This patch modifies the release workflow to include the names of the materials being attested. See this example with the latest released version to see the expected output:
```
Reading from: /Users/javirln/Development/projects/chainloop/platform/backend/artifacts.json
============================================
Image: ghcr.io/chainloop-dev/chainloop/control-plane-migrations:v1.4.3-amd64
  Container name: control-plane-migrations-amd64
  SBOM name: control-plane-migrations-sbom-amd64

Image: ghcr.io/chainloop-dev/chainloop/control-plane-migrations:v1.4.3-arm64
  Container name: control-plane-migrations-arm64
  SBOM name: control-plane-migrations-sbom-arm64

Image: ghcr.io/chainloop-dev/chainloop/artifact-cas:v1.4.3-amd64
  Container name: artifact-cas-amd64
  SBOM name: artifact-cas-sbom-amd64

Image: ghcr.io/chainloop-dev/chainloop/artifact-cas:v1.4.3-arm64
  Container name: artifact-cas-arm64
  SBOM name: artifact-cas-sbom-arm64

Image: ghcr.io/chainloop-dev/chainloop/cli:v1.4.3-amd64
  Container name: cli-amd64
  SBOM name: cli-sbom-amd64

Image: ghcr.io/chainloop-dev/chainloop/control-plane:v1.4.3-arm64
  Container name: control-plane-arm64
  SBOM name: control-plane-sbom-arm64

Image: ghcr.io/chainloop-dev/chainloop/cli:v1.4.3-arm64
  Container name: cli-arm64
  SBOM name: cli-sbom-arm64

Image: ghcr.io/chainloop-dev/chainloop/control-plane:v1.4.3-amd64
  Container name: control-plane-amd64
  SBOM name: control-plane-sbom-amd64

Image: ghcr.io/chainloop-dev/chainloop/control-plane:v1.4.3
  Container name: control-plane-plane:v1.4.3
  SBOM name: control-plane-sbom-plane:v1.4.3

Image: ghcr.io/chainloop-dev/chainloop/artifact-cas:v1.4.3
  Container name: artifact-cas-cas:v1.4.3
  SBOM name: artifact-cas-sbom-cas:v1.4.3

Image: ghcr.io/chainloop-dev/chainloop/control-plane-migrations:v1.4.3
  Container name: control-plane-migrations-migrations:v1.4.3
  SBOM name: control-plane-migrations-sbom-migrations:v1.4.3

Image: ghcr.io/chainloop-dev/chainloop/cli:v1.4.3
  Container name: cli-cli:v1.4.3
  SBOM name: cli-sbom-cli:v1.4.3

```