### PR TITLE
feat(api-token): Allow API tokens to list workflows

### DIFF
--- a/app/controlplane/pkg/biz/apitoken.go
+++ b/app/controlplane/pkg/biz/apitoken.go
@@ -86,8 +86,8 @@ func NewAPITokenUseCase(apiTokenRepo APITokenRepo, jwtConfig *APITokenJWTConfig,
 		DefaultAuthzPolicies: []*authz.Policy{
 			// Add permissions to workflow run
 			authz.PolicyWorkflowRunList, authz.PolicyWorkflowRunRead,
-			// To read and create workflows
-			authz.PolicyWorkflowRead, authz.PolicyWorkflowCreate,
+			// To read, list and create workflows
+			authz.PolicyWorkflowRead, authz.PolicyWorkflowList, authz.PolicyWorkflowCreate,
 			// Add permissions to workflow contract management
 			authz.PolicyWorkflowContractList, authz.PolicyWorkflowContractRead, authz.PolicyWorkflowContractUpdate, authz.PolicyWorkflowContractCreate,
 			// to download artifacts and list referrers


### PR DESCRIPTION
This pull request includes a small change to the `DefaultAuthzPolicies` configuration in the `NewAPITokenUseCase` function. The change adds the ability to list workflows by including `authz.PolicyWorkflowList` in the default authorization policies.

Workflow list commands works as expected:
```
$ chainloop --insecure wf ls --full
WRN API contacted in insecure mode
WRN Both user credentials and $CHAINLOOP_TOKEN set. Ignoring $CHAINLOOP_TOKEN.
┌────────────┬─────────────┬────────────┬──────┬───────────────────────┬────────┬─────────────┬─────────────────┬─────────────────────┐
│ NAME       │ DESCRIPTION │ PROJECT    │ TEAM │ CONTRACT              │ PUBLIC │ RUNNER      │ LAST RUN STATUS │ CREATED AT          │
├────────────┼─────────────┼────────────┼──────┼───────────────────────┼────────┼─────────────┼─────────────────┼─────────────────────┤
│ no-version │             │ no-version │      │ no-version-no-version │ false  │ Unspecified │ success         │ 10 Jun 25 09:39 UTC │
└────────────┴─────────────┴────────────┴──────┴───────────────────────┴────────┴─────────────┴─────────────────┴─────────────────────┘
INF Showing [1-1] out of 1
```

With token:
```
$ chainloop --insecure wf ls --full --token eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiIxZDRkMWJjZS00NTlhLTQyNzAtYWQ1ZS1lODI0NjJkZWQ2NjAiLCJvcmdfbmFtZSI6InRlc3RpbmdhYSIsImlzcyI6ImNwLmNoYWlubG9vcCIsImF1ZCI6WyJhcGktdG9rZW4tYXV0aC5jaGFpbmxvb3AiXSwianRpIjoiMDQ2NWY4ZGMtMWE0MC00N2I2LTgwZWYtNTc5NTc5ZTY4MDM5In0.QK9IoAZ1kramzTGM-0PFQJ02uQJvl4pe9NPx9h1fMK0
WRN API contacted in insecure mode
INF API token provided to the command line
┌────────────┬─────────────┬────────────┬──────┬───────────────────────┬────────┬─────────────┬─────────────────┬─────────────────────┐
│ NAME       │ DESCRIPTION │ PROJECT    │ TEAM │ CONTRACT              │ PUBLIC │ RUNNER      │ LAST RUN STATUS │ CREATED AT          │
├────────────┼─────────────┼────────────┼──────┼───────────────────────┼────────┼─────────────┼─────────────────┼─────────────────────┤
│ no-version │             │ no-version │      │ no-version-no-version │ false  │ Unspecified │ success         │ 10 Jun 25 09:39 UTC │
└────────────┴─────────────┴────────────┴──────┴───────────────────────┴────────┴─────────────┴─────────────────┴─────────────────────┘
INF Showing [1-1] out of 1
```