### PR TITLE
Update JSON schema for runner context to avoid issues with GitLab 

### DIFF
--- a/internal/schemavalidators/external_schemas/runnercontext/runner-context-response-0.1.schema.json
+++ b/internal/schemavalidators/external_schemas/runnercontext/runner-context-response-0.1.schema.json
@@ -7,6 +7,13 @@
                 "id": {
                     "type": "string",
                     "description": "Unique identifier for the runner context schema version"
+                },
+                "errors": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array",
+                    "description": "Array of error messages"
                 }
             },
             "additionalProperties": false,
@@ -319,7 +326,6 @@
                         "additionalProperties": false,
                         "type": "object",
                         "required": [
-                            "owner",
                             "repository"
                         ]
                     },

--- a/internal/schemavalidators/schemavalidators_test.go
+++ b/internal/schemavalidators/schemavalidators_test.go
@@ -195,6 +195,10 @@ func TestValidateRunnerContext(t *testing.T) {
 			filePath: "./testdata/runner_context_rulesets-v0.1.json",
 		},
 		{
+			name:     "0.1 GitLab no protection",
+			filePath: "./testdata/runner_context_gitlab_no_protection-v0.1.json",
+		},
+		{
 			name:     "invalid Chainloop runner context - missing meta",
 			filePath: "./testdata/runner_context_missing-meta-v0.1.json",
 			wantErr:  "missing properties: 'meta'",

--- a/internal/schemavalidators/testdata/runner_context_gitlab_no_protection-v0.1.json
+++ b/internal/schemavalidators/testdata/runner_context_gitlab_no_protection-v0.1.json
@@ -1,0 +1,61 @@
+{
+    "meta": {
+        "id": "chainloop.dev/runner-context/v0.1"
+    },
+    "data": {
+        "tool": "platform@6df8c658",
+        "provider": "gitlab",
+        "repos": [
+            {
+                "repository": "69340413",
+                "branches": [
+                    {
+                        "name": "main",
+                        "active_rules": [
+                            {
+                                "name": "allow_force_push",
+                                "enabled": "false"
+                            },
+                            {
+                                "name": "code_owner_approval_required",
+                                "enabled": "false"
+                            },
+                            {
+                                "name": "push_access_levels",
+                                "enabled": "true",
+                                "context": [
+                                    {
+                                        "name": "access_level",
+                                        "value": "40",
+                                        "enabled": "true"
+                                    },
+                                    {
+                                        "name": "access_level_description",
+                                        "value": "Maintainers",
+                                        "enabled": "true"
+                                    }
+                                ]
+                            },
+                            {
+                                "name": "merge_access_levels",
+                                "enabled": "true",
+                                "context": [
+                                    {
+                                        "name": "access_level",
+                                        "value": "40",
+                                        "enabled": "true"
+                                    },
+                                    {
+                                        "name": "access_level_description",
+                                        "value": "Maintainers",
+                                        "enabled": "true"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
This PR updates the JSON schema for runner context and updates the unit test to avoid issues with runner context material type generated from GitLab. 

Should fix https://github.com/chainloop-dev/chainloop/issues/2397