### PR TITLE
(compliance/contracts): add approved licenses to custom allowlist

### DIFF
--- a/.github/workflows/contracts/chainloop-vault-release.yml
+++ b/.github/workflows/contracts/chainloop-vault-release.yml
@@ -16,6 +16,9 @@ policyGroups:
   - ref: sbom-quality
     with:
       bannedLicenses: GPL, AGPL
+      # sha256:b9a6d9320b8f2693e8d41e496ce56caadacaddcca9be2a64a61749278f425cf2 = Apache-2.0 pkg:golang/github.com/cyberphone/json-canonicalization
+      # sha256:cd65721176ce5fdbb05773c0b1349f993b94ce77a51062cfa7a78b34cc82fc71 = MIT, BSD-3-Clause pkg:golang/github.com/theupdateframework/go-tuf
+      allowedCustomLicenses: Apache 2.0, sha256:b9a6d9320b8f2693e8d41e496ce56caadacaddcca9be2a64a61749278f425cf2, sha256:cd65721176ce5fdbb05773c0b1349f993b94ce77a51062cfa7a78b34cc82fc71
       skippedTypes: file
       bannedComponents: log4j@2.14.1
   - ref: slsa-checks


### PR DESCRIPTION
The sbom-banned-licenses policy correctly flagged unknown licenses in the SBOM. After reviewing and confirming that these are permitted licenses, it is safe to add them to the allowlist. 

Fixes #2451

This PR adds Apache-2.0 as a permitted custom license (via the license.name field in the SBOM). While SPDX identifiers in the id or expression fields are the recommended approach for open source components, we’ve observed some cases where the license.name field is still used.