### PR TITLE
fix(policy): add referenced script traversal

### DIFF
--- a/app/cli/cmd/policy_develop_eval.go
+++ b/app/cli/cmd/policy_develop_eval.go
@@ -65,13 +65,12 @@ evaluates the policy against the provided material or attestation.`,
 		},
 	}
 
-	cmd.Flags().StringVar(&materialPath, "material", "", "path to material or attestation file")
+	cmd.Flags().StringVar(&materialPath, "material", "", "Path to material or attestation file")
 	cobra.CheckErr(cmd.MarkFlagRequired("material"))
-	cmd.Flags().StringVar(&kind, "kind", "", fmt.Sprintf("kind of the material: %q", schemaapi.ListAvailableMaterialKind()))
-	cmd.Flags().StringSliceVar(&annotations, "annotation", []string{}, "key-value pairs of material annotations (key=value)")
-	cmd.Flags().StringVar(&policyPath, "policy", "", "path to custom policy file")
-	cobra.CheckErr(cmd.MarkFlagRequired("policy"))
-	cmd.Flags().StringSliceVar(&inputs, "input", []string{}, "key-value pairs of policy inputs (key=value)")
+	cmd.Flags().StringVar(&kind, "kind", "", fmt.Sprintf("Kind of the material: %q", schemaapi.ListAvailableMaterialKind()))
+	cmd.Flags().StringSliceVar(&annotations, "annotation", []string{}, "Key-value pairs of material annotations (key=value)")
+	cmd.Flags().StringVarP(&policyPath, "policy", "p", "policy.yaml", "Path to custom policy file")
+	cmd.Flags().StringSliceVar(&inputs, "input", []string{}, "Key-value pairs of policy inputs (key=value)")
 
 	return cmd
 }

--- a/app/cli/cmd/policy_develop_lint.go
+++ b/app/cli/cmd/policy_develop_lint.go
@@ -59,7 +59,7 @@ func newPolicyDevelopLintCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&policyPath, "policy", "p", ".", "Path to policy directory")
+	cmd.Flags().StringVarP(&policyPath, "policy", "p", "policy.yaml", "Path to policy file")
 	cmd.Flags().BoolVar(&format, "format", false, "Auto-format file with opa fmt")
 	cmd.Flags().StringVar(&regalConfig, "regal-config", "", "Path to custom regal config (Default: https://github.com/chainloop-dev/chainloop/tree/main/app/cli/internal/policydevel/.regal.yaml)")
 	return cmd

--- a/app/cli/documentation/cli-reference.mdx
+++ b/app/cli/documentation/cli-reference.mdx
@@ -2809,12 +2809,12 @@ chainloop policy eval --policy policy.yaml --material sbom.json --kind SBOM_CYCL
 Options
 
 ```
---annotation strings   key-value pairs of material annotations (key=value)
+--annotation strings   Key-value pairs of material annotations (key=value)
 -h, --help                 help for eval
---input strings        key-value pairs of policy inputs (key=value)
---kind string          kind of the material: ["ARTIFACT" "ATTESTATION" "BLACKDUCK_SCA_JSON" "CHAINLOOP_RUNNER_CONTEXT" "CONTAINER_IMAGE" "CSAF_INFORMATIONAL_ADVISORY" "CSAF_SECURITY_ADVISORY" "CSAF_SECURITY_INCIDENT_RESPONSE" "CSAF_VEX" "EVIDENCE" "GHAS_CODE_SCAN" "GHAS_DEPENDENCY_SCAN" "GHAS_SECRET_SCAN" "GITLAB_SECURITY_REPORT" "HELM_CHART" "JACOCO_XML" "JUNIT_XML" "OPENVEX" "SARIF" "SBOM_CYCLONEDX_JSON" "SBOM_SPDX_JSON" "SLSA_PROVENANCE" "STRING" "TWISTCLI_SCAN_JSON" "ZAP_DAST_ZIP"]
---material string      path to material or attestation file
---policy string        path to custom policy file
+--input strings        Key-value pairs of policy inputs (key=value)
+--kind string          Kind of the material: ["ARTIFACT" "ATTESTATION" "BLACKDUCK_SCA_JSON" "CHAINLOOP_RUNNER_CONTEXT" "CONTAINER_IMAGE" "CSAF_INFORMATIONAL_ADVISORY" "CSAF_SECURITY_ADVISORY" "CSAF_SECURITY_INCIDENT_RESPONSE" "CSAF_VEX" "EVIDENCE" "GHAS_CODE_SCAN" "GHAS_DEPENDENCY_SCAN" "GHAS_SECRET_SCAN" "GITLAB_SECURITY_REPORT" "HELM_CHART" "JACOCO_XML" "JUNIT_XML" "OPENVEX" "SARIF" "SBOM_CYCLONEDX_JSON" "SBOM_SPDX_JSON" "SLSA_PROVENANCE" "STRING" "TWISTCLI_SCAN_JSON" "ZAP_DAST_ZIP"]
+--material string      Path to material or attestation file
+-p, --policy string        Path to custom policy file (default "policy.yaml")
 ```
 
 Options inherited from parent commands

--- a/app/cli/documentation/cli-reference.mdx
+++ b/app/cli/documentation/cli-reference.mdx
@@ -2938,7 +2938,7 @@ Options
 ```
 --format                Auto-format file with opa fmt
 -h, --help                  help for lint
--p, --policy string         Path to policy directory (default ".")
+-p, --policy string         Path to policy file (default "policy.yaml")
 --regal-config string   Path to custom regal config (Default: https://github.com/chainloop-dev/chainloop/tree/main/app/cli/internal/policydevel/.regal.yaml)
 ```
 

--- a/app/cli/internal/action/policy_develop_lint.go
+++ b/app/cli/internal/action/policy_develop_lint.go
@@ -18,7 +18,6 @@ package action
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 
 	"github.com/chainloop-dev/chainloop/app/cli/internal/policydevel"
 )
@@ -45,14 +44,8 @@ func NewPolicyLint(actionOpts *ActionsOpts) (*PolicyLint, error) {
 }
 
 func (action *PolicyLint) Run(_ context.Context, opts *PolicyLintOpts) (*PolicyLintResult, error) {
-	// Resolve absolute path to policy directory
-	absPath, err := filepath.Abs(opts.PolicyPath)
-	if err != nil {
-		return nil, fmt.Errorf("resolving absolute path: %w", err)
-	}
-
 	// Read policies
-	policy, err := policydevel.Lookup(absPath, opts.RegalConfig, opts.Format)
+	policy, err := policydevel.Lookup(opts.PolicyPath, opts.RegalConfig, opts.Format)
 	if err != nil {
 		return nil, fmt.Errorf("loading policy: %w", err)
 	}

--- a/app/cli/internal/policydevel/init.go
+++ b/app/cli/internal/policydevel/init.go
@@ -31,7 +31,7 @@ var templateFS embed.FS
 const (
 	policyTemplateRegoPath   = "templates/example-policy.rego"
 	policyTemplatePath       = "templates/example-policy.yaml"
-	defaultPolicyName        = "chainloop-policy"
+	defaultPolicyName        = "policy"
 	defaultPolicyDescription = "Chainloop validation policy"
 	defaultMaterialKind      = "SBOM_CYCLONEDX_JSON"
 )

--- a/app/cli/internal/policydevel/lint.go
+++ b/app/cli/internal/policydevel/lint.go
@@ -134,8 +134,14 @@ func loadReferencedRegoFiles(policy *PolicyToLint) error {
 		}
 		dir := filepath.Dir(yamlFile.Path)
 		for _, spec := range parsed.Spec.Policies {
-			if spec.GetPath() != "" {
-				absRegoPath := filepath.Join(dir, spec.GetPath())
+			regoPath := spec.GetPath()
+			if regoPath != "" {
+				var absRegoPath string
+				if filepath.IsAbs(regoPath) {
+					absRegoPath = regoPath
+				} else {
+					absRegoPath = filepath.Join(dir, regoPath)
+				}
 				if _, ok := seen[absRegoPath]; ok {
 					continue // avoid duplicates
 				}

--- a/docs/examples/policies/quickstart/README.md
+++ b/docs/examples/policies/quickstart/README.md
@@ -49,13 +49,26 @@ chainloop policy develop eval --policy cdx-fresh.yaml --material cdx-fresh.json 
 
 **Old SBOM (should fail):**
 ```
-INF - cdx-fresh: SBOM created at: 2024-06-15T10:30:00Z which is too old (freshness limit set to 30 days)
-INF policy evaluation failed
+[
+   {
+      "violations": [
+         "SBOM created at: 2024-06-15T10:30:00Z which is too old (freshness limit set to 30 days)"
+      ],
+      "skip_reasons": [],
+      "skipped": false
+   }
+]
 ```
 
 **Fresh SBOM (should pass):**
 ```
-INF policy evaluation passed
+[
+   {
+      "violations": [],
+      "skip_reasons": [],
+      "skipped": false
+   }
+]
 ```
 
 ## Create Your Own Policy
@@ -68,7 +81,7 @@ Create a new policy with the embedded format (single YAML file):
 chainloop policy develop init --embedded --name my-policy --description "My custom policy description"
 ```
 
-**Note**: This creates a file named `my-policy.yaml` (based on the `--name` parameter). Without `--embedded`, it creates separate `chainloop-policy.yaml` and `chainloop-policy.rego` files.
+**Note**: This creates a file named `my-policy.yaml` (based on the `--name` parameter). Without `--embedded` and `--name`, it creates separate `policy.yaml` and `policy.rego` files.
 
 ### Step 2: Write Your Policy Rules
 


### PR DESCRIPTION
This PR changes the way policy file is linted. 
- when *.yaml file is passed all referenced *.rego files will also be linted. 
- when directory is passed or default (cwd) is used it looks for a ```policy.yaml``` file, if not found linting fails. (before it would lint all valid *.yaml and *.rego files)

Closes #2310