### PR TITLE
fix(group): Allow organization members to get group details

### DIFF
--- a/app/controlplane/pkg/authz/authz.go
+++ b/app/controlplane/pkg/authz/authz.go
@@ -368,6 +368,7 @@ var ServerOperationsMap = map[string][]*Policy{
 	"/controlplane.v1.OrganizationService/ListMemberships": {PolicyOrganizationListMemberships},
 	// Groups
 	"/controlplane.v1.GroupService/List": {PolicyGroupList},
+	"/controlplane.v1.GroupService/Get":  {PolicyGroupRead},
 	// Group Memberships
 	"/controlplane.v1.GroupService/ListMembers": {PolicyGroupListMemberships},
 	// For the following endpoints, we rely on the service layer to check the permissions


### PR DESCRIPTION
This pull request adds a new authorization policy for the `Get` method in the `GroupService` API. This change ensures that the `PolicyGroupRead` policy is applied when accessing group details.

Authorization updates:

* [`app/controlplane/pkg/authz/authz.go`](diffhunk://#diff-72141455c72a8057aa8d7219c28c15d4afdd2cc10459d355626022b3787ecaa3R371): Added the `PolicyGroupRead` policy to the `ServerOperationsMap` for the `/controlplane.v1.GroupService/Get` endpoint, enabling proper authorization checks for retrieving group details.