### PR TITLE
feat(policy-devel): drop support for yaml and embedded rego formatting

### DIFF
--- a/app/cli/cmd/policy_develop_lint.go
+++ b/app/cli/cmd/policy_develop_lint.go
@@ -65,7 +65,7 @@ func newPolicyDevelopLintCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&policyPath, "policy", "p", "policy.yaml", "Path to policy file")
-	cmd.Flags().BoolVar(&format, "format", false, "Auto-format file with opa fmt")
+	cmd.Flags().BoolVar(&format, "format", false, "Auto-format standalone policy rego files with opa fmt (embedded policies not supported)")
 	cmd.Flags().StringVar(&regalConfig, "regal-config", "", "Path to custom regal config (Default: https://github.com/chainloop-dev/chainloop/tree/main/app/cli/internal/policydevel/.regal.yaml)")
 	return cmd
 }

--- a/app/cli/documentation/cli-reference.mdx
+++ b/app/cli/documentation/cli-reference.mdx
@@ -2973,7 +2973,7 @@ chainloop policy develop lint [flags]
 Options
 
 ```
---format                Auto-format file with opa fmt
+--format                Auto-format standalone policy rego files with opa fmt (embedded policies not supported)
 -h, --help                  help for lint
 -p, --policy string         Path to policy file (default "policy.yaml")
 --regal-config string   Path to custom regal config (Default: https://github.com/chainloop-dev/chainloop/tree/main/app/cli/internal/policydevel/.regal.yaml)

--- a/app/cli/internal/policydevel/lint.go
+++ b/app/cli/internal/policydevel/lint.go
@@ -16,7 +16,6 @@
 package policydevel
 
 import (
-	"bytes"
 	"context"
 	"embed"
 	"errors"
@@ -122,8 +121,7 @@ func Lookup(absPath, config string, format bool) (*PolicyToLint, error) {
 	return policy, nil
 }
 
-// Loads referenced rego files from all YAML files in the policy
-// Loads referenced rego files from all YAML files in the policy
+// Loads referenced rego files from YAML files in the policy
 func (p *PolicyToLint) loadReferencedRegoFiles(baseDir string) error {
 	seen := make(map[string]struct{})
 	for _, yamlFile := range p.YAMLFiles {
@@ -183,74 +181,9 @@ func (p *PolicyToLint) processFile(filePath string) error {
 }
 
 func (p *PolicyToLint) Validate() {
-	// Validate all YAML files (including their embedded policies)
-	for _, yamlFile := range p.YAMLFiles {
-		p.validateYAMLFile(yamlFile)
-	}
-
 	// Validate standalone rego files
 	for _, regoFile := range p.RegoFiles {
 		p.validateRegoFile(regoFile)
-	}
-}
-
-func (p *PolicyToLint) validateYAMLFile(file *File) {
-	var policy v1.Policy
-	if err := unmarshal.FromRaw(file.Content, unmarshal.RawFormatYAML, &policy, true); err != nil {
-		p.AddError(file.Path, "failed to parse/validate policy", 0)
-		return
-	}
-
-	p.processEmbeddedPolicies(&policy, file)
-
-	// Update policy file with formatted content
-	if p.Format {
-		var root yaml.Node
-		if err := yaml.Unmarshal(file.Content, &root); err != nil {
-			p.AddError(file.Path, "failed to parse YAML", 0)
-			return
-		}
-
-		if err := p.updateEmbeddedRegoInYAML(file, &root); err != nil {
-			p.AddError(file.Path, fmt.Sprintf("failed to update embedded Rego: %v", err), 0)
-			return
-		}
-
-		var buf bytes.Buffer
-		enc := yaml.NewEncoder(&buf)
-		enc.SetIndent(2)
-		defer enc.Close()
-
-		if err := enc.Encode(&root); err != nil {
-			p.AddError(file.Path, err.Error(), 0)
-			return
-		}
-
-		outYAML := buf.Bytes()
-		if err := os.WriteFile(file.Path, outYAML, 0600); err != nil {
-			p.AddError(file.Path, err.Error(), 0)
-		} else {
-			if err := os.WriteFile(file.Path, outYAML, 0600); err != nil {
-				p.AddError(file.Path, fmt.Sprintf("failed to save updated file: %v", err), 0)
-			} else {
-				file.Content = outYAML
-			}
-		}
-	}
-}
-
-func (p *PolicyToLint) processEmbeddedPolicies(pa *v1.Policy, file *File) {
-	for idx, spec := range pa.Spec.Policies {
-		if regoSrc := spec.GetEmbedded(); regoSrc != "" {
-			formatted := p.validateAndFormatRego(
-				regoSrc,
-				fmt.Sprintf("%s:(embedded #%d)", file.Path, idx+1),
-			)
-
-			if p.Format && formatted != regoSrc {
-				spec.Source = &v1.PolicySpecV2_Embedded{Embedded: formatted}
-			}
-		}
 	}
 }
 
@@ -406,62 +339,4 @@ func (p *PolicyToLint) loadDefaultConfig() (*config.Config, error) {
 	}
 
 	return &cfg, nil
-}
-
-// Updates the embedded rego policies in a YAML file
-// Manual update required due to yaml.marshal limitations
-func (p *PolicyToLint) updateEmbeddedRegoInYAML(file *File, rootNode *yaml.Node) error {
-	if rootNode.Kind != yaml.DocumentNode || len(rootNode.Content) == 0 {
-		return fmt.Errorf("unexpected YAML root structure")
-	}
-
-	doc := rootNode.Content[0]
-	if doc.Kind != yaml.MappingNode {
-		return fmt.Errorf("expected mapping node at document root")
-	}
-
-	// Locate spec policy node
-	var specNode *yaml.Node
-	for i := 0; i < len(doc.Content)-1; i += 2 {
-		if doc.Content[i].Value == "spec" && doc.Content[i+1].Kind == yaml.MappingNode {
-			specNode = doc.Content[i+1]
-			break
-		}
-	}
-	if specNode == nil {
-		return fmt.Errorf("spec node not found")
-	}
-
-	// Locate policies node within spec
-	var policiesNode *yaml.Node
-	for i := 0; i < len(specNode.Content)-1; i += 2 {
-		if specNode.Content[i].Value == "policies" && specNode.Content[i+1].Kind == yaml.SequenceNode {
-			policiesNode = specNode.Content[i+1]
-			break
-		}
-	}
-	if policiesNode == nil {
-		return fmt.Errorf("spec.policies node not found")
-	}
-
-	// Iterate over and update each rego policy
-	for _, policy := range policiesNode.Content {
-		if policy.Kind != yaml.MappingNode {
-			continue
-		}
-
-		for i := 0; i < len(policy.Content)-1; i += 2 {
-			key := policy.Content[i]
-			val := policy.Content[i+1]
-
-			if key.Value == "embedded" && val.Kind == yaml.ScalarNode {
-				formatted := p.validateAndFormatRego(val.Value, file.Path)
-				if formatted != val.Value {
-					val.Value = formatted
-				}
-			}
-		}
-	}
-
-	return nil
 }


### PR DESCRIPTION
This PR removes support for yaml and embedded rego formatting due issues caused by yaml libraries limitations.

Closes #2379
