### PR TITLE
feat(ci): Build copy of Bitnami images for vendorized charts

### DIFF
--- a/.github/workflows/build_external_container_images.yaml.yml
+++ b/.github/workflows/build_external_container_images.yaml.yml
@@ -16,36 +16,43 @@ jobs:
         image:
           # On Ref we use the specific commit SHA to ensure reproducible builds
           # It can be: branch, tag or SHA
+          # PostgreSQL version: 16.4.0
           - name: PostgreSQL
             image_name: chainloop-dev/chainloop/postgresql
             path: bitnami/postgresql/16/debian-12
             sparse_checkout: bitnami/postgresql/16/debian-12
             ref: 5d351cc8a742d6a6f417f879ba2df9882b617676
+          # PostgreSQL Exporter version: 0.15.0
           - name: PostgreSQL Exporter
             image_name: chainloop-dev/chainloop/postgres-exporter
             path: bitnami/postgres-exporter/0/debian-12
             sparse_checkout: bitnami/postgres-exporter/0/debian-12
             ref: 1d0408ccfbdc43b90bc6449227ce731079e42f6b
+          # OS Shell version: 12
           - name: OS Shell
             image_name: chainloop-dev/chainloop/os-shell
             path: bitnami/os-shell/12/debian-12
             sparse_checkout: bitnami/os-shell/12/debian-12
             ref: dde1f3b2d7b271de64c6ce948a04716cb96199a1
+          # Dex version: 2.40.0
           - name: Dex
             image_name: chainloop-dev/chainloop/dex
             path: bitnami/dex/2/debian-12
             sparse_checkout: bitnami/dex/2/debian-12
             ref: 19c7a5ade4364ff1b52c65004291203ff2096eb0
+          # Vault version: 1.17.3
           - name: Vault
             image_name: chainloop-dev/chainloop/vault
             path: bitnami/vault/1/debian-12
             sparse_checkout: bitnami/vault/1/debian-12
             ref: 28d8f22ad6b7c3871c2f429c72e5ccf3344ae5bc
+          # Vault CSI Provider version: 1.4.3
           - name: Vault CSI Provider
             image_name: chainloop-dev/chainloop/vault-csi-provider
             path: bitnami/vault-csi-provider/1/debian-12
             sparse_checkout: bitnami/vault-csi-provider/1/debian-12
             ref: 673c94210db93a8df808765b6b213661686aeb33
+          # Vault K8s version: 1.4.2
           - name: Vault K8s
             image_name: chainloop-dev/chainloop/vault-k8s
             path: bitnami/vault-k8s/1/debian-12


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the building, tagging, pushing, and signing of Bitnami-based container images for several key services. The workflow supports reproducible builds by pinning to specific commit SHAs and handles multiple images in parallel using a matrix strategy.

**Container image build and release automation:**

* Added `.github/workflows/build_external_container_images.yaml.yml` workflow to build, tag, and push container images for PostgresSQL, PostgresSQL Exporter, OS Shell, Dex, Vault, Vault CSI Provider, and Vault K8s, using Bitnami containers and specific commit references for reproducibility.
* Automated extraction of application version from Bitnami Dockerfiles and applied it to image tagging, ensuring version accuracy and traceability.
* Integrated Docker Buildx for multi-platform builds (amd64 and arm64), and pushed images to the GitHub Container Registry.
* Implemented image signing using Cosign, with secrets management for signing keys and passwords, to enhance supply chain security.
* Output detailed build information after each image build, including image name, version, and digest, to aid in tracking and verification.

**Container image versions:**

- ghcr.io/javirln/bitnami/dex:2.40.0
- ghcr.io/javirln/bitnami/os-shell:12
- ghcr.io/javirln/bitnami/postgres-exporter:0.15.0
- ghcr.io/javirln/bitnami/postgresql:16.4.0
- ghcr.io/javirln/bitnami/vault:1.17.3
- ghcr.io/javirln/bitnami/vault-csi-provider:1.4.3
- ghcr.io/javirln/bitnami/vault-k8s:1.4.2

#2391 