### PR TITLE
fix(policy-devel): inputs don't accept multiple values

### DIFF
--- a/app/cli/cmd/policy_develop_eval.go
+++ b/app/cli/cmd/policy_develop_eval.go
@@ -72,7 +72,7 @@ evaluates the policy against the provided material or attestation.`,
 	cmd.Flags().StringVar(&kind, "kind", "", fmt.Sprintf("Kind of the material: %q", schemaapi.ListAvailableMaterialKind()))
 	cmd.Flags().StringSliceVar(&annotations, "annotation", []string{}, "Key-value pairs of material annotations (key=value)")
 	cmd.Flags().StringVarP(&policyPath, "policy", "p", "policy.yaml", "Path to custom policy file")
-	cmd.Flags().StringSliceVar(&inputs, "input", []string{}, "Key-value pairs of policy inputs (key=value)")
+	cmd.Flags().StringArrayVar(&inputs, "input", []string{}, "Key-value pairs of policy inputs (key=value)")
 	cmd.Flags().StringSliceVar(&allowedHostnames, "allowed-hostnames", []string{}, "Additional hostnames allowed for http.send requests in policies")
 
 	return cmd

--- a/app/cli/documentation/cli-reference.mdx
+++ b/app/cli/documentation/cli-reference.mdx
@@ -2848,7 +2848,7 @@ Options
 --allowed-hostnames strings   Additional hostnames allowed for http.send requests in policies
 --annotation strings          Key-value pairs of material annotations (key=value)
 -h, --help                        help for eval
---input strings               Key-value pairs of policy inputs (key=value)
+--input stringArray           Key-value pairs of policy inputs (key=value)
 --kind string                 Kind of the material: ["ARTIFACT" "ATTESTATION" "BLACKDUCK_SCA_JSON" "CHAINLOOP_RUNNER_CONTEXT" "CONTAINER_IMAGE" "CSAF_INFORMATIONAL_ADVISORY" "CSAF_SECURITY_ADVISORY" "CSAF_SECURITY_INCIDENT_RESPONSE" "CSAF_VEX" "EVIDENCE" "GHAS_CODE_SCAN" "GHAS_DEPENDENCY_SCAN" "GHAS_SECRET_SCAN" "GITLAB_SECURITY_REPORT" "HELM_CHART" "JACOCO_XML" "JUNIT_XML" "OPENVEX" "SARIF" "SBOM_CYCLONEDX_JSON" "SBOM_SPDX_JSON" "SLSA_PROVENANCE" "STRING" "TWISTCLI_SCAN_JSON" "ZAP_DAST_ZIP"]
 --material string             Path to material or attestation file
 -p, --policy string               Path to custom policy file (default "policy.yaml")


### PR DESCRIPTION
This PR fixes issue with passing arrays in `--input` flag.

### Example
By passing `--input licenses=AGPL,GPL` in the eval command values can now be accessed with `input.args.licenses[0]` and `input.args.licenses[1]` in the rego script.

Closes #2351