### PR TITLE
feat(rbac): implement Project Viewer role

### DIFF
--- a/app/controlplane/pkg/authz/authz.go
+++ b/app/controlplane/pkg/authz/authz.go
@@ -212,6 +212,11 @@ var rolesMap = map[Role][]*Policy{
 		PolicyOrgMetricsRead,
 		PolicyReferrerRead,
 	},
+	// RoleProjectViewer: has read-only permissions on a project
+	RoleProjectViewer: {
+		PolicyWorkflowRead,
+		PolicyWorkflowRunRead,
+	},
 	// RoleProjectAdmin: represents a project administrator. It's the higher role in project resources,
 	// and it's only considered when the org-level role is `RoleOrgMember`
 	RoleProjectAdmin: {
@@ -233,9 +238,6 @@ var rolesMap = map[Role][]*Policy{
 		// integrations
 		PolicyAttachedIntegrationAttach,
 		PolicyAttachedIntegrationDetach,
-
-		// metrics
-		PolicyOrgMetricsRead,
 	},
 }
 


### PR DESCRIPTION
Simple PR to implement Project Viewer permissions.
Note that many permissions are inherited from the "Org Member" role, although RBAC is applied when needed.

I've also removed OrgMetricsRead, which is not needed, since it's assumed from the organization role.

Example command with **Project Admin** role on project "proj13":
```bash
➜ cldev wf create --project proj13 --name wf
WRN API contacted in insecure mode
┌──────┬─────────┬───────────┬────────┬────────┬─────────────────┬─────────────────────┐
│ NAME │ PROJECT │ CONTRACT  │ PUBLIC │ RUNNER │ LAST RUN STATUS │ CREATED AT          │
├──────┼─────────┼───────────┼────────┼────────┼─────────────────┼─────────────────────┤
│ wf   │ proj13  │ proj13-wf │ false  │        │                 │ 25 Jun 25 09:33 UTC │
└──────┴─────────┴───────────┴────────┴────────┴─────────────────┴─────────────────────┘
INF To Attest this workflow you'll need to provide an API token. See "chainloop organization api-token" command for more information.
```

After changing to **Project Viewer** in "proj13":
```bash
➜  cldev wf create --project proj13 --name wf
WRN API contacted in insecure mode
ERR operation not allowed
exit status 1
```
