### PR TITLE
feat(attestation): add warning when outdated contract is used

### DIFF
--- a/app/cli/cmd/attestation_init.go
+++ b/app/cli/cmd/attestation_init.go
@@ -121,6 +121,18 @@ func newAttestationInitCmd() *cobra.Command {
 				return newGracefulError(err)
 			}
 
+			if !attestationDryRun && newWorkflowcontract == "" {
+				err := a.WarnIfOutdatedContract(
+					cmd.Context(),
+					workflowName,
+					projectName,
+					int32(contractRevision),
+				)
+				if err != nil {
+					return newGracefulError(err)
+				}
+			}
+
 			if res.DryRun {
 				logger.Info().Msg("The attestation is being crafted in dry-run mode. It will not get stored once rendered")
 			}

--- a/app/cli/cmd/attestation_init.go
+++ b/app/cli/cmd/attestation_init.go
@@ -121,18 +121,6 @@ func newAttestationInitCmd() *cobra.Command {
 				return newGracefulError(err)
 			}
 
-			if !attestationDryRun && newWorkflowcontract == "" {
-				err := a.WarnIfOutdatedContract(
-					cmd.Context(),
-					workflowName,
-					projectName,
-					int32(contractRevision),
-				)
-				if err != nil {
-					return newGracefulError(err)
-				}
-			}
-
 			if res.DryRun {
 				logger.Info().Msg("The attestation is being crafted in dry-run mode. It will not get stored once rendered")
 			}

--- a/app/cli/internal/action/attestation_init.go
+++ b/app/cli/internal/action/attestation_init.go
@@ -135,7 +135,7 @@ func (action *AttestationInit) Run(ctx context.Context, opts *AttestationInitRun
 	// Show warning if newer contract revision exists
 	if opts.ContractRevision > 0 && int32(opts.ContractRevision) < workflow.ContractRevisionLatest {
 		action.Logger.Warn().
-			Msgf("Newer contract revision available - latest revision: %d", workflow.ContractRevisionLatest)
+			Msgf("Newer contract revision available: %d, pinned version: %d", workflow.ContractRevisionLatest, opts.ContractRevision)
 	}
 
 	// 2 - Get contract

--- a/app/cli/internal/action/attestation_init.go
+++ b/app/cli/internal/action/attestation_init.go
@@ -132,8 +132,10 @@ func (action *AttestationInit) Run(ctx context.Context, opts *AttestationInitRun
 	}
 	workflow := workflowsResp.GetResult()
 
-	if err := action.warnIfOutdatedContract(workflow.ContractRevisionLatest, int32(opts.ContractRevision)); err != nil {
-		return "", err
+	// Show warning if newer contract revision exists
+	if opts.ContractRevision > 0 && int32(opts.ContractRevision) < workflow.ContractRevisionLatest {
+		action.Logger.Warn().
+			Msgf("Newer contract revision available - latest revision: %d", workflow.ContractRevisionLatest)
 	}
 
 	// 2 - Get contract
@@ -329,17 +331,4 @@ func groupMaterialToCraftingSchemaMaterial(gm *v1.PolicyGroup_Material, group *v
 		Name:     gm.Name,
 		Optional: gm.Optional,
 	}, nil
-}
-
-// Shows warning if newer contract revision exists
-func (action *AttestationInit) warnIfOutdatedContract(latestRevision, providedRevision int32) error {
-	if action.dryRun || action.useRemoteState || providedRevision == 0 {
-		return nil
-	}
-
-	if providedRevision < latestRevision {
-		action.Logger.Warn().
-			Msgf("Newer contract revision available - latest revision: %d", latestRevision)
-	}
-	return nil
 }


### PR DESCRIPTION
Adds warning when outdated contract revisions are used during attestation:
```
WRN Newer contract revision available - latest revision: 3
```
Closes #1910 