### PR TITLE
fix(atlas): Bump Atlas version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Generate migrations
         if: ${{ matrix.app == 'controlplane' }}
         env:
-          ATLAS_VERSION: v0.35.0
+          ATLAS_VERSION: v0.36.0
         run: |
           wget -q https://release.ariga.io/atlas/atlas-linux-amd64-$ATLAS_VERSION -O /tmp/atlas
           sudo install /tmp/atlas /usr/local/bin/atlas

--- a/app/controlplane/Dockerfile.migrations
+++ b/app/controlplane/Dockerfile.migrations
@@ -1,9 +1,9 @@
 # Container image built by go-releaser that's used to run migrations against the database during deployment
 # See https://atlasgo.io/guides/deploying/image
 # from: arigaio/atlas:latest
-# docker run arigaio/atlas@sha256:16739cffc8d44d04e76f58842dc12835e183fe7164d0ae55544fc8bc9fbb1e33 version
-# atlas version v0.35.0
-FROM arigaio/atlas@sha256:16739cffc8d44d04e76f58842dc12835e183fe7164d0ae55544fc8bc9fbb1e33 as base
+# docker run arigaio/atlas@sha256:2a621eff7cc837aec47f6504f17bfc95659ad7198f6e93f4145046b831a72066 version
+# atlas version v0.36.3-1fac927-canary
+FROM arigaio/atlas@sha256:2a621eff7cc837aec47f6504f17bfc95659ad7198f6e93f4145046b831a72066 as base
 
 FROM scratch
 # Update permissions to make it readable by the user

--- a/common.mk
+++ b/common.mk
@@ -7,9 +7,9 @@ init: init-api-tools
 	go install github.com/vektra/mockery/v3@v3.5.0
 	# using binary release for atlas, since ent schema handler is not included
 	# in the community version anymore https://github.com/ariga/atlas/issues/2388#issuecomment-1864287189
-	curl -sSf https://atlasgo.sh | ATLAS_VERSION=v0.35.0 sh -s -- -y
 	# install golangci-lint with Go 1.25 support
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v2.4.0
+	curl -sSf https://atlasgo.sh | ATLAS_VERSION=v0.36.0 sh -s -- -y
 
 # initialize API tooling
 .PHONY: init-api-tools


### PR DESCRIPTION
This patch upgrades Atlas to a newer version that addresses and removes existing CVEs.

```
❯ trivy image arigaio/atlas@sha256:2a621eff7cc837aec47f6504f17bfc95659ad7198f6e93f4145046b831a72066
2025-08-18T12:37:26+02:00	INFO	[vuln] Vulnerability scanning is enabled
2025-08-18T12:37:26+02:00	INFO	[secret] Secret scanning is enabled
2025-08-18T12:37:26+02:00	INFO	[secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2025-08-18T12:37:26+02:00	INFO	[secret] Please see also https://aquasecurity.github.io/trivy/v0.57/docs/scanner/secret#recommendation for faster secret detection
2025-08-18T12:37:26+02:00	INFO	Detected OS	family="debian" version="12.11"
2025-08-18T12:37:26+02:00	INFO	[debian] Detecting vulnerabilities...	os_version="12" pkg_num=4
2025-08-18T12:37:26+02:00	INFO	Number of language-specific files	num=1
2025-08-18T12:37:26+02:00	INFO	[gobinary] Detecting vulnerabilities...

arigaio/atlas@sha256:2a621eff7cc837aec47f6504f17bfc95659ad7198f6e93f4145046b831a72066 (debian 12.11)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```

```
❯ grype arigaio/atlas@sha256:2a621eff7cc837aec47f6504f17bfc95659ad7198f6e93f4145046b831a72066
 ✔ Vulnerability DB                [updated]
 ✔ Loaded image                                                     arigaio/atlas@sha256:2a621eff7cc837aec47f6504f17bfc95659ad7198f6e93f4145046b831a72066
 ✔ Parsed image                                                                   sha256:b94f3133de10d506beb99dcbcfeb674322543bb98cb9f8b4a4cf664c21eba1d2
 ✔ Cataloged contents                                                                    cc87f5afab2521cf6667018f8beaa95c056908ba7053c5a9b97fe1e674803c7c
   ├── ✔ Packages                        [166 packages]
   ├── ✔ Executables                     [1 executables]
   ├── ✔ File metadata                   [947 locations]
   └── ✔ File digests                    [947 files]
 ✔ Scanned for vulnerabilities     [0 vulnerability matches]
   ├── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
   └── by status:   0 fixed, 0 not-fixed, 0 ignored
[0000]  WARN current database is invalid error=the vulnerability database was built 8 weeks ago (max allowed age is 5 days)
No vulnerabilities found
```