### PR TITLE
chore(rbac): return graph nodes for public workflows

### DIFF
--- a/app/controlplane/internal/service/workflowrun.go
+++ b/app/controlplane/internal/service/workflowrun.go
@@ -148,9 +148,11 @@ func (s *WorkflowRunService) View(ctx context.Context, req *pb.WorkflowRunServic
 		return nil, errors.BadRequest("invalid", "id or digest required")
 	}
 
-	// Apply RBAC if needed
-	if err = s.authorizeResource(ctx, authz.PolicyWorkflowRunRead, authz.ResourceTypeProject, run.Workflow.ProjectID); err != nil {
-		return nil, err
+	// Apply RBAC only if workflow is not public
+	if !run.Workflow.Public {
+		if err = s.authorizeResource(ctx, authz.PolicyWorkflowRunRead, authz.ResourceTypeProject, run.Workflow.ProjectID); err != nil {
+			return nil, err
+		}
 	}
 
 	var verificationResult *pb.WorkflowRunServiceViewResponse_VerificationResult

--- a/app/controlplane/pkg/data/referrer.go
+++ b/app/controlplane/pkg/data/referrer.go
@@ -261,6 +261,10 @@ func (r *ReferrerRepo) doGet(ctx context.Context, root *ent.Referrer, allowedOrg
 }
 
 func isReferrerVisible(ref *biz.StoredReferrer, allowedOrgs []uuid.UUID, visibleProjectsMap map[uuid.UUID][]uuid.UUID) bool {
+	if ref.InPublicWorkflow {
+		return true
+	}
+
 	for _, oid := range ref.OrgIDs {
 		if !slices.Contains(allowedOrgs, oid) {
 			// skip check in organizations where the user doesn't have access


### PR DESCRIPTION
Include referrers that belong to public worklfows. Also don't apply RBAC on workflow runs from public workflows.