### PR TITLE
feat(policy): change devel commands return to stdout

### DIFF
--- a/app/cli/cmd/output.go
+++ b/app/cli/cmd/output.go
@@ -54,7 +54,8 @@ type tabulatedData interface {
 		*action.APITokenItem |
 		[]*action.APITokenItem |
 		*action.AttestationStatusMaterial |
-		*action.ListMembershipResult
+		*action.ListMembershipResult |
+		*action.PolicyEvalResult
 }
 
 var ErrOutputFormatNotImplemented = errors.New("format not implemented")

--- a/app/cli/cmd/policy_develop_eval.go
+++ b/app/cli/cmd/policy_develop_eval.go
@@ -61,27 +61,7 @@ evaluates the policy against the provided material or attestation.`,
 				return newGracefulError(err)
 			}
 
-			switch {
-			case result.Skipped:
-				logger.Info().Msg("policy evaluation skipped")
-				for _, reason := range result.SkipReasons {
-					logger.Info().Msgf("%s", reason)
-				}
-
-			case len(result.Violations) > 0:
-				for _, violation := range result.Violations {
-					logger.Info().Msgf("- %s", violation)
-				}
-				logger.Info().Msg("policy evaluation failed")
-
-			default:
-				if result.Ignored {
-					logger.Info().Msg("policy was ignored")
-				}
-				logger.Info().Msg("policy evaluation passed")
-			}
-
-			return nil
+			return encodeJSON(result)
 		},
 	}
 

--- a/app/cli/cmd/policy_develop_lint.go
+++ b/app/cli/cmd/policy_develop_lint.go
@@ -17,6 +17,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/chainloop-dev/chainloop/app/cli/internal/action"
 	"github.com/spf13/cobra"
@@ -55,11 +56,7 @@ func newPolicyDevelopLintCmd() *cobra.Command {
 				return nil
 			}
 
-			// Print all validation errors
-			for _, err := range result.Errors {
-				logger.Error().Msg(err)
-			}
-			return fmt.Errorf("policy validation failed with %d issues", len(result.Errors))
+			return encodeResults(result)
 		},
 	}
 
@@ -67,4 +64,18 @@ func newPolicyDevelopLintCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&format, "format", false, "Auto-format file with opa fmt")
 	cmd.Flags().StringVar(&regalConfig, "regal-config", "", "Path to custom regal config (Default: https://github.com/chainloop-dev/chainloop/tree/main/app/cli/internal/policydevel/.regal.yaml)")
 	return cmd
+}
+
+func encodeResults(result *action.PolicyLintResult) error {
+	if result == nil {
+		return nil
+	}
+
+	fmt.Fprintf(os.Stdout, "Found %d issues:\n", len(result.Errors))
+
+	for i, err := range result.Errors {
+		fmt.Fprintf(os.Stdout, "  %d. %s\n", i+1, err)
+	}
+
+	return fmt.Errorf("policy validation failed with %d issues", len(result.Errors))
 }

--- a/app/cli/cmd/policy_develop_lint.go
+++ b/app/cli/cmd/policy_develop_lint.go
@@ -56,7 +56,7 @@ func newPolicyDevelopLintCmd() *cobra.Command {
 				return nil
 			}
 
-			return encodeResults(result)
+			return encodeResult(result)
 		},
 	}
 
@@ -66,16 +66,18 @@ func newPolicyDevelopLintCmd() *cobra.Command {
 	return cmd
 }
 
-func encodeResults(result *action.PolicyLintResult) error {
+func encodeResult(result *action.PolicyLintResult) error {
 	if result == nil {
 		return nil
 	}
 
-	fmt.Fprintf(os.Stdout, "Found %d issues:\n", len(result.Errors))
+	output := fmt.Sprintf("Found %d issues:\n", len(result.Errors))
 
 	for i, err := range result.Errors {
-		fmt.Fprintf(os.Stdout, "  %d. %s\n", i+1, err)
+		output += fmt.Sprintf("  %d. %s\n", i+1, err)
 	}
+
+	fmt.Print(output)
 
 	return fmt.Errorf("policy validation failed with %d issues", len(result.Errors))
 }

--- a/app/cli/cmd/policy_develop_lint.go
+++ b/app/cli/cmd/policy_develop_lint.go
@@ -17,7 +17,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/chainloop-dev/chainloop/app/cli/internal/action"
 	"github.com/spf13/cobra"

--- a/app/cli/internal/policydevel/eval_test.go
+++ b/app/cli/internal/policydevel/eval_test.go
@@ -40,9 +40,10 @@ func TestEvaluate(t *testing.T) {
 			Annotations:  map[string]string{"key": "value"},
 		}
 
-		result, err := Evaluate(opts, logger)
+		results, err := Evaluate(opts, logger)
 		require.NoError(t, err)
-		assert.NotNil(t, result)
+		require.NotEmpty(t, results)
+		assert.NotNil(t, results[0])
 	})
 
 	t.Run("evaluation with auto-detected SBOM CYCLONEDX kind", func(t *testing.T) {
@@ -55,14 +56,14 @@ func TestEvaluate(t *testing.T) {
 			Annotations:  map[string]string{"key": "value"},
 		}
 
-		result, err := Evaluate(opts, logger)
+		results, err := Evaluate(opts, logger)
 		require.NoError(t, err)
-		assert.NotNil(t, result)
+		require.NotEmpty(t, results)
 
-		if len(result.Violations) == 0 {
+		if len(results[0].Violations) == 0 {
 			t.Log("Policy evaluation passed (no violations)")
 		} else {
-			for _, violation := range result.Violations {
+			for _, violation := range results[0].Violations {
 				t.Logf("Violation: %s", violation)
 			}
 		}
@@ -78,14 +79,14 @@ func TestEvaluate(t *testing.T) {
 			Annotations:  map[string]string{"key": "value"},
 		}
 
-		result, err := Evaluate(opts, logger)
+		results, err := Evaluate(opts, logger)
 		require.NoError(t, err)
-		assert.NotNil(t, result)
+		require.NotEmpty(t, results)
 
-		if len(result.Violations) == 0 {
+		if len(results[0].Violations) == 0 {
 			t.Log("Policy evaluation passed (no violations)")
 		} else {
-			for _, violation := range result.Violations {
+			for _, violation := range results[0].Violations {
 				t.Logf("Violation: %s", violation)
 			}
 		}


### PR DESCRIPTION
This PR changes policy evaluation and linting output to support proper redirection (e.g., ```chainloop policy devel eval {flags} > results.json```).