### PR TITLE
fix(release-notes): Fix release outputs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -186,7 +186,7 @@ jobs:
     env:
       CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
     outputs:
-      attestation_hash: ${{ steps.attestation_push.attestation_sha }}
+      attestation_hash: ${{ steps.attestation_push.outputs.attestation_sha }}
     steps:
       - name: Install Chainloop
         run: |


### PR DESCRIPTION
This pull request makes a small correction in the `.github/workflows/release.yaml` file, updating the syntax for accessing the `attestation_sha` output from the `attestation_push` step.

* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL189-R189): Changed `steps.attestation_push.attestation_sha` to `steps.attestation_push.outputs.attestation_sha` to correctly reference the output.