### PR TITLE
chore: use github ref name to update next version

### DIFF
--- a/.github/workflows/utils/bump-project-version.sh
+++ b/.github/workflows/utils/bump-project-version.sh
@@ -21,23 +21,28 @@ if [[ -n "${1}" ]]; then
    project_yaml="${1}"
 fi
 
-# Load the previous version and bump appropriately
-version=$(cat "${project_yaml}" | awk '/^projectVersion:/ {
-    version = $2;
-    if (version ~ /-rc/) {
-        # Handle release candidate versions (e.g., v1.0.0-rc.1 -> v1.0.0-rc.2)
-        split(version, parts, /-rc\./);
-        rc_num = parts[2] + 1;
-        print parts[1] "-rc." rc_num;
-    }
-    else {
-        # Load the previous version and BUMP THE MINOR
-        # Handle minor version bumps (e.g., v1.0.0 -> v1.1.0)
-        split(version, ver_parts, /\./);
-        ver_parts[2] = ver_parts[2] + 1;
-        print ver_parts[1] "." ver_parts[2] ".0";
-    }
-}')
+if [[ -n "$GITHUB_REF_NAME" ]]; then
+  # Bump from provided version tag
+  version=$(echo $GITHUB_REF_NAME | awk -F'[ .]' '{print $1"."$2+1"."0}')
+else
+  # Load the previous version and bump appropriately
+  version=$(cat "${project_yaml}" | awk '/^projectVersion:/ {
+      version = $2;
+      if (version ~ /-rc/) {
+          # Handle release candidate versions (e.g., v1.0.0-rc.1 -> v1.0.0-rc.2)
+          split(version, parts, /-rc\./);
+          rc_num = parts[2] + 1;
+          print parts[1] "-rc." rc_num;
+      }
+      else {
+          # Load the previous version and BUMP THE MINOR
+          # Handle minor version bumps (e.g., v1.0.0 -> v1.1.0)
+          split(version, ver_parts, /\./);
+          ver_parts[2] = ver_parts[2] + 1;
+          print ver_parts[1] "." ver_parts[2] ".0";
+      }
+  }')
+fi
 
 # Update the project yaml file
 sed -i "s#^projectVersion:.*#projectVersion: ${version}#g" "${project_yaml}"


### PR DESCRIPTION
This PR solves the problem when the pushed tag is not the same as the one present in .chainloop.yaml, for example when pushing a patch. Taking the tag value instead of the one in the file, will make the behaviour consistent, avoiding extra PRs to fix the version.

Example (sed error is normal in MacOS):

```shell
> GITHUB_REF_NAME=v1.2.3 DEBUG=1 .github/workflows/utils/bump-project-version.sh
+ [[ -n 1 ]]
+ set -x
+ project_yaml=.chainloop.yml
+ [[ -n '' ]]
+ [[ -n v1.2.3 ]]
++ echo v1.2.3
++ awk '-F[ .]' '{print $1"."$2+1"."0}'
+ version=v1.3.0
+ sed -i 's#^projectVersion:.*#projectVersion: v1.3.0#g' .chainloop.yml
sed: 1: ".chainloop.yml": invalid command code .
```