### PR TITLE
feat(rbac): Enable RBAC for OrgViewers

### DIFF
--- a/app/controlplane/internal/service/service.go
+++ b/app/controlplane/internal/service/service.go
@@ -374,7 +374,7 @@ func rbacEnabled(ctx context.Context) bool {
 
 	// we have an user
 	currentSubject := usercontext.CurrentAuthzSubject(ctx)
-	return currentSubject == string(authz.RoleOrgMember)
+	return currentSubject == string(authz.RoleOrgMember) || currentSubject == string(authz.RoleViewer)
 }
 
 // NOTE: some of these http errors get automatically translated to gRPC status codes


### PR DESCRIPTION
This change enables RBAC for org viewers. They become read only "Members"
warn: This is a breaking change in Chainloop behavoiur