### PR TITLE
Fix issue with plugin extension command not being shown in help

### DIFF
--- a/app/cli/cmd/root.go
+++ b/app/cli/cmd/root.go
@@ -245,8 +245,8 @@ func NewRootCmd(l zerolog.Logger) *cobra.Command {
 		newReferrerDiscoverCmd(), newPolicyCmd(),
 	)
 
-	// Load plugins if we are not running a subcommand
-	if len(os.Args) > 1 && os.Args[1] != "completion" && os.Args[1] != "help" {
+	// Load plugins for root command and subcommands (except completion and help)
+	if len(os.Args) == 1 || (len(os.Args) > 1 && os.Args[1] != "completion" && os.Args[1] != "help") {
 		pluginManager = plugins.NewManager(&logger)
 		if err := loadAllPlugins(rootCmd); err != nil {
 			logger.Error().Err(err).Msg("Failed to load plugins, continuing with built-in commands only")


### PR DESCRIPTION
This PR fixes the issue with the plugin command not being shown in help.

After the change:

```
./dist/cli_darwin_arm64_v8.0/chainloop
Chainloop Command Line Interface

Usage:
  chainloop [command]

Available Commands:
  artifact              Download or upload Artifacts to the CAS
  attestation           Craft Software Supply Chain Attestations
  auth                  Authenticate with the Control Plane
  cas-backend           Operations on Artifact CAS backends
  completion            Generate the autocompletion script for the specified shell
  config                Configure this client
  discover              (Preview) inspect pieces of evidence or artifacts stored through Chainloop
  gather-runner-context Gather runner context data from a given provider.
  integration           Third party integrations
  organization          Organizations management
  policy                Craft chainloop policies
  version               Command line version
  workflow              Workflow management in the control plane
```