### PR TITLE
feat(policy): add organization field to metadata

### DIFF
--- a/app/controlplane/api/gen/frontend/workflowcontract/v1/crafting_schema.ts
+++ b/app/controlplane/api/gen/frontend/workflowcontract/v1/crafting_schema.ts
@@ -383,7 +383,6 @@ export interface Metadata {
   name: string;
   description: string;
   annotations: { [key: string]: string };
-  /** optional organization name to specify the owning organization */
   organization?: string | undefined;
 }
 

--- a/app/controlplane/api/gen/jsonschema/workflowcontract.v1.Metadata.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/workflowcontract.v1.Metadata.jsonschema.json
@@ -20,7 +20,6 @@
       "type": "string"
     },
     "organization": {
-      "description": "optional organization name to specify the owning organization",
       "type": "string"
     }
   },

--- a/app/controlplane/api/gen/jsonschema/workflowcontract.v1.Metadata.schema.json
+++ b/app/controlplane/api/gen/jsonschema/workflowcontract.v1.Metadata.schema.json
@@ -20,7 +20,6 @@
       "type": "string"
     },
     "organization": {
-      "description": "optional organization name to specify the owning organization",
       "type": "string"
     }
   },

--- a/app/controlplane/api/workflowcontract/v1/crafting_schema.pb.go
+++ b/app/controlplane/api/workflowcontract/v1/crafting_schema.pb.go
@@ -659,11 +659,10 @@ type Metadata struct {
 	unknownFields protoimpl.UnknownFields
 
 	// the name of the policy
-	Name        string            `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
-	Description string            `protobuf:"bytes,4,opt,name=description,proto3" json:"description,omitempty"`
-	Annotations map[string]string `protobuf:"bytes,5,rep,name=annotations,proto3" json:"annotations,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	// optional organization name to specify the owning organization
-	Organization *string `protobuf:"bytes,6,opt,name=organization,proto3,oneof" json:"organization,omitempty"`
+	Name         string            `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
+	Description  string            `protobuf:"bytes,4,opt,name=description,proto3" json:"description,omitempty"`
+	Annotations  map[string]string `protobuf:"bytes,5,rep,name=annotations,proto3" json:"annotations,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	Organization *string           `protobuf:"bytes,6,opt,name=organization,proto3,oneof" json:"organization,omitempty"`
 }
 
 func (x *Metadata) Reset() {

--- a/app/controlplane/api/workflowcontract/v1/crafting_schema.proto
+++ b/app/controlplane/api/workflowcontract/v1/crafting_schema.proto
@@ -217,7 +217,6 @@ message Metadata {
 
   string description = 4;
   map<string, string> annotations = 5;
-  // optional organization name to specify the owning organization
   optional string organization = 6;
 }
 


### PR DESCRIPTION
This PR adds optional organization field to metadata.

Closes #2456
