### PR TITLE
chore(authz): Cleanup roles for org viewer

### DIFF
--- a/app/controlplane/pkg/authz/authz.go
+++ b/app/controlplane/pkg/authz/authz.go
@@ -189,13 +189,6 @@ var RolesMap = map[Role][]*Policy{
 		PolicyWorkflowRead,
 		// Organization
 		PolicyOrganizationRead,
-		// Groups
-		PolicyGroupList,
-		PolicyGroupRead,
-		// Group Memberships
-		PolicyGroupListMemberships,
-		// Project Memberships
-		PolicyProjectListMemberships,
 	},
 	// RoleAdmin is an org-scoped role that provides super admin privileges (it's the higher role)
 	RoleAdmin: {


### PR DESCRIPTION
This pull request modifies the `RolesMap` in the `authz.go` file to streamline the policies associated with roles by removing specific group and membership-related policies.

Changes to role policies:

* `app/controlplane/pkg/authz/authz.go`: Removed the following policies from the `RolesMap` definition:
  - `PolicyGroupList`
  - `PolicyGroupRead`
  - `PolicyGroupListMemberships`
  - `PolicyProjectListMemberships`