### PR TITLE
chore(products): fix query for non-inherited membershps

### DIFF
--- a/app/controlplane/pkg/data/project.go
+++ b/app/controlplane/pkg/data/project.go
@@ -337,6 +337,7 @@ func (r *ProjectRepo) queryMembership(orgID uuid.UUID, projectID uuid.UUID, memb
 			membership.MemberID(memberID),
 			membership.ResourceTypeEQ(authz.ResourceTypeProject),
 			membership.ResourceID(projectID),
+			membership.ParentIDIsNil(), // Only top-level memberships
 		).WithOrganization()
 }
 


### PR DESCRIPTION
This query expects one only result per user/group-project. But it might be duplicated when there are inherited memberships, getting a "results are not singular" error message.

This small change fixes it.