### PR TITLE
#2090 - Introduce extensibility to Chainloop CLI

### DIFF
--- a/app/cli/cmd/plugins.go
+++ b/app/cli/cmd/plugins.go
@@ -1,0 +1,354 @@
+//
+// Copyright 2025 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/chainloop-dev/chainloop/pkg/plugins"
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+)
+
+var (
+	pluginManager      *plugins.Manager
+	registeredCommands map[string]string // Track which plugin registered which command
+)
+
+func init() {
+	pluginManager = plugins.NewManager(logger)
+	registeredCommands = make(map[string]string)
+}
+
+func newPluginCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "plugin",
+		Short: "Manage plugins",
+		Long:  "Manage Chainloop plugins for extended functionality",
+	}
+
+	cmd.AddCommand(newPluginListCmd())
+	cmd.AddCommand(newPluginInfoCmd())
+
+	return cmd
+}
+
+func createPluginCommand(plugin *plugins.LoadedPlugin, cmdInfo plugins.CommandInfo) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   cmdInfo.Name,
+		Short: cmdInfo.Description,
+		Long:  fmt.Sprintf("%s\n\nProvided by plugin: %s v%s", cmdInfo.Description, plugin.Metadata.Name, plugin.Metadata.Version),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			// Collect arguments
+			arguments := make(map[string]interface{})
+
+			// Collect flag values
+			for _, flag := range cmdInfo.Flags {
+				switch flag.Type {
+				case "string":
+					if val, err := cmd.Flags().GetString(flag.Name); err == nil {
+						arguments[flag.Name] = val
+					}
+				case "bool":
+					if val, err := cmd.Flags().GetBool(flag.Name); err == nil {
+						arguments[flag.Name] = val
+					}
+				case "int":
+					if val, err := cmd.Flags().GetInt(flag.Name); err == nil {
+						arguments[flag.Name] = val
+					}
+				}
+			}
+
+			// Add positional arguments
+			arguments["args"] = args
+
+			// Add GitHub environment variables to arguments if they exist
+			if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+				arguments["github_token"] = token
+			}
+			if org := os.Getenv("GITHUB_ORG"); org != "" {
+				arguments["github_org"] = org
+			}
+			if repo := os.Getenv("GITHUB_REPO"); repo != "" {
+				arguments["github_repo"] = repo
+			}
+			if apiURL := os.Getenv("GITHUB_API_URL"); apiURL != "" {
+				arguments["github_api_url"] = apiURL
+			} else {
+				arguments["github_api_url"] = "https://api.github.com"
+			}
+
+			// Execute plugin command
+			result, err := plugin.Plugin.Exec(ctx, cmdInfo.Name, arguments)
+			if err != nil {
+				return fmt.Errorf("plugin execution failed: %w", err)
+			}
+
+			// Handle result
+			if result.GetError() != "" {
+				return fmt.Errorf("%s", result.GetError())
+			}
+
+			fmt.Print(result.GetOutput())
+
+			// Return with appropriate exit code
+			if result.GetExitCode() != 0 {
+				os.Exit(result.GetExitCode())
+			}
+
+			return nil
+		},
+	}
+
+	// Add flags
+	for _, flag := range cmdInfo.Flags {
+		switch flag.Type {
+		case "string":
+			defaultVal, _ := flag.Default.(string)
+			cmd.Flags().String(flag.Name, defaultVal, flag.Description)
+		case "bool":
+			defaultVal, _ := flag.Default.(bool)
+			cmd.Flags().Bool(flag.Name, defaultVal, flag.Description)
+		case "int":
+			defaultVal, _ := flag.Default.(int)
+			cmd.Flags().Int(flag.Name, defaultVal, flag.Description)
+		}
+
+		if flag.Required {
+			cmd.MarkFlagRequired(flag.Name)
+		}
+	}
+
+	return cmd
+}
+
+func newPluginListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List installed plugins and their commands",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			plugins := pluginManager.GetAllPlugins()
+
+			if flagOutputFormat == formatJSON {
+				type pluginInfo struct {
+					Name        string   `json:"name"`
+					Version     string   `json:"version"`
+					Description string   `json:"description"`
+					Path        string   `json:"path"`
+					Commands    []string `json:"commands"`
+				}
+
+				var items []pluginInfo
+				for name, plugin := range plugins {
+					var commands []string
+					for _, cmd := range plugin.Metadata.Commands {
+						commands = append(commands, cmd.Name)
+					}
+
+					items = append(items, pluginInfo{
+						Name:        name,
+						Version:     plugin.Metadata.Version,
+						Description: plugin.Metadata.Description,
+						Path:        plugin.Path,
+						Commands:    commands,
+					})
+				}
+
+				return encodeJSON(items)
+			}
+
+			return pluginListTableOutput(plugins)
+		},
+	}
+}
+
+func newPluginInfoCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "info [plugin-name]",
+		Short: "Show detailed information about a plugin",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			pluginName := args[0]
+			plugin, ok := pluginManager.GetPlugin(pluginName)
+			if !ok {
+				return fmt.Errorf("plugin '%s' not found", pluginName)
+			}
+
+			if flagOutputFormat == formatJSON {
+				type pluginDetail struct {
+					Name        string                `json:"name"`
+					Version     string                `json:"version"`
+					Description string                `json:"description"`
+					Path        string                `json:"path"`
+					Commands    []plugins.CommandInfo `json:"commands"`
+				}
+
+				detail := pluginDetail{
+					Name:        plugin.Metadata.Name,
+					Version:     plugin.Metadata.Version,
+					Description: plugin.Metadata.Description,
+					Path:        plugin.Path,
+					Commands:    plugin.Metadata.Commands,
+				}
+
+				return encodeJSON(detail)
+			}
+
+			return pluginInfoTableOutput(plugin)
+		},
+	}
+}
+
+// loadAllPlugins loads all plugins and registers their commands to the root command
+func loadAllPlugins(rootCmd *cobra.Command) error {
+	ctx := context.Background()
+
+	// Load all plugins from the plugins directory
+	if err := pluginManager.LoadPlugins(ctx); err != nil {
+		return fmt.Errorf("failed to load plugins: %w", err)
+	}
+
+	// Get all loaded plugins
+	allPlugins := pluginManager.GetAllPlugins()
+	if len(allPlugins) == 0 {
+		logger.Debug().Msg("No plugins found in plugins directory")
+		return nil
+	}
+
+	logger.Debug().Int("count", len(allPlugins)).Msg("Found plugins")
+
+	// Register commands from all plugins, checking for conflicts
+	for pluginName, plugin := range allPlugins {
+		logger.Debug().
+			Str("name", pluginName).
+			Str("version", plugin.Metadata.Version).
+			Msg("Processing plugin")
+
+		for _, cmdInfo := range plugin.Metadata.Commands {
+			if existingPlugin, exists := registeredCommands[cmdInfo.Name]; exists {
+				return fmt.Errorf("command conflict: command '%s' is provided by both '%s' and '%s' plugins",
+					cmdInfo.Name, existingPlugin, pluginName)
+			}
+
+			// Register the command
+			pluginCmd := createPluginCommand(plugin, cmdInfo)
+			rootCmd.AddCommand(pluginCmd)
+			registeredCommands[cmdInfo.Name] = pluginName
+
+			logger.Debug().
+				Str("command", cmdInfo.Name).
+				Str("plugin", pluginName).
+				Msg("Registered plugin command")
+		}
+	}
+
+	logger.Debug().
+		Int("commands", len(registeredCommands)).
+		Int("plugins", len(allPlugins)).
+		Msg("Successfully registered plugin commands")
+
+	return nil
+}
+
+// cleanupPlugins should be called during application shutdown
+func cleanupPlugins() {
+	if pluginManager != nil {
+		pluginManager.Shutdown()
+	}
+}
+
+// Table output functions
+func pluginListTableOutput(plugins map[string]*plugins.LoadedPlugin) error {
+	if len(plugins) == 0 {
+		fmt.Println("No plugins installed")
+		return nil
+	}
+
+	t := newTableWriter()
+	t.AppendHeader(table.Row{"Name", "Version", "Description", "Commands"})
+
+	for name, plugin := range plugins {
+		commandStr := fmt.Sprintf("%d command(s)", len(plugin.Metadata.Commands))
+		if len(plugin.Metadata.Commands) == 0 {
+			commandStr = "no commands"
+		}
+
+		t.AppendRow(table.Row{name, plugin.Metadata.Version, plugin.Metadata.Description, commandStr})
+		t.AppendSeparator()
+	}
+
+	t.Render()
+
+	t = newTableWriter()
+	t.AppendHeader(table.Row{"Plugin", "Command"})
+	for cmd, plugin := range registeredCommands {
+		t.AppendRow(table.Row{plugin, cmd})
+		t.AppendSeparator()
+	}
+	t.Render()
+
+	return nil
+}
+
+func pluginInfoTableOutput(plugin *plugins.LoadedPlugin) error {
+	t := newTableWriter()
+
+	t.AppendHeader(table.Row{"Name", "Version", "Description", "Commands"})
+	t.AppendRow(table.Row{plugin.Metadata.Name, plugin.Metadata.Version, plugin.Metadata.Description, fmt.Sprintf("%d command(s)", len(plugin.Metadata.Commands))})
+
+	t.Render()
+
+	pluginInfoCommandsTableOutput(plugin)
+	pluginInfoFlagsTableOutput(plugin)
+
+	return nil
+}
+
+func pluginInfoCommandsTableOutput(plugin *plugins.LoadedPlugin) error {
+	t := newTableWriter()
+
+	t.AppendHeader(table.Row{"Plugin", "Command", "Description", "Usage"})
+	for _, cmd := range plugin.Metadata.Commands {
+		t.AppendRow(table.Row{plugin.Metadata.Name, cmd.Name, cmd.Description, cmd.Usage})
+		t.AppendSeparator()
+	}
+
+	t.Render()
+
+	return nil
+}
+
+func pluginInfoFlagsTableOutput(plugin *plugins.LoadedPlugin) error {
+	t := newTableWriter()
+
+	t.AppendHeader(table.Row{"Plugin", "Command", "Flag", "Description", "Type", "Default", "Required"})
+	for _, cmd := range plugin.Metadata.Commands {
+		for _, flag := range cmd.Flags {
+			t.AppendRow(table.Row{plugin.Metadata.Name, cmd.Name, flag.Name, flag.Description, flag.Type, flag.Default, flag.Required})
+			t.AppendSeparator()
+		}
+	}
+
+	t.Render()
+
+	return nil
+}

--- a/app/cli/cmd/root.go
+++ b/app/cli/cmd/root.go
@@ -251,7 +251,15 @@ func NewRootCmd(l zerolog.Logger) *cobra.Command {
 		newAttestationCmd(), newArtifactCmd(), newConfigCmd(),
 		newIntegrationCmd(), newOrganizationCmd(), newCASBackendCmd(),
 		newReferrerDiscoverCmd(),
+		newPluginCmd(),
 	)
+
+	// Load plugins if we are not running a subcommand
+	if len(os.Args) > 1 && os.Args[1] != "completion" && os.Args[1] != "help" {
+		if err := loadAllPlugins(rootCmd); err != nil {
+			logger.Debug().Err(err).Msg("Failed to load plugins, continuing with built-in commands only")
+		}
+	}
 
 	return rootCmd
 }
@@ -337,6 +345,7 @@ func newActionOpts(logger zerolog.Logger, conn *grpc.ClientConn, token string) *
 }
 
 func cleanup(conn *grpc.ClientConn) error {
+	cleanupPlugins()
 	if conn != nil {
 		if err := conn.Close(); err != nil {
 			return err

--- a/pkg/plugins/client.go
+++ b/pkg/plugins/client.go
@@ -1,0 +1,101 @@
+package plugins
+
+import (
+	"context"
+	"net/rpc"
+
+	"github.com/hashicorp/go-plugin"
+)
+
+// ChainloopCliPlugin is the implementation of plugin.Plugin.
+type ChainloopCliPlugin struct {
+	Impl Plugin
+}
+
+func (p *ChainloopCliPlugin) Server(*plugin.MuxBroker) (interface{}, error) {
+	return &RPCServer{Impl: p.Impl}, nil
+}
+
+func (ChainloopCliPlugin) Client(b *plugin.MuxBroker, c *rpc.Client) (interface{}, error) {
+	return &RPCClient{client: c}, nil
+}
+
+// RPCClient is an implementation of Plugin that talks over RPC.
+type RPCClient struct {
+	client *rpc.Client
+}
+
+func (m *RPCClient) Exec(ctx context.Context, command string, arguments map[string]any) (ExecResult, error) {
+	var resp ExecResponse
+	err := m.client.Call("Plugin.Exec", map[string]any{
+		"command":   command,
+		"arguments": arguments,
+	}, &resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (m *RPCClient) GetMetadata(ctx context.Context) (PluginMetadata, error) {
+	var resp PluginMetadata
+	err := m.client.Call("Plugin.GetMetadata", new(any), &resp)
+	return resp, err
+}
+
+// RPCServer is the RPC server that RPCClient talks to, conforming to the requirements of net/rpc.
+type RPCServer struct {
+	Impl Plugin
+}
+
+func (m *RPCServer) Exec(args map[string]any, resp *ExecResponse) error {
+	ctx := context.Background()
+	command := args["command"].(string)
+	arguments := args["arguments"].(map[string]any)
+
+	result, err := m.Impl.Exec(ctx, command, arguments)
+	if err != nil {
+		return err
+	}
+
+	*resp = ExecResponse{
+		Output:   result.GetOutput(),
+		Error:    result.GetError(),
+		ExitCode: result.GetExitCode(),
+		Data:     result.GetData(),
+	}
+	return nil
+}
+
+func (m *RPCServer) GetMetadata(args any, resp *PluginMetadata) error {
+	metadata, err := m.Impl.GetMetadata(context.Background())
+	if err != nil {
+		return err
+	}
+	*resp = metadata
+	return nil
+}
+
+// ExecResponse is a concrete implementation of ExecResult for RPC.
+type ExecResponse struct {
+	Output   string
+	Error    string
+	ExitCode int
+	Data     map[string]any
+}
+
+func (r *ExecResponse) GetOutput() string {
+	return r.Output
+}
+
+func (r *ExecResponse) GetError() string {
+	return r.Error
+}
+
+func (r *ExecResponse) GetExitCode() int {
+	return r.ExitCode
+}
+
+func (r *ExecResponse) GetData() map[string]any {
+	return r.Data
+}

--- a/pkg/plugins/interface.go
+++ b/pkg/plugins/interface.go
@@ -1,0 +1,55 @@
+package plugins
+
+import (
+	"context"
+)
+
+// Plugin is the interface that plugins must implement.
+type Plugin interface {
+	// Exec executes a command within the plugin
+	Exec(ctx context.Context, command string, arguments map[string]any) (ExecResult, error)
+
+	// GetMetadata returns plugin metadata including commands it provides
+	GetMetadata(ctx context.Context) (PluginMetadata, error)
+}
+
+// ExecResult represents the result of executing a plugin command
+type ExecResult interface {
+	// GetOutput returns the command output
+	GetOutput() string
+
+	// GetError returns any error message
+	GetError() string
+
+	// GetExitCode returns the exit code
+	GetExitCode() int
+
+	// GetData returns any structured data
+	GetData() map[string]any
+}
+
+// PluginMetadata contains information about the plugin.
+type PluginMetadata struct {
+	Name        string
+	Version     string
+	Description string
+	Commands    []CommandInfo
+}
+
+// CommandInfo describes a command provided by the plugin
+type CommandInfo struct {
+	Name        string
+	Description string
+	Usage       string
+	Flags       []FlagInfo
+}
+
+// FlagInfo describes a command flag
+type FlagInfo struct {
+	Name        string
+	Shorthand   string
+	Description string
+	Type        string
+	Default     any
+	Required    bool
+}

--- a/pkg/plugins/manager.go
+++ b/pkg/plugins/manager.go
@@ -1,0 +1,157 @@
+package plugins
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+
+	"github.com/hashicorp/go-plugin"
+	"github.com/rs/zerolog"
+)
+
+// Manager handles loading and managing plugins.
+type Manager struct {
+	plugins       map[string]*LoadedPlugin
+	pluginClients map[string]*plugin.Client
+	logger        zerolog.Logger
+}
+
+// LoadedPlugin represents a loaded plugin with its metadata.
+type LoadedPlugin struct {
+	Path     string
+	Plugin   Plugin
+	Metadata PluginMetadata
+}
+
+// NewManager creates a new plugin manager.
+func NewManager(logger zerolog.Logger) *Manager {
+	return &Manager{
+		plugins:       make(map[string]*LoadedPlugin),
+		pluginClients: make(map[string]*plugin.Client),
+		logger:        logger,
+	}
+}
+
+// LoadPlugins loads all plugins from the plugins directory.
+func (m *Manager) LoadPlugins(ctx context.Context) error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to get user home directory: %w", err)
+	}
+
+	pluginsDir := filepath.Join(homeDir, ".config", "chainloop", "plugins") // TODO: make this configurable
+
+	if err := os.MkdirAll(pluginsDir, 0755); err != nil {
+		return fmt.Errorf("failed to create plugins directory: %w", err)
+	}
+
+	entries, err := os.ReadDir(pluginsDir)
+	if err != nil {
+		return fmt.Errorf("failed to read plugins directory: %w", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		pluginPath := filepath.Join(pluginsDir, entry.Name())
+
+		info, err := entry.Info()
+		if err != nil {
+			m.logger.Err(err).Str("pluginPath", pluginPath).Msg("failed to get info for plugin")
+			continue
+		}
+
+		// On Windows, check for .exe extension
+		if runtime.GOOS == "windows" && filepath.Ext(pluginPath) != ".exe" {
+			continue
+		}
+
+		// On Unix, check if executable
+		if runtime.GOOS != "windows" && info.Mode()&0111 == 0 {
+			continue
+		}
+
+		// Load the plugin
+		if err := m.loadPlugin(ctx, pluginPath); err != nil {
+			m.logger.Err(err).Str("pluginPath", pluginPath).Msg("failed to load plugin")
+			continue
+		}
+	}
+
+	return nil
+}
+
+// loadPlugin loads a single plugin.
+func (m *Manager) loadPlugin(ctx context.Context, path string) error {
+	client := plugin.NewClient(&plugin.ClientConfig{
+		HandshakeConfig: Handshake,
+		Plugins:         PluginMap,
+		Cmd:             exec.Command(path),
+		AllowedProtocols: []plugin.Protocol{
+			plugin.ProtocolNetRPC,
+		},
+	})
+
+	// Connect via RPC
+	rpcClient, err := client.Client()
+	if err != nil {
+		client.Kill()
+		return fmt.Errorf("failed to create RPC client: %w", err)
+	}
+
+	// Request the plugin
+	raw, err := rpcClient.Dispense("chainloop")
+	if err != nil {
+		client.Kill()
+		return fmt.Errorf("failed to dispense plugin: %w", err)
+	}
+
+	// Cast to our interface
+	chainloopPlugin, ok := raw.(Plugin)
+	if !ok {
+		client.Kill()
+		return fmt.Errorf("plugin does not implement Plugin interface")
+	}
+
+	// Get plugin metadata
+	metadata, err := chainloopPlugin.GetMetadata(ctx)
+	if err != nil {
+		client.Kill()
+		return fmt.Errorf("failed to get plugin metadata: %w", err)
+	}
+
+	// Store the plugin
+	m.plugins[metadata.Name] = &LoadedPlugin{
+		Path:     path,
+		Plugin:   chainloopPlugin,
+		Metadata: metadata,
+	}
+	m.pluginClients[metadata.Name] = client
+
+	m.logger.Debug().Str("pluginName", metadata.Name).Str("pluginVersion", metadata.Version).Msg("loaded plugin")
+	return nil
+}
+
+// GetPlugin returns a loaded plugin by name.
+func (m *Manager) GetPlugin(name string) (*LoadedPlugin, bool) {
+	plugin, ok := m.plugins[name]
+	return plugin, ok
+}
+
+// GetAllPlugins returns all loaded plugins.
+func (m *Manager) GetAllPlugins() map[string]*LoadedPlugin {
+	return m.plugins
+}
+
+// Shutdown closes all plugin connections.
+func (m *Manager) Shutdown() {
+	for name, client := range m.pluginClients {
+		m.logger.Debug().Str("pluginName", name).Msg("shutting down plugin")
+		client.Kill()
+	}
+}

--- a/pkg/plugins/shared.go
+++ b/pkg/plugins/shared.go
@@ -1,0 +1,33 @@
+package plugins
+
+import (
+	"encoding/gob"
+
+	"github.com/hashicorp/go-plugin"
+)
+
+func init() {
+	// Register types that will be sent over RPC
+	gob.Register(map[string]any{})
+	gob.Register([]any{})
+	gob.Register(ExecResponse{})
+	gob.Register(PluginMetadata{})
+	gob.Register(CommandInfo{})
+	gob.Register(FlagInfo{})
+	gob.Register([]CommandInfo{})
+	gob.Register([]FlagInfo{})
+	gob.Register([]string{})
+	gob.Register([]map[string]any{})
+}
+
+// Handshake is a common handshake that is shared by CLI plugins and the host.
+var Handshake = plugin.HandshakeConfig{
+	ProtocolVersion:  1,
+	MagicCookieKey:   "CHAINLOOP_CLI_PLUGIN",
+	MagicCookieValue: "chainloop-cli-plugin-v1",
+}
+
+// PluginMap is the map of plugins.
+var PluginMap = map[string]plugin.Plugin{
+	"chainloop": &ChainloopCliPlugin{},
+}


### PR DESCRIPTION
This is an experimental approach to https://github.com/chainloop-dev/chainloop/issues/2090 - the part of the whole solution providing the framework part. 

An example implementation could look more or less like this:

**main.go**:

```
package main

import (
	"log"
	"os"

	"github.com/chainloop-dev/chainloop/pkg/plugins"
	"github.com/gr0/example-plugin/pkg"
	"github.com/hashicorp/go-plugin"
)

func main() {
	log.SetOutput(os.Stderr)
	log.Println("Plugin starting...")

	// Create the plugin instance
	pluginInstance := &pkg.ExamplePlugin{}
	log.Println("Plugin instance created")

	plugin.Serve(&plugin.ServeConfig{
		HandshakeConfig: plugins.Handshake,
		Plugins: map[string]plugin.Plugin{
			"chainloop": &plugins.ChainloopCliPlugin{Impl: pluginInstance},
		},
	})
}
```

And the **pkg/plugin.go**:

```
package pkg

import (
	"context"
	"encoding/json"
	"fmt"
	"io"
	"net/http"
	"time"

	"github.com/chainloop-dev/chainloop/pkg/plugins"
)

type ExamplePlugin struct{}

func (p *ExamplePlugin) Exec(ctx context.Context, command string, arguments map[string]interface{}) (plugins.ExecResult, error) {
	switch command {
	case "example-hello":
		return p.execHello(ctx, arguments)
	default:
		return &Result{
			Error:    fmt.Sprintf("Unknown command: %s", command),
			ExitCode: 1,
		}, nil
	}
}

func (p *ExamplePlugin) execHello(ctx context.Context, arguments map[string]interface{}) (plugins.ExecResult, error) {
	return &Result{
		Output: "Hello, World!",
	}, nil
}

func (p *ExamplePlugin) GetMetadata(ctx context.Context) (plugins.PluginMetadata, error) {
	return plugins.PluginMetadata{
		Name:        "example",
		Version:     "1.0.0",
		Description: "Example plugin",
		Commands: []plugins.CommandInfo{
			{
				Name:        "example-hello",
				Description: "Greet with hello",
				Usage:       "chainloop example-hello",
				Flags:       []plugins.FlagInfo{},
			},
		},
	}, nil
}

type Result struct {
	Output   string
	Error    string
	ExitCode int
	Data     map[string]interface{}
}

func (r *Result) GetOutput() string {
	return r.Output
}

func (r *Result) GetError() string {
	return r.Error
}

func (r *Result) GetExitCode() int {
	return r.ExitCode
}

func (r *Result) GetData() map[string]interface{} {
	return r.Data
}
```