### PR TITLE
feat(rbac): sync only known resource policies

### DIFF
--- a/app/controlplane/cmd/wire.go
+++ b/app/controlplane/cmd/wire.go
@@ -64,8 +64,13 @@ func wireApp(*conf.Bootstrap, credentials.ReaderWriter, log.Logger, sdk.Availabl
 			newCASServerOptions,
 			newAuthAllowList,
 			newJWTConfig,
+			authzManagedResources,
 		),
 	)
+}
+
+func authzManagedResources() []authz.Resource {
+	return authz.AuthzManagedResources
 }
 
 func newJWTConfig(conf *conf.Auth) *biz.APITokenJWTConfig {

--- a/app/controlplane/cmd/wire.go
+++ b/app/controlplane/cmd/wire.go
@@ -64,13 +64,13 @@ func wireApp(*conf.Bootstrap, credentials.ReaderWriter, log.Logger, sdk.Availabl
 			newCASServerOptions,
 			newAuthAllowList,
 			newJWTConfig,
-			authzManagedResources,
+			authzConfig,
 		),
 	)
 }
 
-func authzManagedResources() []authz.Resource {
-	return authz.AuthzManagedResources
+func authzConfig() *authz.Config {
+	return &authz.Config{ManagedResources: authz.ManagedResources, RolesMap: authz.RolesMap}
 }
 
 func newJWTConfig(conf *conf.Auth) *biz.APITokenJWTConfig {

--- a/app/controlplane/cmd/wire_gen.go
+++ b/app/controlplane/cmd/wire_gen.go
@@ -107,8 +107,8 @@ func wireApp(bootstrap *conf.Bootstrap, readerWriter credentials.ReaderWriter, l
 	}
 	apiTokenRepo := data.NewAPITokenRepo(dataData, logger)
 	apiTokenJWTConfig := newJWTConfig(auth)
-	v3 := authzManagedResources()
-	enforcer, err := authz.NewDatabaseEnforcer(databaseConfig, v3)
+	config := authzConfig()
+	enforcer, err := authz.NewDatabaseEnforcer(databaseConfig, config)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
@@ -119,9 +119,9 @@ func wireApp(bootstrap *conf.Bootstrap, readerWriter credentials.ReaderWriter, l
 		return nil, nil, err
 	}
 	workflowContractRepo := data.NewWorkflowContractRepo(dataData, logger)
-	v4 := bootstrap.PolicyProviders
-	v5 := newPolicyProviderConfig(v4)
-	registry, err := policies.NewRegistry(logger, v5...)
+	v3 := bootstrap.PolicyProviders
+	v4 := newPolicyProviderConfig(v3)
+	registry, err := policies.NewRegistry(logger, v4...)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
@@ -129,8 +129,8 @@ func wireApp(bootstrap *conf.Bootstrap, readerWriter credentials.ReaderWriter, l
 	workflowContractUseCase := biz.NewWorkflowContractUseCase(workflowContractRepo, registry, auditorUseCase, logger)
 	workflowUseCase := biz.NewWorkflowUsecase(workflowRepo, projectsRepo, workflowContractUseCase, auditorUseCase, membershipUseCase, logger)
 	projectUseCase := biz.NewProjectsUseCase(logger, projectsRepo)
-	v6 := serviceOpts(logger, enforcer, projectUseCase)
-	workflowService := service.NewWorkflowService(workflowUseCase, workflowContractUseCase, projectUseCase, v6...)
+	v5 := serviceOpts(logger, enforcer, projectUseCase)
+	workflowService := service.NewWorkflowService(workflowUseCase, workflowContractUseCase, projectUseCase, v5...)
 	orgInvitationRepo := data.NewOrgInvitation(dataData, logger)
 	orgInvitationUseCase, err := biz.NewOrgInvitationUseCase(orgInvitationRepo, membershipRepo, userRepo, auditorUseCase, logger)
 	if err != nil {
@@ -138,12 +138,12 @@ func wireApp(bootstrap *conf.Bootstrap, readerWriter credentials.ReaderWriter, l
 		return nil, nil, err
 	}
 	confServer := bootstrap.Server
-	authService, err := service.NewAuthService(userUseCase, organizationUseCase, membershipUseCase, orgInvitationUseCase, auth, confServer, auditorUseCase, v6...)
+	authService, err := service.NewAuthService(userUseCase, organizationUseCase, membershipUseCase, orgInvitationUseCase, auth, confServer, auditorUseCase, v5...)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
 	}
-	robotAccountService := service.NewRobotAccountService(robotAccountUseCase, v6...)
+	robotAccountService := service.NewRobotAccountService(robotAccountUseCase, v5...)
 	workflowRunRepo := data.NewWorkflowRunRepo(dataData, logger)
 	signingUseCase, err := biz.NewChainloopSigningUseCase(bootstrap, logger)
 	if err != nil {
@@ -160,21 +160,21 @@ func wireApp(bootstrap *conf.Bootstrap, readerWriter credentials.ReaderWriter, l
 		WorkflowUC:         workflowUseCase,
 		WorkflowContractUC: workflowContractUseCase,
 		CredsReader:        readerWriter,
-		Opts:               v6,
+		Opts:               v5,
 	}
 	workflowRunService := service.NewWorkflowRunService(newWorkflowRunServiceOpts)
 	attestationUseCase := biz.NewAttestationUseCase(casClientUseCase, logger)
 	fanOutDispatcher := dispatcher.New(integrationUseCase, workflowUseCase, workflowRunUseCase, readerWriter, casClientUseCase, availablePlugins, logger)
 	casMappingRepo := data.NewCASMappingRepo(dataData, casBackendRepo, logger)
 	casMappingUseCase := biz.NewCASMappingUseCase(casMappingRepo, membershipRepo, projectsRepo, logger)
-	v7 := bootstrap.PrometheusIntegration
+	v6 := bootstrap.PrometheusIntegration
 	orgMetricsRepo := data.NewOrgMetricsRepo(dataData, logger)
 	orgMetricsUseCase, err := biz.NewOrgMetricsUseCase(orgMetricsRepo, organizationRepo, workflowUseCase, logger)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
 	}
-	prometheusUseCase := biz.NewPrometheusUseCase(v7, organizationUseCase, orgMetricsUseCase, logger)
+	prometheusUseCase := biz.NewPrometheusUseCase(v6, organizationUseCase, orgMetricsUseCase, logger)
 	projectVersionRepo := data.NewProjectVersionRepo(dataData, logger)
 	projectVersionUseCase := biz.NewProjectVersionUseCase(projectVersionRepo, logger)
 	newAttestationServiceOpts := &service.NewAttestationServiceOpts{
@@ -194,24 +194,24 @@ func wireApp(bootstrap *conf.Bootstrap, readerWriter credentials.ReaderWriter, l
 		ProjectUC:          projectUseCase,
 		ProjectVersionUC:   projectVersionUseCase,
 		SigningUseCase:     signingUseCase,
-		Opts:               v6,
+		Opts:               v5,
 	}
 	attestationService := service.NewAttestationService(newAttestationServiceOpts)
-	workflowContractService := service.NewWorkflowSchemaService(workflowContractUseCase, v6...)
-	contextService := service.NewContextService(casBackendUseCase, userUseCase, v6...)
-	casCredentialsService := service.NewCASCredentialsService(casCredentialsUseCase, casMappingUseCase, casBackendUseCase, enforcer, v6...)
-	orgMetricsService := service.NewOrgMetricsService(orgMetricsUseCase, v6...)
-	integrationsService := service.NewIntegrationsService(integrationUseCase, workflowUseCase, availablePlugins, v6...)
-	organizationService := service.NewOrganizationService(membershipUseCase, organizationUseCase, v6...)
-	casBackendService := service.NewCASBackendService(casBackendUseCase, providers, v6...)
-	casRedirectService, err := service.NewCASRedirectService(casMappingUseCase, casCredentialsUseCase, bootstrap_CASServer, v6...)
+	workflowContractService := service.NewWorkflowSchemaService(workflowContractUseCase, v5...)
+	contextService := service.NewContextService(casBackendUseCase, userUseCase, v5...)
+	casCredentialsService := service.NewCASCredentialsService(casCredentialsUseCase, casMappingUseCase, casBackendUseCase, enforcer, v5...)
+	orgMetricsService := service.NewOrgMetricsService(orgMetricsUseCase, v5...)
+	integrationsService := service.NewIntegrationsService(integrationUseCase, workflowUseCase, availablePlugins, v5...)
+	organizationService := service.NewOrganizationService(membershipUseCase, organizationUseCase, v5...)
+	casBackendService := service.NewCASBackendService(casBackendUseCase, providers, v5...)
+	casRedirectService, err := service.NewCASRedirectService(casMappingUseCase, casCredentialsUseCase, bootstrap_CASServer, v5...)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
 	}
-	orgInvitationService := service.NewOrgInvitationService(orgInvitationUseCase, v6...)
-	referrerService := service.NewReferrerService(referrerUseCase, v6...)
-	apiTokenService := service.NewAPITokenService(apiTokenUseCase, v6...)
+	orgInvitationService := service.NewOrgInvitationService(orgInvitationUseCase, v5...)
+	referrerService := service.NewReferrerService(referrerUseCase, v5...)
+	apiTokenService := service.NewAPITokenService(apiTokenUseCase, v5...)
 	attestationStateRepo := data.NewAttestationStateRepo(dataData, logger)
 	attestationStateUseCase, err := biz.NewAttestationStateUseCase(attestationStateRepo, workflowRunRepo)
 	if err != nil {
@@ -222,15 +222,15 @@ func wireApp(bootstrap *conf.Bootstrap, readerWriter credentials.ReaderWriter, l
 		AttestationStateUseCase: attestationStateUseCase,
 		WorkflowUseCase:         workflowUseCase,
 		WorkflowRunUseCase:      workflowRunUseCase,
-		Opts:                    v6,
+		Opts:                    v5,
 	}
 	attestationStateService := service.NewAttestationStateService(newAttestationStateServiceOpt)
-	userService := service.NewUserService(membershipUseCase, organizationUseCase, v6...)
-	signingService := service.NewSigningService(signingUseCase, v6...)
-	prometheusService := service.NewPrometheusService(organizationUseCase, prometheusUseCase, v6...)
+	userService := service.NewUserService(membershipUseCase, organizationUseCase, v5...)
+	signingService := service.NewSigningService(signingUseCase, v5...)
+	prometheusService := service.NewPrometheusService(organizationUseCase, prometheusUseCase, v5...)
 	groupRepo := data.NewGroupRepo(dataData, logger)
 	groupUseCase := biz.NewGroupUseCase(logger, groupRepo, membershipRepo, auditorUseCase)
-	groupService := service.NewGroupService(groupUseCase, v6...)
+	groupService := service.NewGroupService(groupUseCase, v5...)
 	federatedAuthentication := bootstrap.FederatedAuthentication
 	validator, err := newProtoValidator()
 	if err != nil {
@@ -311,8 +311,8 @@ var (
 
 // wire.go:
 
-func authzManagedResources() []authz.Resource {
-	return authz.AuthzManagedResources
+func authzConfig() *authz.Config {
+	return &authz.Config{ManagedResources: authz.ManagedResources, RolesMap: authz.RolesMap}
 }
 
 func newJWTConfig(conf2 *conf.Auth) *biz.APITokenJWTConfig {

--- a/app/controlplane/pkg/authz/authz_integration_test.go
+++ b/app/controlplane/pkg/authz/authz_integration_test.go
@@ -33,9 +33,9 @@ func TestMultiReplicaPropagation(t *testing.T) {
 	db := testhelpers.NewTestDatabase(t)
 	defer db.Close(t)
 
-	enforcerA, err := authz.NewDatabaseEnforcer(testhelpers.NewDataConfig(testhelpers.NewConfData(db, t)), []authz.Resource{})
+	enforcerA, err := authz.NewDatabaseEnforcer(testhelpers.NewDataConfig(testhelpers.NewConfData(db, t)), &authz.Config{})
 	require.NoError(t, err)
-	enforcerB, err := authz.NewDatabaseEnforcer(testhelpers.NewDataConfig(testhelpers.NewConfData(db, t)), []authz.Resource{})
+	enforcerB, err := authz.NewDatabaseEnforcer(testhelpers.NewDataConfig(testhelpers.NewConfData(db, t)), &authz.Config{})
 	require.NoError(t, err)
 
 	// Subject and policies to add

--- a/app/controlplane/pkg/authz/authz_integration_test.go
+++ b/app/controlplane/pkg/authz/authz_integration_test.go
@@ -33,9 +33,9 @@ func TestMultiReplicaPropagation(t *testing.T) {
 	db := testhelpers.NewTestDatabase(t)
 	defer db.Close(t)
 
-	enforcerA, err := authz.NewDatabaseEnforcer(testhelpers.NewDataConfig(testhelpers.NewConfData(db, t)))
+	enforcerA, err := authz.NewDatabaseEnforcer(testhelpers.NewDataConfig(testhelpers.NewConfData(db, t)), []authz.Resource{})
 	require.NoError(t, err)
-	enforcerB, err := authz.NewDatabaseEnforcer(testhelpers.NewDataConfig(testhelpers.NewConfData(db, t)))
+	enforcerB, err := authz.NewDatabaseEnforcer(testhelpers.NewDataConfig(testhelpers.NewConfData(db, t)), []authz.Resource{})
 	require.NoError(t, err)
 
 	// Subject and policies to add

--- a/app/controlplane/pkg/authz/authz_test.go
+++ b/app/controlplane/pkg/authz/authz_test.go
@@ -215,6 +215,19 @@ func TestDoSync(t *testing.T) {
 	got, err = e.GetPolicy()
 	assert.NoError(t, err)
 	assert.Len(t, got, 1)
+
+	// add additional policy, only deletes policies for "known" resources
+	// or deleting a whole section
+	policiesM = map[Role][]*Policy{
+		"bar": {
+			PolicyAttachedIntegrationDetach,
+		},
+	}
+	err = doSync(e, policiesM, []Resource{})
+	assert.NoError(t, err)
+	got, err = e.GetPolicy()
+	assert.NoError(t, err)
+	assert.Len(t, got, 2)
 }
 
 func TestClearPolicies(t *testing.T) {

--- a/app/controlplane/pkg/authz/authz_test.go
+++ b/app/controlplane/pkg/authz/authz_test.go
@@ -134,7 +134,7 @@ func TestSyncRBACRoles(t *testing.T) {
 	defer closer.Close()
 
 	// load all the roles
-	err := syncRBACRoles(e, []Resource{})
+	err := syncRBACRoles(e, &Config{RolesMap: RolesMap})
 	assert.NoError(t, err)
 
 	// Check the inherited roles owner -> admin -> viewer
@@ -148,7 +148,7 @@ func TestSyncRBACRoles(t *testing.T) {
 	assert.Equal(t, string(RoleOwner), u[0])
 
 	// Make sure we are adding all the policies for the listed roles
-	for r, policies := range rolesMap {
+	for r, policies := range RolesMap {
 		got, err := e.GetFilteredPolicy(0, string(r))
 		assert.NoError(t, err)
 		assert.Len(t, got, len(policies))
@@ -181,7 +181,7 @@ func TestDoSync(t *testing.T) {
 	}
 
 	// load custom policies
-	err := doSync(e, policiesM, []Resource{})
+	err := doSync(e, &Config{RolesMap: policiesM})
 	assert.NoError(t, err)
 	got, err := e.GetPolicy()
 	assert.NoError(t, err)
@@ -197,7 +197,7 @@ func TestDoSync(t *testing.T) {
 		},
 	}
 
-	err = doSync(e, policiesM, []Resource{ResourceWorkflowContract, ResourceCASArtifact})
+	err = doSync(e, &Config{RolesMap: policiesM, ManagedResources: []string{ResourceWorkflowContract, ResourceCASArtifact}})
 	assert.NoError(t, err)
 	got, err = e.GetPolicy()
 	assert.NoError(t, err)
@@ -210,7 +210,7 @@ func TestDoSync(t *testing.T) {
 		},
 	}
 
-	err = doSync(e, policiesM, []Resource{ResourceWorkflowContract, ResourceCASArtifact})
+	err = doSync(e, &Config{RolesMap: policiesM, ManagedResources: []string{ResourceWorkflowContract, ResourceCASArtifact}})
 	assert.NoError(t, err)
 	got, err = e.GetPolicy()
 	assert.NoError(t, err)
@@ -223,7 +223,7 @@ func TestDoSync(t *testing.T) {
 			PolicyAttachedIntegrationDetach,
 		},
 	}
-	err = doSync(e, policiesM, []Resource{})
+	err = doSync(e, &Config{RolesMap: policiesM})
 	assert.NoError(t, err)
 	got, err = e.GetPolicy()
 	assert.NoError(t, err)
@@ -270,7 +270,7 @@ func testEnforcer(t *testing.T) (*Enforcer, io.Closer) {
 		require.FailNow(t, err.Error())
 	}
 
-	enforcer, err := NewFiletypeEnforcer(f.Name(), []Resource{})
+	enforcer, err := NewFiletypeEnforcer(f.Name(), &Config{})
 	require.NoError(t, err)
 	return enforcer, f
 }

--- a/app/controlplane/pkg/authz/authz_test.go
+++ b/app/controlplane/pkg/authz/authz_test.go
@@ -134,7 +134,7 @@ func TestSyncRBACRoles(t *testing.T) {
 	defer closer.Close()
 
 	// load all the roles
-	err := syncRBACRoles(e)
+	err := syncRBACRoles(e, []Resource{})
 	assert.NoError(t, err)
 
 	// Check the inherited roles owner -> admin -> viewer
@@ -181,7 +181,7 @@ func TestDoSync(t *testing.T) {
 	}
 
 	// load custom policies
-	err := doSync(e, policiesM)
+	err := doSync(e, policiesM, []Resource{})
 	assert.NoError(t, err)
 	got, err := e.GetPolicy()
 	assert.NoError(t, err)
@@ -197,7 +197,7 @@ func TestDoSync(t *testing.T) {
 		},
 	}
 
-	err = doSync(e, policiesM)
+	err = doSync(e, policiesM, []Resource{ResourceWorkflowContract, ResourceCASArtifact})
 	assert.NoError(t, err)
 	got, err = e.GetPolicy()
 	assert.NoError(t, err)
@@ -210,7 +210,7 @@ func TestDoSync(t *testing.T) {
 		},
 	}
 
-	err = doSync(e, policiesM)
+	err = doSync(e, policiesM, []Resource{ResourceWorkflowContract, ResourceCASArtifact})
 	assert.NoError(t, err)
 	got, err = e.GetPolicy()
 	assert.NoError(t, err)
@@ -257,7 +257,7 @@ func testEnforcer(t *testing.T) (*Enforcer, io.Closer) {
 		require.FailNow(t, err.Error())
 	}
 
-	enforcer, err := NewFiletypeEnforcer(f.Name())
+	enforcer, err := NewFiletypeEnforcer(f.Name(), []Resource{})
 	require.NoError(t, err)
 	return enforcer, f
 }

--- a/app/controlplane/pkg/biz/testhelpers/wire.go
+++ b/app/controlplane/pkg/biz/testhelpers/wire.go
@@ -61,13 +61,13 @@ func WireTestData(*TestDatabase, *testing.T, log.Logger, credentials.ReaderWrite
 			NewCASServerOptions,
 			newAuthAllowList,
 			newJWTConfig,
-			authzManagedResources,
+			authzConfig,
 		),
 	)
 }
 
-func authzManagedResources() []authz.Resource {
-	return authz.AuthzManagedResources
+func authzConfig() *authz.Config {
+	return &authz.Config{ManagedResources: authz.ManagedResources, RolesMap: authz.RolesMap}
 }
 
 func newJWTConfig(conf *conf.Auth) *biz.APITokenJWTConfig {

--- a/app/controlplane/pkg/biz/testhelpers/wire.go
+++ b/app/controlplane/pkg/biz/testhelpers/wire.go
@@ -61,8 +61,13 @@ func WireTestData(*TestDatabase, *testing.T, log.Logger, credentials.ReaderWrite
 			NewCASServerOptions,
 			newAuthAllowList,
 			newJWTConfig,
+			authzManagedResources,
 		),
 	)
+}
+
+func authzManagedResources() []authz.Resource {
+	return authz.AuthzManagedResources
 }
 
 func newJWTConfig(conf *conf.Auth) *biz.APITokenJWTConfig {

--- a/app/controlplane/pkg/biz/testhelpers/wire_gen.go
+++ b/app/controlplane/pkg/biz/testhelpers/wire_gen.go
@@ -132,8 +132,8 @@ func WireTestData(testDatabase *TestDatabase, t *testing.T, logger log.Logger, r
 	}
 	apiTokenRepo := data.NewAPITokenRepo(dataData, logger)
 	apiTokenJWTConfig := newJWTConfig(auth)
-	v3 := authzManagedResources()
-	enforcer, err := authz.NewDatabaseEnforcer(databaseConfig, v3)
+	config := authzConfig()
+	enforcer, err := authz.NewDatabaseEnforcer(databaseConfig, config)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
@@ -201,8 +201,8 @@ var (
 
 // wire.go:
 
-func authzManagedResources() []authz.Resource {
-	return authz.AuthzManagedResources
+func authzConfig() *authz.Config {
+	return &authz.Config{ManagedResources: authz.ManagedResources, RolesMap: authz.RolesMap}
 }
 
 func newJWTConfig(conf2 *conf.Auth) *biz.APITokenJWTConfig {

--- a/app/controlplane/pkg/biz/testhelpers/wire_gen.go
+++ b/app/controlplane/pkg/biz/testhelpers/wire_gen.go
@@ -132,7 +132,8 @@ func WireTestData(testDatabase *TestDatabase, t *testing.T, logger log.Logger, r
 	}
 	apiTokenRepo := data.NewAPITokenRepo(dataData, logger)
 	apiTokenJWTConfig := newJWTConfig(auth)
-	enforcer, err := authz.NewDatabaseEnforcer(databaseConfig)
+	v3 := authzManagedResources()
+	enforcer, err := authz.NewDatabaseEnforcer(databaseConfig, v3)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
@@ -199,6 +200,10 @@ var (
 )
 
 // wire.go:
+
+func authzManagedResources() []authz.Resource {
+	return authz.AuthzManagedResources
+}
 
 func newJWTConfig(conf2 *conf.Auth) *biz.APITokenJWTConfig {
 	return &biz.APITokenJWTConfig{


### PR DESCRIPTION
This small patch adds some flexibility to the RBAC policies syncer so that it doesn't delete policies for "unknown" resources. This allows other sources for policies to coexist seamlessly.
The Enforcer can now be configured with a custom set of role mappings and managed resources.

Refs #2121 