### PR TITLE
fix(group/project): Fixes invitation query

### DIFF
--- a/app/controlplane/pkg/data/group.go
+++ b/app/controlplane/pkg/data/group.go
@@ -172,8 +172,8 @@ func (g GroupRepo) ListPendingInvitationsByGroup(ctx context.Context, orgID uuid
 			orginvitation.OrganizationIDEQ(orgID),
 			orginvitation.DeletedAtIsNil(),
 			orginvitation.StatusEQ(biz.OrgInvitationStatusPending),
-			func(_ *sql.Selector) {
-				sqljson.ValueEQ(orginvitation.FieldContext, groupID.String(), sqljson.DotPath("group_id_to_join"))
+			func(s *sql.Selector) {
+				s.Where(sqljson.ValueEQ(orginvitation.FieldContext, groupID.String(), sqljson.DotPath("group_id_to_join")))
 			},
 		).
 		WithOrganization().

--- a/app/controlplane/pkg/data/project.go
+++ b/app/controlplane/pkg/data/project.go
@@ -388,8 +388,8 @@ func (r *ProjectRepo) ListPendingInvitationsByProject(ctx context.Context, orgID
 			orginvitation.OrganizationIDEQ(orgID),
 			orginvitation.DeletedAtIsNil(),
 			orginvitation.StatusEQ(biz.OrgInvitationStatusPending),
-			func(_ *sql.Selector) {
-				sqljson.ValueEQ(orginvitation.FieldContext, projectID.String(), sqljson.DotPath("project_id_to_join"))
+			func(s *sql.Selector) {
+				s.Where(sqljson.ValueEQ(orginvitation.FieldContext, projectID.String(), sqljson.DotPath("project_id_to_join")))
 			},
 		).
 		WithOrganization().


### PR DESCRIPTION
This patch fixes the queries that look for invitations since they were not taking into account the project and group respectively.