### PR TITLE
feat(groups/projects): Allow system calls to CRUD of group and projects

### DIFF
--- a/app/controlplane/pkg/auditor/events/group.go
+++ b/app/controlplane/pkg/auditor/events/group.go
@@ -87,7 +87,7 @@ func (g *GroupCreated) ActionInfo() (json.RawMessage, error) {
 }
 
 func (g *GroupCreated) Description() string {
-	return fmt.Sprintf("{{ if .ActorEmail }}{{ .ActorEmail }}{{ else }}API Token {{ .ActorID }}{{ end }} has created the group %s", g.GroupName)
+	return fmt.Sprintf("{{ if .ActorEmail }}{{ .ActorEmail }}{{ else }}system@chainloop.dev{{ end }} has created the group %s", g.GroupName)
 }
 
 // GroupUpdated represents an update to a group
@@ -112,9 +112,9 @@ func (g *GroupUpdated) ActionInfo() (json.RawMessage, error) {
 
 func (g *GroupUpdated) Description() string {
 	if g.OldName != nil && g.NewName != nil {
-		return fmt.Sprintf("{{ if .ActorEmail }}{{ .ActorEmail }}{{ else }}API Token {{ .ActorID }}{{ end }} has renamed the group from %s to %s", *g.OldName, *g.NewName)
+		return fmt.Sprintf("{{ if .ActorEmail }}{{ .ActorEmail }}{{ else }}system@chainloop.dev{{ end }} has renamed the group from %s to %s", *g.OldName, *g.NewName)
 	}
-	return fmt.Sprintf("{{ if .ActorEmail }}{{ .ActorEmail }}{{ else }}API Token {{ .ActorID }}{{ end }} has updated the group %s", g.GroupName)
+	return fmt.Sprintf("{{ if .ActorEmail }}{{ .ActorEmail }}{{ else }}system@chainloop.dev{{ end }} has updated the group %s", g.GroupName)
 }
 
 // GroupDeleted represents the deletion of a group
@@ -135,7 +135,7 @@ func (g *GroupDeleted) ActionInfo() (json.RawMessage, error) {
 }
 
 func (g *GroupDeleted) Description() string {
-	return fmt.Sprintf("{{ if .ActorEmail }}{{ .ActorEmail }}{{ else }}API Token {{ .ActorID }}{{ end }} has deleted the group %s", g.GroupName)
+	return fmt.Sprintf("{{ if .ActorEmail }}{{ .ActorEmail }}{{ else }}system@chainloop.dev{{ end }} has deleted the group %s", g.GroupName)
 }
 
 // GroupMemberAdded represents the addition of a member to a group
@@ -168,7 +168,7 @@ func (g *GroupMemberAdded) Description() string {
 		maintainerStatus = " as a maintainer"
 	}
 
-	return fmt.Sprintf("{{ if .ActorEmail }}{{ .ActorEmail }}{{ else }}API Token {{ .ActorID }}{{ end }} has added user %s to the group %s%s",
+	return fmt.Sprintf("{{ if .ActorEmail }}{{ .ActorEmail }}{{ else }}system@chainloop.dev{{ end }} has added user %s to the group %s%s",
 		g.UserEmail, g.GroupName, maintainerStatus)
 }
 
@@ -196,7 +196,7 @@ func (g *GroupMemberRemoved) ActionInfo() (json.RawMessage, error) {
 }
 
 func (g *GroupMemberRemoved) Description() string {
-	return fmt.Sprintf("{{ if .ActorEmail }}{{ .ActorEmail }}{{ else }}API Token {{ .ActorID }}{{ end }} has removed user %s from the group %s",
+	return fmt.Sprintf("{{ if .ActorEmail }}{{ .ActorEmail }}{{ else }}system@chainloop.dev{{ end }} has removed user %s from the group %s",
 		g.UserEmail, g.GroupName)
 }
 
@@ -226,6 +226,6 @@ func (g *GroupMemberUpdated) ActionInfo() (json.RawMessage, error) {
 }
 
 func (g *GroupMemberUpdated) Description() string {
-	return fmt.Sprintf("{{ if .ActorEmail }}{{ .ActorEmail }}{{ else }}API Token {{ .ActorID }}{{ end }} has updated user %s in the group %s",
+	return fmt.Sprintf("{{ if .ActorEmail }}{{ .ActorEmail }}{{ else }}system@chainloop.dev{{ end }} has updated user %s in the group %s",
 		g.UserEmail, g.GroupName)
 }

--- a/app/controlplane/pkg/auditor/events/group_test.go
+++ b/app/controlplane/pkg/auditor/events/group_test.go
@@ -151,10 +151,11 @@ func TestGroupEvents(t *testing.T) {
 			opts := []auditor.GeneratorOption{
 				auditor.WithOrgID(orgUUID),
 			}
-			if tt.actor == auditor.ActorTypeAPIToken {
-				opts = append(opts, auditor.WithActor(auditor.ActorTypeAPIToken, tt.actorID, ""))
-			} else {
+
+			if tt.actor == auditor.ActorTypeUser {
 				opts = append(opts, auditor.WithActor(auditor.ActorTypeUser, tt.actorID, testEmail))
+			} else {
+				opts = append(opts, auditor.WithActor(auditor.ActorTypeSystem, uuid.Nil, ""))
 			}
 
 			eventPayload, err := auditor.GenerateAuditEvent(tt.event, opts...)

--- a/app/controlplane/pkg/auditor/events/project.go
+++ b/app/controlplane/pkg/auditor/events/project.go
@@ -109,12 +109,12 @@ func (p *ProjectMemberRoleUpdated) ActionInfo() (json.RawMessage, error) {
 func (p *ProjectMemberRoleUpdated) Description() string {
 	if p.UserID != nil {
 		// User role update
-		return fmt.Sprintf("{{ if .ActorEmail }}{{ .ActorEmail }}{{ else }}API Token {{ .ActorID }}{{ end }} has updated user '%s' role in project '%s' from '%s' to '%s'",
+		return fmt.Sprintf("{{ if .ActorEmail }}{{ .ActorEmail }}{{ else }}system@chainloop.dev{{ end }} has updated user '%s' role in project '%s' from '%s' to '%s'",
 			p.UserEmail, p.ProjectName, prettyRole(p.OldRole), prettyRole(p.NewRole))
 	}
 
 	// Group role update
-	return fmt.Sprintf("{{ if .ActorEmail }}{{ .ActorEmail }}{{ else }}API Token {{ .ActorID }}{{ end }} has updated group '%s' role in project '%s' from '%s' to '%s'",
+	return fmt.Sprintf("{{ if .ActorEmail }}{{ .ActorEmail }}{{ else }}system@chainloop.dev{{ end }} has updated group '%s' role in project '%s' from '%s' to '%s'",
 		p.GroupName, p.ProjectName, prettyRole(p.OldRole), prettyRole(p.NewRole))
 }
 
@@ -156,12 +156,12 @@ func (p *ProjectMembershipAdded) Description() string {
 
 	if p.UserID != nil {
 		// User addition
-		return fmt.Sprintf("{{ if .ActorEmail }}{{ .ActorEmail }}{{ else }}API Token {{ .ActorID }}{{ end }} has added user '%s' to the project '%s'%s",
+		return fmt.Sprintf("{{ if .ActorEmail }}{{ .ActorEmail }}{{ else }}system@chainloop.dev{{ end }} has added user '%s' to the project '%s'%s",
 			p.UserEmail, p.ProjectName, roleDesc)
 	}
 
 	// Group addition
-	return fmt.Sprintf("{{ if .ActorEmail }}{{ .ActorEmail }}{{ else }}API Token {{ .ActorID }}{{ end }} has added group '%s' to the project '%s'%s",
+	return fmt.Sprintf("{{ if .ActorEmail }}{{ .ActorEmail }}{{ else }}system@chainloop.dev{{ end }} has added group '%s' to the project '%s'%s",
 		p.GroupName, p.ProjectName, roleDesc)
 }
 
@@ -196,11 +196,11 @@ func (p *ProjectMembershipRemoved) ActionInfo() (json.RawMessage, error) {
 func (p *ProjectMembershipRemoved) Description() string {
 	if p.UserID != nil {
 		// User removal
-		return fmt.Sprintf("{{ if .ActorEmail }}{{ .ActorEmail }}{{ else }}API Token {{ .ActorID }}{{ end }} has removed user '%s' from the project '%s'",
+		return fmt.Sprintf("{{ if .ActorEmail }}{{ .ActorEmail }}{{ else }}system@chainloop.dev{{ end }} has removed user '%s' from the project '%s'",
 			p.UserEmail, p.ProjectName)
 	}
 
 	// Group removal
-	return fmt.Sprintf("{{ if .ActorEmail }}{{ .ActorEmail }}{{ else }}API Token {{ .ActorID }}{{ end }} has removed group '%s' from the project '%s'",
+	return fmt.Sprintf("{{ if .ActorEmail }}{{ .ActorEmail }}{{ else }}system@chainloop.dev{{ end }} has removed group '%s' from the project '%s'",
 		p.GroupName, p.ProjectName)
 }

--- a/app/controlplane/pkg/auditor/events/project_test.go
+++ b/app/controlplane/pkg/auditor/events/project_test.go
@@ -21,10 +21,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/authz"
-
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/auditor"
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/auditor/events"
+	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/authz"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -81,7 +80,7 @@ func TestProjectEvents(t *testing.T) {
 			actorID:  userUUID,
 		},
 		{
-			name: "ProjectMembershipAdded with API Token",
+			name: "ProjectMembershipAdded by system",
 			event: &events.ProjectMembershipAdded{
 				ProjectBase: &events.ProjectBase{
 					ProjectID:   &projectUUID,
@@ -91,8 +90,8 @@ func TestProjectEvents(t *testing.T) {
 				UserEmail: userEmail,
 				Role:      string(authz.RoleProjectViewer),
 			},
-			expected: "testdata/projects/project_member_added_with_api_token.json",
-			actor:    auditor.ActorTypeAPIToken,
+			expected: "testdata/projects/project_member_added_by_system.json",
+			actor:    auditor.ActorTypeSystem,
 			actorID:  userUUID,
 		},
 		{
@@ -112,7 +111,7 @@ func TestProjectEvents(t *testing.T) {
 			actorID:  userUUID,
 		},
 		{
-			name: "ProjectMemberRoleUpdated with API Token",
+			name: "ProjectMemberRoleUpdated by system",
 			event: &events.ProjectMemberRoleUpdated{
 				ProjectBase: &events.ProjectBase{
 					ProjectID:   &projectUUID,
@@ -123,8 +122,8 @@ func TestProjectEvents(t *testing.T) {
 				OldRole:   string(authz.RoleProjectViewer),
 				NewRole:   "role:project:admin",
 			},
-			expected: "testdata/projects/project_member_role_updated_with_api_token.json",
-			actor:    auditor.ActorTypeAPIToken,
+			expected: "testdata/projects/project_member_role_updated_by_system.json",
+			actor:    auditor.ActorTypeSystem,
 			actorID:  userUUID,
 		},
 		{
@@ -142,7 +141,7 @@ func TestProjectEvents(t *testing.T) {
 			actorID:  userUUID,
 		},
 		{
-			name: "ProjectMembershipRemoved with API Token",
+			name: "ProjectMembershipRemoved by system",
 			event: &events.ProjectMembershipRemoved{
 				ProjectBase: &events.ProjectBase{
 					ProjectID:   &projectUUID,
@@ -151,8 +150,8 @@ func TestProjectEvents(t *testing.T) {
 				UserID:    &memberUUID,
 				UserEmail: userEmail,
 			},
-			expected: "testdata/projects/project_member_removed_with_api_token.json",
-			actor:    auditor.ActorTypeAPIToken,
+			expected: "testdata/projects/project_member_removed_by_system.json",
+			actor:    auditor.ActorTypeSystem,
 			actorID:  userUUID,
 		},
 	}
@@ -162,10 +161,10 @@ func TestProjectEvents(t *testing.T) {
 			opts := []auditor.GeneratorOption{
 				auditor.WithOrgID(orgUUID),
 			}
-			if tt.actor == auditor.ActorTypeAPIToken {
-				opts = append(opts, auditor.WithActor(auditor.ActorTypeAPIToken, tt.actorID, ""))
-			} else {
+			if tt.actor == auditor.ActorTypeUser {
 				opts = append(opts, auditor.WithActor(auditor.ActorTypeUser, tt.actorID, testEmail))
+			} else {
+				opts = append(opts, auditor.WithActor(auditor.ActorTypeSystem, uuid.Nil, ""))
 			}
 
 			eventPayload, err := auditor.GenerateAuditEvent(tt.event, opts...)

--- a/app/controlplane/pkg/auditor/events/testdata/projects/project_member_added_by_system.json
+++ b/app/controlplane/pkg/auditor/events/testdata/projects/project_member_added_by_system.json
@@ -2,11 +2,11 @@
   "ActionType": "ProjectMembershipAdded",
   "TargetType": "Project",
   "TargetID": "3089bb36-e27b-428b-8009-d015c8737c56",
-  "ActorType": "API_TOKEN",
-  "ActorID": "1089bb36-e27b-428b-8009-d015c8737c54",
+  "ActorType": "SYSTEM",
+  "ActorID": null,
   "ActorEmail": "",
   "OrgID": "1089bb36-e27b-428b-8009-d015c8737c54",
-  "Description": "API Token 1089bb36-e27b-428b-8009-d015c8737c54 has added user 'test@example.com' to the project 'test-project' with role 'viewer'",
+  "Description": "system@chainloop.dev has added user 'test@example.com' to the project 'test-project' with role 'viewer'",
   "Info": {
     "project_id": "3089bb36-e27b-428b-8009-d015c8737c56",
     "project_name": "test-project",
@@ -14,5 +14,5 @@
     "user_email": "test@example.com",
     "role": "role:project:viewer"
   },
-  "Digest": "sha256:e166950b0f58a8d79a22f50c05e87cbcd6792017e8082c2a25be3371a3b323db"
+  "Digest": "sha256:4001d6187db2e8b9d70a052ad44db1a432237cf88800f048f19d5b1b143f3bb8"
 }

--- a/app/controlplane/pkg/auditor/events/testdata/projects/project_member_removed_by_system.json
+++ b/app/controlplane/pkg/auditor/events/testdata/projects/project_member_removed_by_system.json
@@ -2,16 +2,16 @@
   "ActionType": "ProjectMembershipRemoved",
   "TargetType": "Project",
   "TargetID": "3089bb36-e27b-428b-8009-d015c8737c56",
-  "ActorType": "API_TOKEN",
-  "ActorID": "1089bb36-e27b-428b-8009-d015c8737c54",
+  "ActorType": "SYSTEM",
+  "ActorID": null,
   "ActorEmail": "",
   "OrgID": "1089bb36-e27b-428b-8009-d015c8737c54",
-  "Description": "API Token 1089bb36-e27b-428b-8009-d015c8737c54 has removed user 'test@example.com' from the project 'test-project'",
+  "Description": "system@chainloop.dev has removed user 'test@example.com' from the project 'test-project'",
   "Info": {
     "project_id": "3089bb36-e27b-428b-8009-d015c8737c56",
     "project_name": "test-project",
     "user_id": "4089bb36-e27b-428b-8009-d015c8737c57",
     "user_email": "test@example.com"
   },
-  "Digest": "sha256:15800e73f6bc26f866647be23c37d3448195b316f4d07f82280a1acd75821de2"
+  "Digest": "sha256:843bec1b22da94ea7320c20556893a53b04bf795d0f6dd6a6f5cd58e88da928f"
 }

--- a/app/controlplane/pkg/auditor/events/testdata/projects/project_member_role_updated_by_system.json
+++ b/app/controlplane/pkg/auditor/events/testdata/projects/project_member_role_updated_by_system.json
@@ -2,11 +2,11 @@
   "ActionType": "ProjectMemberRoleUpdated",
   "TargetType": "Project",
   "TargetID": "3089bb36-e27b-428b-8009-d015c8737c56",
-  "ActorType": "API_TOKEN",
-  "ActorID": "1089bb36-e27b-428b-8009-d015c8737c54",
+  "ActorType": "SYSTEM",
+  "ActorID": null,
   "ActorEmail": "",
   "OrgID": "1089bb36-e27b-428b-8009-d015c8737c54",
-  "Description": "API Token 1089bb36-e27b-428b-8009-d015c8737c54 has updated user 'test@example.com' role in project 'test-project' from 'viewer' to 'admin'",
+  "Description": "system@chainloop.dev has updated user 'test@example.com' role in project 'test-project' from 'viewer' to 'admin'",
   "Info": {
     "project_id": "3089bb36-e27b-428b-8009-d015c8737c56",
     "project_name": "test-project",
@@ -15,5 +15,5 @@
     "old_role": "role:project:viewer",
     "new_role": "role:project:admin"
   },
-  "Digest": "sha256:5ab471ec21db79fcad5a0634c6a767f8532cf840047c906984361b0a9153d6b8"
+  "Digest": "sha256:5d99de1aed32c9ab88025686cd2029ffa411b734dd44b957defba40df4c6246e"
 }

--- a/app/controlplane/pkg/biz/orginvitation_integration_test.go
+++ b/app/controlplane/pkg/biz/orginvitation_integration_test.go
@@ -302,7 +302,7 @@ func (s *OrgInvitationIntegrationTestSuite) TestInvitationWithGroupContext() {
 	userUUID := uuid.MustParse(s.user.ID)
 	orgUUID := uuid.MustParse(s.org1.ID)
 
-	group, err := s.Group.Create(ctx, orgUUID, groupName, groupDescription, userUUID)
+	group, err := s.Group.Create(ctx, orgUUID, groupName, groupDescription, &userUUID)
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), group)
 
@@ -559,7 +559,7 @@ func (s *OrgInvitationIntegrationTestSuite) TestInvitationWithProjectContext() {
 		// Create a test group
 		groupName := "combined-test-group"
 		groupDescription := "A group for testing combined invitation context"
-		group, err := s.Group.Create(ctx, orgUUID, groupName, groupDescription, userUUID)
+		group, err := s.Group.Create(ctx, orgUUID, groupName, groupDescription, &userUUID)
 		require.NoError(t, err)
 		require.NotNil(t, group)
 

--- a/app/controlplane/pkg/biz/project.go
+++ b/app/controlplane/pkg/biz/project.go
@@ -244,8 +244,8 @@ func (uc *ProjectUseCase) AddMemberToProject(ctx context.Context, orgID uuid.UUI
 		return nil, NewErrValidationStr("options cannot be nil")
 	}
 
-	if orgID == uuid.Nil || opts.RequesterID == uuid.Nil {
-		return nil, NewErrValidationStr("organization ID and requester ID cannot be empty")
+	if orgID == uuid.Nil {
+		return nil, NewErrValidationStr("organization ID cannot be empty")
 	}
 
 	// Ensure only one of UserEmail or GroupReference is provided
@@ -264,9 +264,11 @@ func (uc *ProjectUseCase) AddMemberToProject(ctx context.Context, orgID uuid.UUI
 		return nil, err
 	}
 
-	// Verify the requester has permissions to add members to the project
-	if err := uc.verifyRequesterHasPermissions(ctx, orgID, resolvedProjectID, opts.RequesterID); err != nil {
-		return nil, fmt.Errorf("requester does not have permission to add members to this project: %w", err)
+	// Verify the requester has permissions to add members to the project (if a requester is provided)
+	if opts.RequesterID != uuid.Nil {
+		if err := uc.verifyRequesterHasPermissions(ctx, orgID, resolvedProjectID, opts.RequesterID); err != nil {
+			return nil, fmt.Errorf("requester does not have permission to add members to this project: %w", err)
+		}
 	}
 
 	var result *AddMemberToProjectResult
@@ -433,8 +435,8 @@ func (uc *ProjectUseCase) RemoveMemberFromProject(ctx context.Context, orgID uui
 		return NewErrValidationStr("options cannot be nil")
 	}
 
-	if orgID == uuid.Nil || opts.RequesterID == uuid.Nil {
-		return NewErrValidationStr("organization ID and requester ID cannot be empty")
+	if orgID == uuid.Nil {
+		return NewErrValidationStr("organization ID cannot be empty")
 	}
 
 	// Ensure only one of UserEmail or GroupReference is provided
@@ -448,9 +450,11 @@ func (uc *ProjectUseCase) RemoveMemberFromProject(ctx context.Context, orgID uui
 		return err
 	}
 
-	// Verify the requester has permissions to remove members from the project
-	if err := uc.verifyRequesterHasPermissions(ctx, orgID, resolvedProjectID, opts.RequesterID); err != nil {
-		return fmt.Errorf("requester does not have permission to remove members from this project: %w", err)
+	// Verify the requester has permissions to remove members from the project (if a requester is provided)
+	if opts.RequesterID != uuid.Nil {
+		if err := uc.verifyRequesterHasPermissions(ctx, orgID, resolvedProjectID, opts.RequesterID); err != nil {
+			return fmt.Errorf("requester does not have permission to remove members from this project: %w", err)
+		}
 	}
 
 	// Process based on whether we're removing a user or a group
@@ -668,8 +672,8 @@ func (uc *ProjectUseCase) UpdateMemberRole(ctx context.Context, orgID uuid.UUID,
 		return NewErrValidationStr("options cannot be nil")
 	}
 
-	if orgID == uuid.Nil || opts.RequesterID == uuid.Nil {
-		return NewErrValidationStr("organization ID and requester ID cannot be empty")
+	if orgID == uuid.Nil {
+		return NewErrValidationStr("organization ID cannot be empty")
 	}
 
 	// Ensure only one of UserEmail or GroupReference is provided
@@ -688,9 +692,11 @@ func (uc *ProjectUseCase) UpdateMemberRole(ctx context.Context, orgID uuid.UUID,
 		return err
 	}
 
-	// Verify the requester has permissions to update member roles in the project
-	if err := uc.verifyRequesterHasPermissions(ctx, orgID, resolvedProjectID, opts.RequesterID); err != nil {
-		return fmt.Errorf("requester does not have permission to update member roles in this project: %w", err)
+	// Verify the requester has permissions to update member roles in the project (if a requester is provided)
+	if opts.RequesterID != uuid.Nil {
+		if err := uc.verifyRequesterHasPermissions(ctx, orgID, resolvedProjectID, opts.RequesterID); err != nil {
+			return fmt.Errorf("requester does not have permission to update member roles in this project: %w", err)
+		}
 	}
 
 	// Process based on whether we're updating a user or a group

--- a/app/controlplane/pkg/biz/testhelpers/wire_gen.go
+++ b/app/controlplane/pkg/biz/testhelpers/wire_gen.go
@@ -7,6 +7,7 @@
 package testhelpers
 
 import (
+	"fmt"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/conf/controlplane/config/v1"
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/auditor"
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/authz"
@@ -213,7 +214,12 @@ func newJWTConfig(conf2 *conf.Auth) *biz.APITokenJWTConfig {
 
 // Connection to nats is optional, if not configured, pubsub will be disabled
 func newNatsConnection() (*nats.Conn, error) {
-	return nil, nil
+	nc, err := nats.Connect("nats://0.0.0.0:4222")
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to nats: %w", err)
+	}
+
+	return nc, nil
 }
 
 func newAuthAllowList(conf2 *conf.Bootstrap) *v1.AllowList {


### PR DESCRIPTION
This patch refactors several business cases related to groups and projects to make them reusable by the system in other calls. The main change is the removal of the mandatory requester previously required in those operations.

Additionally, it updates the audit log to properly handle and record system-initiated calls.

One exception though on the membership management of groups and projects is that the system cannot create invitation for users to join the system if the request is coming from the actual system.