### PR TITLE
feat(projects): Allow to include groups to projects

### DIFF
--- a/app/controlplane/api/controlplane/v1/project.pb.go
+++ b/app/controlplane/api/controlplane/v1/project.pb.go
@@ -853,6 +853,7 @@ type ProjectMembershipReference struct {
 	// Types that are assignable to MembershipReference:
 	//
 	//	*ProjectMembershipReference_UserEmail
+	//	*ProjectMembershipReference_GroupReference
 	MembershipReference isProjectMembershipReference_MembershipReference `protobuf_oneof:"membership_reference"`
 }
 
@@ -902,16 +903,31 @@ func (x *ProjectMembershipReference) GetUserEmail() string {
 	return ""
 }
 
+func (x *ProjectMembershipReference) GetGroupReference() *IdentityReference {
+	if x, ok := x.GetMembershipReference().(*ProjectMembershipReference_GroupReference); ok {
+		return x.GroupReference
+	}
+	return nil
+}
+
 type isProjectMembershipReference_MembershipReference interface {
 	isProjectMembershipReference_MembershipReference()
 }
 
 type ProjectMembershipReference_UserEmail struct {
 	// The user to add to the project
-	UserEmail string `protobuf:"bytes,3,opt,name=user_email,json=userEmail,proto3,oneof"`
+	UserEmail string `protobuf:"bytes,1,opt,name=user_email,json=userEmail,proto3,oneof"`
+}
+
+type ProjectMembershipReference_GroupReference struct {
+	// The group to add to the project
+	GroupReference *IdentityReference `protobuf:"bytes,2,opt,name=group_reference,json=groupReference,proto3,oneof"`
 }
 
 func (*ProjectMembershipReference_UserEmail) isProjectMembershipReference_MembershipReference() {}
+
+func (*ProjectMembershipReference_GroupReference) isProjectMembershipReference_MembershipReference() {
+}
 
 type ProjectServiceAPITokenCreateResponse_APITokenFull struct {
 	state         protoimpl.MessageState
@@ -1124,12 +1140,17 @@ var file_controlplane_v1_project_proto_rawDesc = []byte{
 	0x06, 0xba, 0x48, 0x03, 0xc8, 0x01, 0x01, 0x52, 0x0f, 0x6d, 0x65, 0x6d, 0x62, 0x65, 0x72, 0x52,
 	0x65, 0x66, 0x65, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x22, 0x24, 0x0a, 0x22, 0x50, 0x72, 0x6f, 0x6a,
 	0x65, 0x63, 0x74, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x52, 0x65, 0x6d, 0x6f, 0x76, 0x65,
-	0x4d, 0x65, 0x6d, 0x62, 0x65, 0x72, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x5e,
-	0x0a, 0x1a, 0x50, 0x72, 0x6f, 0x6a, 0x65, 0x63, 0x74, 0x4d, 0x65, 0x6d, 0x62, 0x65, 0x72, 0x73,
-	0x68, 0x69, 0x70, 0x52, 0x65, 0x66, 0x65, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x12, 0x28, 0x0a, 0x0a,
-	0x75, 0x73, 0x65, 0x72, 0x5f, 0x65, 0x6d, 0x61, 0x69, 0x6c, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09,
-	0x42, 0x07, 0xba, 0x48, 0x04, 0x72, 0x02, 0x60, 0x01, 0x48, 0x00, 0x52, 0x09, 0x75, 0x73, 0x65,
-	0x72, 0x45, 0x6d, 0x61, 0x69, 0x6c, 0x42, 0x16, 0x0a, 0x14, 0x6d, 0x65, 0x6d, 0x62, 0x65, 0x72,
+	0x4d, 0x65, 0x6d, 0x62, 0x65, 0x72, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0xad,
+	0x01, 0x0a, 0x1a, 0x50, 0x72, 0x6f, 0x6a, 0x65, 0x63, 0x74, 0x4d, 0x65, 0x6d, 0x62, 0x65, 0x72,
+	0x73, 0x68, 0x69, 0x70, 0x52, 0x65, 0x66, 0x65, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x12, 0x28, 0x0a,
+	0x0a, 0x75, 0x73, 0x65, 0x72, 0x5f, 0x65, 0x6d, 0x61, 0x69, 0x6c, 0x18, 0x01, 0x20, 0x01, 0x28,
+	0x09, 0x42, 0x07, 0xba, 0x48, 0x04, 0x72, 0x02, 0x60, 0x01, 0x48, 0x00, 0x52, 0x09, 0x75, 0x73,
+	0x65, 0x72, 0x45, 0x6d, 0x61, 0x69, 0x6c, 0x12, 0x4d, 0x0a, 0x0f, 0x67, 0x72, 0x6f, 0x75, 0x70,
+	0x5f, 0x72, 0x65, 0x66, 0x65, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b,
+	0x32, 0x22, 0x2e, 0x63, 0x6f, 0x6e, 0x74, 0x72, 0x6f, 0x6c, 0x70, 0x6c, 0x61, 0x6e, 0x65, 0x2e,
+	0x76, 0x31, 0x2e, 0x49, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x74, 0x79, 0x52, 0x65, 0x66, 0x65, 0x72,
+	0x65, 0x6e, 0x63, 0x65, 0x48, 0x00, 0x52, 0x0e, 0x67, 0x72, 0x6f, 0x75, 0x70, 0x52, 0x65, 0x66,
+	0x65, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x42, 0x16, 0x0a, 0x14, 0x6d, 0x65, 0x6d, 0x62, 0x65, 0x72,
 	0x73, 0x68, 0x69, 0x70, 0x5f, 0x72, 0x65, 0x66, 0x65, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x2a, 0x77,
 	0x0a, 0x11, 0x50, 0x72, 0x6f, 0x6a, 0x65, 0x63, 0x74, 0x4d, 0x65, 0x6d, 0x62, 0x65, 0x72, 0x52,
 	0x6f, 0x6c, 0x65, 0x12, 0x23, 0x0a, 0x1f, 0x50, 0x52, 0x4f, 0x4a, 0x45, 0x43, 0x54, 0x5f, 0x4d,
@@ -1253,24 +1274,25 @@ var file_controlplane_v1_project_proto_depIdxs = []int32{
 	0,  // 16: controlplane.v1.ProjectServiceAddMemberRequest.role:type_name -> controlplane.v1.ProjectMemberRole
 	17, // 17: controlplane.v1.ProjectServiceRemoveMemberRequest.project_reference:type_name -> controlplane.v1.IdentityReference
 	14, // 18: controlplane.v1.ProjectServiceRemoveMemberRequest.member_reference:type_name -> controlplane.v1.ProjectMembershipReference
-	18, // 19: controlplane.v1.ProjectServiceAPITokenCreateResponse.APITokenFull.item:type_name -> controlplane.v1.APITokenItem
-	1,  // 20: controlplane.v1.ProjectService.APITokenCreate:input_type -> controlplane.v1.ProjectServiceAPITokenCreateRequest
-	5,  // 21: controlplane.v1.ProjectService.APITokenList:input_type -> controlplane.v1.ProjectServiceAPITokenListRequest
-	3,  // 22: controlplane.v1.ProjectService.APITokenRevoke:input_type -> controlplane.v1.ProjectServiceAPITokenRevokeRequest
-	7,  // 23: controlplane.v1.ProjectService.ListMembers:input_type -> controlplane.v1.ProjectServiceListMembersRequest
-	10, // 24: controlplane.v1.ProjectService.AddMember:input_type -> controlplane.v1.ProjectServiceAddMemberRequest
-	12, // 25: controlplane.v1.ProjectService.RemoveMember:input_type -> controlplane.v1.ProjectServiceRemoveMemberRequest
-	2,  // 26: controlplane.v1.ProjectService.APITokenCreate:output_type -> controlplane.v1.ProjectServiceAPITokenCreateResponse
-	6,  // 27: controlplane.v1.ProjectService.APITokenList:output_type -> controlplane.v1.ProjectServiceAPITokenListResponse
-	4,  // 28: controlplane.v1.ProjectService.APITokenRevoke:output_type -> controlplane.v1.ProjectServiceAPITokenRevokeResponse
-	8,  // 29: controlplane.v1.ProjectService.ListMembers:output_type -> controlplane.v1.ProjectServiceListMembersResponse
-	11, // 30: controlplane.v1.ProjectService.AddMember:output_type -> controlplane.v1.ProjectServiceAddMemberResponse
-	13, // 31: controlplane.v1.ProjectService.RemoveMember:output_type -> controlplane.v1.ProjectServiceRemoveMemberResponse
-	26, // [26:32] is the sub-list for method output_type
-	20, // [20:26] is the sub-list for method input_type
-	20, // [20:20] is the sub-list for extension type_name
-	20, // [20:20] is the sub-list for extension extendee
-	0,  // [0:20] is the sub-list for field type_name
+	17, // 19: controlplane.v1.ProjectMembershipReference.group_reference:type_name -> controlplane.v1.IdentityReference
+	18, // 20: controlplane.v1.ProjectServiceAPITokenCreateResponse.APITokenFull.item:type_name -> controlplane.v1.APITokenItem
+	1,  // 21: controlplane.v1.ProjectService.APITokenCreate:input_type -> controlplane.v1.ProjectServiceAPITokenCreateRequest
+	5,  // 22: controlplane.v1.ProjectService.APITokenList:input_type -> controlplane.v1.ProjectServiceAPITokenListRequest
+	3,  // 23: controlplane.v1.ProjectService.APITokenRevoke:input_type -> controlplane.v1.ProjectServiceAPITokenRevokeRequest
+	7,  // 24: controlplane.v1.ProjectService.ListMembers:input_type -> controlplane.v1.ProjectServiceListMembersRequest
+	10, // 25: controlplane.v1.ProjectService.AddMember:input_type -> controlplane.v1.ProjectServiceAddMemberRequest
+	12, // 26: controlplane.v1.ProjectService.RemoveMember:input_type -> controlplane.v1.ProjectServiceRemoveMemberRequest
+	2,  // 27: controlplane.v1.ProjectService.APITokenCreate:output_type -> controlplane.v1.ProjectServiceAPITokenCreateResponse
+	6,  // 28: controlplane.v1.ProjectService.APITokenList:output_type -> controlplane.v1.ProjectServiceAPITokenListResponse
+	4,  // 29: controlplane.v1.ProjectService.APITokenRevoke:output_type -> controlplane.v1.ProjectServiceAPITokenRevokeResponse
+	8,  // 30: controlplane.v1.ProjectService.ListMembers:output_type -> controlplane.v1.ProjectServiceListMembersResponse
+	11, // 31: controlplane.v1.ProjectService.AddMember:output_type -> controlplane.v1.ProjectServiceAddMemberResponse
+	13, // 32: controlplane.v1.ProjectService.RemoveMember:output_type -> controlplane.v1.ProjectServiceRemoveMemberResponse
+	27, // [27:33] is the sub-list for method output_type
+	21, // [21:27] is the sub-list for method input_type
+	21, // [21:21] is the sub-list for extension type_name
+	21, // [21:21] is the sub-list for extension extendee
+	0,  // [0:21] is the sub-list for field type_name
 }
 
 func init() { file_controlplane_v1_project_proto_init() }
@@ -1471,6 +1493,7 @@ func file_controlplane_v1_project_proto_init() {
 	}
 	file_controlplane_v1_project_proto_msgTypes[13].OneofWrappers = []interface{}{
 		(*ProjectMembershipReference_UserEmail)(nil),
+		(*ProjectMembershipReference_GroupReference)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{

--- a/app/controlplane/api/controlplane/v1/project.proto
+++ b/app/controlplane/api/controlplane/v1/project.proto
@@ -144,7 +144,9 @@ message ProjectMembershipReference {
   // The membership reference can be a user email or groups references in the future
   oneof membership_reference {
     // The user to add to the project
-    string user_email = 3 [(buf.validate.field).string.email = true];
+    string user_email = 1 [(buf.validate.field).string.email = true];
+    // The group to add to the project
+    IdentityReference group_reference = 2;
   }
 }
 

--- a/app/controlplane/api/gen/frontend/controlplane/v1/project.ts
+++ b/app/controlplane/api/gen/frontend/controlplane/v1/project.ts
@@ -156,7 +156,11 @@ export interface ProjectServiceRemoveMemberResponse {
 /** ProjectMembershipReference is used to reference a user or group in the context of project membership */
 export interface ProjectMembershipReference {
   /** The user to add to the project */
-  userEmail?: string | undefined;
+  userEmail?:
+    | string
+    | undefined;
+  /** The group to add to the project */
+  groupReference?: IdentityReference | undefined;
 }
 
 function createBaseProjectServiceAPITokenCreateRequest(): ProjectServiceAPITokenCreateRequest {
@@ -1244,13 +1248,16 @@ export const ProjectServiceRemoveMemberResponse = {
 };
 
 function createBaseProjectMembershipReference(): ProjectMembershipReference {
-  return { userEmail: undefined };
+  return { userEmail: undefined, groupReference: undefined };
 }
 
 export const ProjectMembershipReference = {
   encode(message: ProjectMembershipReference, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.userEmail !== undefined) {
-      writer.uint32(26).string(message.userEmail);
+      writer.uint32(10).string(message.userEmail);
+    }
+    if (message.groupReference !== undefined) {
+      IdentityReference.encode(message.groupReference, writer.uint32(18).fork()).ldelim();
     }
     return writer;
   },
@@ -1262,12 +1269,19 @@ export const ProjectMembershipReference = {
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
-        case 3:
-          if (tag !== 26) {
+        case 1:
+          if (tag !== 10) {
             break;
           }
 
           message.userEmail = reader.string();
+          continue;
+        case 2:
+          if (tag !== 18) {
+            break;
+          }
+
+          message.groupReference = IdentityReference.decode(reader, reader.uint32());
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -1279,12 +1293,17 @@ export const ProjectMembershipReference = {
   },
 
   fromJSON(object: any): ProjectMembershipReference {
-    return { userEmail: isSet(object.userEmail) ? String(object.userEmail) : undefined };
+    return {
+      userEmail: isSet(object.userEmail) ? String(object.userEmail) : undefined,
+      groupReference: isSet(object.groupReference) ? IdentityReference.fromJSON(object.groupReference) : undefined,
+    };
   },
 
   toJSON(message: ProjectMembershipReference): unknown {
     const obj: any = {};
     message.userEmail !== undefined && (obj.userEmail = message.userEmail);
+    message.groupReference !== undefined &&
+      (obj.groupReference = message.groupReference ? IdentityReference.toJSON(message.groupReference) : undefined);
     return obj;
   },
 
@@ -1295,6 +1314,9 @@ export const ProjectMembershipReference = {
   fromPartial<I extends Exact<DeepPartial<ProjectMembershipReference>, I>>(object: I): ProjectMembershipReference {
     const message = createBaseProjectMembershipReference();
     message.userEmail = object.userEmail ?? undefined;
+    message.groupReference = (object.groupReference !== undefined && object.groupReference !== null)
+      ? IdentityReference.fromPartial(object.groupReference)
+      : undefined;
     return message;
   },
 };

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.ProjectMembershipReference.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.ProjectMembershipReference.jsonschema.json
@@ -4,6 +4,10 @@
   "additionalProperties": false,
   "description": "ProjectMembershipReference is used to reference a user or group in the context of project membership",
   "patternProperties": {
+    "^(group_reference)$": {
+      "$ref": "controlplane.v1.IdentityReference.jsonschema.json",
+      "description": "The group to add to the project"
+    },
     "^(user_email)$": {
       "description": "The user to add to the project",
       "format": "email",
@@ -11,6 +15,10 @@
     }
   },
   "properties": {
+    "groupReference": {
+      "$ref": "controlplane.v1.IdentityReference.jsonschema.json",
+      "description": "The group to add to the project"
+    },
     "userEmail": {
       "description": "The user to add to the project",
       "format": "email",

--- a/app/controlplane/api/gen/jsonschema/controlplane.v1.ProjectMembershipReference.schema.json
+++ b/app/controlplane/api/gen/jsonschema/controlplane.v1.ProjectMembershipReference.schema.json
@@ -4,6 +4,10 @@
   "additionalProperties": false,
   "description": "ProjectMembershipReference is used to reference a user or group in the context of project membership",
   "patternProperties": {
+    "^(groupReference)$": {
+      "$ref": "controlplane.v1.IdentityReference.schema.json",
+      "description": "The group to add to the project"
+    },
     "^(userEmail)$": {
       "description": "The user to add to the project",
       "format": "email",
@@ -11,6 +15,10 @@
     }
   },
   "properties": {
+    "group_reference": {
+      "$ref": "controlplane.v1.IdentityReference.schema.json",
+      "description": "The group to add to the project"
+    },
     "user_email": {
       "description": "The user to add to the project",
       "format": "email",

--- a/app/controlplane/cmd/wire_gen.go
+++ b/app/controlplane/cmd/wire_gen.go
@@ -128,9 +128,9 @@ func wireApp(bootstrap *conf.Bootstrap, readerWriter credentials.ReaderWriter, l
 	}
 	workflowContractUseCase := biz.NewWorkflowContractUseCase(workflowContractRepo, registry, auditorUseCase, logger)
 	workflowUseCase := biz.NewWorkflowUsecase(workflowRepo, projectsRepo, workflowContractUseCase, auditorUseCase, membershipUseCase, logger)
-	projectUseCase := biz.NewProjectsUseCase(logger, projectsRepo, membershipRepo, auditorUseCase)
 	groupRepo := data.NewGroupRepo(dataData, logger)
 	groupUseCase := biz.NewGroupUseCase(logger, groupRepo, membershipRepo, auditorUseCase)
+	projectUseCase := biz.NewProjectsUseCase(logger, projectsRepo, membershipRepo, auditorUseCase, groupUseCase, membershipUseCase)
 	v5 := serviceOpts(logger, enforcer, projectUseCase, groupUseCase)
 	workflowService := service.NewWorkflowService(workflowUseCase, workflowContractUseCase, projectUseCase, v5...)
 	orgInvitationRepo := data.NewOrgInvitation(dataData, logger)

--- a/app/controlplane/pkg/auditor/events/project.go
+++ b/app/controlplane/pkg/auditor/events/project.go
@@ -29,12 +29,16 @@ import (
 var (
 	_ auditor.LogEntry = (*ProjectMemberAdded)(nil)
 	_ auditor.LogEntry = (*ProjectMemberRemoved)(nil)
+	_ auditor.LogEntry = (*ProjectGroupAdded)(nil)
+	_ auditor.LogEntry = (*ProjectGroupRemoved)(nil)
 )
 
 const (
 	ProjectType                    auditor.TargetType = "Project"
 	ProjectMemberAddedActionType   string             = "ProjectMemberAdded"
 	ProjectMemberRemovedActionType string             = "ProjectMemberRemoved"
+	ProjectGroupAddedActionType    string             = "ProjectGroupAdded"
+	ProjectGroupRemovedActionType  string             = "ProjectGroupRemoved"
 )
 
 // ProjectBase is the base struct for project events
@@ -63,6 +67,16 @@ func (p *ProjectBase) ActionInfo() (json.RawMessage, error) {
 	return json.Marshal(&p)
 }
 
+// Helper function to make role names more user-friendly
+func prettyRole(role string) string {
+	// Convert the role to a prettier format
+	prettyRole := role
+	if strings.HasPrefix(role, "role:project:") {
+		prettyRole = strings.TrimPrefix(role, "role:project:")
+	}
+	return prettyRole
+}
+
 // ProjectMemberAdded represents the addition of a member to a project
 type ProjectMemberAdded struct {
 	*ProjectBase
@@ -88,15 +102,12 @@ func (p *ProjectMemberAdded) ActionInfo() (json.RawMessage, error) {
 }
 
 func (p *ProjectMemberAdded) Description() string {
-	// Convert the role to a prettier format
-	prettyRole := p.Role
-	if strings.HasPrefix(p.Role, "role:project:") {
-		prettyRole = strings.TrimPrefix(p.Role, "role:project:")
+	roleDesc := ""
+	if p.Role != "" {
+		roleDesc = fmt.Sprintf(" with role '%s'", prettyRole(p.Role))
 	}
 
-	roleDesc := fmt.Sprintf(" with role '%s'", prettyRole)
-
-	return fmt.Sprintf("{{ if .ActorEmail }}{{ .ActorEmail }}{{ else }}API Token {{ .ActorID }}{{ end }} has added user %s to the project %s%s",
+	return fmt.Sprintf("{{ if .ActorEmail }}{{ .ActorEmail }}{{ else }}API Token {{ .ActorID }}{{ end }} has added user '%s' to the project '%s'%s",
 		p.UserEmail, p.ProjectName, roleDesc)
 }
 
@@ -124,6 +135,69 @@ func (p *ProjectMemberRemoved) ActionInfo() (json.RawMessage, error) {
 }
 
 func (p *ProjectMemberRemoved) Description() string {
-	return fmt.Sprintf("{{ if .ActorEmail }}{{ .ActorEmail }}{{ else }}API Token {{ .ActorID }}{{ end }} has removed user %s from the project %s",
+	return fmt.Sprintf("{{ if .ActorEmail }}{{ .ActorEmail }}{{ else }}API Token {{ .ActorID }}{{ end }} has removed user '%s' from the project '%s'",
 		p.UserEmail, p.ProjectName)
+}
+
+// ProjectGroupAdded represents the addition of a group to a project
+type ProjectGroupAdded struct {
+	*ProjectBase
+	GroupID   *uuid.UUID `json:"group_id,omitempty"`
+	GroupName string     `json:"group_name,omitempty"`
+	Role      string     `json:"role,omitempty"`
+}
+
+func (p *ProjectGroupAdded) ActionType() string {
+	return ProjectGroupAddedActionType
+}
+
+func (p *ProjectGroupAdded) ActionInfo() (json.RawMessage, error) {
+	if _, err := p.ProjectBase.ActionInfo(); err != nil {
+		return nil, err
+	}
+
+	if p.GroupID == nil {
+		return nil, fmt.Errorf("group ID is required")
+	}
+
+	return json.Marshal(&p)
+}
+
+func (p *ProjectGroupAdded) Description() string {
+	// Create a prettier role description
+	roleDesc := ""
+	if p.Role != "" {
+		roleDesc = fmt.Sprintf(" with role '%s'", prettyRole(p.Role))
+	}
+
+	return fmt.Sprintf("{{ if .ActorEmail }}{{ .ActorEmail }}{{ else }}API Token {{ .ActorID }}{{ end }} has added group '%s' to the project '%s'%s",
+		p.GroupName, p.ProjectName, roleDesc)
+}
+
+// ProjectGroupRemoved represents the removal of a group from a project
+type ProjectGroupRemoved struct {
+	*ProjectBase
+	GroupID   *uuid.UUID `json:"group_id,omitempty"`
+	GroupName string     `json:"group_name,omitempty"`
+}
+
+func (p *ProjectGroupRemoved) ActionType() string {
+	return ProjectGroupRemovedActionType
+}
+
+func (p *ProjectGroupRemoved) ActionInfo() (json.RawMessage, error) {
+	if _, err := p.ProjectBase.ActionInfo(); err != nil {
+		return nil, err
+	}
+
+	if p.GroupID == nil {
+		return nil, fmt.Errorf("group ID is required")
+	}
+
+	return json.Marshal(&p)
+}
+
+func (p *ProjectGroupRemoved) Description() string {
+	return fmt.Sprintf("{{ if .ActorEmail }}{{ .ActorEmail }}{{ else }}API Token {{ .ActorID }}{{ end }} has removed group '%s' from the project '%s'",
+		p.GroupName, p.ProjectName)
 }

--- a/app/controlplane/pkg/authz/authz.go
+++ b/app/controlplane/pkg/authz/authz.go
@@ -194,6 +194,8 @@ var RolesMap = map[Role][]*Policy{
 		PolicyGroupRead,
 		// Group Memberships
 		PolicyGroupListMemberships,
+		// Project Memberships
+		PolicyProjectListMemberships,
 	},
 	// RoleAdmin is an org-scoped role that provides super admin privileges (it's the higher role)
 	RoleAdmin: {

--- a/app/controlplane/pkg/biz/testhelpers/wire_gen.go
+++ b/app/controlplane/pkg/biz/testhelpers/wire_gen.go
@@ -151,9 +151,9 @@ func WireTestData(testDatabase *TestDatabase, t *testing.T, logger log.Logger, r
 	}
 	projectVersionRepo := data.NewProjectVersionRepo(dataData, logger)
 	projectVersionUseCase := biz.NewProjectVersionUseCase(projectVersionRepo, logger)
-	projectUseCase := biz.NewProjectsUseCase(logger, projectsRepo, membershipRepo, auditorUseCase)
 	groupRepo := data.NewGroupRepo(dataData, logger)
 	groupUseCase := biz.NewGroupUseCase(logger, groupRepo, membershipRepo, auditorUseCase)
+	projectUseCase := biz.NewProjectsUseCase(logger, projectsRepo, membershipRepo, auditorUseCase, groupUseCase, membershipUseCase)
 	testingRepos := &TestingRepos{
 		Membership:       membershipRepo,
 		Referrer:         referrerRepo,

--- a/app/controlplane/pkg/data/membership.go
+++ b/app/controlplane/pkg/data/membership.go
@@ -22,9 +22,11 @@ import (
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/authz"
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/biz"
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/data/ent"
+	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/data/ent/groupmembership"
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/data/ent/membership"
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/data/ent/organization"
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/data/ent/user"
+
 	"github.com/go-kratos/kratos/v2/log"
 	"github.com/google/uuid"
 )
@@ -255,6 +257,44 @@ func (r *MembershipRepo) ListAllByUser(ctx context.Context, userID uuid.UUID) ([
 	}
 
 	return entMembershipsToBiz(mm), nil
+}
+
+// ListGroupMembershipsByUser returns all memberships of the users inherited from groups
+func (r *MembershipRepo) ListGroupMembershipsByUser(ctx context.Context, userID uuid.UUID) ([]*biz.Membership, error) {
+	// First query all group memberships for the user directly
+	groupMemberships, err := r.data.DB.GroupMembership.Query().Where(
+		groupmembership.UserID(userID),
+		groupmembership.DeletedAtIsNil(),
+	).All(ctx)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to query user's group memberships: %w", err)
+	}
+
+	// Extract group IDs
+	groupIDs := make([]uuid.UUID, 0, len(groupMemberships))
+	for _, gm := range groupMemberships {
+		groupIDs = append(groupIDs, gm.GroupID)
+	}
+
+	var res []*ent.Membership
+
+	// If user belongs to groups, query those group memberships
+	if len(groupIDs) > 0 {
+		groupRoleMemberships, err := r.data.DB.Membership.Query().Where(
+			membership.MembershipTypeEQ(authz.MembershipTypeGroup),
+			membership.MemberIDIn(groupIDs...),
+		).All(ctx)
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to query group role memberships: %w", err)
+		}
+
+		// Append group role memberships to the result
+		res = append(res, groupRoleMemberships...)
+	}
+
+	return entMembershipsToBiz(res), nil
 }
 
 func (r *MembershipRepo) ListAllByResource(ctx context.Context, rt authz.ResourceType, id uuid.UUID) ([]*biz.Membership, error) {


### PR DESCRIPTION
This patch updates the logic for managing project memberships to support both users and groups. The `ProjectMembershipReference` now accepts a generic `IdentityReference`, allowing the underlying logic to determine whether the reference is a user or a group and handle it accordingly.

The logic responsible for retrieving a user’s memberships has also been changed to include the groups the user belongs to, merging all memberships into a single slice. Additionally, the `authorizeResource` method has been revised: instead of failing immediately when no matching role is found for a given resource type and ID, it now checks all roles associated with that resource and authorizes the request if any role matches.

Audit logs have been added to track when groups are added to projects, and the integration tests have been updated to reflect these changes.

And finally some refactors to reduce redundancy