### PR TITLE
feat(scorecards): Update labs reference on scorecards

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -85,7 +85,7 @@ jobs:
 
   chainloop_push:
     name: Chainloop Push
-    uses: chainloop-dev/labs/.github/workflows/chainloop_push.yml@6bbd1c2b3022e48ae60afa0c2b90f3b6d31bcf11
+    uses: chainloop-dev/labs/.github/workflows/chainloop_push.yml@1e19b4d199657cf44ebcb0f554f0b7276d1c4543
     needs:
       - analysis
     secrets:


### PR DESCRIPTION
This patch updates the referece of `chainloop_push` action from Labs.