### PR TITLE
Adjust plugin describe command output

### DIFF
--- a/app/cli/cmd/plugins.go
+++ b/app/cli/cmd/plugins.go
@@ -340,26 +340,17 @@ func pluginListTableOutput(plugins map[string]*plugins.LoadedPlugin) {
 
 func pluginInfoTableOutput(plugin *plugins.LoadedPlugin) {
 	t := newTableWriter()
-
-	t.AppendHeader(table.Row{"Name", "Version", "Description", "Commands"})
-	t.AppendRow(table.Row{plugin.Metadata.Name, plugin.Metadata.Version, plugin.Metadata.Description, fmt.Sprintf("%d command(s)", len(plugin.Metadata.Commands))})
-
+	t.SetTitle(fmt.Sprintf("Plugin: %s", plugin.Metadata.Name))
+	t.AppendSeparator()
+	t.AppendRow(table.Row{"Version", plugin.Metadata.Version})
+	t.AppendSeparator()
+	t.AppendRow(table.Row{"Description", plugin.Metadata.Description})
+	t.AppendSeparator()
+	t.AppendRow(table.Row{"Commands", fmt.Sprintf("%d command(s)", len(plugin.Metadata.Commands))})
+	t.AppendSeparator()
 	t.Render()
 
-	pluginInfoCommandsTableOutput(plugin)
 	pluginInfoFlagsTableOutput(plugin)
-}
-
-func pluginInfoCommandsTableOutput(plugin *plugins.LoadedPlugin) {
-	t := newTableWriter()
-
-	t.AppendHeader(table.Row{"Plugin", "Command", "Description", "Usage"})
-	for _, cmd := range plugin.Metadata.Commands {
-		t.AppendRow(table.Row{plugin.Metadata.Name, cmd.Name, cmd.Description, cmd.Usage})
-		t.AppendSeparator()
-	}
-
-	t.Render()
 }
 
 func pluginInfoFlagsTableOutput(plugin *plugins.LoadedPlugin) {
@@ -378,15 +369,18 @@ func pluginInfoFlagsTableOutput(plugin *plugins.LoadedPlugin) {
 		return
 	}
 
-	t := newTableWriter()
-
-	t.AppendHeader(table.Row{"Plugin", "Command", "Flag", "Description", "Type", "Default", "Required"})
 	for _, cmd := range plugin.Metadata.Commands {
-		for _, flag := range cmd.Flags {
-			t.AppendRow(table.Row{plugin.Metadata.Name, cmd.Name, flag.Name, flag.Description, flag.Type, flag.Default, flag.Required})
-			t.AppendSeparator()
-		}
-	}
+		t := newTableWriter()
+		t.SetTitle(fmt.Sprintf("Command: %s, flags:", cmd.Name))
+		t.AppendSeparator()
 
-	t.Render()
+		for _, flag := range cmd.Flags {
+			defaultValue := ""
+			if flag.Default != nil {
+				defaultValue = fmt.Sprintf("(default: %v)", flag.Default)
+			}
+			t.AppendRow(table.Row{fmt.Sprintf("--%s", flag.Name), flag.Description, defaultValue})
+		}
+		t.Render()
+	}
 }

--- a/app/cli/cmd/plugins.go
+++ b/app/cli/cmd/plugins.go
@@ -387,8 +387,12 @@ func pluginInfoFlagsTableOutput(plugin *plugins.LoadedPlugin) {
 
 		maxFlagLen += 2 // For the "--" prefix
 		for _, flag := range cmd.Flags {
-			flagName := fmt.Sprintf("  --%s", flag.Name)
-			padding := strings.Repeat(" ", maxFlagLen-len(flag.Name)+4) // +4 for extra spacing
+			shorthand := "   "
+			if flag.Shorthand != "" {
+				shorthand = fmt.Sprintf("-%s,", flag.Shorthand)
+			}
+			flagName := fmt.Sprintf("  %s--%s", shorthand, flag.Name)
+			padding := strings.Repeat(" ", maxFlagLen-len(flag.Name)+2)
 
 			defaultValue := ""
 			if flag.Default != nil {

--- a/app/cli/cmd/plugins.go
+++ b/app/cli/cmd/plugins.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/chainloop-dev/chainloop/app/cli/internal/action"
 	"github.com/chainloop-dev/chainloop/app/cli/pkg/plugins"
@@ -371,16 +372,33 @@ func pluginInfoFlagsTableOutput(plugin *plugins.LoadedPlugin) {
 
 	for _, cmd := range plugin.Metadata.Commands {
 		t := newTableWriter()
-		t.SetTitle(fmt.Sprintf("Command: %s, flags:", cmd.Name))
+		t.SetTitle(fmt.Sprintf("Command: %s", cmd.Name))
 		t.AppendSeparator()
 
+		flagDetails := "Flags:\n"
+
+		// Find the longest flag name to align descriptions properly
+		maxFlagLen := 0
 		for _, flag := range cmd.Flags {
+			if len(flag.Name) > maxFlagLen {
+				maxFlagLen = len(flag.Name)
+			}
+		}
+
+		maxFlagLen += 2 // For the "--" prefix
+		for _, flag := range cmd.Flags {
+			flagName := fmt.Sprintf("  --%s", flag.Name)
+			padding := strings.Repeat(" ", maxFlagLen-len(flag.Name)+4) // +4 for extra spacing
+
 			defaultValue := ""
 			if flag.Default != nil {
-				defaultValue = fmt.Sprintf("(default: %v)", flag.Default)
+				defaultValue = fmt.Sprintf(" (default: %v)", flag.Default)
 			}
-			t.AppendRow(table.Row{fmt.Sprintf("--%s", flag.Name), flag.Description, defaultValue})
+
+			flagDetails += fmt.Sprintf("%s%s%s%s\n", flagName, padding, flag.Description, defaultValue)
 		}
+
+		t.AppendRow(table.Row{flagDetails})
 		t.Render()
 	}
 }


### PR DESCRIPTION
This PR adjusts the output of the:

```
chainloop config plugin describe --name platform
```

To something like this:

```
┌──────────────────────────────────────────────────────────────────┐
│ Plugin: platform                                                 │
├─────────────┬────────────────────────────────────────────────────┤
│ Version     │ v0.218.0-43-ge9b96e4e                              │
├─────────────┼────────────────────────────────────────────────────┤
│ Description │ Chainloop platform plugin for runner context data. │
├─────────────┼────────────────────────────────────────────────────┤
│ Commands    │ 1 command(s)                                       │
└─────────────┴────────────────────────────────────────────────────┘
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Command: gather-runner-context, flags:                                                                               │
├───────────────────┬─────────────────────────────────────────────────────────────────┬────────────────────────────────┤
│ --runner-provider │ Provider name                                                   │                                │
│ --runner-token    │ Provider access token with read rights to the given repository. │                                │
│ --runner-org      │ Provider organization name                                      │                                │
│ --runner-repo     │ Provider repository name                                        │                                │
│ --runner-api-url  │ Provider API URL                                                │                                │
│ --output-file     │ Output file path for the protection data (JSON format)          │ (default: runner-context.json) │
└───────────────────┴─────────────────────────────────────────────────────────────────┴────────────────────────────────┘
```

Let me know what you think.