### PR TITLE
fix(rbac): apply api token permissions in middleware

### DIFF
--- a/app/controlplane/pkg/authz/authz.go
+++ b/app/controlplane/pkg/authz/authz.go
@@ -410,10 +410,6 @@ var ServerOperationsMap = map[string][]*Policy{
 
 	// Projects: Check happen at service level
 
-	// Project API Token
-	"/controlplane.v1.ProjectService/APITokenCreate": {},
-	"/controlplane.v1.ProjectService/APITokenList":   {},
-	"/controlplane.v1.ProjectService/APITokenRevoke": {},
 	// Project Memberships
 	"/controlplane.v1.ProjectService/ListMembers":            {},
 	"/controlplane.v1.ProjectService/AddMember":              {},
@@ -422,9 +418,9 @@ var ServerOperationsMap = map[string][]*Policy{
 	"/controlplane.v1.ProjectService/ListPendingInvitations": {},
 
 	// API tokens RBAC are handled at the service level
-	"/controlplane.v1.APITokenService/List":   {},
-	"/controlplane.v1.APITokenService/Create": {},
-	"/controlplane.v1.APITokenService/Revoke": {},
+	"/controlplane.v1.APITokenService/List":   {PolicyAPITokenList},
+	"/controlplane.v1.APITokenService/Create": {PolicyAPITokenCreate},
+	"/controlplane.v1.APITokenService/Revoke": {PolicyAPITokenRevoke},
 }
 
 // Implements https://pkg.go.dev/entgo.io/ent/schema/field#EnumValues


### PR DESCRIPTION
API token endpoints are being allowed for all org level roles, including Viewer.