### PR TITLE
fix(rbac): revert "feat(rbac): skip invalid role combinations (#2266)"

### DIFF
--- a/app/controlplane/pkg/biz/membership.go
+++ b/app/controlplane/pkg/biz/membership.go
@@ -340,21 +340,7 @@ func (uc *MembershipUseCase) ListAllMembershipsForUser(ctx context.Context, user
 		return nil, fmt.Errorf("failed to list group memberships for user: %w", err)
 	}
 
-	// remove incompatible/illegal combinations (org viewer and project admin)
-	combined := make([]*Membership, 0)
-	combined = append(combined, userMemberships...)
-	for _, um := range userMemberships {
-		for _, gm := range groupMemberships {
-			if um.ResourceType == authz.ResourceTypeOrganization && um.Role == authz.RoleViewer &&
-				gm.Role == authz.RoleProjectAdmin && gm.OrganizationID == um.OrganizationID {
-				// if user is org viewer and project admin through a group, skip it.
-				continue
-			}
-			combined = append(combined, gm)
-		}
-	}
-
-	return combined, nil
+	return append(userMemberships, groupMemberships...), nil
 }
 
 // SetProjectOwner sets the project owner (admin role). It skips the operation if an owner exists already

--- a/app/controlplane/pkg/biz/project.go
+++ b/app/controlplane/pkg/biz/project.go
@@ -323,11 +323,6 @@ func (uc *ProjectUseCase) addUserToProject(ctx context.Context, orgID uuid.UUID,
 		return uc.handleNonExistingUser(ctx, orgID, projectID, opts)
 	}
 
-	// Org viewers cannot be added as project admin, since they cannot perform updates on resources
-	if opts.Role == authz.RoleProjectAdmin && userMembership.Role == authz.RoleViewer {
-		return nil, NewErrValidationStr("users with org role Org Viewer cannot be Project Admins")
-	}
-
 	userUUID := uuid.MustParse(userMembership.User.ID)
 
 	// Check if the user is already a member of the project

--- a/app/controlplane/pkg/biz/project_integration_test.go
+++ b/app/controlplane/pkg/biz/project_integration_test.go
@@ -91,7 +91,7 @@ func (s *projectMembersIntegrationTestSuite) TestListMembers() {
 	// Add users to organization
 	_, err = s.Membership.Create(ctx, s.org.ID, user2.ID)
 	require.NoError(s.T(), err)
-	_, err = s.Membership.Create(ctx, s.org.ID, user3.ID, biz.WithMembershipRole(authz.RoleOrgMember))
+	_, err = s.Membership.Create(ctx, s.org.ID, user3.ID)
 	require.NoError(s.T(), err)
 
 	// Add users to the project
@@ -201,7 +201,7 @@ func (s *projectMembersIntegrationTestSuite) TestAddMemberToProject() {
 	// Add users to organization
 	_, err = s.Membership.Create(ctx, s.org.ID, user2.ID)
 	require.NoError(s.T(), err)
-	_, err = s.Membership.Create(ctx, s.org.ID, user3.ID, biz.WithMembershipRole(authz.RoleOrgMember))
+	_, err = s.Membership.Create(ctx, s.org.ID, user3.ID)
 	require.NoError(s.T(), err)
 
 	projectID := s.project.ID
@@ -421,7 +421,7 @@ func (s *projectMembersIntegrationTestSuite) TestRemoveMemberFromProject() {
 	// Add users to organization
 	_, err = s.Membership.Create(ctx, s.org.ID, user2.ID)
 	require.NoError(s.T(), err)
-	_, err = s.Membership.Create(ctx, s.org.ID, user3.ID, biz.WithMembershipRole(authz.RoleOrgMember))
+	_, err = s.Membership.Create(ctx, s.org.ID, user3.ID)
 	require.NoError(s.T(), err)
 	_, err = s.Membership.Create(ctx, s.org.ID, user4.ID)
 	require.NoError(s.T(), err)
@@ -649,7 +649,7 @@ func (s *projectAdminPermissionsTestSuite) TestAdminPermissions() {
 	require.NoError(s.T(), err)
 
 	// Add the user to the organization
-	_, err = s.Membership.Create(ctx, s.org.ID, user2.ID, biz.WithCurrentMembership(), biz.WithMembershipRole(authz.RoleOrgMember))
+	_, err = s.Membership.Create(ctx, s.org.ID, user2.ID, biz.WithCurrentMembership())
 	require.NoError(s.T(), err)
 
 	// Grant project admin role to the user
@@ -770,7 +770,7 @@ func (s *projectPermissionsTestSuite) SetupTest() {
 	assert.NoError(err)
 
 	// Add project admin user to organization as a regular member
-	_, err = s.Membership.Create(ctx, s.org.ID, s.projectAdminUser.ID, biz.WithCurrentMembership(), biz.WithMembershipRole(authz.RoleOrgMember))
+	_, err = s.Membership.Create(ctx, s.org.ID, s.projectAdminUser.ID, biz.WithCurrentMembership())
 	assert.NoError(err)
 
 	// Create a regular user
@@ -778,7 +778,7 @@ func (s *projectPermissionsTestSuite) SetupTest() {
 	assert.NoError(err)
 
 	// Add regular user to organization as a regular member
-	_, err = s.Membership.Create(ctx, s.org.ID, s.regularUser.ID, biz.WithMembershipRole(authz.RoleOrgMember))
+	_, err = s.Membership.Create(ctx, s.org.ID, s.regularUser.ID)
 	assert.NoError(err)
 
 	// Create a project for tests
@@ -1340,7 +1340,7 @@ func (s *projectMembersIntegrationTestSuite) TestUpdateUserRoleInProject() {
 	// Add users to organization
 	_, err = s.Membership.Create(ctx, s.org.ID, user1.ID)
 	require.NoError(s.T(), err)
-	_, err = s.Membership.Create(ctx, s.org.ID, user2.ID, biz.WithMembershipRole(authz.RoleOrgMember))
+	_, err = s.Membership.Create(ctx, s.org.ID, user2.ID)
 	require.NoError(s.T(), err)
 
 	projectID := s.project.ID


### PR DESCRIPTION
This reverts commit b1e76a830e51f622208c94c36beaf31c3507c290. We'll allow these combinations and properly inform users.