### PR TITLE
fix(build): add GPL to banned licenses and simplify AGPL list, resolves chainloop-dev/chainloop#2406

### DIFF
--- a/.github/workflows/contracts/chainloop-vault-release.yml
+++ b/.github/workflows/contracts/chainloop-vault-release.yml
@@ -15,7 +15,7 @@ policies:
 policyGroups:
   - ref: sbom-quality
     with:
-      bannedLicenses: AGPL-1.0-only, AGPL-1.0-or-later, AGPL-3.0-only, AGPL-3.0-or-later
+      bannedLicenses: GPL, AGPL
       bannedComponents: log4j@2.14.1
   - ref: slsa-checks
     with:


### PR DESCRIPTION
This change:
- Add GPL to the list of banned licenses in the contract.
- Simplify the list of AGPL spdx identifiers to just AGPL since the sbom-banned-licenses policy now looks for all the licenses matching license*