### PR TITLE
Revert adding sbom settings in .goreleaser.yml 

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -216,12 +216,6 @@ docker_manifests:
       - "ghcr.io/chainloop-dev/chainloop/cli:{{ .Tag }}-amd64"
       - "ghcr.io/chainloop-dev/chainloop/cli:{{ .Tag }}-arm64"
 
-# Enable retrieving golang packages license information https://github.com/anchore/syft#configuration
-# https://goreleaser.com/customization/sbom/
-sboms:
-  - env:
-      - SYFT_GOLANG_SEARCH_REMOTE_LICENSES=true
-
 release:
   extra_files:
     - glob: ./.github/workflows/cosign.pub


### PR DESCRIPTION
This reverts commit 1815547c81b8d7e5e001f454aa870325f7f53b07.

Issue https://github.com/chainloop-dev/chainloop/issues/2363 was already fixed by [063e95242d8ea4397b885dc5e318a50e3e7b4b49](https://github.com/chainloop-dev/chainloop/commit/063e95242d8ea4397b885dc5e318a50e3e7b4b49). SBOMs for the cli are not generated by goreleaser adding the new setting in the .goreleaser.yml is not necessary.

