### PR TITLE
chore(rbac): Allow OrgViewers to see organization memberships

### DIFF
--- a/app/controlplane/internal/service/group.go
+++ b/app/controlplane/internal/service/group.go
@@ -236,8 +236,14 @@ func (g *GroupService) ListMembers(ctx context.Context, req *pb.GroupServiceList
 		return nil, err
 	}
 
-	if err := g.userHasPermissionToListGroupMember(ctx, currentOrg.ID, req.GetGroupReference()); err != nil {
-		return nil, err
+	orgRole := usercontext.CurrentAuthzSubject(ctx)
+
+	// Viewers can see group memberships
+	// TODO: replace this with enforcer check once group_memberships and memberships are merged
+	if authz.Role(orgRole) != authz.RoleViewer {
+		if err := g.userHasPermissionToListGroupMember(ctx, currentOrg.ID, req.GetGroupReference()); err != nil {
+			return nil, err
+		}
 	}
 
 	currentUser, err := requireCurrentUser(ctx)

--- a/app/controlplane/pkg/authz/authz.go
+++ b/app/controlplane/pkg/authz/authz.go
@@ -158,8 +158,10 @@ var (
 	PolicyWorkflowDelete = &Policy{ResourceWorkflow, ActionDelete}
 	// Projects
 	PolicyProjectCreate = &Policy{ResourceProject, ActionCreate}
+
 	// User Membership
-	PolicyOrganizationRead = &Policy{Organization, ActionRead}
+	PolicyOrganizationRead            = &Policy{Organization, ActionRead}
+	PolicyOrganizationListMemberships = &Policy{OrganizationMemberships, ActionList}
 
 	// Group Memberships
 	PolicyGroupListPendingInvitations = &Policy{ResourceGroup, ActionList}
@@ -215,6 +217,9 @@ var RolesMap = map[Role][]*Policy{
 		PolicyWorkflowRead,
 		// Organization
 		PolicyOrganizationRead,
+
+		// List organization memberships
+		PolicyOrganizationListMemberships,
 	},
 	// RoleAdmin is an org-scoped role that provides super admin privileges (it's the higher role)
 	RoleAdmin: {
@@ -385,6 +390,10 @@ var ServerOperationsMap = map[string][]*Policy{
 	// since all the permissions here are in the context of an organization
 	// Create new organization
 	"/controlplane.v1.OrganizationService/Create": {},
+
+	// List global memberships
+	"/controlplane.v1.OrganizationService/ListMemberships": {PolicyOrganizationListMemberships},
+
 	// NOTE: this is about listing my own memberships, not about listing all the memberships in the organization
 	"/controlplane.v1.UserService/ListMemberships": {},
 	// Set the current organization for the current user


### PR DESCRIPTION
As read-only admins, Org Viewers should be able to see all organization resources. 
This PR allow viewers to:
* query organization memberships  (before, only admins and owners could)
* query group memberships (berfore, only admins and group maintainers could)

Demo (sarah@chainloop.local as OrgViewer):
```
➜  cldev org member ls
WRN API contacted in insecure mode
┌──────────────────────────────────────┬───────────────────────┬────────┬─────────────────────┐
│ ID                                   │ EMAIL                 │ ROLE   │ JOINED AT           │
├──────────────────────────────────────┼───────────────────────┼────────┼─────────────────────┤
│ 4afbb744-bb94-43e7-a35e-a2f7e1493e60 │ john@chainloop.local  │ owner  │ 18 Jul 25 12:08 UTC │
├──────────────────────────────────────┼───────────────────────┼────────┼─────────────────────┤
│ 088a9b48-d7fe-4e19-80d6-fc8ba6313417 │ sarah@chainloop.local │ viewer │ 17 Jul 25 16:01 UTC │
└──────────────────────────────────────┴───────────────────────┴────────┴─────────────────────┘
INF Showing [1-2] out of 2
```

As contributor:
```
✗ cldev org member ls
WRN API contacted in insecure mode
ERR operation not allowed
exit status 1
```

As Org Admin:
```
✗ cldev org member ls
WRN API contacted in insecure mode
┌──────────────────────────────────────┬───────────────────────┬───────┬─────────────────────┐
│ ID                                   │ EMAIL                 │ ROLE  │ JOINED AT           │
├──────────────────────────────────────┼───────────────────────┼───────┼─────────────────────┤
│ 4afbb744-bb94-43e7-a35e-a2f7e1493e60 │ john@chainloop.local  │ owner │ 18 Jul 25 12:08 UTC │
├──────────────────────────────────────┼───────────────────────┼───────┼─────────────────────┤
│ 088a9b48-d7fe-4e19-80d6-fc8ba6313417 │ sarah@chainloop.local │ admin │ 17 Jul 25 16:01 UTC │
└──────────────────────────────────────┴───────────────────────┴───────┴─────────────────────┘
INF Showing [1-2] out of 2
```
