### PR TITLE
feat(crafting-schema): update default contract

### DIFF
--- a/app/controlplane/pkg/biz/workflow.go
+++ b/app/controlplane/pkg/biz/workflow.go
@@ -135,7 +135,7 @@ func (uc *WorkflowUseCase) Create(ctx context.Context, opts *WorkflowCreateOpts)
 
 	contractName := fmt.Sprintf("%s-%s", opts.Project, opts.Name)
 
-	defaultContract, err := CreateDefaultContract(contractName)
+	defaultContract, err := createDefaultContract(contractName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create default contract: %w", err)
 	}

--- a/app/controlplane/pkg/biz/workflowcontract.go
+++ b/app/controlplane/pkg/biz/workflowcontract.go
@@ -210,8 +210,8 @@ type WorkflowContractCreateOpts struct {
 	AddUniquePrefix bool
 }
 
-// CreateDefaultContract creates a new default contract with the specified name
-func CreateDefaultContract(name string) (*Contract, error) {
+// createDefaultContract creates a new default contract with the specified name
+func createDefaultContract(name string) (*Contract, error) {
 	defaultSchema := &schemav1.CraftingSchemaV2{
 		ApiVersion: "chainloop.dev/v1",
 		Kind:       "Contract",
@@ -263,7 +263,7 @@ func (uc *WorkflowContractUseCase) Create(ctx context.Context, opts *WorkflowCon
 		contract = c
 	} else {
 		// Use default contract with the user-provided name
-		c, err := CreateDefaultContract(opts.Name)
+		c, err := createDefaultContract(opts.Name)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create default contract: %w", err)
 		}

--- a/app/controlplane/pkg/biz/workflowcontract_integration_test.go
+++ b/app/controlplane/pkg/biz/workflowcontract_integration_test.go
@@ -320,8 +320,7 @@ func (s *workflowContractIntegrationTestSuite) TestCreateWithCustomContract() {
 		require.NoError(s.T(), err)
 		contractWithVersion, err := s.WorkflowContract.Describe(ctx, s.org.ID, contract.ID.String(), 1)
 		require.NoError(s.T(), err)
-		c, err := biz.CreateDefaultContract("empty")
-		require.NoError(s.T(), err)
+		c := contractWithVersion.Version.Schema
 		s.Equal(c.Format, unmarshal.RawFormatYAML)
 		s.Equal(c.Raw, contractWithVersion.Version.Schema.Raw)
 		s.NotNil(contractWithVersion.Version.Schema.Schema)


### PR DESCRIPTION
This PR updates default contract schema used during workflow creation when no schema is given and contract creation when no schema is given to schema v2.