### PR TITLE
chore(devel): Use in-house images in docker compose file

### DIFF
--- a/devel/compose.common.yml
+++ b/devel/compose.common.yml
@@ -1,7 +1,7 @@
 # NOTE: This setup is meant to be used for development purposes only.
 services:
   postgresql:
-    image: docker.io/bitnami/postgresql:16
+    image: "ghcr.io/chainloop-dev/chainloop/postgresql:16.4.0"
     # Expose the port to the host to enable baremetal controlplane development
     ports:
       - 5432:5432

--- a/devel/compose.labs.yml
+++ b/devel/compose.labs.yml
@@ -7,7 +7,7 @@ services:
   dex:
     volumes:
       - ".:/wd"
-    image: docker.io/bitnami/dex:2
+    image: "ghcr.io/chainloop-dev/chainloop/dex:2.43.1"
     working_dir: /wd/dex
     command: "serve config.labs.yaml"
     ports:

--- a/devel/compose.yml
+++ b/devel/compose.yml
@@ -8,7 +8,7 @@ services:
   dex:
     volumes:
       - ".:/wd"
-    image: docker.io/bitnami/dex:2
+    image: "ghcr.io/chainloop-dev/chainloop/dex:2.43.1"
     working_dir: /wd/dex
     command: "serve config.dev.yaml"
     ports:


### PR DESCRIPTION
This pull request updates the container images used for key services in the development Docker Compose files. The changes ensure that the images are pulled from the organization's own container registry and are pinned to specific versions.

**Container image updates:**

* Updated the `postgresql` service in `devel/compose.common.yml` to use `ghcr.io/chainloop-dev/chainloop/postgresql:16.4.0` instead of the generic Bitnami image.

* Updated the `dex` service in both `devel/compose.labs.yml` and `devel/compose.yml` to use `ghcr.io/chainloop-dev/chainloop/dex:2.43.1` instead of the generic Bitnami image. [[1]](diffhunk://#diff-f60f75bd50f651d5f09d3afce6446e5bb3a911e4302957c8e0130fc8bee53626L10-R10) [[2]](diffhunk://#diff-1dea3cd00d4352daf3b972d82bd192ffdbd428516567c4f3652c9790189dd697L11-R11)