### PR TITLE
fix(cli): return consistent authentication error

### DIFF
--- a/app/cli/main.go
+++ b/app/cli/main.go
@@ -106,7 +106,14 @@ func errorInfo(err error, logger zerolog.Logger) (string, int) {
 	return msg, exitCode
 }
 
-func isWrappedErr(grpcStatus *status.Status, err *errors.Error) bool {
-	target := errors.FromError(grpcStatus.Err())
+// target is the expected error
+// grpcStatus is the actual error that might be wrapped in both the status and the error
+func isWrappedErr(grpcStatus *status.Status, target *errors.Error) bool {
+	err := errors.FromError(grpcStatus.Err())
+	// The error might be wrapped since the CLI sometimes returns a wrapped error
+	if errors.Is(err, target) {
+		return true
+	}
+
 	return target.Code == err.Code && err.Message == target.Message
 }


### PR DESCRIPTION
The problem was that the attestation process wrapped the error in the CLI, but our code wasn't checking actual wrapped errors—just the messages. By extending the isWrappedError function to support both behaviors, we can make it work. 

```
$ go run main.go att init --workflow test --project bar
This command is will run against the organization "chainloop"
Please confirm to continue y/N
y
ERR your authentication token has expired, please run chainloop auth login again
exit status 1
```

Fixes #2434