### PR TITLE
chore(golang): Bump version of Golang to 1.24.4 and fix CVEs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3.6.1
         with:
-          go-version: "1.24.2"
+          go-version: "1.24.4"
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3.6.1
         with:
-          go-version: "1.24.2"
+          go-version: "1.24.4"
 
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
@@ -67,7 +67,7 @@ jobs:
 
       - uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3.6.1
         with:
-          go-version: "1.24.2"
+          go-version: "1.24.4"
 
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,7 +78,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3.6.1
         with:
-          go-version: "1.24.2"
+          go-version: "1.24.4"
 
       # install qemu binaries for multiarch builds (needed by goreleaser/buildx)
       - name: Setup qemu

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3.6.1
         with:
-          go-version: "1.24.2"
+          go-version: "1.24.4"
           cache: true
           cache-dependency-path: go.sum
 
@@ -42,7 +42,7 @@ jobs:
       - name: Generate migrations
         if: ${{ matrix.app == 'controlplane' }}
         env:
-          ATLAS_VERSION: v0.32.0
+          ATLAS_VERSION: v0.35.0
         run: |
           wget -q https://release.ariga.io/atlas/atlas-linux-amd64-$ATLAS_VERSION -O /tmp/atlas
           sudo install /tmp/atlas /usr/local/bin/atlas

--- a/app/artifact-cas/Dockerfile
+++ b/app/artifact-cas/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24@sha256:991aa6a6e4431f2f01e869a812934bd60fbc87fb939e4a1ea54b8494ab9d2fc6 AS builder
+FROM golang:1.24.4@sha256:be70d93633d07a2acae4ff3401672b04f23e5850b0248d65c23e30dc75dded09 AS builder
 
 # Not linked libraries since it will be injected into a scratch container
 ENV CGO_ENABLED=0

--- a/app/artifact-cas/Dockerfile.goreleaser
+++ b/app/artifact-cas/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-FROM golang:1.24@sha256:991aa6a6e4431f2f01e869a812934bd60fbc87fb939e4a1ea54b8494ab9d2fc6 AS builder
+FROM golang:1.24.4@sha256:be70d93633d07a2acae4ff3401672b04f23e5850b0248d65c23e30dc75dded09 AS builder
 
 FROM scratch
 

--- a/app/cli/Dockerfile.goreleaser
+++ b/app/cli/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-FROM golang:1.24@sha256:991aa6a6e4431f2f01e869a812934bd60fbc87fb939e4a1ea54b8494ab9d2fc6 AS builder
+FROM golang:1.24.4@sha256:be70d93633d07a2acae4ff3401672b04f23e5850b0248d65c23e30dc75dded09 AS builder
 RUN mkdir -p /.config/chainloop
 
 FROM scratch

--- a/app/controlplane/Dockerfile
+++ b/app/controlplane/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24@sha256:991aa6a6e4431f2f01e869a812934bd60fbc87fb939e4a1ea54b8494ab9d2fc6 AS builder
+FROM golang:1.24.4@sha256:be70d93633d07a2acae4ff3401672b04f23e5850b0248d65c23e30dc75dded09 AS builder
 
 # Not linked libraries since it will be injected into a scratch container
 ENV CGO_ENABLED=0

--- a/app/controlplane/Dockerfile.goreleaser
+++ b/app/controlplane/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-FROM golang:1.24@sha256:991aa6a6e4431f2f01e869a812934bd60fbc87fb939e4a1ea54b8494ab9d2fc6 AS builder
+FROM golang:1.24.4@sha256:be70d93633d07a2acae4ff3401672b04f23e5850b0248d65c23e30dc75dded09 AS builder
 
 FROM scratch
 

--- a/app/controlplane/Dockerfile.migrations
+++ b/app/controlplane/Dockerfile.migrations
@@ -1,9 +1,9 @@
 # Container image built by go-releaser that's used to run migrations against the database during deployment
 # See https://atlasgo.io/guides/deploying/image
 # from: arigaio/atlas:latest
-# docker run arigaio/atlas@sha256:5b52e74c938e2e32df081be435501d0de8f7a019840d7cc844997e6af0061bc1 version
-# atlas version v0.32.1-819f32c-canary
-FROM arigaio/atlas@sha256:5b52e74c938e2e32df081be435501d0de8f7a019840d7cc844997e6af0061bc1 as base
+# docker run arigaio/atlas@sha256:16739cffc8d44d04e76f58842dc12835e183fe7164d0ae55544fc8bc9fbb1e33 version
+# atlas version v0.35.0
+FROM arigaio/atlas@sha256:16739cffc8d44d04e76f58842dc12835e183fe7164d0ae55544fc8bc9fbb1e33 as base
 
 FROM scratch
 # Update permissions to make it readable by the user

--- a/common.mk
+++ b/common.mk
@@ -7,7 +7,7 @@ init: init-api-tools
 	go install github.com/vektra/mockery/v2@v2.53.4
 	# using binary release for atlas, since ent schema handler is not included
 	# in the community version anymore https://github.com/ariga/atlas/issues/2388#issuecomment-1864287189
-	curl -sSf https://atlasgo.sh | ATLAS_VERSION=v0.32.0 sh -s -- -y
+	curl -sSf https://atlasgo.sh | ATLAS_VERSION=v0.35.0 sh -s -- -y
 
 # initialize API tooling
 .PHONY: init-api-tools

--- a/docs/examples/ci-workflows/github.yaml
+++ b/docs/examples/ci-workflows/github.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.24.2"
+          go-version: "1.24.4"
 
       # Generate SBOM using syft in cycloneDX format
       - uses: anchore/sbom-action@v0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chainloop-dev/chainloop
 
-go 1.24.2
+go 1.24.4
 
 require (
 	cloud.google.com/go/secretmanager v1.14.2


### PR DESCRIPTION
This patch bumps the Golang version to 1.24.4 fixing several CVEs as well as the Atlas version to v0.35.0 which also fixes a few CVEs.