### PR TITLE
feat(invitations): Expand invitation context to external metadata

### DIFF
--- a/app/controlplane/pkg/biz/group.go
+++ b/app/controlplane/pkg/biz/group.go
@@ -557,7 +557,7 @@ func (uc *GroupUseCase) handleNonExistingUser(ctx context.Context, orgID, groupI
 
 	// Create an organization invitation with group context
 	invitationContext := &OrgInvitationContext{
-		GroupIDToJoin:   groupID,
+		GroupIDToJoin:   &groupID,
 		GroupMaintainer: opts.Maintainer,
 	}
 

--- a/app/controlplane/pkg/biz/orginvitation.go
+++ b/app/controlplane/pkg/biz/orginvitation.go
@@ -17,6 +17,7 @@ package biz
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -65,6 +66,8 @@ type OrgInvitationContext struct {
 	ProjectIDToJoin uuid.UUID `json:"project_id_to_join,omitempty"`
 	// ProjectRole is the role to assign to the user in the project
 	ProjectRole authz.Role `json:"project_role,omitempty"`
+	// ExternalMetadata can be used to store additional information
+	ExternalMetadata json.RawMessage `json:"external_metadata,omitempty"`
 }
 
 type OrgInvitationRepo interface {

--- a/app/controlplane/pkg/biz/orginvitation_integration_test.go
+++ b/app/controlplane/pkg/biz/orginvitation_integration_test.go
@@ -647,6 +647,30 @@ func (s *OrgInvitationIntegrationTestSuite) TestInvitationWithProjectContext() {
 	})
 }
 
+func (s *OrgInvitationIntegrationTestSuite) TestInvitationWithExternalMetadata() {
+	ctx := context.Background()
+	receiverEmail := "externalmeta@cyberdyne.io"
+	externalMeta := []byte(`{"foo":"bar","baz":123}`)
+	invitationContext := &biz.OrgInvitationContext{
+		ExternalMetadata: externalMeta,
+	}
+
+	invite, err := s.OrgInvitation.Create(
+		ctx,
+		s.org1.ID,
+		s.user.ID,
+		receiverEmail,
+		biz.WithInvitationRole(authz.RoleViewer),
+		biz.WithInvitationContext(invitationContext),
+	)
+	s.Require().NoError(err)
+	s.Require().NotNil(invite)
+
+	s.Require().NotNil(invite.Context)
+	s.Require().NotNil(invite.Context.ExternalMetadata)
+	s.JSONEq(string(externalMeta), string(invite.Context.ExternalMetadata), "ExternalMetadata should be persisted and retrievable")
+}
+
 // Utility struct to hold the test suite
 type OrgInvitationIntegrationTestSuite struct {
 	testhelpers.UseCasesEachTestSuite

--- a/app/controlplane/pkg/biz/project.go
+++ b/app/controlplane/pkg/biz/project.go
@@ -392,7 +392,7 @@ func (uc *ProjectUseCase) handleNonExistingUser(ctx context.Context, orgID, proj
 
 	// Create an organization invitation with project context
 	invitationContext := &OrgInvitationContext{
-		ProjectIDToJoin: projectID,
+		ProjectIDToJoin: &projectID,
 		ProjectRole:     opts.Role,
 	}
 

--- a/app/controlplane/pkg/biz/project_integration_test.go
+++ b/app/controlplane/pkg/biz/project_integration_test.go
@@ -330,7 +330,7 @@ func (s *projectMembersIntegrationTestSuite) TestAddMemberToProject() {
 
 		// Verify the invitation has project context
 		s.NotNil(foundInvitation.Context, "Invitation should have context")
-		s.Equal(projectID, foundInvitation.Context.ProjectIDToJoin)
+		s.Equal(projectID, *foundInvitation.Context.ProjectIDToJoin)
 		s.Equal(authz.RoleProjectViewer, foundInvitation.Context.ProjectRole)
 	})
 

--- a/app/controlplane/pkg/biz/project_integration_test.go
+++ b/app/controlplane/pkg/biz/project_integration_test.go
@@ -1807,7 +1807,7 @@ func (s *projectMembersIntegrationTestSuite) TestAddNonExistingMemberToProject()
 
 		// Verify the invitation has project context
 		s.NotNil(foundInvitation.Context, "Invitation should have context")
-		s.Equal(projectID, foundInvitation.Context.ProjectIDToJoin)
+		s.Equal(projectID, *foundInvitation.Context.ProjectIDToJoin)
 		s.Equal(authz.RoleProjectViewer, foundInvitation.Context.ProjectRole)
 		s.Equal(authz.RoleOrgMember, foundInvitation.Role)
 	})

--- a/app/controlplane/pkg/biz/testhelpers/database.go
+++ b/app/controlplane/pkg/biz/testhelpers/database.go
@@ -82,13 +82,14 @@ type TestingUseCases struct {
 }
 
 type TestingRepos struct {
-	Membership       biz.MembershipRepo
-	Referrer         biz.ReferrerRepo
-	Workflow         biz.WorkflowRepo
-	WorkflowRunRepo  biz.WorkflowRunRepo
-	AttestationState biz.AttestationStateRepo
-	OrganizationRepo biz.OrganizationRepo
-	GroupRepo        biz.GroupRepo
+	Membership        biz.MembershipRepo
+	Referrer          biz.ReferrerRepo
+	Workflow          biz.WorkflowRepo
+	WorkflowRunRepo   biz.WorkflowRunRepo
+	AttestationState  biz.AttestationStateRepo
+	OrganizationRepo  biz.OrganizationRepo
+	GroupRepo         biz.GroupRepo
+	OrgInvitationRepo biz.OrgInvitationRepo
 }
 
 type newTestingOpts struct {

--- a/app/controlplane/pkg/biz/testhelpers/wire_gen.go
+++ b/app/controlplane/pkg/biz/testhelpers/wire_gen.go
@@ -155,13 +155,14 @@ func WireTestData(testDatabase *TestDatabase, t *testing.T, logger log.Logger, r
 	groupUseCase := biz.NewGroupUseCase(logger, groupRepo, membershipRepo, userRepo, orgInvitationUseCase, auditorUseCase, orgInvitationRepo, enforcer, membershipUseCase)
 	projectUseCase := biz.NewProjectsUseCase(logger, projectsRepo, membershipRepo, auditorUseCase, groupUseCase, membershipUseCase, orgInvitationUseCase, orgInvitationRepo, enforcer)
 	testingRepos := &TestingRepos{
-		Membership:       membershipRepo,
-		Referrer:         referrerRepo,
-		Workflow:         workflowRepo,
-		WorkflowRunRepo:  workflowRunRepo,
-		AttestationState: attestationStateRepo,
-		OrganizationRepo: organizationRepo,
-		GroupRepo:        groupRepo,
+		Membership:        membershipRepo,
+		Referrer:          referrerRepo,
+		Workflow:          workflowRepo,
+		WorkflowRunRepo:   workflowRunRepo,
+		AttestationState:  attestationStateRepo,
+		OrganizationRepo:  organizationRepo,
+		GroupRepo:         groupRepo,
+		OrgInvitationRepo: orgInvitationRepo,
 	}
 	testingUseCases := &TestingUseCases{
 		DB:                     testDatabase,


### PR DESCRIPTION
This pull request introduces changes to improve the handling of organization invitations, particularly in the context of joining groups and projects. The updates include modifying the `OrgInvitationContext` structure to use pointers for UUID fields, adding support for external metadata, and enhancing test coverage to handle edge cases like nil UUIDs.


Before, since the groupID and projectID were not pointers, they were being stored in the DB as their nil representation of UUUID the `0000-0000...` by adding a pointer, the are not store at all. The UUID != uuid.Nil check is there for already stored data.
