### PR TITLE
fix(build): include go package licenses in sbom fixes#2363 for the cli

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -216,6 +216,12 @@ docker_manifests:
       - "ghcr.io/chainloop-dev/chainloop/cli:{{ .Tag }}-amd64"
       - "ghcr.io/chainloop-dev/chainloop/cli:{{ .Tag }}-arm64"
 
+# Enable retrieving golang packages license information https://github.com/anchore/syft#configuration
+# https://goreleaser.com/customization/sbom/
+sboms:
+  - env:
+      - SYFT_GOLANG_SEARCH_REMOTE_LICENSES=true
+
 release:
   extra_files:
     - glob: ./.github/workflows/cosign.pub


### PR DESCRIPTION
Today, we are generating the cli SBOMs tool with goreleaser, which uses Syft. Syft's default configuration doesn't include license information for Go packages in the SBOM. 

Syft provides a set of settings described in https://github.com/anchore/syft/wiki/Configuration#list-of-configurable-values. Setting the environment variable SYFT_GOLANG_SEARCH_REMOTE_LICENSES=true will enable retrieving the license information for go packages when generating SBOMs .

```
golang:
   # search for go package licences by retrieving the package from a network proxy
   # SYFT_GOLANG_SEARCH_REMOTE_LICENSES env var
   search-remote-licenses: false

   # remote proxy to use when retrieving go packages from the network,
   # if unset this defaults to $GOPROXY followed by https://proxy.golang.org
   # SYFT_GOLANG_PROXY env var
   proxy: ""
```

The setting is added to the .goreleaser.yml, new sbom section, as recommended in https://goreleaser.com/customization/sbom/.