### PR TITLE
chore: expose referrer config

### DIFF
--- a/app/controlplane/cmd/wire.go
+++ b/app/controlplane/cmd/wire.go
@@ -65,6 +65,7 @@ func wireApp(*conf.Bootstrap, credentials.ReaderWriter, log.Logger, sdk.Availabl
 			newAuthAllowList,
 			newJWTConfig,
 			authzConfig,
+			biz.NewIndexConfig,
 		),
 	)
 }

--- a/app/controlplane/pkg/biz/biz.go
+++ b/app/controlplane/pkg/biz/biz.go
@@ -58,7 +58,6 @@ var ProviderSet = wire.NewSet(
 	NewUserAccessSyncerUseCase,
 	NewGroupUseCase,
 	NewCASBackendChecker,
-	NewIndexConfig,
 	wire.Bind(new(PromObservable), new(*PrometheusUseCase)),
 	wire.Struct(new(NewIntegrationUseCaseOpts), "*"),
 	wire.Struct(new(NewUserUseCaseParams), "*"),

--- a/app/controlplane/pkg/biz/testhelpers/wire.go
+++ b/app/controlplane/pkg/biz/testhelpers/wire.go
@@ -62,6 +62,7 @@ func WireTestData(*TestDatabase, *testing.T, log.Logger, credentials.ReaderWrite
 			newAuthAllowList,
 			newJWTConfig,
 			authzConfig,
+			biz.NewIndexConfig,
 		),
 	)
 }


### PR DESCRIPTION
remove from provider and instead inject it in the app runtime