### PR TITLE
feat(policy): allow arguments with comma character

### DIFF
--- a/pkg/policies/policies_test.go
+++ b/pkg/policies/policies_test.go
@@ -773,6 +773,11 @@ func (s *testSuite) TestGetInputArguments() {
 			expected: map[string]any{"foo": []string{"bar1", "bar2", "bar3"}},
 		},
 		{
+			name:     "csv input with escaped comma",
+			inputs:   map[string]string{"foo": "bar1\\,bar2,bar3"},
+			expected: map[string]any{"foo": []string{"bar1,bar2", "bar3"}},
+		},
+		{
 			name:     "csv input with empty slots",
 			inputs:   map[string]string{"foo": ",bar1,,,bar2,bar3,,"},
 			expected: map[string]any{"foo": []string{"bar1", "bar2", "bar3"}},


### PR DESCRIPTION
This PR adds a way to escape ```,``` character with ```\``` in policy arguments.

Closes #1979 