### PR TITLE
fix(rbac): allow OrgViewer to access project actions

### DIFF
--- a/app/controlplane/pkg/authz/authz.go
+++ b/app/controlplane/pkg/authz/authz.go
@@ -201,6 +201,14 @@ var RolesMap = map[Role][]*Policy{
 		PolicyWorkflowRead,
 		// Organization
 		PolicyOrganizationRead,
+		// Projects (only for viewers to access the route, RBAC is done at project level)
+		PolicyProjectListMemberships,
+		PolicyProjectAddMemberships,
+		PolicyProjectRemoveMemberships,
+		PolicyProjectUpdateMemberships,
+		PolicyProjectAPITokenList,
+		PolicyProjectAPITokenCreate,
+		PolicyProjectAPITokenRevoke,
 	},
 	// RoleAdmin is an org-scoped role that provides super admin privileges (it's the higher role)
 	RoleAdmin: {

--- a/app/controlplane/pkg/authz/authz.go
+++ b/app/controlplane/pkg/authz/authz.go
@@ -201,14 +201,6 @@ var RolesMap = map[Role][]*Policy{
 		PolicyWorkflowRead,
 		// Organization
 		PolicyOrganizationRead,
-		// Projects (only for viewers to access the route, RBAC is done at project level)
-		PolicyProjectListMemberships,
-		PolicyProjectAddMemberships,
-		PolicyProjectRemoveMemberships,
-		PolicyProjectUpdateMemberships,
-		PolicyProjectAPITokenList,
-		PolicyProjectAPITokenCreate,
-		PolicyProjectAPITokenRevoke,
 	},
 	// RoleAdmin is an org-scoped role that provides super admin privileges (it's the higher role)
 	RoleAdmin: {
@@ -398,16 +390,19 @@ var ServerOperationsMap = map[string][]*Policy{
 	"/controlplane.v1.GroupService/RemoveMember":                 {},
 	"/controlplane.v1.GroupService/ListPendingInvitations":       {},
 	"/controlplane.v1.GroupService/UpdateMemberMaintainerStatus": {},
+
+	// Projects: Check happen at service level
+
 	// Project API Token
-	"/controlplane.v1.ProjectService/APITokenCreate": {PolicyProjectAPITokenCreate},
-	"/controlplane.v1.ProjectService/APITokenList":   {PolicyProjectAPITokenList},
-	"/controlplane.v1.ProjectService/APITokenRevoke": {PolicyProjectAPITokenRevoke},
+	"/controlplane.v1.ProjectService/APITokenCreate": {},
+	"/controlplane.v1.ProjectService/APITokenList":   {},
+	"/controlplane.v1.ProjectService/APITokenRevoke": {},
 	// Project Memberships
-	"/controlplane.v1.ProjectService/ListMembers":            {PolicyProjectListMemberships},
-	"/controlplane.v1.ProjectService/AddMember":              {PolicyProjectAddMemberships},
-	"/controlplane.v1.ProjectService/RemoveMember":           {PolicyProjectRemoveMemberships},
-	"/controlplane.v1.ProjectService/UpdateMemberRole":       {PolicyProjectUpdateMemberships},
-	"/controlplane.v1.ProjectService/ListPendingInvitations": {PolicyProjectListMemberships},
+	"/controlplane.v1.ProjectService/ListMembers":            {},
+	"/controlplane.v1.ProjectService/AddMember":              {},
+	"/controlplane.v1.ProjectService/RemoveMember":           {},
+	"/controlplane.v1.ProjectService/UpdateMemberRole":       {},
+	"/controlplane.v1.ProjectService/ListPendingInvitations": {},
 }
 
 // Implements https://pkg.go.dev/entgo.io/ent/schema/field#EnumValues


### PR DESCRIPTION
RBAC check is done at service level, but routes must be enabled for OrgViewers, since they can be ProjectAdmins