### PR TITLE
feat(cli): add terminal output as property on json output for att push

### DIFF
--- a/app/cli/cmd/attestation_push.go
+++ b/app/cli/cmd/attestation_push.go
@@ -16,6 +16,7 @@
 package cmd
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 
@@ -103,6 +104,17 @@ func newAttestationPushCmd() *cobra.Command {
 			}
 
 			res.Status.Digest = res.Digest
+
+			// If we are returning the json format, we also want to render the attestation table as one property so it can also be consumed
+			if flagOutputFormat == formatJSON {
+				// Render the attestation status to a string
+				buf := &bytes.Buffer{}
+				if err := fullStatusTableWithWriter(res.Status, buf); err != nil {
+					return fmt.Errorf("failed to render output: %w", err)
+				}
+
+				res.Status.TerminalOutput = buf.Bytes()
+			}
 
 			// In TABLE format, we render the attestation status
 			if err := encodeOutput(res.Status, fullStatusTable); err != nil {

--- a/app/cli/cmd/output.go
+++ b/app/cli/cmd/output.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 The Chainloop Authors.
+// Copyright 2023-2025 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -101,8 +101,12 @@ func encodeJSONToWriter(v interface{}, w io.Writer) error {
 }
 
 func newTableWriter() table.Writer {
+	return newTableWriterWithWriter(os.Stdout)
+}
+
+func newTableWriterWithWriter(w io.Writer) table.Writer {
 	tw := table.NewWriter()
 	tw.SetStyle(table.StyleLight)
-	tw.SetOutputMirror(os.Stdout)
+	tw.SetOutputMirror(w)
 	return tw
 }

--- a/app/cli/internal/action/attestation_status.go
+++ b/app/cli/internal/action/attestation_status.go
@@ -59,6 +59,8 @@ type AttestationStatusResult struct {
 	TimestampAuthority          string                          `json:"timestamp_authority"`
 	// This might only be set if the attestation is pushed
 	Digest string `json:"digest"`
+	// This is the human readable output of the attestation status
+	TerminalOutput []byte `json:"terminal_output"`
 }
 
 type AttestationResultRunnerContext struct {


### PR DESCRIPTION
This PR adds the terminal-based status output of the `att push` command to the JSON output.

This enables programmatic clients to consume both the json properties as well as the rendered ones at the same time.

The result is base64 encoded

![image](https://github.com/user-attachments/assets/cb504b80-2153-48ac-84ba-c8adcefac6b7)
