### PR TITLE
chore(rbac): Revert Prevent user with org viewer role to become group maintainers

### DIFF
--- a/app/controlplane/pkg/biz/group.go
+++ b/app/controlplane/pkg/biz/group.go
@@ -579,11 +579,6 @@ func (uc *GroupUseCase) addExistingUserToGroup(ctx context.Context, orgID, group
 		return nil, NewErrAlreadyExistsStr("user is already a member of this group")
 	}
 
-	// If trying to make the user a maintainer, verify they don't have the org viewer role
-	if opts.Maintainer && userMembership.Role == authz.RoleViewer {
-		return nil, NewErrValidationStr("users with organization viewer role cannot be group maintainers")
-	}
-
 	// Add the user to the group
 	membership, err := uc.groupRepo.AddMemberToGroup(ctx, orgID, groupID, userUUID, opts.Maintainer)
 	if err != nil {
@@ -811,20 +806,6 @@ func (uc *GroupUseCase) UpdateMemberMaintainerStatus(ctx context.Context, orgID 
 	}
 	if existingMembership == nil {
 		return NewErrValidationStr("user is not a member of this group")
-	}
-
-	// If trying to make the user a maintainer, verify they don't have the org viewer role
-	if opts.IsMaintainer {
-		// Check the user's org role
-		userOrgMembership, err := uc.membershipRepo.FindByOrgAndUser(ctx, orgID, userUUID)
-		if err != nil {
-			return fmt.Errorf("failed to check user's organization role: %w", err)
-		}
-
-		// Prevent org viewers from becoming maintainers
-		if userOrgMembership.Role == authz.RoleViewer {
-			return NewErrValidationStr("users with organization viewer role cannot be group maintainers")
-		}
 	}
 
 	// Update the member's maintainer status

--- a/app/controlplane/pkg/biz/group_integration_test.go
+++ b/app/controlplane/pkg/biz/group_integration_test.go
@@ -705,7 +705,7 @@ func (s *groupMembersIntegrationTestSuite) TestAddMemberToGroup() {
 	// Add users to organization
 	_, err = s.Membership.Create(ctx, s.org.ID, user2.ID)
 	require.NoError(s.T(), err)
-	_, err = s.Membership.Create(ctx, s.org.ID, user3.ID, biz.WithMembershipRole(authz.RoleOrgMember))
+	_, err = s.Membership.Create(ctx, s.org.ID, user3.ID)
 	require.NoError(s.T(), err)
 
 	s.Run("add member using group ID", func() {
@@ -945,11 +945,11 @@ func (s *groupMembersIntegrationTestSuite) TestRemoveMemberFromGroup() {
 	require.NoError(s.T(), err)
 
 	// Add users to organization
-	_, err = s.Membership.Create(ctx, s.org.ID, user2.ID, biz.WithMembershipRole(authz.RoleOrgMember))
+	_, err = s.Membership.Create(ctx, s.org.ID, user2.ID)
 	require.NoError(s.T(), err)
-	_, err = s.Membership.Create(ctx, s.org.ID, user3.ID, biz.WithMembershipRole(authz.RoleOrgMember))
+	_, err = s.Membership.Create(ctx, s.org.ID, user3.ID)
 	require.NoError(s.T(), err)
-	_, err = s.Membership.Create(ctx, s.org.ID, user4.ID, biz.WithMembershipRole(authz.RoleOrgMember))
+	_, err = s.Membership.Create(ctx, s.org.ID, user4.ID)
 	require.NoError(s.T(), err)
 
 	// Add users to the group
@@ -1175,9 +1175,9 @@ func (s *groupMembersIntegrationTestSuite) TestGroupMemberCount() {
 	require.NoError(s.T(), err)
 
 	// Add users to organization
-	_, err = s.Membership.Create(ctx, s.org.ID, user2.ID, biz.WithMembershipRole(authz.RoleOrgMember))
+	_, err = s.Membership.Create(ctx, s.org.ID, user2.ID)
 	require.NoError(s.T(), err)
-	_, err = s.Membership.Create(ctx, s.org.ID, user3.ID, biz.WithMembershipRole(authz.RoleOrgMember))
+	_, err = s.Membership.Create(ctx, s.org.ID, user3.ID)
 	require.NoError(s.T(), err)
 
 	// Check initial member count
@@ -1278,9 +1278,9 @@ func (s *groupMembersIntegrationTestSuite) TestUpdateMemberMaintainerStatus() {
 	require.NoError(s.T(), err)
 
 	// Add users to organization
-	_, err = s.Membership.Create(ctx, s.org.ID, user2.ID, biz.WithMembershipRole(authz.RoleOrgMember))
+	_, err = s.Membership.Create(ctx, s.org.ID, user2.ID)
 	require.NoError(s.T(), err)
-	_, err = s.Membership.Create(ctx, s.org.ID, user3.ID, biz.WithMembershipRole(authz.RoleOrgMember))
+	_, err = s.Membership.Create(ctx, s.org.ID, user3.ID)
 	require.NoError(s.T(), err)
 
 	// Add users to the group (user2 as a regular member, user3 as a maintainer)
@@ -1705,7 +1705,7 @@ func (s *groupMembersIntegrationTestSuite) TestAddMemberToGroupSystemCall() {
 	require.NoError(s.T(), err)
 
 	// Add user to organization
-	_, err = s.Membership.Create(ctx, s.org.ID, systemUser.ID, biz.WithMembershipRole(authz.RoleOrgMember))
+	_, err = s.Membership.Create(ctx, s.org.ID, systemUser.ID)
 	require.NoError(s.T(), err)
 
 	// Add the user to the group without a requester ID (system call)
@@ -1753,7 +1753,7 @@ func (s *groupMembersIntegrationTestSuite) TestUpdateMemberMaintainerStatusSyste
 	require.NoError(s.T(), err)
 
 	// Add user to organization
-	_, err = s.Membership.Create(ctx, s.org.ID, systemUser.ID, biz.WithMembershipRole(authz.RoleOrgMember))
+	_, err = s.Membership.Create(ctx, s.org.ID, systemUser.ID)
 	require.NoError(s.T(), err)
 
 	// First add the user to the group (with requester ID for this setup step)


### PR DESCRIPTION
We are not limiting this combination. Clients will be handling this.
This reverts commit 536bc1aed001bc177f5f27bae8b589ed35460e45. PR #2232
