### PR TITLE
build(contract): skip empty license verification for the SBOM component type file

### DIFF
--- a/.github/workflows/contracts/chainloop-vault-release.yml
+++ b/.github/workflows/contracts/chainloop-vault-release.yml
@@ -16,6 +16,7 @@ policyGroups:
   - ref: sbom-quality
     with:
       bannedLicenses: GPL, AGPL
+      skippedTypes: file
       bannedComponents: log4j@2.14.1
   - ref: slsa-checks
     with:


### PR DESCRIPTION
This passes the input to skip components with type "file" when executing the sbom-with-licenses policy. This will prevent unnecessary flagging as components with no license. These types of components are files installed as part of another component as a library and no additional license validation is needed.