### PR TITLE
feat: add default version when workflow is created

### DIFF
--- a/app/controlplane/pkg/biz/workflow_integration_test.go
+++ b/app/controlplane/pkg/biz/workflow_integration_test.go
@@ -193,6 +193,10 @@ func (s *workflowIntegrationTestSuite) TestCreate() {
 			s.Equal(tc.opts.Project, got.Project)
 			s.NotEmpty(got.ContractID)
 			s.NotEmpty(got.ContractName)
+			// There is a project version created
+			pv, err := s.TestingUseCases.ProjectVersion.FindByProjectAndVersion(ctx, got.ProjectID.String(), "")
+			s.NoError(err)
+			s.NotNil(pv)
 		})
 	}
 }

--- a/app/controlplane/pkg/biz/workflow_integration_test.go
+++ b/app/controlplane/pkg/biz/workflow_integration_test.go
@@ -194,7 +194,7 @@ func (s *workflowIntegrationTestSuite) TestCreate() {
 			s.NotEmpty(got.ContractID)
 			s.NotEmpty(got.ContractName)
 			// There is a project version created
-			pv, err := s.TestingUseCases.ProjectVersion.FindByProjectAndVersion(ctx, got.ProjectID.String(), "")
+			pv, err := s.ProjectVersion.FindByProjectAndVersion(ctx, got.ProjectID.String(), "")
 			s.NoError(err)
 			s.NotNil(pv)
 		})

--- a/app/controlplane/pkg/data/projectversion.go
+++ b/app/controlplane/pkg/data/projectversion.go
@@ -109,6 +109,15 @@ func createProjectVersionWithTx(ctx context.Context, tx *ent.Tx, projectID uuid.
 		Save(ctx)
 }
 
+func findProjectVersionWithTx(ctx context.Context, tx *ent.Tx, projectID uuid.UUID, version string) (*ent.ProjectVersion, error) {
+	return tx.ProjectVersion.Query().
+		Where(
+			projectversion.ProjectID(projectID),
+			projectversion.VersionEQ(version),
+			projectversion.DeletedAtIsNil(),
+		).Only(ctx)
+}
+
 func entProjectVersionToBiz(v *ent.ProjectVersion) *biz.ProjectVersion {
 	pv := &biz.ProjectVersion{
 		ID:                v.ID,

--- a/app/controlplane/pkg/data/projectversion.go
+++ b/app/controlplane/pkg/data/projectversion.go
@@ -109,8 +109,8 @@ func createProjectVersionWithTx(ctx context.Context, tx *ent.Tx, projectID uuid.
 		Save(ctx)
 }
 
-func findProjectVersionWithClient(ctx context.Context, tx *ent.Client, projectID uuid.UUID, version string) (*ent.ProjectVersion, error) {
-	return tx.ProjectVersion.Query().
+func findProjectVersionWithClient(ctx context.Context, client *ent.Client, projectID uuid.UUID, version string) (*ent.ProjectVersion, error) {
+	return client.ProjectVersion.Query().
 		Where(
 			projectversion.ProjectID(projectID),
 			projectversion.VersionEQ(version),

--- a/app/controlplane/pkg/data/projectversion.go
+++ b/app/controlplane/pkg/data/projectversion.go
@@ -109,7 +109,7 @@ func createProjectVersionWithTx(ctx context.Context, tx *ent.Tx, projectID uuid.
 		Save(ctx)
 }
 
-func findProjectVersionWithTx(ctx context.Context, tx *ent.Tx, projectID uuid.UUID, version string) (*ent.ProjectVersion, error) {
+func findProjectVersionWithClient(ctx context.Context, tx *ent.Client, projectID uuid.UUID, version string) (*ent.ProjectVersion, error) {
 	return tx.ProjectVersion.Query().
 		Where(
 			projectversion.ProjectID(projectID),

--- a/app/controlplane/pkg/data/workflow.go
+++ b/app/controlplane/pkg/data/workflow.go
@@ -97,6 +97,17 @@ func (r *WorkflowRepo) Create(ctx context.Context, opts *biz.WorkflowCreateOpts)
 			return fmt.Errorf("creating project: %w", err)
 		}
 
+		// Find or create the default project version
+		if _, err := findProjectVersionWithTx(ctx, tx, projectID, ""); err != nil {
+			if !ent.IsNotFound(err) {
+				return fmt.Errorf("finding project version: %w", err)
+			}
+
+			if _, err := createProjectVersionWithTx(ctx, tx, projectID, "", false); err != nil {
+				return fmt.Errorf("creating project version: %w", err)
+			}
+		}
+
 		// We do not have an explicit contract
 		// 1 - try to find it with the default name
 		// 2 - if not found, create it with the default name

--- a/app/controlplane/pkg/data/workflow.go
+++ b/app/controlplane/pkg/data/workflow.go
@@ -98,7 +98,7 @@ func (r *WorkflowRepo) Create(ctx context.Context, opts *biz.WorkflowCreateOpts)
 		}
 
 		// Find or create the default project version
-		if _, err := findProjectVersionWithClient(ctx, tx, projectID, ""); err != nil {
+		if _, err := findProjectVersionWithClient(ctx, tx.Client(), projectID, ""); err != nil {
 			if !ent.IsNotFound(err) {
 				return fmt.Errorf("finding project version: %w", err)
 			}

--- a/app/controlplane/pkg/data/workflow.go
+++ b/app/controlplane/pkg/data/workflow.go
@@ -98,7 +98,7 @@ func (r *WorkflowRepo) Create(ctx context.Context, opts *biz.WorkflowCreateOpts)
 		}
 
 		// Find or create the default project version
-		if _, err := findProjectVersionWithTx(ctx, tx, projectID, ""); err != nil {
+		if _, err := findProjectVersionWithClient(ctx, tx, projectID, ""); err != nil {
 			if !ent.IsNotFound(err) {
 				return fmt.Errorf("finding project version: %w", err)
 			}


### PR DESCRIPTION
This PR makes sure there is a default version for any new project created through a workflow flow.

before this, only during attestations the project would have had a version