### PR TITLE
fix(rbac): inherit group roles in referrer and casredirect services

### DIFF
--- a/app/controlplane/cmd/wire_gen.go
+++ b/app/controlplane/cmd/wire_gen.go
@@ -98,9 +98,8 @@ func wireApp(bootstrap *conf.Bootstrap, readerWriter credentials.ReaderWriter, l
 	v2 := _wireValue
 	casClientUseCase := biz.NewCASClientUseCase(casCredentialsUseCase, bootstrap_CASServer, logger, v2...)
 	referrerRepo := data.NewReferrerRepo(dataData, workflowRepo, logger)
-	projectsRepo := data.NewProjectsRepo(dataData, logger)
 	referrerSharedIndex := bootstrap.ReferrerSharedIndex
-	referrerUseCase, err := biz.NewReferrerUseCase(referrerRepo, workflowRepo, membershipRepo, projectsRepo, referrerSharedIndex, logger)
+	referrerUseCase, err := biz.NewReferrerUseCase(referrerRepo, workflowRepo, membershipUseCase, referrerSharedIndex, logger)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
@@ -118,6 +117,7 @@ func wireApp(bootstrap *conf.Bootstrap, readerWriter credentials.ReaderWriter, l
 		cleanup()
 		return nil, nil, err
 	}
+	projectsRepo := data.NewProjectsRepo(dataData, logger)
 	workflowContractRepo := data.NewWorkflowContractRepo(dataData, logger)
 	v3 := bootstrap.PolicyProviders
 	v4 := newPolicyProviderConfig(v3)
@@ -168,7 +168,7 @@ func wireApp(bootstrap *conf.Bootstrap, readerWriter credentials.ReaderWriter, l
 	attestationUseCase := biz.NewAttestationUseCase(casClientUseCase, logger)
 	fanOutDispatcher := dispatcher.New(integrationUseCase, workflowUseCase, workflowRunUseCase, readerWriter, casClientUseCase, availablePlugins, logger)
 	casMappingRepo := data.NewCASMappingRepo(dataData, casBackendRepo, logger)
-	casMappingUseCase := biz.NewCASMappingUseCase(casMappingRepo, membershipRepo, projectsRepo, logger)
+	casMappingUseCase := biz.NewCASMappingUseCase(casMappingRepo, membershipUseCase, logger)
 	v6 := bootstrap.PrometheusIntegration
 	orgMetricsRepo := data.NewOrgMetricsRepo(dataData, logger)
 	orgMetricsUseCase, err := biz.NewOrgMetricsUseCase(orgMetricsRepo, organizationRepo, workflowUseCase, logger)

--- a/app/controlplane/pkg/biz/casmapping.go
+++ b/app/controlplane/pkg/biz/casmapping.go
@@ -52,14 +52,13 @@ type CASMappingRepo interface {
 }
 
 type CASMappingUseCase struct {
-	repo           CASMappingRepo
-	membershipRepo MembershipRepo
-	projectsRepo   ProjectsRepo
-	logger         *log.Helper
+	repo         CASMappingRepo
+	membershipUC *MembershipUseCase
+	logger       *log.Helper
 }
 
-func NewCASMappingUseCase(repo CASMappingRepo, mRepo MembershipRepo, pRepo ProjectsRepo, logger log.Logger) *CASMappingUseCase {
-	return &CASMappingUseCase{repo, mRepo, pRepo, servicelogger.ScopedHelper(logger, "cas-mapping-usecase")}
+func NewCASMappingUseCase(repo CASMappingRepo, membershipUC *MembershipUseCase, logger log.Logger) *CASMappingUseCase {
+	return &CASMappingUseCase{repo, membershipUC, servicelogger.ScopedHelper(logger, "cas-mapping-usecase")}
 }
 
 type CASMappingCreateOpts struct {
@@ -99,7 +98,7 @@ func (uc *CASMappingUseCase) FindCASMappingForDownloadByUser(ctx context.Context
 		return nil, NewErrInvalidUUID(err)
 	}
 
-	userOrgs, projectIDs, err := getOrgsAndRBACInfoForUser(ctx, userUUID, uc.membershipRepo, uc.projectsRepo)
+	userOrgs, projectIDs, err := uc.membershipUC.GetOrgsAndRBACInfoForUser(ctx, userUUID)
 	if err != nil {
 		return nil, err
 	}

--- a/app/controlplane/pkg/biz/referrer.go
+++ b/app/controlplane/pkg/biz/referrer.go
@@ -35,15 +35,14 @@ import (
 )
 
 type ReferrerUseCase struct {
-	repo           ReferrerRepo
-	membershipRepo MembershipRepo
-	workflowRepo   WorkflowRepo
-	projectsRepo   ProjectsRepo
-	logger         *log.Helper
-	indexConfig    *conf.ReferrerSharedIndex
+	repo              ReferrerRepo
+	membershipUseCase *MembershipUseCase
+	workflowRepo      WorkflowRepo
+	logger            *log.Helper
+	indexConfig       *conf.ReferrerSharedIndex
 }
 
-func NewReferrerUseCase(repo ReferrerRepo, wfRepo WorkflowRepo, mRepo MembershipRepo, projectsRepo ProjectsRepo, indexCfg *conf.ReferrerSharedIndex, l log.Logger) (*ReferrerUseCase, error) {
+func NewReferrerUseCase(repo ReferrerRepo, wfRepo WorkflowRepo, membershipUseCase *MembershipUseCase, indexCfg *conf.ReferrerSharedIndex, l log.Logger) (*ReferrerUseCase, error) {
 	if l == nil {
 		l = log.NewStdLogger(io.Discard)
 	}
@@ -60,12 +59,11 @@ func NewReferrerUseCase(repo ReferrerRepo, wfRepo WorkflowRepo, mRepo Membership
 	}
 
 	return &ReferrerUseCase{
-		repo:           repo,
-		membershipRepo: mRepo,
-		indexConfig:    indexCfg,
-		workflowRepo:   wfRepo,
-		projectsRepo:   projectsRepo,
-		logger:         logger,
+		repo:              repo,
+		membershipUseCase: membershipUseCase,
+		indexConfig:       indexCfg,
+		workflowRepo:      wfRepo,
+		logger:            logger,
 	}, nil
 }
 
@@ -172,7 +170,7 @@ func (s *ReferrerUseCase) GetFromRootUser(ctx context.Context, digest, rootKind,
 		return nil, NewErrInvalidUUID(err)
 	}
 
-	userOrgs, projectIDs, err := getOrgsAndRBACInfoForUser(ctx, userUUID, s.membershipRepo, s.projectsRepo)
+	userOrgs, projectIDs, err := s.membershipUseCase.GetOrgsAndRBACInfoForUser(ctx, userUUID)
 	if err != nil {
 		return nil, err
 	}

--- a/app/controlplane/pkg/biz/referrer_integration_test.go
+++ b/app/controlplane/pkg/biz/referrer_integration_test.go
@@ -87,7 +87,7 @@ func (s *referrerIntegrationTestSuite) TestGetFromRootInPublicSharedIndex() {
 	})
 
 	s.T().Run("it should appear if we whitelist org2", func(t *testing.T) {
-		uc, err := biz.NewReferrerUseCase(s.Repos.Referrer, s.Repos.Workflow, s.Repos.Membership, nil,
+		uc, err := biz.NewReferrerUseCase(s.Repos.Referrer, s.Repos.Workflow, s.Membership,
 			&conf.ReferrerSharedIndex{
 				Enabled:     true,
 				AllowedOrgs: []string{s.org2.ID},
@@ -463,7 +463,7 @@ func (s *referrerIntegrationTestSuite) SetupTest() {
 	_, err = s.Membership.Create(ctx, s.org2.ID, s.user2.ID, biz.WithCurrentMembership())
 	require.NoError(s.T(), err)
 
-	s.sharedEnabledUC, err = biz.NewReferrerUseCase(s.Repos.Referrer, s.Repos.Workflow, s.Repos.Membership, nil,
+	s.sharedEnabledUC, err = biz.NewReferrerUseCase(s.Repos.Referrer, s.Repos.Workflow, s.Membership,
 		&conf.ReferrerSharedIndex{
 			Enabled:     true,
 			AllowedOrgs: []string{s.org1.ID},

--- a/app/controlplane/pkg/biz/testhelpers/wire_gen.go
+++ b/app/controlplane/pkg/biz/testhelpers/wire_gen.go
@@ -116,7 +116,7 @@ func WireTestData(testDatabase *TestDatabase, t *testing.T, logger log.Logger, r
 	robotAccountRepo := data.NewRobotAccountRepo(dataData, logger)
 	robotAccountUseCase := biz.NewRootAccountUseCase(robotAccountRepo, workflowRepo, auth, logger)
 	casMappingRepo := data.NewCASMappingRepo(dataData, casBackendRepo, logger)
-	casMappingUseCase := biz.NewCASMappingUseCase(casMappingRepo, membershipRepo, projectsRepo, logger)
+	casMappingUseCase := biz.NewCASMappingUseCase(casMappingRepo, membershipUseCase, logger)
 	orgInvitationRepo := data.NewOrgInvitation(dataData, logger)
 	groupRepo := data.NewGroupRepo(dataData, logger)
 	orgInvitationUseCase, err := biz.NewOrgInvitationUseCase(orgInvitationRepo, membershipRepo, userRepo, auditorUseCase, groupRepo, projectsRepo, logger)
@@ -126,7 +126,7 @@ func WireTestData(testDatabase *TestDatabase, t *testing.T, logger log.Logger, r
 	}
 	referrerRepo := data.NewReferrerRepo(dataData, workflowRepo, logger)
 	referrerSharedIndex := _wireReferrerSharedIndexValue
-	referrerUseCase, err := biz.NewReferrerUseCase(referrerRepo, workflowRepo, membershipRepo, projectsRepo, referrerSharedIndex, logger)
+	referrerUseCase, err := biz.NewReferrerUseCase(referrerRepo, workflowRepo, membershipUseCase, referrerSharedIndex, logger)
 	if err != nil {
 		cleanup()
 		return nil, nil, err


### PR DESCRIPTION
Group roles weren't being taken into account to build the visible projects filter.
