### PR TITLE
fix(policy): policy devel lint --format removes the comments

### DIFF
--- a/docs/examples/policies/chainloop-commit.yaml
+++ b/docs/examples/policies/chainloop-commit.yaml
@@ -21,45 +21,44 @@ spec:
     - kind: ATTESTATION
       embedded: |
         package main
-        
+
         import rego.v1
-                  
+
         ################################
         # Common section do NOT change #
         ################################
-        
+
         result := {
-          "skipped": skipped,
-          "violations": violations,
-          "skip_reason": skip_reason,
+        	"skipped": skipped,
+        	"violations": violations,
+        	"skip_reason": skip_reason,
         }
-          
+
         default skip_reason := ""
-          
+
         skip_reason := m if {
-          not valid_input
-          m := "the file content is not recognized"
+        	not valid_input
+        	m := "the file content is not recognized"
         }
-          
+
         default skipped := true
-        
+
         skipped := false if valid_input
-                  
+
         ########################################
         # EO Common section, custom code below #
         ########################################
-        
+
         # TODO: update to validate if the file is expected, i.e checking the tool that generates it
         valid_input := true
-        
+
         violations contains msg if {
-          not has_commit
-          msg := "missing commit in attestation material"
+        	not has_commit
+        	msg := "missing commit in attestation material"
         }
-        
+
         has_commit if {
-          some sub in input.subject
-          sub.name == "git.head"
-          sub.digest.sha1
+        	some sub in input.subject
+        	sub.name == "git.head"
+        	sub.digest.sha1
         }
-    

--- a/docs/examples/policies/chainloop-qa.yaml
+++ b/docs/examples/policies/chainloop-qa.yaml
@@ -24,45 +24,45 @@ spec:
     - kind: ATTESTATION
       embedded: |
         package main
-        
+
         import rego.v1
-        
+
         ################################
         # Common section do NOT change #
         ################################
-        
+
         result := {
-          "skipped": skipped,
-          "violations": violations,
-          "skip_reason": skip_reason,
+        	"skipped": skipped,
+        	"violations": violations,
+        	"skip_reason": skip_reason,
         }
-        
+
         default skip_reason := ""
-        
+
         skip_reason := m if {
-          not valid_input
-          m := "the file content is not recognized"
+        	not valid_input
+        	m := "the file content is not recognized"
         }
-        
+
         default skipped := true
-        
+
         skipped := false if valid_input
-        
+
         ########################################
         # EO Common section, custom code below #
         ########################################
-        
+
         # TODO: update to validate if the file is expected, i.e checking the tool that generates it
         valid_input := true
-        
+
         violations contains msg if {
-          not is_approved
-          
-          msg:= "Container image is not approved"
+        	not is_approved
+
+        	msg := "Container image is not approved"
         }
-        
+
         is_approved if {
-          input.predicate.annotations.approval == "true"
-          some material in input.predicate.materials
-          material.annotations["chainloop.material.type"] == "CONTAINER_IMAGE"
+        	input.predicate.annotations.approval == "true"
+        	some material in input.predicate.materials
+        	material.annotations["chainloop.material.type"] == "CONTAINER_IMAGE"
         }

--- a/docs/examples/policies/quickstart/cdx-fresh.yaml
+++ b/docs/examples/policies/quickstart/cdx-fresh.yaml
@@ -1,57 +1,57 @@
 apiVersion: workflowcontract.chainloop.dev/v1
 kind: Policy
 metadata:
-    name: cdx-fresh
-    description: Checks that SBOM is maximum of 30 days old
-    annotations:
-        category: quickstart
+  name: cdx-fresh
+  description: Checks that SBOM is maximum of 30 days old
+  annotations:
+    category: quickstart
 spec:
-    policies:
-        - embedded: |
-            package main
+  policies:
+    - embedded: |
+        package main
 
-            import rego.v1
+        import rego.v1
 
-            ################################
-            # Common section do NOT change #
-            ################################
+        ################################
+        # Common section do NOT change #
+        ################################
 
-            result := {
-            	"skipped": skipped,
-            	"violations": violations,
-            	"skip_reason": skip_reason,
-            	"ignore": ignore,
-            }
+        result := {
+        	"skipped": skipped,
+        	"violations": violations,
+        	"skip_reason": skip_reason,
+        	"ignore": ignore,
+        }
 
-            default skip_reason := ""
+        default skip_reason := ""
 
-            skip_reason := m if {
-            	not valid_input
-            	m := "invalid input"
-            }
+        skip_reason := m if {
+        	not valid_input
+        	m := "invalid input"
+        }
 
-            default skipped := true
+        default skipped := true
 
-            skipped := false if valid_input
+        skipped := false if valid_input
 
-            default ignore := false
+        default ignore := false
 
-            ########################################
-            # EO Common section, custom code below #
-            ########################################
-            # Validates if the input is valid and can be understood by this policy
-            valid_input := true
+        ########################################
+        # EO Common section, custom code below #
+        ########################################
+        # Validates if the input is valid and can be understood by this policy
+        valid_input := true
 
-            limit := 30
-            nanosecs_per_second := (1000 * 1000) * 1000
-            nanosecs_per_day := ((24 * 60) * 60) * nanosecs_per_second
-            maximum_age := limit * nanosecs_per_day
+        limit := 30
+        nanosecs_per_second := (1000 * 1000) * 1000
+        nanosecs_per_day := ((24 * 60) * 60) * nanosecs_per_second
+        maximum_age := limit * nanosecs_per_day
 
-            # If the input is valid, check for any policy violation here
-            violations contains msg if {
-            	sbom_ns = time.parse_rfc3339_ns(input.metadata.timestamp)
-            	exceeding = time.now_ns() - (sbom_ns + maximum_age)
-            	exceeding > 0
-            	msg := sprintf("SBOM created at: %s which is too old (freshness limit set to %d days)", [input.metadata.timestamp, limit])
-            }
-          kind: SBOM_CYCLONEDX_JSON
+        # If the input is valid, check for any policy violation here
+        violations contains msg if {
+        	sbom_ns = time.parse_rfc3339_ns(input.metadata.timestamp)
+        	exceeding = time.now_ns() - (sbom_ns + maximum_age)
+        	exceeding > 0
+        	msg := sprintf("SBOM created at: %s which is too old (freshness limit set to %d days)", [input.metadata.timestamp, limit])
+        }
+      kind: SBOM_CYCLONEDX_JSON

--- a/docs/examples/policies/sarif-errors.yaml
+++ b/docs/examples/policies/sarif-errors.yaml
@@ -22,44 +22,44 @@ spec:
     - kind: SARIF
       embedded: |
         package main
-        
+
         import rego.v1
-          
+
         ################################
         # Common section do NOT change #
         ################################
-        
+
         result := {
-            "skipped": skipped,
-            "violations": violations,
-            "skip_reason": skip_reason,
+        	"skipped": skipped,
+        	"violations": violations,
+        	"skip_reason": skip_reason,
         }
-        
+
         default skip_reason := ""
-        
+
         skip_reason := m if {
-            not valid_input
-            m := "the file content is not recognized"
+        	not valid_input
+        	m := "the file content is not recognized"
         }
-        
+
         default skipped := true
-        
+
         skipped := false if valid_input
-        
+
         ########################################
         # EO Common section, custom code below #
         ########################################
-        
+
         # TODO: update to validate if the file is expected, i.e checking the tool that generates it
         valid_input := true
-        
+
         violations contains msg if {
-          has_errors
-          msg := "There are errors in the SARIF report"
+        	has_errors
+        	msg := "There are errors in the SARIF report"
         }
-        
+
         has_errors if {
-          some run in input.runs
-          some result in run.results
-          result.level == "error"
+        	some run in input.runs
+        	some result in run.results
+        	result.level == "error"
         }

--- a/docs/examples/policies/sbom/cyclonedx-banned-licenses.yaml
+++ b/docs/examples/policies/sbom/cyclonedx-banned-licenses.yaml
@@ -24,42 +24,42 @@ spec:
     - kind: SBOM_CYCLONEDX_JSON
       embedded: |
         package main
-        
+
         import rego.v1
-              
+
         ################################
         # Common section do NOT change #
         ################################
-        
+
         result := {
-          "skipped": skipped,
-          "violations": violations,
-          "skip_reason": skip_reason,
+        	"skipped": skipped,
+        	"violations": violations,
+        	"skip_reason": skip_reason,
         }
-        
+
         default skip_reason := ""
-        
+
         skip_reason := m if {
-          not valid_input
-          m := "the file content is not recognized"
+        	not valid_input
+        	m := "the file content is not recognized"
         }
-        
+
         default skipped := true
-        
+
         skipped := false if valid_input
-        
+
         ########################################
         # EO Common section, custom code below #
         ########################################
-        
+
         # TODO: update to validate if the file is expected, i.e checking the tool that generates it
         valid_input := true
 
         banned_licenses := ["GPL-2.0", "GPL-3.0"]
 
         violations contains ref if {
-          some comp in input.components
-          some lic in comp.licenses
-          lic.license.name in banned_licenses
-          ref := sprintf("Forbidden license %v for %v (%v)", [license.name, comp.name, comp["bom-ref"]])
+        	some comp in input.components
+        	some lic in comp.licenses
+        	lic.license.name in banned_licenses
+        	ref := sprintf("Forbidden license %v for %v (%v)", [license.name, comp.name, comp["bom-ref"]])
         }

--- a/docs/examples/policies/sbom/cyclonedx-banned-packages.yaml
+++ b/docs/examples/policies/sbom/cyclonedx-banned-packages.yaml
@@ -24,57 +24,57 @@ spec:
     - kind: SBOM_CYCLONEDX_JSON
       embedded: |
         package main
-        
+
         import rego.v1
-        
+
         ################################
         # Common section do NOT change #
         ################################
-        
+
         result := {
-          "skipped": skipped,
-          "violations": violations,
-          "skip_reason": skip_reason,
+        	"skipped": skipped,
+        	"violations": violations,
+        	"skip_reason": skip_reason,
         }
-        
+
         default skip_reason := ""
-        
+
         skip_reason := m if {
-          not valid_input
-          m := "the file content is not recognized"
+        	not valid_input
+        	m := "the file content is not recognized"
         }
-        
+
         default skipped := true
-        
+
         skipped := false if valid_input
-        
+
         ########################################
         # EO Common section, custom code below #
         ########################################
-        
+
         # TODO: update to validate if the file is expected, i.e checking the tool that generates it
         valid_input := true
-        
+
         # It supports packages with version. When specified, requires it to be semver, and would also fail when version is lower
         banned_packages := ["log4j@2.14.1"]
-    
+
         # all versions
         violations contains ref if {
-          some comp in input.components
-          some banned in banned_packages
-          nv := split(banned, "@")
-          not nv[1]
-          comp.name == nv[0]
-          ref := sprintf("Banned package: %v", [comp.name])
+        	some comp in input.components
+        	some banned in banned_packages
+        	nv := split(banned, "@")
+        	not nv[1]
+        	comp.name == nv[0]
+        	ref := sprintf("Banned package: %v", [comp.name])
         }
-    
+
         # specific versions
         violations contains ref if {
-          some comp in input.components
-          some banned banned_packages
-          nv := split(banned, "@")
-          comp.name == nv[0]
-          result := semver.compare(comp.version, nv[1])
-          result <= 0
-          ref := sprintf("Banned package: %v %v", [comp.name, comp.version])
+        	some comp in input.components
+        	some banned in banned_packages
+        	nv := split(banned, "@")
+        	comp.name == nv[0]
+        	result := semver.compare(comp.version, nv[1])
+        	result <= 0
+        	ref := sprintf("Banned package: %v %v", [comp.name, comp.version])
         }

--- a/docs/examples/policies/sbom/cyclonedx-freshness.yaml
+++ b/docs/examples/policies/sbom/cyclonedx-freshness.yaml
@@ -24,48 +24,48 @@ spec:
     - kind: SBOM_CYCLONEDX_JSON
       embedded: |
         package main
-        
+
         import rego.v1
-        
+
         ################################
         # Common section do NOT change #
         ################################
-        
+
         result := {
-          "skipped": skipped,
-          "violations": violations,
-          "skip_reason": skip_reason,
+        	"skipped": skipped,
+        	"violations": violations,
+        	"skip_reason": skip_reason,
         }
-        
+
         default skip_reason := ""
-        
+
         skip_reason := m if {
-          not valid_input
-          m := "the file content is not recognized"
+        	not valid_input
+        	m := "the file content is not recognized"
         }
-        
+
         default skipped := true
-        
+
         skipped := false if valid_input
-        
+
         ########################################
         # EO Common section, custom code below #
         ########################################
-        
+
         # TODO: update to validate if the file is expected, i.e checking the tool that generates it
         valid_input := true
-      
+
         limit := 30
-        
-        nanosecs_per_second = (1000 * 1000) * 1000
-        
-        nanosecs_per_day = ((24 * 60) * 60) * nanosecs_per_second
-        
-        maximum_age = limit * nanosecs_per_day
-        
+
+        nanosecs_per_second := (1000 * 1000) * 1000
+
+        nanosecs_per_day := ((24 * 60) * 60) * nanosecs_per_second
+
+        maximum_age := limit * nanosecs_per_day
+
         violations contains msg if {
-          sbom_ns = time.parse_rfc3339_ns(input.metadata.timestamp)
-          exceeding = time.now_ns() - (sbom_ns + maximum_age)
-          exceeding > 0
-          msg := sprintf("SBOM created at: %s which is too old (freshness limit set to %d days)", [input.metadata.timestamp, limit])
+        	sbom_ns = time.parse_rfc3339_ns(input.metadata.timestamp)
+        	exceeding = time.now_ns() - (sbom_ns + maximum_age)
+        	exceeding > 0
+        	msg := sprintf("SBOM created at: %s which is too old (freshness limit set to %d days)", [input.metadata.timestamp, limit])
         }

--- a/docs/examples/policies/sbom/cyclonedx-licenses.yaml
+++ b/docs/examples/policies/sbom/cyclonedx-licenses.yaml
@@ -7,44 +7,43 @@ metadata:
     category: sbom
 spec:
   policies:
-  - kind: SBOM_CYCLONEDX_JSON
-    embedded: |
-      package main
-  
-      import rego.v1
-      
-      # Global result object
-      result := {
-        "skipped": skipped,
-        "violations": violations,
-        "skip_reason": skip_reason,
-      }
-  
-      default skip_reason := ""
-      
-      skip_reason := m if {
-        not valid_input
-        m := "the file content is not recognized"
-      }
-      
-      default skipped := true
-      
-      skipped := false if valid_input
-      
-      valid_input if {
-        # expect at least 1 component in the SBOM
-        count(input.components) > 0
-      }
-  
-      violations contains msg if {
-        count(without_license) > 0
-        msg := sprintf("Missing licenses for %s", [components_str])
-      }
-  
-      components_str := concat(", ", [comp.purl | some comp in without_license])
-  
-      without_license contains comp if {
-        some comp in input.components
-        not comp.licenses
-      }
+    - kind: SBOM_CYCLONEDX_JSON
+      embedded: |
+        package main
 
+        import rego.v1
+
+        # Global result object
+        result := {
+        	"skipped": skipped,
+        	"violations": violations,
+        	"skip_reason": skip_reason,
+        }
+
+        default skip_reason := ""
+
+        skip_reason := m if {
+        	not valid_input
+        	m := "the file content is not recognized"
+        }
+
+        default skipped := true
+
+        skipped := false if valid_input
+
+        valid_input if {
+        	# expect at least 1 component in the SBOM
+        	count(input.components) > 0
+        }
+
+        violations contains msg if {
+        	count(without_license) > 0
+        	msg := sprintf("Missing licenses for %s", [components_str])
+        }
+
+        components_str := concat(", ", [comp.purl | some comp in without_license])
+
+        without_license contains comp if {
+        	some comp in input.components
+        	not comp.licenses
+        }

--- a/docs/examples/policies/sbom/cyclonedx-required-packages.yaml
+++ b/docs/examples/policies/sbom/cyclonedx-required-packages.yaml
@@ -24,48 +24,48 @@ spec:
     - kind: SBOM_CYCLONEDX_JSON
       embedded: |
         package main
-        
+
         import rego.v1
-        
+
         ################################
         # Common section do NOT change #
         ################################
-        
+
         result := {
-          "skipped": skipped,
-          "violations": violations,
-          "skip_reason": skip_reason,
+        	"skipped": skipped,
+        	"violations": violations,
+        	"skip_reason": skip_reason,
         }
-        
+
         default skip_reason := ""
-        
+
         skip_reason := m if {
-          not valid_input
-          m := "the file content is not recognized"
+        	not valid_input
+        	m := "the file content is not recognized"
         }
-        
+
         default skipped := true
-        
+
         skipped := false if valid_input
-        
+
         ########################################
         # EO Common section, custom code below #
         ########################################
-        
+
         # TODO: update to validate if the file is expected, i.e checking the tool that generates it
         valid_input := true
-        
+
         required_packages := {"glibc", "libcrypto3"}
-          
+
         violations contains msg if {
-          count(all_matches) != count(required_packages)
-          missing := required_packages - all_matches
-          some i
-          msg := sprintf("missing package: %v", [missing[i]])
+        	count(all_matches) != count(required_packages)
+        	missing := required_packages - all_matches
+        	some i
+        	msg := sprintf("missing package: %v", [missing[i]])
         }
-          
+
         all_matches contains name if {
-          some comp in input.components
-          comp.name in required_packages
-          name := comp.name
+        	some comp in input.components
+        	comp.name in required_packages
+        	name := comp.name
         }

--- a/docs/examples/policies/sbom/sbom-present.yaml
+++ b/docs/examples/policies/sbom/sbom-present.yaml
@@ -24,52 +24,52 @@ spec:
     - kind: ATTESTATION
       embedded: |
         package main
-          
+
         # Verifies there is a SBOM material, even if not enforced by contract
-        
+
         import rego.v1
-        
+
         ################################
         # Common section do NOT change #
         ################################
-        
+
         result := {
-          "skipped": skipped,
-          "violations": violations,
-          "skip_reason": skip_reason,
+        	"skipped": skipped,
+        	"violations": violations,
+        	"skip_reason": skip_reason,
         }
-        
+
         default skip_reason := ""
-        
+
         skip_reason := m if {
-          not valid_input
-          m := "the file content is not recognized"
+        	not valid_input
+        	m := "the file content is not recognized"
         }
-        
+
         default skipped := true
-        
+
         skipped := false if valid_input
-        
+
         ########################################
         # EO Common section, custom code below #
         ########################################
-        
+
         # TODO: update to validate if the file is expected, i.e checking the tool that generates it
         valid_input := true
-        
+
         violations contains msg if {
-          not has_sbom
-          msg := "missing SBOM material"
+        	not has_sbom
+        	msg := "missing SBOM material"
         }
-        
+
         # Collect all material types
         kinds contains kind if {
-          some material in input.predicate.materials
-          kind := material.annotations["chainloop.material.type"]
+        	some material in input.predicate.materials
+        	kind := material.annotations["chainloop.material.type"]
         }
-      
+
         has_sbom if {
-          values := ["SBOM_SPDX_JSON","SBOM_CYCLONEDX_JSON"]      
-          some kind in kinds
-          kind in values
+        	values := ["SBOM_SPDX_JSON", "SBOM_CYCLONEDX_JSON"]
+        	some kind in kinds
+        	kind in values
         }

--- a/docs/examples/policies/sbom/spdx-sbom-syft.yaml
+++ b/docs/examples/policies/sbom/spdx-sbom-syft.yaml
@@ -21,47 +21,47 @@ metadata:
     category: sbom
 spec:
   policies:
-  - kind: SBOM_SPDX_JSON
-    embedded: |
-      package main
-  
-      import rego.v1
-      
-      ################################
-      # Common section do NOT change #
-      ################################
-    
-      result := {
-        "skipped": skipped,
-        "violations": violations,
-        "skip_reason": skip_reason,
-      }
-    
-      default skip_reason := ""
-    
-      skip_reason := m if {
-        not valid_input
-        m := "the file content is not recognized"
-      }
-    
-      default skipped := true
-    
-      skipped := false if valid_input
-    
-      ########################################
-      # EO Common section, custom code below #
-      ########################################
-    
-      # TODO: update to validate if the file is expected, i.e checking the tool that generates it
-      valid_input := true
-      
-      violations contains msg if {
-        not made_with_syft
-  
-        msg := "Not made with syft"
-      }
-  
-      made_with_syft if {
-        some creator in input.creationInfo.creators
-        contains(creator, "syft")
-      }
+    - kind: SBOM_SPDX_JSON
+      embedded: |
+        package main
+
+        import rego.v1
+
+        ################################
+        # Common section do NOT change #
+        ################################
+
+        result := {
+        	"skipped": skipped,
+        	"violations": violations,
+        	"skip_reason": skip_reason,
+        }
+
+        default skip_reason := ""
+
+        skip_reason := m if {
+        	not valid_input
+        	m := "the file content is not recognized"
+        }
+
+        default skipped := true
+
+        skipped := false if valid_input
+
+        ########################################
+        # EO Common section, custom code below #
+        ########################################
+
+        # TODO: update to validate if the file is expected, i.e checking the tool that generates it
+        valid_input := true
+
+        violations contains msg if {
+        	not made_with_syft
+
+        	msg := "Not made with syft"
+        }
+
+        made_with_syft if {
+        	some creator in input.creationInfo.creators
+        	contains(creator, "syft")
+        }

--- a/docs/examples/policies/trivy-vulns.yaml
+++ b/docs/examples/policies/trivy-vulns.yaml
@@ -21,47 +21,47 @@ spec:
   policies:
     - embedded: |
         package main
-        
+
         import rego.v1
-        
+
         ################################
         # Common section do NOT change #
         ################################
-        
+
         result := {
-            "skipped": skipped,
-            "violations": violations,
-            "skip_reason": skip_reason,
+        	"skipped": skipped,
+        	"violations": violations,
+        	"skip_reason": skip_reason,
         }
-        
+
         default skip_reason := ""
-        
+
         skip_reason := m if {
-            not valid_input
-            m := "the file content is not recognized"
+        	not valid_input
+        	m := "the file content is not recognized"
         }
-        
+
         default skipped := true
-        
+
         skipped := false if valid_input
-        
+
         ########################################
         # EO Common section, custom code below #
         ########################################
-        
+
         # TODO: update to validate if the file is expected, i.e checking the tool that generates it
         valid_input := true
-        
+
         # Verifies there is a SBOM material, even if not enforced by contract
-        
+
         violations contains msg if {
-          has_vulnerabilities
-          msg := "CVE report has vulnerabilities with severity MEDIUM or HIGH"
+        	has_vulnerabilities
+        	msg := "CVE report has vulnerabilities with severity MEDIUM or HIGH"
         }
-        
+
         has_vulnerabilities if {
-          severities := ["HIGH", "MEDIUM"]
-          some result in input.Results
-          some vuln in result.Vulnerabilities
-          vuln.Severity in severities
+        	severities := ["HIGH", "MEDIUM"]
+        	some result in input.Results
+        	some vuln in result.Vulnerabilities
+        	vuln.Severity in severities
         }


### PR DESCRIPTION
This PR solves problem with comments being removed when `--format` is used. 
Example policies in docs were re-linted with the tool.

Closes #2320 