### PR TITLE
fix(startup): Remove NATS configuration from default dev config

### DIFF
--- a/app/controlplane/configs/config.devel.yaml
+++ b/app/controlplane/configs/config.devel.yaml
@@ -16,8 +16,8 @@ server:
     #   certificate: "../../devel/devkeys/selfsigned/controlplane.crt"
     #   private_key: "../../devel/devkeys/selfsigned/controlplane.key"
 
-nats_server:
- uri: nats://0.0.0.0:4222
+#nats_server:
+# uri: nats://0.0.0.0:4222
 
 # Restrict organization creation to role:instance:admin
 restrict_org_creation: true


### PR DESCRIPTION
This patch comments out the NATS configuration in the default config file, as it’s not required to start the control plane.