### PR TITLE
fix(chart): increase auto-generated entropy

### DIFF
--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -7,7 +7,7 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.230.0
+version: 1.230.1
 # Do not update appVersion, this is handled automatically by the release process
 appVersion: v1.4.5
 

--- a/deployment/chainloop/templates/controlplane/secret-config.yaml
+++ b/deployment/chainloop/templates/controlplane/secret-config.yaml
@@ -13,7 +13,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 type: Opaque
-{{- $hmacpass := include "common.secrets.passwords.manage" (dict "secret" (include "chainloop.controlplane.fullname" .) "key" "generated_jws_hmac_secret" "providedValues" (list "controlplane.auth.passphrase") "context" $) }}
+{{- $hmacpass := include "common.secrets.passwords.manage" (dict "secret" (include "chainloop.controlplane.fullname" .) "key" "generated_jws_hmac_secret" "providedValues" (list "controlplane.auth.passphrase") "length" 32  "context" $) }}
 data:
   # We store it also as a different key so it can be reused during upgrades by the common.secrets.passwords.manage helper
   generated_jws_hmac_secret: {{ $hmacpass }}


### PR DESCRIPTION
```diff
helm template foo chainloop --set development=true > /tmp/after.yaml && diff -u /tmp/before.yaml /tmp/after.yaml
--- /tmp/before.yaml	2025-06-05 17:30:30
+++ /tmp/after.yaml	2025-06-05 17:37:29
@@ -442,7 +442,7 @@
 type: Opaque
 data:
   # We store it also as a different key so it can be reused during upgrades by the common.secrets.passwords.manage helper
-  generated_jws_hmac_secret: "Mk1JRk1KRFlIWg=="
+  generated_jws_hmac_secret: "WlVYM25DQUpJZmJDcDIxSGlWMTYxZDc5dDV6ZEZCSU4="
   db_migrate_source: "cG9zdGdyZXM6Ly9jaGFpbmxvb3A6Y2hhaW5sb29wcHdkQGZvby1wb3N0Z3Jlc3FsOjU0MzIvY2hhaW5sb29wLWNwP3NzbG1vZGU9ZGlzYWJsZQ=="
 stringData:
   config.secret.yaml: |
@@ -466,7 +466,7 @@
       # HMAC key used to sign the JWTs generated by the controlplane
       # The helper returns the base64 quoted value of the secret
       # We need to remove the quotes and then decoding it so it's compatible with the stringData stanza
-      generated_jws_hmac_secret: "2MIFMJDYHZ"
+      generated_jws_hmac_secret: "ZUX3nCAJIfbCp21HiV161d79t5zdFBIN"
```

Thanks @snieguu for the report