### PR TITLE
fix(group): Deletion of groups handle correctly

### DIFF
--- a/app/controlplane/pkg/data/ent/migrate/migrations/20250714172256.sql
+++ b/app/controlplane/pkg/data/ent/migrate/migrations/20250714172256.sql
@@ -1,0 +1,44 @@
+-- Fix memberships for deleted groups
+-- This migration does the following:
+-- 1. Removes entries from the membership table where the member_id is a deleted group or resource_id is a deleted group
+-- 2. Marks group memberships with deleted group IDs as deleted (sets deleted_at)
+-- 3. Marks as deleted any pending invitations for deleted groups
+
+-- First, delete all memberships where the member is a deleted group or the resource is a deleted group
+DELETE FROM "memberships"
+WHERE "member_id" IN (
+    SELECT "id" FROM "groups"
+    WHERE "deleted_at" IS NOT NULL
+) OR (
+    "resource_id" IN (
+        SELECT "id" FROM "groups"
+        WHERE "deleted_at" IS NOT NULL
+    )
+    AND "resource_type" = 'group'
+);
+
+-- Next, mark all group_memberships as deleted for deleted groups
+-- Only update records that don't already have a deleted_at value
+UPDATE "group_memberships"
+SET
+    "deleted_at" = NOW(),
+    "updated_at" = NOW()
+WHERE
+    "group_id" IN (
+        SELECT "id" FROM "groups"
+        WHERE "deleted_at" IS NOT NULL
+    )
+  AND "deleted_at" IS NULL;
+
+-- Finally, ark as deleted any pending invitations for deleted groups
+UPDATE "org_invitations"
+SET
+    "deleted_at" = NOW()
+WHERE
+    "status" = 'pending'
+  AND "deleted_at" IS NULL
+  AND "context"::jsonb ? 'group_id_to_join'
+  AND "context"::jsonb->>'group_id_to_join' IN (
+    SELECT "id"::text FROM "groups"
+    WHERE "deleted_at" IS NOT NULL
+);

--- a/app/controlplane/pkg/data/ent/migrate/migrations/atlas.sum
+++ b/app/controlplane/pkg/data/ent/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:i8q/MAG0rdlc1GCi0fAagiO70ZEhj6wvvFp8kgM+l50=
+h1:WasPyGuTE05lx75h+qqmoAknSDJPoN50E8hqbhNFVQs=
 20230706165452_init-schema.sql h1:VvqbNFEQnCvUVyj2iDYVQQxDM0+sSXqocpt/5H64k8M=
 20230710111950-cas-backend.sql h1:A8iBuSzZIEbdsv9ipBtscZQuaBp3V5/VMw7eZH6GX+g=
 20230712094107-cas-backends-workflow-runs.sql h1:a5rzxpVGyd56nLRSsKrmCFc9sebg65RWzLghKHh5xvI=
@@ -96,3 +96,4 @@ h1:i8q/MAG0rdlc1GCi0fAagiO70ZEhj6wvvFp8kgM+l50=
 20250702112642.sql h1:wrjVS+5h2hs7KNwPRBece5LgAsoEzxN/zNfvCnjoIUw=
 20250704090359.sql h1:a0ksfjy2dtzviJL16HbC4eT1xBxy2qFH5mNFOpYlUrA=
 20250710105502.sql h1:EA6Ta1qsZcrNoOrO5zUNgiweHDtjl0HUlobukRuruko=
+20250714172256.sql h1:S0ImNk0sMjWVVZvS6VVHn2h96/nx8GOf4aVxELbJAcg=

--- a/app/controlplane/pkg/data/project.go
+++ b/app/controlplane/pkg/data/project.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/data/ent/group"
+
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqljson"
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/authz"
@@ -277,7 +279,7 @@ func (r *ProjectRepo) FindProjectMembershipByProjectAndID(ctx context.Context, o
 		projectMembership.User = entUserToBizUser(u)
 	case authz.MembershipTypeGroup:
 		// Fetch the group details for group memberships
-		g, err := r.data.DB.Group.Get(ctx, memberID)
+		g, err := r.data.DB.Group.Query().Where(group.ID(memberID), group.DeletedAtIsNil()).Only(ctx)
 		if err != nil {
 			if ent.IsNotFound(err) {
 				return nil, biz.NewErrNotFound("group")


### PR DESCRIPTION
This patch fixes issues with group removal, where related resources were being left behind. Deleting a group now performs the following actions:
- Marks the group as deleted
- Marks all user group memberships as deleted
- Removes all group-related entries from the membership table, including users with the maintainer role and group memberships in projects
- Marks all pending invitations associated with the group as deleted, if any

It also creates a migration that fixes all current dangling groups if any in the system by performing the same steps as above.