### PR TITLE
fix(projects): Always load organization on memberships

### DIFF
--- a/app/controlplane/pkg/data/membership.go
+++ b/app/controlplane/pkg/data/membership.go
@@ -284,7 +284,7 @@ func (r *MembershipRepo) ListGroupMembershipsByUser(ctx context.Context, userID 
 		groupRoleMemberships, err := r.data.DB.Membership.Query().Where(
 			membership.MembershipTypeEQ(authz.MembershipTypeGroup),
 			membership.MemberIDIn(groupIDs...),
-		).All(ctx)
+		).WithOrganization().All(ctx)
 
 		if err != nil {
 			return nil, fmt.Errorf("failed to query group role memberships: %w", err)

--- a/app/controlplane/pkg/data/project.go
+++ b/app/controlplane/pkg/data/project.go
@@ -335,7 +335,7 @@ func (r *ProjectRepo) queryMembership(orgID uuid.UUID, projectID uuid.UUID, memb
 			membership.MemberID(memberID),
 			membership.ResourceTypeEQ(authz.ResourceTypeProject),
 			membership.ResourceID(projectID),
-		)
+		).WithOrganization()
 }
 
 // entProjectToBiz converts an ent.Project to a biz.Project


### PR DESCRIPTION
This patch eagerly loads the organization of the membership, so it's available and can be used to check roles in the service and business layers.