### PR TITLE
feat(telemetry): add cli edition variable

### DIFF
--- a/app/cli/cmd/root.go
+++ b/app/cli/cmd/root.go
@@ -409,6 +409,7 @@ func recordCommand(executedCmd *cobra.Command, authInfo *token.ParsedToken) erro
 
 	tags := telemetry.Tags{
 		"cli_version":         Version,
+		"edition":             Edition,
 		"cp_url_hash":         controlplaneHash,
 		"cp_installation_url": controlplaneURL,
 		"chainloop_source":    "cli",

--- a/app/cli/cmd/version.go
+++ b/app/cli/cmd/version.go
@@ -29,8 +29,12 @@ import (
 )
 
 const devVersion = "dev"
+const ossEdition = "oss"
 
-var Version = devVersion
+var (
+	Version = devVersion
+	Edition = ossEdition
+)
 
 type info struct {
 	Version string


### PR DESCRIPTION
This PR adds `edition` variable to cli telemetry to differentiate between `oss` and `ee` editions