### PR TITLE
feat(policy): policy eval should fail if no execution path is met

### DIFF
--- a/app/cli/cmd/policy_develop_eval.go
+++ b/app/cli/cmd/policy_develop_eval.go
@@ -63,6 +63,13 @@ evaluates the policy against the provided material or attestation.`,
 				return newGracefulError(err)
 			}
 
+			// Check if any result was ignored
+			for _, res := range result {
+				if res.Ignored {
+					return fmt.Errorf("policy evaluation failed: no execution branch matched")
+				}
+			}
+
 			return encodeJSON(result)
 		},
 	}

--- a/app/cli/cmd/policy_develop_eval.go
+++ b/app/cli/cmd/policy_develop_eval.go
@@ -60,14 +60,7 @@ evaluates the policy against the provided material or attestation.`,
 
 			result, err := policyEval.Run()
 			if err != nil {
-				return newGracefulError(err)
-			}
-
-			// Check if any result was ignored
-			for _, res := range result {
-				if res.Ignored {
-					return fmt.Errorf("policy evaluation failed: no execution branch matched")
-				}
+				return err
 			}
 
 			return encodeJSON(result)

--- a/app/cli/internal/policydevel/eval.go
+++ b/app/cli/internal/policydevel/eval.go
@@ -48,13 +48,13 @@ func Evaluate(opts *EvalOptions, logger zerolog.Logger) ([]*EvalResult, error) {
 	// 1. Create crafting schema
 	schema, err := createCraftingSchema(opts.PolicyPath, opts.Inputs)
 	if err != nil {
-		return nil, fmt.Errorf("creating crafting schema: %w", err)
+		return nil, err
 	}
 
 	// 2. Craft material with annotations
 	material, err := craftMaterial(opts.MaterialPath, opts.MaterialKind, &logger)
 	if err != nil {
-		return nil, fmt.Errorf("material crafting: %w", err)
+		return nil, err
 	}
 	material.Annotations = opts.Annotations
 
@@ -95,14 +95,7 @@ func verifyMaterial(schema *v1.CraftingSchema, material *v12.Attestation_Materia
 
 	// no evaluations were returned
 	if len(policyEvs) == 0 {
-		return []*EvalResult{
-			{
-				Ignored:     true,
-				Skipped:     false,
-				SkipReasons: []string{},
-				Violations:  []string{},
-			},
-		}, nil
+		return nil, fmt.Errorf("no execution branch matched for kind %s", material.MaterialType.String())
 	}
 
 	results := make([]*EvalResult, 0, len(policyEvs))

--- a/app/cli/internal/policydevel/eval_test.go
+++ b/app/cli/internal/policydevel/eval_test.go
@@ -41,9 +41,8 @@ func TestEvaluate(t *testing.T) {
 		}
 
 		results, err := Evaluate(opts, logger)
-		require.NoError(t, err)
-		require.NotEmpty(t, results)
-		assert.NotNil(t, results[0])
+		require.Error(t, err)
+		assert.Empty(t, results)
 	})
 
 	t.Run("evaluation with auto-detected SBOM CYCLONEDX kind", func(t *testing.T) {


### PR DESCRIPTION
This PR adds error when no evaluations on provided material were performed.

## Example
```
apiVersion: workflowcontract.chainloop.dev/v1
kind: Policy
metadata:
  name: policy
  description: Chainloop validation policy
spec:
  policies:
    - embedded: |
        package main

        import rego.v1

        ################################
        # Common section do NOT change #
        ################################

        result := {
          "skipped": skipped,
          "violations": violations,
          "skip_reason": skip_reason,
          "ignore": ignore,
        }

        default skip_reason := ""

        skip_reason := m if {
          not valid_input
          m := "invalid input"
        }

        default skipped := true

        skipped := false if valid_input

        default ignore := false

        ########################################
        # EO Common section, custom code below #
        ########################################
        # Validates if the input is valid and can be understood by this policy
        valid_input := true

        # insert code here

        # If the input is valid, check for any policy violation here
        # default violations := []

        violations contains msg if {
          valid_input
          msg := "test"
        }
      kind: EVIDENCE
    - embedded: |
        package main

        import rego.v1

        ################################
        # Common section do NOT change #
        ################################

        result := {
          "skipped": skipped,
          "violations": violations,
          "skip_reason": skip_reason,
          "ignore": ignore,
        }

        default skip_reason := ""

        skip_reason := m if {
          not valid_input
          m := "invalid input"
        }

        default skipped := true

        skipped := false if valid_input

        default ignore := false

        ########################################
        # EO Common section, custom code below #
        ########################################
        # Validates if the input is valid and can be understood by this policy
        valid_input := true

        # insert code here

        # If the input is valid, check for any policy violation here
        # default violations := []

        violations contains msg if {
          valid_input
          msg := "test"
        }
      kind: STRING
```
For policy with no defined path for kind `SBOM_CYCLONEDX_JSON` when validated against valid cyclonedx json file it outputs:
```
ERR evaluating policy: no execution branch matched for kind SBOM_CYCLONEDX_JSON
exit status 1
```

Closes #2334