### PR TITLE
fix(group): Set proper role when sending invitations to join

### DIFF
--- a/app/controlplane/pkg/biz/group.go
+++ b/app/controlplane/pkg/biz/group.go
@@ -494,7 +494,7 @@ func (uc *GroupUseCase) handleNonExistingUser(ctx context.Context, orgID, groupI
 	}
 
 	// Create an invitation for the user to join the organization
-	if _, err := uc.orgInvitationUC.Create(ctx, orgID.String(), opts.RequesterID.String(), opts.UserEmail, WithInvitationRole(authz.RoleViewer), WithInvitationContext(invitationContext)); err != nil {
+	if _, err := uc.orgInvitationUC.Create(ctx, orgID.String(), opts.RequesterID.String(), opts.UserEmail, WithInvitationRole(authz.RoleOrgMember), WithInvitationContext(invitationContext)); err != nil {
 		return nil, fmt.Errorf("failed to create invitation: %w", err)
 	}
 

--- a/app/controlplane/pkg/biz/group_integration_test.go
+++ b/app/controlplane/pkg/biz/group_integration_test.go
@@ -789,7 +789,7 @@ func (s *groupMembersIntegrationTestSuite) TestAddMemberToGroup() {
 			if inv.ReceiverEmail == "not-in-org@example.com" {
 				found = true
 				s.Equal(biz.OrgInvitationStatusPending, inv.Status)
-				s.Equal(string(authz.RoleViewer), string(inv.Role))
+				s.Equal(string(authz.RoleOrgMember), string(inv.Role))
 
 				// Verify the invitation context
 				s.NotNil(inv.Context, "Invitation context should not be nil")


### PR DESCRIPTION
So users can leverage RBAC, the target role in the organization for non-found members, should be `Organization Member`.