### PR TITLE
fix(cli): do not fail on federated tokens

### DIFF
--- a/app/cli/internal/action/attestation_init.go
+++ b/app/cli/internal/action/attestation_init.go
@@ -225,7 +225,8 @@ func (action *AttestationInit) Run(ctx context.Context, opts *AttestationInitRun
 	if action.AuthTokenRaw != "" {
 		authInfo, err = extractAuthInfo(action.AuthTokenRaw)
 		if err != nil {
-			return "", err
+			// Do not fail since we might be using federated auth for which we do can't extract info yet
+			action.Logger.Warn().Msgf("can't extract info for the auth token: %v", err)
 		}
 	}
 


### PR DESCRIPTION
This is a regression introduced during the token info retrieval

Fixes #2160 