### PR TITLE
fix(group): Calculate member count as a whole

### DIFF
--- a/app/controlplane/cmd/wire_gen.go
+++ b/app/controlplane/cmd/wire_gen.go
@@ -38,7 +38,8 @@ func wireApp(bootstrap *conf.Bootstrap, readerWriter credentials.ReaderWriter, l
 		return nil, nil, err
 	}
 	userRepo := data.NewUserRepo(dataData, logger)
-	membershipRepo := data.NewMembershipRepo(dataData, logger)
+	groupRepo := data.NewGroupRepo(dataData, logger)
+	membershipRepo := data.NewMembershipRepo(dataData, groupRepo, logger)
 	organizationRepo := data.NewOrganizationRepo(dataData, logger)
 	casBackendRepo := data.NewCASBackendRepo(dataData, logger)
 	providers := loader.LoadProviders(readerWriter)
@@ -128,7 +129,6 @@ func wireApp(bootstrap *conf.Bootstrap, readerWriter credentials.ReaderWriter, l
 	}
 	workflowContractUseCase := biz.NewWorkflowContractUseCase(workflowContractRepo, registry, auditorUseCase, logger)
 	workflowUseCase := biz.NewWorkflowUsecase(workflowRepo, projectsRepo, workflowContractUseCase, auditorUseCase, membershipUseCase, logger)
-	groupRepo := data.NewGroupRepo(dataData, logger)
 	orgInvitationRepo := data.NewOrgInvitation(dataData, logger)
 	orgInvitationUseCase, err := biz.NewOrgInvitationUseCase(orgInvitationRepo, membershipRepo, userRepo, auditorUseCase, groupRepo, projectsRepo, logger)
 	if err != nil {

--- a/app/controlplane/cmd/wire_gen.go
+++ b/app/controlplane/cmd/wire_gen.go
@@ -38,8 +38,7 @@ func wireApp(bootstrap *conf.Bootstrap, readerWriter credentials.ReaderWriter, l
 		return nil, nil, err
 	}
 	userRepo := data.NewUserRepo(dataData, logger)
-	groupRepo := data.NewGroupRepo(dataData, logger)
-	membershipRepo := data.NewMembershipRepo(dataData, groupRepo, logger)
+	membershipRepo := data.NewMembershipRepo(dataData, logger)
 	organizationRepo := data.NewOrganizationRepo(dataData, logger)
 	casBackendRepo := data.NewCASBackendRepo(dataData, logger)
 	providers := loader.LoadProviders(readerWriter)
@@ -129,6 +128,7 @@ func wireApp(bootstrap *conf.Bootstrap, readerWriter credentials.ReaderWriter, l
 	}
 	workflowContractUseCase := biz.NewWorkflowContractUseCase(workflowContractRepo, registry, auditorUseCase, logger)
 	workflowUseCase := biz.NewWorkflowUsecase(workflowRepo, projectsRepo, workflowContractUseCase, auditorUseCase, membershipUseCase, logger)
+	groupRepo := data.NewGroupRepo(dataData, logger)
 	orgInvitationRepo := data.NewOrgInvitation(dataData, logger)
 	orgInvitationUseCase, err := biz.NewOrgInvitationUseCase(orgInvitationRepo, membershipRepo, userRepo, auditorUseCase, groupRepo, projectsRepo, logger)
 	if err != nil {

--- a/app/controlplane/pkg/biz/group.go
+++ b/app/controlplane/pkg/biz/group.go
@@ -55,6 +55,8 @@ type GroupRepo interface {
 	ListPendingInvitationsByGroup(ctx context.Context, orgID uuid.UUID, groupID uuid.UUID, paginationOpts *pagination.OffsetPaginationOpts) ([]*OrgInvitation, int, error)
 	// ListProjectsByGroup retrieves a list of projects that a group is a member of with pagination.
 	ListProjectsByGroup(ctx context.Context, orgID uuid.UUID, groupID uuid.UUID, visibleProjectIDs []uuid.UUID, paginationOpts *pagination.OffsetPaginationOpts) ([]*GroupProjectInfo, int, error)
+	// UpdateGroupMemberCount updates the member count of a group.
+	UpdateGroupMemberCount(ctx context.Context, groupID uuid.UUID) error
 }
 
 // GroupMembership represents a membership of a user in a group.

--- a/app/controlplane/pkg/biz/testhelpers/wire_gen.go
+++ b/app/controlplane/pkg/biz/testhelpers/wire_gen.go
@@ -37,8 +37,7 @@ func WireTestData(testDatabase *TestDatabase, t *testing.T, logger log.Logger, r
 	if err != nil {
 		return nil, nil, err
 	}
-	groupRepo := data.NewGroupRepo(dataData, logger)
-	membershipRepo := data.NewMembershipRepo(dataData, groupRepo, logger)
+	membershipRepo := data.NewMembershipRepo(dataData, logger)
 	organizationRepo := data.NewOrganizationRepo(dataData, logger)
 	casBackendRepo := data.NewCASBackendRepo(dataData, logger)
 	bootstrap_CASServer := NewCASBackendConfig()
@@ -119,6 +118,7 @@ func WireTestData(testDatabase *TestDatabase, t *testing.T, logger log.Logger, r
 	casMappingRepo := data.NewCASMappingRepo(dataData, casBackendRepo, logger)
 	casMappingUseCase := biz.NewCASMappingUseCase(casMappingRepo, membershipUseCase, logger)
 	orgInvitationRepo := data.NewOrgInvitation(dataData, logger)
+	groupRepo := data.NewGroupRepo(dataData, logger)
 	orgInvitationUseCase, err := biz.NewOrgInvitationUseCase(orgInvitationRepo, membershipRepo, userRepo, auditorUseCase, groupRepo, projectsRepo, logger)
 	if err != nil {
 		cleanup()

--- a/app/controlplane/pkg/biz/testhelpers/wire_gen.go
+++ b/app/controlplane/pkg/biz/testhelpers/wire_gen.go
@@ -37,7 +37,8 @@ func WireTestData(testDatabase *TestDatabase, t *testing.T, logger log.Logger, r
 	if err != nil {
 		return nil, nil, err
 	}
-	membershipRepo := data.NewMembershipRepo(dataData, logger)
+	groupRepo := data.NewGroupRepo(dataData, logger)
+	membershipRepo := data.NewMembershipRepo(dataData, groupRepo, logger)
 	organizationRepo := data.NewOrganizationRepo(dataData, logger)
 	casBackendRepo := data.NewCASBackendRepo(dataData, logger)
 	bootstrap_CASServer := NewCASBackendConfig()
@@ -118,7 +119,6 @@ func WireTestData(testDatabase *TestDatabase, t *testing.T, logger log.Logger, r
 	casMappingRepo := data.NewCASMappingRepo(dataData, casBackendRepo, logger)
 	casMappingUseCase := biz.NewCASMappingUseCase(casMappingRepo, membershipUseCase, logger)
 	orgInvitationRepo := data.NewOrgInvitation(dataData, logger)
-	groupRepo := data.NewGroupRepo(dataData, logger)
 	orgInvitationUseCase, err := biz.NewOrgInvitationUseCase(orgInvitationRepo, membershipRepo, userRepo, auditorUseCase, groupRepo, projectsRepo, logger)
 	if err != nil {
 		cleanup()

--- a/app/controlplane/pkg/data/ent/migrate/migrations/20250715100956.sql
+++ b/app/controlplane/pkg/data/ent/migrate/migrations/20250715100956.sql
@@ -9,5 +9,4 @@ SET "member_count" = (
     FROM "group_memberships" gm
     WHERE gm."group_id" = g."id"
       AND gm."deleted_at" IS NULL
-)
-WHERE 1=1; -- Apply to all groups
+); -- Apply to all groups

--- a/app/controlplane/pkg/data/ent/migrate/migrations/20250715100956.sql
+++ b/app/controlplane/pkg/data/ent/migrate/migrations/20250715100956.sql
@@ -1,0 +1,13 @@
+-- Fix group member counts by calculating the correct number of members for each group
+-- This migration addresses any inconsistencies in the member_count field of the groups table
+-- by counting the actual number of non-deleted memberships for each group.
+
+-- Update the member_count in groups table based on a count of active memberships
+UPDATE "groups" g
+SET "member_count" = (
+    SELECT COUNT(*)
+    FROM "group_memberships" gm
+    WHERE gm."group_id" = g."id"
+      AND gm."deleted_at" IS NULL
+)
+WHERE 1=1; -- Apply to all groups

--- a/app/controlplane/pkg/data/ent/migrate/migrations/atlas.sum
+++ b/app/controlplane/pkg/data/ent/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:WasPyGuTE05lx75h+qqmoAknSDJPoN50E8hqbhNFVQs=
+h1:XoiYtAbqVAQdLw1aRpVIJu6sqZPWEZR3WuocvtoCi2Y=
 20230706165452_init-schema.sql h1:VvqbNFEQnCvUVyj2iDYVQQxDM0+sSXqocpt/5H64k8M=
 20230710111950-cas-backend.sql h1:A8iBuSzZIEbdsv9ipBtscZQuaBp3V5/VMw7eZH6GX+g=
 20230712094107-cas-backends-workflow-runs.sql h1:a5rzxpVGyd56nLRSsKrmCFc9sebg65RWzLghKHh5xvI=
@@ -97,3 +97,4 @@ h1:WasPyGuTE05lx75h+qqmoAknSDJPoN50E8hqbhNFVQs=
 20250704090359.sql h1:a0ksfjy2dtzviJL16HbC4eT1xBxy2qFH5mNFOpYlUrA=
 20250710105502.sql h1:EA6Ta1qsZcrNoOrO5zUNgiweHDtjl0HUlobukRuruko=
 20250714172256.sql h1:S0ImNk0sMjWVVZvS6VVHn2h96/nx8GOf4aVxELbJAcg=
+20250715100956.sql h1:8gZbbUts4ZcQRqhg/ZmZoIC5ScoonGDKaxJcvaglkoo=

--- a/app/controlplane/pkg/data/ent/migrate/migrations/atlas.sum
+++ b/app/controlplane/pkg/data/ent/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:XoiYtAbqVAQdLw1aRpVIJu6sqZPWEZR3WuocvtoCi2Y=
+h1:bxjg7J7Xk0+87+PhS0+F/c4AcHJZ3pkf0FnPMZa39Q0=
 20230706165452_init-schema.sql h1:VvqbNFEQnCvUVyj2iDYVQQxDM0+sSXqocpt/5H64k8M=
 20230710111950-cas-backend.sql h1:A8iBuSzZIEbdsv9ipBtscZQuaBp3V5/VMw7eZH6GX+g=
 20230712094107-cas-backends-workflow-runs.sql h1:a5rzxpVGyd56nLRSsKrmCFc9sebg65RWzLghKHh5xvI=
@@ -97,4 +97,4 @@ h1:XoiYtAbqVAQdLw1aRpVIJu6sqZPWEZR3WuocvtoCi2Y=
 20250704090359.sql h1:a0ksfjy2dtzviJL16HbC4eT1xBxy2qFH5mNFOpYlUrA=
 20250710105502.sql h1:EA6Ta1qsZcrNoOrO5zUNgiweHDtjl0HUlobukRuruko=
 20250714172256.sql h1:S0ImNk0sMjWVVZvS6VVHn2h96/nx8GOf4aVxELbJAcg=
-20250715100956.sql h1:8gZbbUts4ZcQRqhg/ZmZoIC5ScoonGDKaxJcvaglkoo=
+20250715100956.sql h1:y9eOaPMpQTlcJppjaGzeuHBTNDwe6sGbxSVU8e7LL1o=

--- a/app/controlplane/pkg/data/group.go
+++ b/app/controlplane/pkg/data/group.go
@@ -228,9 +228,6 @@ func (g GroupRepo) Create(ctx context.Context, orgID uuid.UUID, opts *biz.Create
 			SetDescription(opts.Description).
 			SetOrganizationID(orgID)
 
-		// Set initial member count to 0, we'll update it after transaction
-		builder = builder.SetMemberCount(0)
-
 		// Add member if userID is provided
 		if opts.UserID != nil {
 			builder = builder.AddMemberIDs(*opts.UserID)

--- a/app/controlplane/pkg/data/membership.go
+++ b/app/controlplane/pkg/data/membership.go
@@ -34,14 +34,16 @@ import (
 )
 
 type MembershipRepo struct {
-	data *Data
-	log  *log.Helper
+	data      *Data
+	log       *log.Helper
+	groupRepo biz.GroupRepo
 }
 
-func NewMembershipRepo(data *Data, logger log.Logger) biz.MembershipRepo {
+func NewMembershipRepo(data *Data, groupRepo biz.GroupRepo, logger log.Logger) biz.MembershipRepo {
 	return &MembershipRepo{
-		data: data,
-		log:  log.NewHelper(logger),
+		data:      data,
+		groupRepo: groupRepo,
+		log:       log.NewHelper(logger),
 	}
 }
 
@@ -253,7 +255,10 @@ func (r *MembershipRepo) Delete(ctx context.Context, id uuid.UUID) error {
 		return fmt.Errorf("failed to get membership: %w", err)
 	}
 
-	return WithTx(ctx, r.data.DB, func(tx *ent.Tx) error {
+	// Prepare a slice to hold group IDs that need to be updated
+	var groupIDs []uuid.UUID
+
+	if trErr := WithTx(ctx, r.data.DB, func(tx *ent.Tx) error {
 		// Delete the specific membership
 		if err := tx.Membership.DeleteOneID(id).Exec(ctx); err != nil {
 			return fmt.Errorf("failed to delete membership: %w", err)
@@ -279,6 +284,21 @@ func (r *MembershipRepo) Delete(ctx context.Context, id uuid.UUID) error {
 			// Remove the user from all groups in the organization by soft-deleting group memberships
 			now := time.Now()
 
+			// Find all group IDs where this user is a member in this organization
+			groupMemberships, grpMemErr := tx.GroupMembership.Query().Where(
+				groupmembership.UserID(userID),
+				groupmembership.DeletedAtIsNil(),
+				groupmembership.HasGroupWith(group.OrganizationID(orgID)),
+			).Select(groupmembership.FieldGroupID).All(ctx)
+			if grpMemErr != nil {
+				return fmt.Errorf("failed to fetch group IDs for user %s in organization %s: %w", userID, orgID, err)
+			}
+
+			// Collect group IDs to update member counts later
+			for _, gm := range groupMemberships {
+				groupIDs = append(groupIDs, gm.GroupID)
+			}
+
 			// Soft delete all group memberships for this user in this organization
 			if _, err := tx.GroupMembership.Update().Where(
 				groupmembership.UserID(userID),
@@ -287,22 +307,27 @@ func (r *MembershipRepo) Delete(ctx context.Context, id uuid.UUID) error {
 			).SetDeletedAt(now).SetUpdatedAt(now).Save(ctx); err != nil {
 				return fmt.Errorf("failed to delete group memberships for user %s in organization %s: %w", userID, orgID, err)
 			}
-
-			// Decrement the member count of each group this user was a member of
-			// We don't need a separate check for groups the user was a maintainer of
-			// because all memberships were already deleted above
-			if _, err := tx.Group.Update().
-				Where(
-					group.HasMembersWith(user.ID(userID)),
-					group.HasOrganizationWith(organization.ID(orgID)),
-				).
-				AddMemberCount(-1).Save(ctx); err != nil {
-				return fmt.Errorf("failed to decrement group member count: %w", err)
-			}
 		}
 
 		return nil
-	})
+	}); trErr != nil {
+		return trErr
+	}
+
+	// For each affected group, update the member count based on actual query
+	updated := map[uuid.UUID]struct{}{}
+	for _, gid := range groupIDs {
+		if _, seen := updated[gid]; seen {
+			// deduplicate group IDs
+			continue
+		}
+		updated[gid] = struct{}{}
+		if err := r.groupRepo.UpdateGroupMemberCount(ctx, gid); err != nil {
+			return fmt.Errorf("failed to update group member count for group %s: %w", gid, err)
+		}
+	}
+
+	return nil
 }
 
 // RBAC methods

--- a/app/controlplane/pkg/data/membership.go
+++ b/app/controlplane/pkg/data/membership.go
@@ -34,14 +34,16 @@ import (
 )
 
 type MembershipRepo struct {
-	data *Data
-	log  *log.Helper
+	data      *Data
+	log       *log.Helper
+	groupRepo biz.GroupRepo
 }
 
-func NewMembershipRepo(data *Data, logger log.Logger) biz.MembershipRepo {
+func NewMembershipRepo(data *Data, groupRepo biz.GroupRepo, logger log.Logger) biz.MembershipRepo {
 	return &MembershipRepo{
-		data: data,
-		log:  log.NewHelper(logger),
+		data:      data,
+		groupRepo: groupRepo,
+		log:       log.NewHelper(logger),
 	}
 }
 
@@ -253,7 +255,10 @@ func (r *MembershipRepo) Delete(ctx context.Context, id uuid.UUID) error {
 		return fmt.Errorf("failed to get membership: %w", err)
 	}
 
-	return WithTx(ctx, r.data.DB, func(tx *ent.Tx) error {
+	// Prepare a slice to hold group IDs that need to be updated
+	var groupIDs []uuid.UUID
+
+	if trErr := WithTx(ctx, r.data.DB, func(tx *ent.Tx) error {
 		// Delete the specific membership
 		if err := tx.Membership.DeleteOneID(id).Exec(ctx); err != nil {
 			return fmt.Errorf("failed to delete membership: %w", err)
@@ -279,6 +284,21 @@ func (r *MembershipRepo) Delete(ctx context.Context, id uuid.UUID) error {
 			// Remove the user from all groups in the organization by soft-deleting group memberships
 			now := time.Now()
 
+			// Find all group IDs where this user is a member in this organization
+			groupMemberships, grpMemErr := tx.GroupMembership.Query().Where(
+				groupmembership.UserID(userID),
+				groupmembership.DeletedAtIsNil(),
+				groupmembership.HasGroupWith(group.OrganizationID(orgID)),
+			).Select(groupmembership.FieldGroupID).All(ctx)
+			if grpMemErr != nil {
+				return fmt.Errorf("failed to fetch group IDs for user %s in organization %s: %w", userID, orgID, err)
+			}
+
+			// Collect group IDs to update member counts later
+			for _, gm := range groupMemberships {
+				groupIDs = append(groupIDs, gm.GroupID)
+			}
+
 			// Soft delete all group memberships for this user in this organization
 			if _, err := tx.GroupMembership.Update().Where(
 				groupmembership.UserID(userID),
@@ -287,22 +307,27 @@ func (r *MembershipRepo) Delete(ctx context.Context, id uuid.UUID) error {
 			).SetDeletedAt(now).SetUpdatedAt(now).Save(ctx); err != nil {
 				return fmt.Errorf("failed to delete group memberships for user %s in organization %s: %w", userID, orgID, err)
 			}
-
-			// Decrement the member count of each group this user was a member of
-			// Only decrement if member_count > 0 to avoid negative values
-			if _, err := tx.Group.Update().
-				Where(
-					group.HasGroupUsersWith(groupmembership.UserID(userID), groupmembership.DeletedAtIsNil()),
-					group.HasOrganizationWith(organization.ID(orgID)),
-					group.MemberCountGT(0),
-				).
-				AddMemberCount(-1).Save(ctx); err != nil {
-				return fmt.Errorf("failed to decrement group member count: %w", err)
-			}
 		}
 
 		return nil
-	})
+	}); trErr != nil {
+		return trErr
+	}
+
+	// For each affected group, update the member count based on actual query
+	updated := map[uuid.UUID]struct{}{}
+	for _, gid := range groupIDs {
+		if _, seen := updated[gid]; seen {
+			// deduplicate group IDs
+			continue
+		}
+		updated[gid] = struct{}{}
+		if err := r.groupRepo.UpdateGroupMemberCount(ctx, gid); err != nil {
+			return fmt.Errorf("failed to update group member count for group %s: %w", gid, err)
+		}
+	}
+
+	return nil
 }
 
 // RBAC methods


### PR DESCRIPTION
This patch updates the way group membership counts are maintained. Instead of incrementing or decrementing the counter on each insertion or deletion, the total number of members is now recalculated after every transaction and the count is updated accordingly.