### PR TITLE
fix(rbac): allow uploads to org members, refactor CAS credential logic

### DIFF
--- a/app/controlplane/pkg/authz/authz.go
+++ b/app/controlplane/pkg/authz/authz.go
@@ -255,6 +255,9 @@ var RolesMap = map[Role][]*Policy{
 		PolicyProjectListMemberships,
 		PolicyProjectAddMemberships,
 		PolicyProjectRemoveMemberships,
+
+		// CAS uploads
+		PolicyArtifactUpload,
 	},
 	// RoleProjectViewer: has read-only permissions on a project
 	RoleProjectViewer: {


### PR DESCRIPTION
This PR provides logic to permit uploads to org members, but downloads only if the CAS mapping exist in any of their allowed projects.

Refs #2121 