### PR TITLE
fix: federated token middleware

### DIFF
--- a/app/controlplane/configs/config.devel.yaml
+++ b/app/controlplane/configs/config.devel.yaml
@@ -104,6 +104,6 @@ prometheus_integration:
 #     url: http://localhost:8002/v1
 
 enable_profiler: true
-federated_authentication:
-  enabled: true
-  url: http://localhost:8002/machine-identity/verify-token
+# federated_authentication:
+#   enabled: true
+#   url: http://localhost:8002/machine-identity/verify-token


### PR DESCRIPTION
there was a cas validation that was introduced in the wrong place, before loading the context from the federated token.