### PR TITLE
Improve error reporting from plugins loading

### DIFF
--- a/app/cli/cmd/root.go
+++ b/app/cli/cmd/root.go
@@ -247,7 +247,7 @@ func NewRootCmd(l zerolog.Logger) *cobra.Command {
 
 	// Load plugins if we are not running a subcommand
 	if len(os.Args) > 1 && os.Args[1] != "completion" && os.Args[1] != "help" {
-		pluginManager = plugins.NewManager()
+		pluginManager = plugins.NewManager(&logger)
 		if err := loadAllPlugins(rootCmd); err != nil {
 			logger.Error().Err(err).Msg("Failed to load plugins, continuing with built-in commands only")
 		}

--- a/app/cli/pkg/plugins/manager.go
+++ b/app/cli/pkg/plugins/manager.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
@@ -62,7 +63,8 @@ func (m *Manager) LoadPlugins(ctx context.Context) error {
 	for _, plugin := range plugins {
 		// Load the plugin - if there is an error just skip it - we can think of a better strategy later
 		if err := m.loadPlugin(ctx, plugin); err != nil {
-			fmt.Printf("failed to load plugin: %s\n", err)
+			fmt.Printf("failed to load plugin: %s - reason: %s\n", plugin, getFirstErrorLine(err))
+
 			continue
 		}
 	}
@@ -145,4 +147,19 @@ func (m *Manager) Shutdown() {
 	for _, client := range m.pluginClients {
 		client.Kill()
 	}
+}
+
+// getFirstErrorLine extracts only the first line from an error message
+func getFirstErrorLine(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	errStr := err.Error()
+	// Split by newline and return only the first part
+	parts := strings.Split(errStr, "\n")
+	if len(parts) > 0 {
+		return parts[0]
+	}
+	return errStr
 }

--- a/app/cli/pkg/plugins/manager.go
+++ b/app/cli/pkg/plugins/manager.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
@@ -150,19 +149,4 @@ func (m *Manager) Shutdown() {
 	for _, client := range m.pluginClients {
 		client.Kill()
 	}
-}
-
-// getFirstErrorLine extracts only the first line from an error message
-func getFirstErrorLine(err error) string {
-	if err == nil {
-		return ""
-	}
-
-	errStr := err.Error()
-	// Split by newline and return only the first part
-	parts := strings.Split(errStr, "\n")
-	if len(parts) > 0 {
-		return parts[0]
-	}
-	return errStr
 }


### PR DESCRIPTION
This PR adds improvement error reporting for CLI plugins - https://github.com/chainloop-dev/chainloop/issues/2210. 

I would use a logger, but the problem is that in order for the plugins mechanism to be able to expand the Cobra command I'm loading the plugins before the logger is actually initialized, so before the flags are passed to the CLI command. That means at that point I don't know the user wants a debug, info or any other log level. 

If we agree on the change the response from the CLI looks as follows:

```sh
2025-07-07T23:18:29.823+0200 [WARN]  plugin: plugin failed to exit gracefully
failed to load plugin: /Users/gro/Library/Application Support/chainloop/plugins/chainloop - reason: failed to create RPC client: Unrecognized remote plugin message: Chainloop Command Line Interface
No plugins installed
```

It is definitely not ideal, but way better compared to the full log. If you have other ideas @migmartri I'm listening :) 