### PR TITLE
fix(tokens): revoke ambiguous API tokens

### DIFF
--- a/app/controlplane/pkg/data/apitoken.go
+++ b/app/controlplane/pkg/data/apitoken.go
@@ -76,6 +76,8 @@ func (r *APITokenRepo) FindByNameInOrg(ctx context.Context, orgID uuid.UUID, nam
 
 	if projectID != nil {
 		query = query.Where(apitoken.ProjectIDEQ(*projectID))
+	} else {
+		query = query.Where(apitoken.ProjectIDIsNil())
 	}
 
 	token, err := query.Only(ctx)


### PR DESCRIPTION
Fixes revocation of system-level tokens when they are ambiguous (another one with the same name exists in a project)