### PR TITLE
feat(plugin): allow subcommands and platform configuration

### DIFF
--- a/app/cli/cmd/config.go
+++ b/app/cli/cmd/config.go
@@ -26,7 +26,7 @@ import (
 
 // Map of all the possible configuration options that we expect viper to handle
 var confOptions = struct {
-	authToken, controlplaneAPI, CASAPI, controlplaneCA, CASCA, insecure, organization *confOpt
+	authToken, controlplaneAPI, CASAPI, controlplaneCA, CASCA, insecure, organization, platformAPI *confOpt
 }{
 	insecure: &confOpt{
 		viperKey: "api-insecure",
@@ -53,6 +53,10 @@ var confOptions = struct {
 	organization: &confOpt{
 		viperKey: "organization",
 		flagName: "org",
+	},
+	platformAPI: &confOpt{
+		viperKey: "platform.API",
+		flagName: "platform",
 	},
 }
 

--- a/app/cli/cmd/plugins.go
+++ b/app/cli/cmd/plugins.go
@@ -106,6 +106,7 @@ func createPluginCommand(_ *cobra.Command, plugin *plugins.LoadedPlugin, cmdInfo
 			// Create plugin configuration with command, arguments, and flags
 			config := plugins.PluginExecConfig{
 				Command:         cmdInfo.Name,
+				ParentCommand:   cmdInfo.ParentCommand,
 				Args:            args,
 				Flags:           flags,
 				ChainloopConfig: cliConfig,

--- a/app/cli/cmd/plugins.go
+++ b/app/cli/cmd/plugins.go
@@ -103,6 +103,11 @@ func createPluginCommand(_ *cobra.Command, plugin *plugins.LoadedPlugin, cmdInfo
 				Token:           viper.GetString(confOptions.authToken.viperKey),
 			}
 
+			// Create platform configuration from viper
+			platformConfig := plugins.PlatformConfig{
+				API: viper.GetString(confOptions.platformAPI.viperKey),
+			}
+
 			// Create plugin configuration with command, arguments, and flags
 			config := plugins.PluginExecConfig{
 				Command:         cmdInfo.Name,
@@ -110,6 +115,7 @@ func createPluginCommand(_ *cobra.Command, plugin *plugins.LoadedPlugin, cmdInfo
 				Args:            args,
 				Flags:           flags,
 				ChainloopConfig: cliConfig,
+				PlatformConfig:  platformConfig,
 			}
 
 			// execute plugin command using the action pattern

--- a/app/cli/cmd/plugins.go
+++ b/app/cli/cmd/plugins.go
@@ -277,6 +277,27 @@ func newPluginInstallCmd() *cobra.Command {
 	return cmd
 }
 
+// findCommand recursively searches for a command by name in the command tree
+func findCommand(rootCmd *cobra.Command, name string) *cobra.Command {
+	// Check if the root command itself matches
+	if rootCmd.Name() == name {
+		return rootCmd
+	}
+	
+	// Search through all subcommands recursively
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Name() == name {
+			return cmd
+		}
+		// Recursively search in subcommands
+		if found := findCommand(cmd, name); found != nil {
+			return found
+		}
+	}
+	
+	return nil
+}
+
 // loadAllPlugins loads all plugins and registers their commands to the root command
 func loadAllPlugins(rootCmd *cobra.Command) error {
 	ctx := rootCmd.Context()
@@ -301,7 +322,19 @@ func loadAllPlugins(rootCmd *cobra.Command) error {
 			}
 
 			pluginCmd := createPluginCommand(rootCmd, plugin, cmdInfo)
-			rootCmd.AddCommand(pluginCmd)
+			
+			// If ParentCommand is specified, try to find the parent and add as subcommand otherwise add as top-level command
+			if cmdInfo.ParentCommand != "" {
+				parentCmd := findCommand(rootCmd, cmdInfo.ParentCommand)
+				if parentCmd == nil {
+					return fmt.Errorf("parent command '%s' not found for plugin command '%s' from plugin '%s'",
+						cmdInfo.ParentCommand, cmdInfo.Name, pluginName)
+				}
+				parentCmd.AddCommand(pluginCmd)
+			} else {
+				rootCmd.AddCommand(pluginCmd)
+			}
+			
 			registeredCommands[cmdInfo.Name] = pluginName
 		}
 	}

--- a/app/cli/cmd/plugins.go
+++ b/app/cli/cmd/plugins.go
@@ -290,7 +290,7 @@ func findCommand(rootCmd *cobra.Command, name string) *cobra.Command {
 	if rootCmd.Name() == name {
 		return rootCmd
 	}
-	
+
 	// Search through all subcommands recursively
 	for _, cmd := range rootCmd.Commands() {
 		if cmd.Name() == name {
@@ -301,7 +301,7 @@ func findCommand(rootCmd *cobra.Command, name string) *cobra.Command {
 			return found
 		}
 	}
-	
+
 	return nil
 }
 
@@ -329,7 +329,7 @@ func loadAllPlugins(rootCmd *cobra.Command) error {
 			}
 
 			pluginCmd := createPluginCommand(rootCmd, plugin, cmdInfo)
-			
+
 			// If ParentCommand is specified, try to find the parent and add as subcommand otherwise add as top-level command
 			if cmdInfo.ParentCommand != "" {
 				parentCmd := findCommand(rootCmd, cmdInfo.ParentCommand)
@@ -341,7 +341,7 @@ func loadAllPlugins(rootCmd *cobra.Command) error {
 			} else {
 				rootCmd.AddCommand(pluginCmd)
 			}
-			
+
 			registeredCommands[cmdInfo.Name] = pluginName
 		}
 	}

--- a/app/cli/cmd/root.go
+++ b/app/cli/cmd/root.go
@@ -41,15 +41,16 @@ import (
 )
 
 var (
-	flagCfgFile      string
-	flagDebug        bool
-	flagOutputFormat string
-	actionOpts       *action.ActionsOpts
-	logger           zerolog.Logger
-	defaultCPAPI     = "api.cp.chainloop.dev:443"
-	defaultCASAPI    = "api.cas.chainloop.dev:443"
-	apiToken         string
-	flagYes          bool
+	flagCfgFile        string
+	flagDebug          bool
+	flagOutputFormat   string
+	actionOpts         *action.ActionsOpts
+	logger             zerolog.Logger
+	defaultCPAPI       = "api.cp.chainloop.dev:443"
+	defaultCASAPI      = "api.cas.chainloop.dev:443"
+	defaultPlatformAPI = "api.app.chainloop.dev:443"
+	apiToken           string
+	flagYes            bool
 )
 
 const (
@@ -222,6 +223,11 @@ func NewRootCmd(l zerolog.Logger) *cobra.Command {
 	rootCmd.PersistentFlags().String(confOptions.CASCA.flagName, "", fmt.Sprintf("CUSTOM CA file for the Artifacts CAS API (optional) ($%s)", calculateEnvVarName(confOptions.CASCA.viperKey)))
 	cobra.CheckErr(viper.BindPFlag(confOptions.CASCA.viperKey, rootCmd.PersistentFlags().Lookup(confOptions.CASCA.flagName)))
 	cobra.CheckErr(viper.BindEnv(confOptions.CASCA.viperKey, calculateEnvVarName(confOptions.CASCA.viperKey)))
+
+	// Platform API configuration
+	rootCmd.PersistentFlags().String(confOptions.platformAPI.flagName, defaultPlatformAPI, fmt.Sprintf("URL for the Platform API ($%s)", calculateEnvVarName(confOptions.platformAPI.viperKey)))
+	cobra.CheckErr(viper.BindPFlag(confOptions.platformAPI.viperKey, rootCmd.PersistentFlags().Lookup(confOptions.platformAPI.flagName)))
+	cobra.CheckErr(viper.BindEnv(confOptions.platformAPI.viperKey, calculateEnvVarName(confOptions.platformAPI.viperKey)))
 
 	rootCmd.PersistentFlags().BoolP("insecure", "i", false, fmt.Sprintf("Skip TLS transport during connection to the control plane ($%s)", calculateEnvVarName(confOptions.insecure.viperKey)))
 	cobra.CheckErr(viper.BindPFlag(confOptions.insecure.viperKey, rootCmd.PersistentFlags().Lookup("insecure")))

--- a/app/cli/documentation/cli-reference.mdx
+++ b/app/cli/documentation/cli-reference.mdx
@@ -30,6 +30,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -62,6 +63,7 @@ Options inherited from parent commands
 --debug                     Enable debug/verbose logging mode
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -97,6 +99,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -128,6 +131,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -162,6 +166,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -218,6 +223,7 @@ Options inherited from parent commands
 --local-state-path string   path to store the attestation state locally, default: [tmpDir]/chainloop_attestation.tmp.json
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -255,6 +261,7 @@ Options inherited from parent commands
 --local-state-path string   path to store the attestation state locally, default: [tmpDir]/chainloop_attestation.tmp.json
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -296,6 +303,7 @@ Options inherited from parent commands
 --local-state-path string   path to store the attestation state locally, default: [tmpDir]/chainloop_attestation.tmp.json
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -358,6 +366,7 @@ Options inherited from parent commands
 --local-state-path string   path to store the attestation state locally, default: [tmpDir]/chainloop_attestation.tmp.json
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -393,6 +402,7 @@ Options inherited from parent commands
 --local-state-path string   path to store the attestation state locally, default: [tmpDir]/chainloop_attestation.tmp.json
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -427,6 +437,7 @@ Options inherited from parent commands
 --local-state-path string   path to store the attestation state locally, default: [tmpDir]/chainloop_attestation.tmp.json
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -474,6 +485,7 @@ Options inherited from parent commands
 --local-state-path string   path to store the attestation state locally, default: [tmpDir]/chainloop_attestation.tmp.json
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -500,6 +512,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -530,6 +543,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -565,6 +579,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -596,6 +611,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -622,6 +638,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -651,6 +668,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -689,6 +707,7 @@ Options inherited from parent commands
 --name string               CAS backend name
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -727,6 +746,7 @@ Options inherited from parent commands
 --name string               CAS backend name
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -765,6 +785,7 @@ Options inherited from parent commands
 --name string               CAS backend name
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -801,6 +822,7 @@ Options inherited from parent commands
 --name string               CAS backend name
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -832,6 +854,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -867,6 +890,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -898,6 +922,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -927,6 +952,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -963,6 +989,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -999,6 +1026,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -1037,6 +1065,7 @@ Options inherited from parent commands
 --name string               CAS backend name
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -1070,6 +1099,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -1105,6 +1135,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -1131,6 +1162,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -1166,6 +1198,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -1196,6 +1229,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -1227,6 +1261,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -1262,6 +1297,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -1297,6 +1333,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -1327,6 +1364,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -1357,6 +1395,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -1393,6 +1432,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -1423,6 +1463,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -1456,6 +1497,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -1482,6 +1524,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -1508,6 +1551,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -1552,6 +1596,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -1583,6 +1628,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -1618,6 +1664,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -1650,6 +1697,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -1676,6 +1724,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -1708,6 +1757,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -1743,6 +1793,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -1773,6 +1824,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -1808,6 +1860,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -1834,6 +1887,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -1873,6 +1927,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -1904,6 +1959,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -1939,6 +1995,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -1969,6 +2026,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -1995,6 +2053,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -2025,6 +2084,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -2059,6 +2119,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             output format, valid options are table, json, token (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -2094,6 +2155,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -2127,6 +2189,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -2158,6 +2221,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -2189,6 +2253,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -2224,6 +2289,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -2254,6 +2320,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -2289,6 +2356,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -2320,6 +2388,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -2350,6 +2419,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -2376,6 +2446,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -2407,6 +2478,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -2442,6 +2514,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -2468,6 +2541,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -2500,6 +2574,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -2535,6 +2610,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -2565,6 +2641,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -2596,6 +2673,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -2654,6 +2732,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -2686,6 +2765,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -2730,6 +2810,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -2763,6 +2844,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -2789,6 +2871,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -2816,6 +2899,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -2866,6 +2950,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -2901,6 +2986,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -2952,6 +3038,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -2991,6 +3078,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -3026,6 +3114,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -3056,6 +3145,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -3082,6 +3172,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -3108,6 +3199,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -3152,6 +3244,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -3183,6 +3276,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -3218,6 +3312,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -3250,6 +3345,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -3276,6 +3372,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -3310,6 +3407,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -3341,6 +3439,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -3373,6 +3472,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             output format, valid options are table, json or schema (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -3408,6 +3508,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -3438,6 +3539,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -3471,6 +3573,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -3525,6 +3628,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -3557,6 +3661,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -3589,6 +3694,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -3624,6 +3730,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -3674,6 +3781,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -3710,6 +3818,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -3736,6 +3845,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -3772,6 +3882,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             output format, valid options are table, json, attestation, statement or payload-pae (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -3807,6 +3918,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```
@@ -3843,6 +3955,7 @@ Options inherited from parent commands
 -i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
 -n, --org string                organization name
 -o, --output string             Output format, valid options are json and table (default "table")
+--platform string           URL for the Platform API ($CHAINLOOP_PLATFORM_API) (default "api.app.chainloop.dev:443")
 -t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
 -y, --yes                       Skip confirmation
 ```

--- a/app/cli/pkg/plugins/interface.go
+++ b/app/cli/pkg/plugins/interface.go
@@ -48,6 +48,8 @@ type PluginCommandInfo struct {
 	Description string
 	Usage       string
 	Flags       []*FlagInfo
+	// Optional: if specified, this command will be added as a subcommand to the parent
+	ParentCommand string
 }
 
 // FlagInfo describes a command flag.

--- a/app/cli/pkg/plugins/interface.go
+++ b/app/cli/pkg/plugins/interface.go
@@ -70,6 +70,11 @@ type PluginExecConfig struct {
 	Args            []string
 	Flags           map[string]*SimpleFlag
 	ChainloopConfig ChainloopConfig
+	PlatformConfig  PlatformConfig
+}
+
+type PlatformConfig struct {
+	API string
 }
 
 type SimpleFlag struct {

--- a/app/cli/pkg/plugins/interface.go
+++ b/app/cli/pkg/plugins/interface.go
@@ -64,7 +64,9 @@ type FlagInfo struct {
 
 // PluginExecConfig is the configuration for a plugin command execution.
 type PluginExecConfig struct {
-	Command         string
+	Command string
+	// Optional: the parent command if this is a subcommand
+	ParentCommand   string
 	Args            []string
 	Flags           map[string]*SimpleFlag
 	ChainloopConfig ChainloopConfig


### PR DESCRIPTION
### Summary
- Enable plugins to register subcommands under existing CLI commands 
- Provide configuration for backend API access
