### PR TITLE
chore(rbac): Set organization ID in all memberships

### DIFF
--- a/app/controlplane/pkg/biz/membership.go
+++ b/app/controlplane/pkg/biz/membership.go
@@ -58,7 +58,7 @@ type MembershipRepo interface {
 
 	ListAllByUser(ctx context.Context, userID uuid.UUID) ([]*Membership, error)
 	ListAllByResource(ctx context.Context, rt authz.ResourceType, id uuid.UUID) ([]*Membership, error)
-	AddResourceRole(ctx context.Context, resourceType authz.ResourceType, resID uuid.UUID, mType authz.MembershipType, memberID uuid.UUID, role authz.Role) error
+	AddResourceRole(ctx context.Context, orgID uuid.UUID, resourceType authz.ResourceType, resID uuid.UUID, mType authz.MembershipType, memberID uuid.UUID, role authz.Role) error
 }
 
 type MembershipsRBAC interface {
@@ -327,7 +327,7 @@ func (uc *MembershipUseCase) ListAllMembershipsForUser(ctx context.Context, user
 }
 
 // SetProjectOwner sets the project owner (admin role). It skips the operation if an owner exists already
-func (uc *MembershipUseCase) SetProjectOwner(ctx context.Context, projectID, userID uuid.UUID) error {
+func (uc *MembershipUseCase) SetProjectOwner(ctx context.Context, orgID, projectID, userID uuid.UUID) error {
 	mm, err := uc.repo.ListAllByResource(ctx, authz.ResourceTypeProject, projectID)
 	if err != nil {
 		return fmt.Errorf("failed to find membership: %w", err)
@@ -340,7 +340,7 @@ func (uc *MembershipUseCase) SetProjectOwner(ctx context.Context, projectID, use
 		}
 	}
 
-	if err = uc.repo.AddResourceRole(ctx, authz.ResourceTypeProject, projectID, authz.MembershipTypeUser, userID, authz.RoleProjectAdmin); err != nil {
+	if err = uc.repo.AddResourceRole(ctx, orgID, authz.ResourceTypeProject, projectID, authz.MembershipTypeUser, userID, authz.RoleProjectAdmin); err != nil {
 		return fmt.Errorf("failed to set project owner: %w", err)
 	}
 

--- a/app/controlplane/pkg/biz/workflow.go
+++ b/app/controlplane/pkg/biz/workflow.go
@@ -160,7 +160,11 @@ func (uc *WorkflowUseCase) Create(ctx context.Context, opts *WorkflowCreateOpts)
 
 	// Set project admin if a new project has been created
 	if opts.Owner != nil {
-		if err = uc.membershipUC.SetProjectOwner(ctx, wf.ProjectID, *opts.Owner); err != nil {
+		orgUUID, err := uuid.Parse(opts.OrgID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse org ID %q: %w", opts.OrgID, err)
+		}
+		if err = uc.membershipUC.SetProjectOwner(ctx, orgUUID, wf.ProjectID, *opts.Owner); err != nil {
 			return nil, fmt.Errorf("failed to set project owner: %w", err)
 		}
 	}

--- a/app/controlplane/pkg/data/membership.go
+++ b/app/controlplane/pkg/data/membership.go
@@ -270,8 +270,9 @@ func (r *MembershipRepo) ListAllByResource(ctx context.Context, rt authz.Resourc
 	return entMembershipsToBiz(mm), nil
 }
 
-func (r *MembershipRepo) AddResourceRole(ctx context.Context, resourceType authz.ResourceType, resID uuid.UUID, mType authz.MembershipType, memberID uuid.UUID, role authz.Role) error {
+func (r *MembershipRepo) AddResourceRole(ctx context.Context, orgID uuid.UUID, resourceType authz.ResourceType, resID uuid.UUID, mType authz.MembershipType, memberID uuid.UUID, role authz.Role) error {
 	err := r.data.DB.Membership.Create().
+		SetOrganizationID(orgID).
 		SetMembershipType(mType).
 		SetMemberID(memberID).
 		SetResourceType(resourceType).


### PR DESCRIPTION
Initially, the field was meant to be deprecated, but it's worth maintaining it for future queries for org memberships, that include all org resource memberships.
