### PR TITLE
chore(rbac): Set organization ID in all project memberships

### DIFF
--- a/app/controlplane/pkg/data/membership.go
+++ b/app/controlplane/pkg/data/membership.go
@@ -250,7 +250,7 @@ func (r *MembershipRepo) ListAllByUser(ctx context.Context, userID uuid.UUID) ([
 	mm, err := r.data.DB.Membership.Query().Where(
 		membership.MembershipTypeEQ(authz.MembershipTypeUser),
 		membership.MemberID(userID),
-	).All(ctx)
+	).WithOrganization().All(ctx)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to query memberships: %w", err)


### PR DESCRIPTION
This patch updates the project membership logic to always set the organization ID in the relationships and take them into account.