### PR TITLE
fix(attestation): material annotations output

### DIFF
--- a/app/cli/cmd/attestation_add.go
+++ b/app/cli/cmd/attestation_add.go
@@ -29,7 +29,6 @@ import (
 	"github.com/chainloop-dev/chainloop/app/cli/cmd/output"
 	"github.com/chainloop-dev/chainloop/app/cli/pkg/action"
 	schemaapi "github.com/chainloop-dev/chainloop/app/controlplane/api/workflowcontract/v1"
-	"github.com/chainloop-dev/chainloop/pkg/attestation/crafter/materials"
 	"github.com/chainloop-dev/chainloop/pkg/resourceloader"
 )
 
@@ -195,9 +194,6 @@ func displayMaterialInfo(status *action.AttestationStatusMaterial, policyEvaluat
 	if len(status.Material.Annotations) > 0 {
 		mt.AppendRow(table.Row{"Annotations", "------"})
 		for _, a := range status.Material.Annotations {
-			if materials.IsLegacyAnnotation(a.Name) {
-				continue
-			}
 			value := a.Value
 			if value == "" {
 				value = NotSet

--- a/app/cli/cmd/attestation_status.go
+++ b/app/cli/cmd/attestation_status.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/chainloop-dev/chainloop/app/cli/cmd/output"
 	"github.com/chainloop-dev/chainloop/app/cli/pkg/action"
-	"github.com/chainloop-dev/chainloop/pkg/attestation/crafter/materials"
 	"github.com/chainloop-dev/chainloop/pkg/attestation/renderer/chainloop"
 )
 
@@ -115,9 +114,6 @@ func attestationStatusTableOutput(status *action.AttestationStatusResult, w io.W
 	if len(status.Annotations) > 0 {
 		gt.AppendRow(table.Row{"Annotations", "------"})
 		for _, a := range status.Annotations {
-			if materials.IsLegacyAnnotation(a.Name) {
-				continue
-			}
 			value := a.Value
 			if value == "" {
 				value = NotSet
@@ -224,9 +220,6 @@ func materialsTable(status *action.AttestationStatusResult, w io.Writer, full bo
 		if len(m.Annotations) > 0 {
 			mt.AppendRow(table.Row{"Annotations", "------"})
 			for _, a := range m.Annotations {
-				if materials.IsLegacyAnnotation(a.Name) {
-					continue
-				}
 				value := a.Value
 				if value == "" {
 					value = NotSet


### PR DESCRIPTION
Fixed regression introduced in https://github.com/chainloop-dev/chainloop/pull/2481 where legacy annotations were filtered out in `att add` and `att status`.