### PR TITLE
fix(groups): Avoid listing removed project versions marked as latest

### DIFF
--- a/app/controlplane/pkg/data/group.go
+++ b/app/controlplane/pkg/data/group.go
@@ -678,7 +678,7 @@ func (g GroupRepo) ListProjectsByGroup(ctx context.Context, orgID uuid.UUID, gro
 			project.DeletedAtIsNil(),
 		).
 		WithVersions(func(query *ent.ProjectVersionQuery) {
-			query.Where(projectversion.Latest(true)).Select(projectversion.FieldID)
+			query.Where(projectversion.Latest(true), projectversion.DeletedAtIsNil()).Select(projectversion.FieldID)
 		}).
 		All(ctx)
 	if err != nil {


### PR DESCRIPTION
This pull request includes a small but important change to the query logic in the `ListProjectsByGroup` method of the `GroupRepo` implementation. The change ensures that only non-deleted project versions are selected in addition to the latest versions.

* [`app/controlplane/pkg/data/group.go`](diffhunk://#diff-9de0461d6462eaa9b6c24a3da33235a91f45c65ebd5a291e81dd59743936c2b8L681-R681): Updated the `WithVersions` query to include a condition that filters out deleted project versions by adding `projectversion.DeletedAtIsNil()` to the query.