### PR TITLE
feat(policies): add rego boilerplate injection

### DIFF
--- a/pkg/policies/testdata/container_policy.yaml
+++ b/pkg/policies/testdata/container_policy.yaml
@@ -1,0 +1,20 @@
+apiVersion: workflowcontract.chainloop.dev/v1
+kind: Policy
+metadata:
+  name: container-policy
+  description: test policy
+  annotations:
+    category: containers
+spec:
+  policies:
+    - kind: CONTAINER_IMAGE
+      embedded: |
+        package main
+        
+        import rego.v1
+        
+        result := {
+          "violations": [],
+          "skipped": true,
+          "skip_reason": sprintf("the tag is '%s'", [input.chainloop_metadata.annotations["chainloop.material.image.tag"]])
+        }

--- a/pkg/policies/testdata/group_with_inputs.yaml
+++ b/pkg/policies/testdata/group_with_inputs.yaml
@@ -1,0 +1,23 @@
+apiVersion: workflowcontract.chainloop.dev/v1
+kind: PolicyGroup
+metadata:
+  name: group-with-inputs
+  description: test group
+  annotations:
+    category: test
+spec:
+  inputs:
+    - name: user_name
+      required: true
+    - name: domainName
+      required: false
+      default: "chainloop.dev"
+  policies:
+    materials:
+      - name: sbom
+        type: SBOM_CYCLONEDX_JSON
+        policies:
+          - ref: file://testdata/policy_with_inputs.yaml
+            with:
+              email: "{{inputs.user_name}}@{{inputs.domainName}}"
+

--- a/pkg/policies/testdata/group_with_interpolated_material.yaml
+++ b/pkg/policies/testdata/group_with_interpolated_material.yaml
@@ -1,0 +1,25 @@
+apiVersion: workflowcontract.chainloop.dev/v1
+kind: PolicyGroup
+metadata:
+  name: group-with-inputs
+  description: test group
+  annotations:
+    category: test
+spec:
+  inputs:
+    - name: sbom_name
+      default: "sbom"
+    - name: user_name
+      required: true
+    - name: domainName
+      required: false
+      default: "chainloop.dev"
+  policies:
+    materials:
+      - name: "{{ inputs.sbom_name }}"
+        type: SBOM_CYCLONEDX_JSON
+        policies:
+          - ref: file://testdata/policy_with_inputs.yaml
+            with:
+              email: "{{inputs.user_name}}@{{inputs.domainName}}"
+

--- a/pkg/policies/testdata/materials.rego
+++ b/pkg/policies/testdata/materials.rego
@@ -1,0 +1,54 @@
+package main
+
+import rego.v1
+
+# Verifies there is a VEX material, even if not enforced by contract
+
+################################
+# Common section do NOT change #
+################################
+
+result := {
+    "skipped": skipped,
+    "violations": violations,
+    "skip_reason": skip_reason,
+}
+
+default skip_reason := ""
+
+skip_reason := m if {
+    not valid_input
+    m := "invalid input"
+}
+
+default skipped := true
+
+skipped := false if valid_input
+
+########################################
+# EO Common section, custom code below #
+########################################
+
+# Validates if the input is valid and can be understood by this policy
+valid_input := true
+
+# If the input is valid, check for any policy violation here
+violations contains msg if {
+    valid_input
+    not has_vex
+    msg := "missing VEX material"
+}
+
+# Collect all material types
+kinds contains kind if {
+    some material in input.predicate.materials
+    kind := material.annotations["chainloop.material.type"]
+}
+
+has_vex if {
+    "CSAF_VEX" in kinds
+}
+
+has_vex if {
+    "OPENVEX" in kinds
+}

--- a/pkg/policies/testdata/materials.yaml
+++ b/pkg/policies/testdata/materials.yaml
@@ -1,0 +1,7 @@
+apiVersion: workflowcontract.chainloop.dev/v1
+kind: Policy
+metadata:
+  name: materials
+spec:
+  type: ATTESTATION
+  path: materials.rego

--- a/pkg/policies/testdata/missing_rego.yaml
+++ b/pkg/policies/testdata/missing_rego.yaml
@@ -1,0 +1,7 @@
+apiVersion: workflowcontract.chainloop.dev/v1
+kind: Policy
+metadata:
+  name: missing-rego
+spec:
+  type: ATTESTATION
+  path: this_is_a_missing.rego

--- a/pkg/policies/testdata/multi-kind.yaml
+++ b/pkg/policies/testdata/multi-kind.yaml
@@ -1,0 +1,13 @@
+apiVersion: workflowcontract.chainloop.dev/v1
+kind: Policy
+metadata:
+  name: multikind
+  description: multikind policy
+  annotations:
+    category: SBOM
+spec:
+  policies:
+    - kind: SBOM_SPDX_JSON
+      path: sbom_syft.rego
+    - kind: ATTESTATION
+      path: workflow.rego

--- a/pkg/policies/testdata/policy_group.yaml
+++ b/pkg/policies/testdata/policy_group.yaml
@@ -1,0 +1,16 @@
+apiVersion: workflowcontract.chainloop.dev/v1
+kind: PolicyGroup
+metadata:
+  name: sbom-quality
+  description: This policy group applies a number of SBOM-related policies
+  annotations:
+    category: SBOM
+spec:
+  policies:
+    attestation:
+      - ref: file://testdata/with_arguments.yaml
+    materials:
+      - name: sbom
+        type: SBOM_SPDX_JSON
+        policies:
+          - ref: file://testdata/multi-kind.yaml

--- a/pkg/policies/testdata/policy_group_multikind.yaml
+++ b/pkg/policies/testdata/policy_group_multikind.yaml
@@ -1,0 +1,16 @@
+apiVersion: workflowcontract.chainloop.dev/v1
+kind: PolicyGroup
+metadata:
+  name: sbom-quality
+  description: This policy group applies a number of SBOM-related policies
+  annotations:
+    category: SBOM
+spec:
+  policies:
+    materials:
+      - type: SBOM_CYCLONEDX_JSON
+        policies:
+          - ref: file://testdata/policy_with_ignore.yaml
+      - type: OPENVEX
+        policies:
+          - ref: file://testdata/policy_openvex_no_ignore.yaml

--- a/pkg/policies/testdata/policy_group_no_name.yaml
+++ b/pkg/policies/testdata/policy_group_no_name.yaml
@@ -1,0 +1,15 @@
+apiVersion: workflowcontract.chainloop.dev/v1
+kind: PolicyGroup
+metadata:
+  name: sbom-quality
+  description: policy group with name-less material
+  annotations:
+    category: SBOM
+spec:
+  policies:
+    attestation:
+      - ref: file://testdata/with_arguments.yaml
+    materials:
+      - type: SBOM_SPDX_JSON
+        policies:
+          - ref: file://testdata/multi-kind.yaml

--- a/pkg/policies/testdata/policy_group_wrong.yaml
+++ b/pkg/policies/testdata/policy_group_wrong.yaml
@@ -1,0 +1,16 @@
+apiVersion: workflowcontract.chainloop.dev/v1
+kind: PolicyGroup
+metadata:
+  name: sbom-quality
+  description: This policy group applies a number of SBOM-related policies
+  annotations:
+    category: SBOM
+spec:
+  policies:
+    attestation:
+      - ref: file://testdata/with_arguments.yaml
+    materials:
+      # No type specified in this material
+      - name: sbom
+        policies:
+          - ref: file://testdata/multi-kind.yaml

--- a/pkg/policies/testdata/policy_multi_kind_with_ignore.yaml
+++ b/pkg/policies/testdata/policy_multi_kind_with_ignore.yaml
@@ -1,0 +1,69 @@
+apiVersion: workflowcontract.chainloop.dev/v1
+kind: Policy
+metadata:
+  name: multikindignore
+  description: multikind policy
+  annotations:
+    category: SBOM
+spec:
+  policies:
+    - kind: SARIF
+      embedded: |
+        package main
+
+        import rego.v1
+
+        result := {
+          "skipped": true,
+          "violations": [],
+          "skip_reason": "this one should be ignored",
+          "ignore": true,
+        }
+    - kind: SBOM_CYCLONEDX_JSON
+      embedded: |
+        package main
+        
+        import rego.v1
+        
+        result := {
+          "skipped": true,
+          "violations": [],
+          "skip_reason": "this one should be ignored",
+          "ignore": true,
+        }
+    - kind: SBOM_CYCLONEDX_JSON
+      embedded: |
+        package main
+        
+        import rego.v1
+        
+        result := {
+          "skipped": true,
+          "violations": [],
+          "skip_reason": "this on is skipped",
+          "ignore": false,
+        }
+    - kind: OPENVEX
+      embedded: |
+        package main
+        
+        import rego.v1
+        
+        result := {
+          "skipped": false,
+          "violations": [],
+          "skip_reason": "",
+          "ignore": false,
+        }
+    - kind: OPENVEX
+      embedded: |
+        package main
+        
+        import rego.v1
+        
+        result := {
+          "skipped": false,
+          "violations": [],
+          "skip_reason": "",
+          "ignore": false,
+        }

--- a/pkg/policies/testdata/policy_openvex_no_ignore.yaml
+++ b/pkg/policies/testdata/policy_openvex_no_ignore.yaml
@@ -1,0 +1,33 @@
+apiVersion: workflowcontract.chainloop.dev/v1
+kind: Policy
+metadata:
+  name: multikindignore
+  description: multikind policy
+  annotations:
+    category: SBOM
+spec:
+  policies:
+    - kind: OPENVEX
+      embedded: |
+        package main
+        
+        import rego.v1
+        
+        result := {
+          "skipped": false,
+          "violations": [],
+          "skip_reason": "",
+          "ignore": false,
+        }
+    - kind: OPENVEX
+      embedded: |
+        package main
+        
+        import rego.v1
+        
+        result := {
+          "skipped": false,
+          "violations": [],
+          "skip_reason": "",
+          "ignore": false,
+        }

--- a/pkg/policies/testdata/policy_result_format.yaml
+++ b/pkg/policies/testdata/policy_result_format.yaml
@@ -1,0 +1,41 @@
+apiVersion: workflowcontract.chainloop.dev/v1
+kind: Policy
+metadata:
+  name: policy-result-format
+  description: Policy with new result format
+  annotations:
+    category: SBOM
+spec:
+  policies:
+    - kind: SBOM_CYCLONEDX_JSON
+      embedded: |
+        package main
+          
+        import rego.v1
+        
+        result := {
+          "skipped": skipped,
+          "violations": violations,
+          "skip_reason": skip_reason,
+        }
+      
+        default skip_reason := ""
+        
+        skip_reason := m if {
+          not valid_input
+          m := "invalid input"
+        }
+      
+        default skipped := true
+        
+        skipped := false if valid_input
+        
+        violations contains msg if {
+          valid_input
+          input.specVersion != "1.5"
+          msg := sprintf("wrong CycloneDX version. Expected 1.5, but it was %s", [input.specVersion])
+        }
+      
+        valid_input if {
+          input.specVersion
+        }

--- a/pkg/policies/testdata/policy_result_skipped.yaml
+++ b/pkg/policies/testdata/policy_result_skipped.yaml
@@ -1,0 +1,31 @@
+apiVersion: workflowcontract.chainloop.dev/v1
+kind: Policy
+metadata:
+  name: policy-result-skipped
+  description: Policy with new result format
+  annotations:
+    category: SBOM
+spec:
+  policies:
+    - kind: SBOM_CYCLONEDX_JSON
+      embedded: |
+        package main
+          
+        import rego.v1
+        
+        result := {
+          "skipped": true,
+          "violations": [],
+          "skip_reason": "this one is skipped",
+        }
+    - kind: SBOM_CYCLONEDX_JSON
+      embedded: |
+        package main
+        
+        import rego.v1
+        
+        result := {
+          "skipped": true,
+          "violations": [],
+          "skip_reason": "this is also skipped",
+        }

--- a/pkg/policies/testdata/policy_with_ignore.yaml
+++ b/pkg/policies/testdata/policy_with_ignore.yaml
@@ -1,0 +1,47 @@
+apiVersion: workflowcontract.chainloop.dev/v1
+kind: Policy
+metadata:
+  name: policy-result-format
+  description: Policy with new result format
+  annotations:
+    category: SBOM
+spec:
+  policies:
+    - kind: SBOM_CYCLONEDX_JSON
+      embedded: |
+        package main
+        
+        import rego.v1
+        
+        result := {
+          "skipped": skipped,
+          "violations": violations,
+          "skip_reason": skip_reason,
+          "ignore": ignore,
+        }
+        
+        default skip_reason := ""
+        
+        skip_reason := m if {
+          not valid_input
+          m := "invalid input"
+        }
+        
+        default skipped := true
+        default ignore := false
+        
+        skipped := false if valid_input
+        
+        ignore := true if {
+          input.specVersion == "1.0"
+        }
+        
+        violations contains msg if {
+          valid_input
+          input.specVersion != "1.5"
+          msg := sprintf("wrong CycloneDX version. Expected 1.5, but it was %s", [input.specVersion])
+        }
+        
+        valid_input if {
+          input.specVersion
+        }

--- a/pkg/policies/testdata/policy_with_inputs.yaml
+++ b/pkg/policies/testdata/policy_with_inputs.yaml
@@ -1,0 +1,23 @@
+apiVersion: workflowcontract.chainloop.dev/v1
+kind: Policy
+metadata:
+  name: policy-with-inputs
+  description: Policy with inputs
+  annotations:
+    category: SBOM
+spec:
+  inputs:
+    - name: email
+      required: true
+  policies:
+    - kind: SBOM_CYCLONEDX_JSON
+      embedded: |
+        package main
+          
+        import rego.v1
+        
+        result := {
+          "skipped": true,
+          "violations": [],
+          "skip_reason": sprintf("the email is: %s", [input.args.email]),
+        }

--- a/pkg/policies/testdata/sbom-spdx.json
+++ b/pkg/policies/testdata/sbom-spdx.json
@@ -1,0 +1,1874 @@
+{
+ "spdxVersion": "SPDX-2.3",
+ "dataLicense": "CC0-1.0",
+ "SPDXID": "SPDXRef-DOCUMENT",
+ "name": ".",
+ "documentNamespace": "https://anchore.com/syft/dir/5d82480d-1f44-4351-b216-24880a877ce4",
+ "creationInfo": {
+  "licenseListVersion": "3.20",
+  "creators": [
+   "Organization: Anchore, Inc",
+   "Tool: syft-0.73.0"
+  ],
+  "created": "2023-02-25T15:16:03Z"
+ },
+ "packages": [
+  {
+   "name": "@algolia/autocomplete-core",
+   "SPDXID": "SPDXRef-Package-npm--algolia-autocomplete-core-d4f529d2efd5d873",
+   "versionInfo": "1.7.4",
+   "downloadLocation": "NOASSERTION",
+   "sourceInfo": "acquired package info from installed node module manifest file: package-lock.json",
+   "licenseConcluded": "MIT",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete-core:\\@algolia\\/autocomplete-core:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete-core:\\@algolia\\/autocomplete_core:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete_core:\\@algolia\\/autocomplete-core:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete_core:\\@algolia\\/autocomplete_core:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete:\\@algolia\\/autocomplete-core:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete:\\@algolia\\/autocomplete_core:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/autocomplete-core:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/autocomplete_core:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:npm/%40algolia/autocomplete-core@1.7.4"
+    }
+   ]
+  },
+  {
+   "name": "@algolia/autocomplete-core",
+   "SPDXID": "SPDXRef-Package-npm--algolia-autocomplete-core-a75e9cc60748602d",
+   "versionInfo": "1.7.4",
+   "downloadLocation": "NOASSERTION",
+   "sourceInfo": "acquired package info from installed node module manifest file: yarn.lock",
+   "licenseConcluded": "MIT",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete-core:\\@algolia\\/autocomplete-core:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete-core:\\@algolia\\/autocomplete_core:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete_core:\\@algolia\\/autocomplete-core:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete_core:\\@algolia\\/autocomplete_core:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete:\\@algolia\\/autocomplete-core:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete:\\@algolia\\/autocomplete_core:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/autocomplete-core:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/autocomplete_core:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:npm/%40algolia/autocomplete-core@1.7.4"
+    }
+   ]
+  },
+  {
+   "name": "@algolia/autocomplete-preset-algolia",
+   "SPDXID": "SPDXRef-Package-npm--algolia-autocomplete-preset-algolia-2efe8108bf5904fb",
+   "versionInfo": "1.7.4",
+   "downloadLocation": "NOASSERTION",
+   "sourceInfo": "acquired package info from installed node module manifest file: package-lock.json",
+   "licenseConcluded": "MIT",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete-preset-algolia:\\@algolia\\/autocomplete-preset-algolia:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete-preset-algolia:\\@algolia\\/autocomplete_preset_algolia:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete_preset_algolia:\\@algolia\\/autocomplete-preset-algolia:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete_preset_algolia:\\@algolia\\/autocomplete_preset_algolia:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete-preset:\\@algolia\\/autocomplete-preset-algolia:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete-preset:\\@algolia\\/autocomplete_preset_algolia:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete_preset:\\@algolia\\/autocomplete-preset-algolia:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete_preset:\\@algolia\\/autocomplete_preset_algolia:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete:\\@algolia\\/autocomplete-preset-algolia:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete:\\@algolia\\/autocomplete_preset_algolia:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/autocomplete-preset-algolia:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/autocomplete_preset_algolia:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:npm/%40algolia/autocomplete-preset-algolia@1.7.4"
+    }
+   ]
+  },
+  {
+   "name": "@algolia/autocomplete-preset-algolia",
+   "SPDXID": "SPDXRef-Package-npm--algolia-autocomplete-preset-algolia-719fbc0a971c8423",
+   "versionInfo": "1.7.4",
+   "downloadLocation": "NOASSERTION",
+   "sourceInfo": "acquired package info from installed node module manifest file: yarn.lock",
+   "licenseConcluded": "MIT",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete-preset-algolia:\\@algolia\\/autocomplete-preset-algolia:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete-preset-algolia:\\@algolia\\/autocomplete_preset_algolia:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete_preset_algolia:\\@algolia\\/autocomplete-preset-algolia:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete_preset_algolia:\\@algolia\\/autocomplete_preset_algolia:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete-preset:\\@algolia\\/autocomplete-preset-algolia:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete-preset:\\@algolia\\/autocomplete_preset_algolia:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete_preset:\\@algolia\\/autocomplete-preset-algolia:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete_preset:\\@algolia\\/autocomplete_preset_algolia:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete:\\@algolia\\/autocomplete-preset-algolia:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete:\\@algolia\\/autocomplete_preset_algolia:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/autocomplete-preset-algolia:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/autocomplete_preset_algolia:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:npm/%40algolia/autocomplete-preset-algolia@1.7.4"
+    }
+   ]
+  },
+  {
+   "name": "@algolia/autocomplete-shared",
+   "SPDXID": "SPDXRef-Package-npm--algolia-autocomplete-shared-c04c8898a671ed16",
+   "versionInfo": "1.7.4",
+   "downloadLocation": "NOASSERTION",
+   "sourceInfo": "acquired package info from installed node module manifest file: package-lock.json",
+   "licenseConcluded": "MIT",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete-shared:\\@algolia\\/autocomplete-shared:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete-shared:\\@algolia\\/autocomplete_shared:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete_shared:\\@algolia\\/autocomplete-shared:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete_shared:\\@algolia\\/autocomplete_shared:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete:\\@algolia\\/autocomplete-shared:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete:\\@algolia\\/autocomplete_shared:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/autocomplete-shared:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/autocomplete_shared:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:npm/%40algolia/autocomplete-shared@1.7.4"
+    }
+   ]
+  },
+  {
+   "name": "@algolia/autocomplete-shared",
+   "SPDXID": "SPDXRef-Package-npm--algolia-autocomplete-shared-349e9c24c2b4f2c5",
+   "versionInfo": "1.7.4",
+   "downloadLocation": "NOASSERTION",
+   "sourceInfo": "acquired package info from installed node module manifest file: yarn.lock",
+   "licenseConcluded": "MIT",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete-shared:\\@algolia\\/autocomplete-shared:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete-shared:\\@algolia\\/autocomplete_shared:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete_shared:\\@algolia\\/autocomplete-shared:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete_shared:\\@algolia\\/autocomplete_shared:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete:\\@algolia\\/autocomplete-shared:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/autocomplete:\\@algolia\\/autocomplete_shared:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/autocomplete-shared:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/autocomplete_shared:1.7.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:npm/%40algolia/autocomplete-shared@1.7.4"
+    }
+   ]
+  },
+  {
+   "name": "@algolia/cache-browser-local-storage",
+   "SPDXID": "SPDXRef-Package-npm--algolia-cache-browser-local-storage-7f047bcfa53ed7ee",
+   "versionInfo": "4.14.3",
+   "downloadLocation": "NOASSERTION",
+   "sourceInfo": "acquired package info from installed node module manifest file: package-lock.json",
+   "licenseConcluded": "MIT",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache-browser-local-storage:\\@algolia\\/cache-browser-local-storage:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache-browser-local-storage:\\@algolia\\/cache_browser_local_storage:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache_browser_local_storage:\\@algolia\\/cache-browser-local-storage:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache_browser_local_storage:\\@algolia\\/cache_browser_local_storage:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache-browser-local:\\@algolia\\/cache-browser-local-storage:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache-browser-local:\\@algolia\\/cache_browser_local_storage:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache_browser_local:\\@algolia\\/cache-browser-local-storage:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache_browser_local:\\@algolia\\/cache_browser_local_storage:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache-browser:\\@algolia\\/cache-browser-local-storage:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache-browser:\\@algolia\\/cache_browser_local_storage:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache_browser:\\@algolia\\/cache-browser-local-storage:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache_browser:\\@algolia\\/cache_browser_local_storage:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache:\\@algolia\\/cache-browser-local-storage:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache:\\@algolia\\/cache_browser_local_storage:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/cache-browser-local-storage:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/cache_browser_local_storage:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:npm/%40algolia/cache-browser-local-storage@4.14.3"
+    }
+   ]
+  },
+  {
+   "name": "@algolia/cache-browser-local-storage",
+   "SPDXID": "SPDXRef-Package-npm--algolia-cache-browser-local-storage-699118b8ecb40e29",
+   "versionInfo": "4.14.3",
+   "downloadLocation": "NOASSERTION",
+   "sourceInfo": "acquired package info from installed node module manifest file: yarn.lock",
+   "licenseConcluded": "MIT",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache-browser-local-storage:\\@algolia\\/cache-browser-local-storage:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache-browser-local-storage:\\@algolia\\/cache_browser_local_storage:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache_browser_local_storage:\\@algolia\\/cache-browser-local-storage:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache_browser_local_storage:\\@algolia\\/cache_browser_local_storage:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache-browser-local:\\@algolia\\/cache-browser-local-storage:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache-browser-local:\\@algolia\\/cache_browser_local_storage:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache_browser_local:\\@algolia\\/cache-browser-local-storage:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache_browser_local:\\@algolia\\/cache_browser_local_storage:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache-browser:\\@algolia\\/cache-browser-local-storage:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache-browser:\\@algolia\\/cache_browser_local_storage:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache_browser:\\@algolia\\/cache-browser-local-storage:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache_browser:\\@algolia\\/cache_browser_local_storage:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache:\\@algolia\\/cache-browser-local-storage:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache:\\@algolia\\/cache_browser_local_storage:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/cache-browser-local-storage:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/cache_browser_local_storage:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:npm/%40algolia/cache-browser-local-storage@4.14.3"
+    }
+   ]
+  },
+  {
+   "name": "@algolia/cache-common",
+   "SPDXID": "SPDXRef-Package-npm--algolia-cache-common-b83a20f4252c841a",
+   "versionInfo": "4.14.3",
+   "downloadLocation": "NOASSERTION",
+   "sourceInfo": "acquired package info from installed node module manifest file: package-lock.json",
+   "licenseConcluded": "MIT",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache-common:\\@algolia\\/cache-common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache-common:\\@algolia\\/cache_common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache_common:\\@algolia\\/cache-common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache_common:\\@algolia\\/cache_common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache:\\@algolia\\/cache-common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache:\\@algolia\\/cache_common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/cache-common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/cache_common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:npm/%40algolia/cache-common@4.14.3"
+    }
+   ]
+  },
+  {
+   "name": "@algolia/cache-common",
+   "SPDXID": "SPDXRef-Package-npm--algolia-cache-common-8feb5c8eb82329a3",
+   "versionInfo": "4.14.3",
+   "downloadLocation": "NOASSERTION",
+   "sourceInfo": "acquired package info from installed node module manifest file: yarn.lock",
+   "licenseConcluded": "MIT",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache-common:\\@algolia\\/cache-common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache-common:\\@algolia\\/cache_common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache_common:\\@algolia\\/cache-common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache_common:\\@algolia\\/cache_common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache:\\@algolia\\/cache-common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache:\\@algolia\\/cache_common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/cache-common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/cache_common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:npm/%40algolia/cache-common@4.14.3"
+    }
+   ]
+  },
+  {
+   "name": "@algolia/cache-in-memory",
+   "SPDXID": "SPDXRef-Package-npm--algolia-cache-in-memory-5b4709d3757a3a6d",
+   "versionInfo": "4.14.3",
+   "downloadLocation": "NOASSERTION",
+   "sourceInfo": "acquired package info from installed node module manifest file: package-lock.json",
+   "licenseConcluded": "MIT",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache-in-memory:\\@algolia\\/cache-in-memory:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache-in-memory:\\@algolia\\/cache_in_memory:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache_in_memory:\\@algolia\\/cache-in-memory:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache_in_memory:\\@algolia\\/cache_in_memory:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache-in:\\@algolia\\/cache-in-memory:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache-in:\\@algolia\\/cache_in_memory:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache_in:\\@algolia\\/cache-in-memory:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache_in:\\@algolia\\/cache_in_memory:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache:\\@algolia\\/cache-in-memory:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache:\\@algolia\\/cache_in_memory:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/cache-in-memory:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/cache_in_memory:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:npm/%40algolia/cache-in-memory@4.14.3"
+    }
+   ]
+  },
+  {
+   "name": "@algolia/cache-in-memory",
+   "SPDXID": "SPDXRef-Package-npm--algolia-cache-in-memory-a4bf58feef42f315",
+   "versionInfo": "4.14.3",
+   "downloadLocation": "NOASSERTION",
+   "sourceInfo": "acquired package info from installed node module manifest file: yarn.lock",
+   "licenseConcluded": "MIT",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache-in-memory:\\@algolia\\/cache-in-memory:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache-in-memory:\\@algolia\\/cache_in_memory:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache_in_memory:\\@algolia\\/cache-in-memory:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache_in_memory:\\@algolia\\/cache_in_memory:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache-in:\\@algolia\\/cache-in-memory:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache-in:\\@algolia\\/cache_in_memory:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache_in:\\@algolia\\/cache-in-memory:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache_in:\\@algolia\\/cache_in_memory:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache:\\@algolia\\/cache-in-memory:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/cache:\\@algolia\\/cache_in_memory:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/cache-in-memory:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/cache_in_memory:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:npm/%40algolia/cache-in-memory@4.14.3"
+    }
+   ]
+  },
+  {
+   "name": "@algolia/client-account",
+   "SPDXID": "SPDXRef-Package-npm--algolia-client-account-ccad52fb07b66b08",
+   "versionInfo": "4.14.3",
+   "downloadLocation": "NOASSERTION",
+   "sourceInfo": "acquired package info from installed node module manifest file: package-lock.json",
+   "licenseConcluded": "MIT",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client-account:\\@algolia\\/client-account:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client-account:\\@algolia\\/client_account:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client_account:\\@algolia\\/client-account:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client_account:\\@algolia\\/client_account:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client:\\@algolia\\/client-account:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client:\\@algolia\\/client_account:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/client-account:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/client_account:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:npm/%40algolia/client-account@4.14.3"
+    }
+   ]
+  },
+  {
+   "name": "@algolia/client-account",
+   "SPDXID": "SPDXRef-Package-npm--algolia-client-account-dcac7f21f13a1b6",
+   "versionInfo": "4.14.3",
+   "downloadLocation": "NOASSERTION",
+   "sourceInfo": "acquired package info from installed node module manifest file: yarn.lock",
+   "licenseConcluded": "MIT",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client-account:\\@algolia\\/client-account:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client-account:\\@algolia\\/client_account:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client_account:\\@algolia\\/client-account:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client_account:\\@algolia\\/client_account:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client:\\@algolia\\/client-account:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client:\\@algolia\\/client_account:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/client-account:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/client_account:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:npm/%40algolia/client-account@4.14.3"
+    }
+   ]
+  },
+  {
+   "name": "@algolia/client-analytics",
+   "SPDXID": "SPDXRef-Package-npm--algolia-client-analytics-da8f8d5e4a42283c",
+   "versionInfo": "4.14.3",
+   "downloadLocation": "NOASSERTION",
+   "sourceInfo": "acquired package info from installed node module manifest file: package-lock.json",
+   "licenseConcluded": "MIT",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client-analytics:\\@algolia\\/client-analytics:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client-analytics:\\@algolia\\/client_analytics:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client_analytics:\\@algolia\\/client-analytics:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client_analytics:\\@algolia\\/client_analytics:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client:\\@algolia\\/client-analytics:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client:\\@algolia\\/client_analytics:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/client-analytics:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/client_analytics:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:npm/%40algolia/client-analytics@4.14.3"
+    }
+   ]
+  },
+  {
+   "name": "@algolia/client-analytics",
+   "SPDXID": "SPDXRef-Package-npm--algolia-client-analytics-7aa06ac329e132f6",
+   "versionInfo": "4.14.3",
+   "downloadLocation": "NOASSERTION",
+   "sourceInfo": "acquired package info from installed node module manifest file: yarn.lock",
+   "licenseConcluded": "MIT",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client-analytics:\\@algolia\\/client-analytics:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client-analytics:\\@algolia\\/client_analytics:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client_analytics:\\@algolia\\/client-analytics:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client_analytics:\\@algolia\\/client_analytics:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client:\\@algolia\\/client-analytics:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client:\\@algolia\\/client_analytics:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/client-analytics:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/client_analytics:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:npm/%40algolia/client-analytics@4.14.3"
+    }
+   ]
+  },
+  {
+   "name": "@algolia/client-common",
+   "SPDXID": "SPDXRef-Package-npm--algolia-client-common-fdab2e146ab09cb0",
+   "versionInfo": "4.14.3",
+   "downloadLocation": "NOASSERTION",
+   "sourceInfo": "acquired package info from installed node module manifest file: package-lock.json",
+   "licenseConcluded": "MIT",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client-common:\\@algolia\\/client-common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client-common:\\@algolia\\/client_common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client_common:\\@algolia\\/client-common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client_common:\\@algolia\\/client_common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client:\\@algolia\\/client-common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client:\\@algolia\\/client_common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/client-common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/client_common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:npm/%40algolia/client-common@4.14.3"
+    }
+   ]
+  },
+  {
+   "name": "@algolia/client-common",
+   "SPDXID": "SPDXRef-Package-npm--algolia-client-common-1e82fe4ac5f06142",
+   "versionInfo": "4.14.3",
+   "downloadLocation": "NOASSERTION",
+   "sourceInfo": "acquired package info from installed node module manifest file: yarn.lock",
+   "licenseConcluded": "MIT",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client-common:\\@algolia\\/client-common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client-common:\\@algolia\\/client_common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client_common:\\@algolia\\/client-common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client_common:\\@algolia\\/client_common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client:\\@algolia\\/client-common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client:\\@algolia\\/client_common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/client-common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/client_common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:npm/%40algolia/client-common@4.14.3"
+    }
+   ]
+  },
+  {
+   "name": "@algolia/client-personalization",
+   "SPDXID": "SPDXRef-Package-npm--algolia-client-personalization-5860c568f6a2884b",
+   "versionInfo": "4.14.3",
+   "downloadLocation": "NOASSERTION",
+   "sourceInfo": "acquired package info from installed node module manifest file: package-lock.json",
+   "licenseConcluded": "MIT",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client-personalization:\\@algolia\\/client-personalization:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client-personalization:\\@algolia\\/client_personalization:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client_personalization:\\@algolia\\/client-personalization:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client_personalization:\\@algolia\\/client_personalization:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client:\\@algolia\\/client-personalization:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client:\\@algolia\\/client_personalization:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/client-personalization:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/client_personalization:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:npm/%40algolia/client-personalization@4.14.3"
+    }
+   ]
+  },
+  {
+   "name": "@algolia/client-personalization",
+   "SPDXID": "SPDXRef-Package-npm--algolia-client-personalization-5230f032c64636a3",
+   "versionInfo": "4.14.3",
+   "downloadLocation": "NOASSERTION",
+   "sourceInfo": "acquired package info from installed node module manifest file: yarn.lock",
+   "licenseConcluded": "MIT",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client-personalization:\\@algolia\\/client-personalization:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client-personalization:\\@algolia\\/client_personalization:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client_personalization:\\@algolia\\/client-personalization:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client_personalization:\\@algolia\\/client_personalization:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client:\\@algolia\\/client-personalization:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client:\\@algolia\\/client_personalization:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/client-personalization:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/client_personalization:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:npm/%40algolia/client-personalization@4.14.3"
+    }
+   ]
+  },
+  {
+   "name": "@algolia/client-search",
+   "SPDXID": "SPDXRef-Package-npm--algolia-client-search-dd73cb953fef8932",
+   "versionInfo": "4.14.3",
+   "downloadLocation": "NOASSERTION",
+   "sourceInfo": "acquired package info from installed node module manifest file: package-lock.json",
+   "licenseConcluded": "MIT",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client-search:\\@algolia\\/client-search:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client-search:\\@algolia\\/client_search:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client_search:\\@algolia\\/client-search:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client_search:\\@algolia\\/client_search:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client:\\@algolia\\/client-search:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client:\\@algolia\\/client_search:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/client-search:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/client_search:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:npm/%40algolia/client-search@4.14.3"
+    }
+   ]
+  },
+  {
+   "name": "@algolia/client-search",
+   "SPDXID": "SPDXRef-Package-npm--algolia-client-search-a19e56cf638775e2",
+   "versionInfo": "4.14.3",
+   "downloadLocation": "NOASSERTION",
+   "sourceInfo": "acquired package info from installed node module manifest file: yarn.lock",
+   "licenseConcluded": "MIT",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client-search:\\@algolia\\/client-search:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client-search:\\@algolia\\/client_search:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client_search:\\@algolia\\/client-search:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client_search:\\@algolia\\/client_search:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client:\\@algolia\\/client-search:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/client:\\@algolia\\/client_search:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/client-search:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/client_search:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:npm/%40algolia/client-search@4.14.3"
+    }
+   ]
+  },
+  {
+   "name": "@algolia/events",
+   "SPDXID": "SPDXRef-Package-npm--algolia-events-5f312ad698b9cd07",
+   "versionInfo": "4.0.1",
+   "downloadLocation": "NOASSERTION",
+   "sourceInfo": "acquired package info from installed node module manifest file: package-lock.json",
+   "licenseConcluded": "MIT",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/events:\\@algolia\\/events:4.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/events:4.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:npm/%40algolia/events@4.0.1"
+    }
+   ]
+  },
+  {
+   "name": "@algolia/events",
+   "SPDXID": "SPDXRef-Package-npm--algolia-events-4f529c22422af8a",
+   "versionInfo": "4.0.1",
+   "downloadLocation": "NOASSERTION",
+   "sourceInfo": "acquired package info from installed node module manifest file: yarn.lock",
+   "licenseConcluded": "MIT",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/events:\\@algolia\\/events:4.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/events:4.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:npm/%40algolia/events@4.0.1"
+    }
+   ]
+  },
+  {
+   "name": "@algolia/logger-common",
+   "SPDXID": "SPDXRef-Package-npm--algolia-logger-common-4beb0a564e01e8dd",
+   "versionInfo": "4.14.3",
+   "downloadLocation": "NOASSERTION",
+   "sourceInfo": "acquired package info from installed node module manifest file: package-lock.json",
+   "licenseConcluded": "MIT",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/logger-common:\\@algolia\\/logger-common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/logger-common:\\@algolia\\/logger_common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/logger_common:\\@algolia\\/logger-common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/logger_common:\\@algolia\\/logger_common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/logger:\\@algolia\\/logger-common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/logger:\\@algolia\\/logger_common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/logger-common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/logger_common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:npm/%40algolia/logger-common@4.14.3"
+    }
+   ]
+  },
+  {
+   "name": "@algolia/logger-common",
+   "SPDXID": "SPDXRef-Package-npm--algolia-logger-common-b5611c2c52827c17",
+   "versionInfo": "4.14.3",
+   "downloadLocation": "NOASSERTION",
+   "sourceInfo": "acquired package info from installed node module manifest file: yarn.lock",
+   "licenseConcluded": "MIT",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/logger-common:\\@algolia\\/logger-common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/logger-common:\\@algolia\\/logger_common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/logger_common:\\@algolia\\/logger-common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/logger_common:\\@algolia\\/logger_common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/logger:\\@algolia\\/logger-common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/logger:\\@algolia\\/logger_common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/logger-common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/logger_common:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:npm/%40algolia/logger-common@4.14.3"
+    }
+   ]
+  },
+  {
+   "name": "@algolia/logger-console",
+   "SPDXID": "SPDXRef-Package-npm--algolia-logger-console-7d44d092b7346496",
+   "versionInfo": "4.14.3",
+   "downloadLocation": "NOASSERTION",
+   "sourceInfo": "acquired package info from installed node module manifest file: package-lock.json",
+   "licenseConcluded": "MIT",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/logger-console:\\@algolia\\/logger-console:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/logger-console:\\@algolia\\/logger_console:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/logger_console:\\@algolia\\/logger-console:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/logger_console:\\@algolia\\/logger_console:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/logger:\\@algolia\\/logger-console:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/logger:\\@algolia\\/logger_console:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/logger-console:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/logger_console:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:npm/%40algolia/logger-console@4.14.3"
+    }
+   ]
+  },
+  {
+   "name": "@algolia/logger-console",
+   "SPDXID": "SPDXRef-Package-npm--algolia-logger-console-bd05c3862ee5c855",
+   "versionInfo": "4.14.3",
+   "downloadLocation": "NOASSERTION",
+   "sourceInfo": "acquired package info from installed node module manifest file: yarn.lock",
+   "licenseConcluded": "MIT",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/logger-console:\\@algolia\\/logger-console:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/logger-console:\\@algolia\\/logger_console:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/logger_console:\\@algolia\\/logger-console:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/logger_console:\\@algolia\\/logger_console:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/logger:\\@algolia\\/logger-console:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/logger:\\@algolia\\/logger_console:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/logger-console:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/logger_console:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:npm/%40algolia/logger-console@4.14.3"
+    }
+   ]
+  },
+  {
+   "name": "@algolia/requester-browser-xhr",
+   "SPDXID": "SPDXRef-Package-npm--algolia-requester-browser-xhr-2547173fb30f7bf4",
+   "versionInfo": "4.14.3",
+   "downloadLocation": "NOASSERTION",
+   "sourceInfo": "acquired package info from installed node module manifest file: package-lock.json",
+   "licenseConcluded": "MIT",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/requester-browser-xhr:\\@algolia\\/requester-browser-xhr:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/requester-browser-xhr:\\@algolia\\/requester_browser_xhr:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/requester_browser_xhr:\\@algolia\\/requester-browser-xhr:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/requester_browser_xhr:\\@algolia\\/requester_browser_xhr:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/requester-browser:\\@algolia\\/requester-browser-xhr:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/requester-browser:\\@algolia\\/requester_browser_xhr:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/requester_browser:\\@algolia\\/requester-browser-xhr:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/requester_browser:\\@algolia\\/requester_browser_xhr:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/requester:\\@algolia\\/requester-browser-xhr:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/requester:\\@algolia\\/requester_browser_xhr:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/requester-browser-xhr:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/requester_browser_xhr:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:npm/%40algolia/requester-browser-xhr@4.14.3"
+    }
+   ]
+  },
+  {
+   "name": "@algolia/requester-browser-xhr",
+   "SPDXID": "SPDXRef-Package-npm--algolia-requester-browser-xhr-afdcaeba77bd9241",
+   "versionInfo": "4.14.3",
+   "downloadLocation": "NOASSERTION",
+   "sourceInfo": "acquired package info from installed node module manifest file: yarn.lock",
+   "licenseConcluded": "MIT",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/requester-browser-xhr:\\@algolia\\/requester-browser-xhr:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/requester-browser-xhr:\\@algolia\\/requester_browser_xhr:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/requester_browser_xhr:\\@algolia\\/requester-browser-xhr:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/requester_browser_xhr:\\@algolia\\/requester_browser_xhr:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/requester-browser:\\@algolia\\/requester-browser-xhr:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/requester-browser:\\@algolia\\/requester_browser_xhr:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/requester_browser:\\@algolia\\/requester-browser-xhr:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/requester_browser:\\@algolia\\/requester_browser_xhr:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/requester:\\@algolia\\/requester-browser-xhr:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\@algolia\\/requester:\\@algolia\\/requester_browser_xhr:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/requester-browser-xhr:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:*:\\@algolia\\/requester_browser_xhr:4.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:npm/%40algolia/requester-browser-xhr@4.14.3"
+    }
+   ]
+  }
+ ],
+ "relationships": [
+  {
+   "spdxElementId": "SPDXRef-DOCUMENT",
+   "relatedSpdxElement": "SPDXRef-DOCUMENT",
+   "relationshipType": "DESCRIBES"
+  }
+ ]
+}

--- a/pkg/policies/testdata/sbom_syft.rego
+++ b/pkg/policies/testdata/sbom_syft.rego
@@ -1,0 +1,43 @@
+package main
+
+import rego.v1
+
+################################
+# Common section do NOT change #
+################################
+
+result := {
+    "skipped": skipped,
+    "violations": violations,
+    "skip_reason": skip_reason,
+}
+
+default skip_reason := ""
+
+skip_reason := m if {
+    not valid_input
+    m := "invalid input"
+}
+
+default skipped := true
+
+skipped := false if valid_input
+
+########################################
+# EO Common section, custom code below #
+########################################
+
+# Validates if the input is valid and can be understood by this policy
+valid_input := true
+
+# If the input is valid, check for any policy violation here
+violations contains msg if {
+    valid_input
+    not made_with_syft
+    msg := "Not made with syft"
+}
+
+made_with_syft if {
+    some creator in input.creationInfo.creators
+    contains(creator, "syft")
+}

--- a/pkg/policies/testdata/sbom_syft.yaml
+++ b/pkg/policies/testdata/sbom_syft.yaml
@@ -1,0 +1,10 @@
+apiVersion: workflowcontract.chainloop.dev/v1
+kind: Policy
+metadata:
+  name: made-with-syft
+  description: This policy checks that the SPDX SBOM was created with syft
+  annotations:
+    category: SBOM
+spec:
+  type: SBOM_SPDX_JSON
+  path: sbom_syft.rego

--- a/pkg/policies/testdata/sbom_syft_not_typed.yaml
+++ b/pkg/policies/testdata/sbom_syft_not_typed.yaml
@@ -1,0 +1,6 @@
+apiVersion: workflowcontract.chainloop.dev/v1
+kind: Policy
+metadata:
+  name: made-with-syft
+spec:
+  path: sbom_syft.rego

--- a/pkg/policies/testdata/statement.json
+++ b/pkg/policies/testdata/statement.json
@@ -1,0 +1,247 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [
+    {
+      "name": "chainloop.workflow.chainloop-vault-release",
+      "digest": {
+        "sha256": "9ae495a85891eb1130fefc17bc89940c9aa96acb8355c26a3e0d73a5097d41d4"
+      }
+    },
+    {
+      "name": "git.head",
+      "digest": {
+        "sha1": "53f95f066b620172301e2a3879e7d593da05727e"
+      },
+      "annotations": {
+        "author.email": "devel@chainloop.dev",
+        "author.name": "Developer",
+        "date": "2024-07-12T10:16:04Z",
+        "message": "chore(vulns): fix CVEs in base image (#1088)\n\nSigned-off-by: Jose I. Paris <jiparis@chainloop.dev>",
+        "remotes": [
+          {
+            "name": "origin",
+            "url": "https://github.com/chainloop-dev/chainloop"
+          }
+        ]
+      }
+    }
+  ],
+  "predicateType": "chainloop.dev/attestation/v0.2",
+  "predicate": {
+    "buildType": "chainloop.dev/workflowrun/v0.1",
+    "builder": {
+      "id": "chainloop.dev/cli/0.90.1@sha256:431a0765636854095f0c78d01b61eb5558abe7c8de1608aa93eef1530deee0b6"
+    },
+    "env": {
+      "GITHUB_ACTOR": "jiparis",
+      "GITHUB_REF": "refs/tags/v0.93.7",
+      "GITHUB_REPOSITORY": "chainloop-dev/chainloop",
+      "GITHUB_REPOSITORY_OWNER": "chainloop-dev",
+      "GITHUB_RUN_ID": "9906853011",
+      "GITHUB_SHA": "53f95f066b620172301e2a3879e7d593da05727e",
+      "RUNNER_NAME": "GitHub Actions 193",
+      "RUNNER_OS": "Linux"
+    },
+    "materials": [
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782291120414953",
+          "chainloop.material.type": "SBOM_CYCLONEDX_JSON"
+        },
+        "digest": {
+          "sha256": "bc449b71c4a47f2f69b514f27e1d61250ff0af0cc554a68d331b40042d90a3da"
+        },
+        "name": "cas.cyclonedx.json"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782293352471920",
+          "chainloop.material.type": "ARTIFACT"
+        },
+        "digest": {
+          "sha256": "972ca204670aee23ed070619333fb04410ed996bf3c063ff88d35de0702fd478"
+        },
+        "name": "chainloop-cli-0.93.7-darwin-amd64.tar.gz"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782295934163620",
+          "chainloop.material.type": "ARTIFACT"
+        },
+        "digest": {
+          "sha256": "27e4efa094adef0dc5375da7bce70437dde9d35d1e20598240debfc318f374da"
+        },
+        "name": "chainloop-cli-0.93.7-darwin-amd64.tar.gz.sig"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782297645680131",
+          "chainloop.material.type": "ARTIFACT"
+        },
+        "digest": {
+          "sha256": "389ea065be2dd50d07b27619b8594d4738b2c86481db969f62dd549e579af1e2"
+        },
+        "name": "chainloop-cli-0.93.7-darwin-arm64.tar.gz"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782300158976415",
+          "chainloop.material.type": "ARTIFACT"
+        },
+        "digest": {
+          "sha256": "47d5c22ee0f56bf3e7eed5c283fe66e5f61a7a9e913b9af1550dd07e71ac09e1"
+        },
+        "name": "chainloop-cli-0.93.7-darwin-arm64.tar.gz.sig"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782301800977382",
+          "chainloop.material.type": "ARTIFACT"
+        },
+        "digest": {
+          "sha256": "a57b0b11a51b8ebbc9d421bd68e6e82fd021f4e87742780ef30f0aaca0bdd1c2"
+        },
+        "name": "chainloop-cli-0.93.7-linux-amd64.tar.gz"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782304541799505",
+          "chainloop.material.type": "ARTIFACT"
+        },
+        "digest": {
+          "sha256": "754dea96fc2addc0fdb70f725686fd4b5e01a1aa69a1ed0726e4d08866400d42"
+        },
+        "name": "chainloop-cli-0.93.7-linux-amd64.tar.gz.sig"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782306140039811",
+          "chainloop.material.type": "ARTIFACT"
+        },
+        "digest": {
+          "sha256": "c63ee103397001d2e9727d30d02a4ce4e55b7e32da55f042a414c7424b42b21d"
+        },
+        "name": "chainloop-cli-0.93.7-linux-arm64.tar.gz"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782308650938558",
+          "chainloop.material.type": "ARTIFACT"
+        },
+        "digest": {
+          "sha256": "b5c7c73c9d4cd325b8da64135c28685715e8e19f6b48357eaf1a02e693734f37"
+        },
+        "name": "chainloop-cli-0.93.7-linux-arm64.tar.gz.sig"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782309843066922",
+          "chainloop.material.type": "ARTIFACT"
+        },
+        "digest": {
+          "sha256": "897f1dfc64736dd66ea8881ab07689d59e1bc147c45da0baa1de416834a46a3d"
+        },
+        "name": "checksums.txt"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782311062937592",
+          "chainloop.material.type": "ARTIFACT"
+        },
+        "digest": {
+          "sha256": "2f804aa3b95a81802c24e384e5e87e86f02ec23d043c9c4d3aa9243ee866b60b"
+        },
+        "name": "checksums.txt.sig"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782311526704542",
+          "chainloop.material.type": "SBOM_CYCLONEDX_JSON"
+        },
+        "digest": {
+          "sha256": "8b53305ead21a9ede6e0e3aee2fcc04f04796716e1a2b566ce03f3f8cbc2b130"
+        },
+        "name": "controlplane.cyclonedx.json"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782313410977824",
+          "chainloop.material.type": "ARTIFACT"
+        },
+        "digest": {
+          "sha256": "91c0b92358109bfc31ea4c58902d9b7f4f582ff9c4782fb276a685e914d3cc82"
+        },
+        "name": "cosign.pub"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782315689903312",
+          "chainloop.material.type": "HELM_CHART"
+        },
+        "digest": {
+          "sha256": "7cbbda1e5ab71fef561c0f123f5f584c8e0de523d4da80379599ce7a05c04c1f"
+        },
+        "name": "chainloop-0.93.7.tar.gz"
+      },
+      {
+        "annotations": {
+          "chainloop.material.image.tag": "v0.93.7",
+          "chainloop.material.name": "material-1720782317669410353",
+          "chainloop.material.type": "CONTAINER_IMAGE"
+        },
+        "digest": {
+          "sha256": "4a8eb6f9ae76460b682e7e9eb5504df9f7f2b2250d9c5cb63204442e265e2c5a"
+        },
+        "name": "ghcr.io/chainloop-dev/chainloop/control-plane"
+      },
+      {
+        "annotations": {
+          "chainloop.material.image.tag": "v0.93.7",
+          "chainloop.material.name": "material-1720782318334142313",
+          "chainloop.material.type": "CONTAINER_IMAGE"
+        },
+        "digest": {
+          "sha256": "4d329b2aee79b35ec5e6c462be5d8000565d5ccd13602427cd889fc91c187fc8"
+        },
+        "name": "ghcr.io/chainloop-dev/chainloop/artifact-cas"
+      },
+      {
+        "annotations": {
+          "chainloop.material.image.tag": "v0.93.7",
+          "chainloop.material.name": "material-1720782319034635257",
+          "chainloop.material.type": "CONTAINER_IMAGE"
+        },
+        "digest": {
+          "sha256": "571a5543151d651cbc62679c3f50c2e6cadfd2ff20279374c6d6106b3f70560f"
+        },
+        "name": "ghcr.io/chainloop-dev/chainloop/cli"
+      }
+    ],
+    "metadata": {
+      "finishedAt": "2024-07-12T11:05:19.808858785Z",
+      "initializedAt": "2024-07-12T11:04:48.604833219Z",
+      "name": "chainloop-vault-release",
+      "organization": "read-only-demo",
+      "project": "chainloop",
+      "team": "",
+      "workflowID": "2acc7ee5-21d1-4500-9ca4-2d25748a1ce0",
+      "workflowRunID": "37dd3d94-06e3-483f-83c2-18b1137e73ee"
+    },
+    "runnerType": "GITHUB_ACTION",
+    "runnerURL": "https://github.com/chainloop-dev/chainloop/actions/runs/9906853011"
+  }
+}

--- a/pkg/policies/testdata/statement_gitlab.json
+++ b/pkg/policies/testdata/statement_gitlab.json
@@ -1,0 +1,247 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [
+    {
+      "name": "chainloop.workflow.chainloop-vault-release",
+      "digest": {
+        "sha256": "9ae495a85891eb1130fefc17bc89940c9aa96acb8355c26a3e0d73a5097d41d4"
+      }
+    },
+    {
+      "name": "git.head",
+      "digest": {
+        "sha1": "53f95f066b620172301e2a3879e7d593da05727e"
+      },
+      "annotations": {
+        "author.email": "devel@chainloop.dev",
+        "author.name": "Developer",
+        "date": "2024-07-12T10:16:04Z",
+        "message": "chore(vulns): fix CVEs in base image (#1088)\n\nSigned-off-by: Jose I. Paris <jiparis@chainloop.dev>",
+        "remotes": [
+          {
+            "name": "origin",
+            "url": "https://github.com/chainloop-dev/chainloop"
+          }
+        ]
+      }
+    }
+  ],
+  "predicateType": "chainloop.dev/attestation/v0.2",
+  "predicate": {
+    "buildType": "chainloop.dev/workflowrun/v0.1",
+    "builder": {
+      "id": "chainloop.dev/cli/0.90.1@sha256:431a0765636854095f0c78d01b61eb5558abe7c8de1608aa93eef1530deee0b6"
+    },
+    "env": {
+      "GITHUB_ACTOR": "jiparis",
+      "GITHUB_REF": "refs/tags/v0.93.7",
+      "GITHUB_REPOSITORY": "chainloop-dev/chainloop",
+      "GITHUB_REPOSITORY_OWNER": "chainloop-dev",
+      "GITHUB_RUN_ID": "9906853011",
+      "GITHUB_SHA": "53f95f066b620172301e2a3879e7d593da05727e",
+      "RUNNER_NAME": "GitHub Actions 193",
+      "RUNNER_OS": "Linux"
+    },
+    "materials": [
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782291120414953",
+          "chainloop.material.type": "SBOM_CYCLONEDX_JSON"
+        },
+        "digest": {
+          "sha256": "bc449b71c4a47f2f69b514f27e1d61250ff0af0cc554a68d331b40042d90a3da"
+        },
+        "name": "cas.cyclonedx.json"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782293352471920",
+          "chainloop.material.type": "ARTIFACT"
+        },
+        "digest": {
+          "sha256": "972ca204670aee23ed070619333fb04410ed996bf3c063ff88d35de0702fd478"
+        },
+        "name": "chainloop-cli-0.93.7-darwin-amd64.tar.gz"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782295934163620",
+          "chainloop.material.type": "ARTIFACT"
+        },
+        "digest": {
+          "sha256": "27e4efa094adef0dc5375da7bce70437dde9d35d1e20598240debfc318f374da"
+        },
+        "name": "chainloop-cli-0.93.7-darwin-amd64.tar.gz.sig"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782297645680131",
+          "chainloop.material.type": "ARTIFACT"
+        },
+        "digest": {
+          "sha256": "389ea065be2dd50d07b27619b8594d4738b2c86481db969f62dd549e579af1e2"
+        },
+        "name": "chainloop-cli-0.93.7-darwin-arm64.tar.gz"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782300158976415",
+          "chainloop.material.type": "ARTIFACT"
+        },
+        "digest": {
+          "sha256": "47d5c22ee0f56bf3e7eed5c283fe66e5f61a7a9e913b9af1550dd07e71ac09e1"
+        },
+        "name": "chainloop-cli-0.93.7-darwin-arm64.tar.gz.sig"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782301800977382",
+          "chainloop.material.type": "ARTIFACT"
+        },
+        "digest": {
+          "sha256": "a57b0b11a51b8ebbc9d421bd68e6e82fd021f4e87742780ef30f0aaca0bdd1c2"
+        },
+        "name": "chainloop-cli-0.93.7-linux-amd64.tar.gz"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782304541799505",
+          "chainloop.material.type": "ARTIFACT"
+        },
+        "digest": {
+          "sha256": "754dea96fc2addc0fdb70f725686fd4b5e01a1aa69a1ed0726e4d08866400d42"
+        },
+        "name": "chainloop-cli-0.93.7-linux-amd64.tar.gz.sig"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782306140039811",
+          "chainloop.material.type": "ARTIFACT"
+        },
+        "digest": {
+          "sha256": "c63ee103397001d2e9727d30d02a4ce4e55b7e32da55f042a414c7424b42b21d"
+        },
+        "name": "chainloop-cli-0.93.7-linux-arm64.tar.gz"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782308650938558",
+          "chainloop.material.type": "ARTIFACT"
+        },
+        "digest": {
+          "sha256": "b5c7c73c9d4cd325b8da64135c28685715e8e19f6b48357eaf1a02e693734f37"
+        },
+        "name": "chainloop-cli-0.93.7-linux-arm64.tar.gz.sig"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782309843066922",
+          "chainloop.material.type": "ARTIFACT"
+        },
+        "digest": {
+          "sha256": "897f1dfc64736dd66ea8881ab07689d59e1bc147c45da0baa1de416834a46a3d"
+        },
+        "name": "checksums.txt"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782311062937592",
+          "chainloop.material.type": "ARTIFACT"
+        },
+        "digest": {
+          "sha256": "2f804aa3b95a81802c24e384e5e87e86f02ec23d043c9c4d3aa9243ee866b60b"
+        },
+        "name": "checksums.txt.sig"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782311526704542",
+          "chainloop.material.type": "SBOM_CYCLONEDX_JSON"
+        },
+        "digest": {
+          "sha256": "8b53305ead21a9ede6e0e3aee2fcc04f04796716e1a2b566ce03f3f8cbc2b130"
+        },
+        "name": "controlplane.cyclonedx.json"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782313410977824",
+          "chainloop.material.type": "ARTIFACT"
+        },
+        "digest": {
+          "sha256": "91c0b92358109bfc31ea4c58902d9b7f4f582ff9c4782fb276a685e914d3cc82"
+        },
+        "name": "cosign.pub"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782315689903312",
+          "chainloop.material.type": "HELM_CHART"
+        },
+        "digest": {
+          "sha256": "7cbbda1e5ab71fef561c0f123f5f584c8e0de523d4da80379599ce7a05c04c1f"
+        },
+        "name": "chainloop-0.93.7.tar.gz"
+      },
+      {
+        "annotations": {
+          "chainloop.material.image.tag": "v0.93.7",
+          "chainloop.material.name": "material-1720782317669410353",
+          "chainloop.material.type": "CONTAINER_IMAGE"
+        },
+        "digest": {
+          "sha256": "4a8eb6f9ae76460b682e7e9eb5504df9f7f2b2250d9c5cb63204442e265e2c5a"
+        },
+        "name": "ghcr.io/chainloop-dev/chainloop/control-plane"
+      },
+      {
+        "annotations": {
+          "chainloop.material.image.tag": "v0.93.7",
+          "chainloop.material.name": "material-1720782318334142313",
+          "chainloop.material.type": "CONTAINER_IMAGE"
+        },
+        "digest": {
+          "sha256": "4d329b2aee79b35ec5e6c462be5d8000565d5ccd13602427cd889fc91c187fc8"
+        },
+        "name": "ghcr.io/chainloop-dev/chainloop/artifact-cas"
+      },
+      {
+        "annotations": {
+          "chainloop.material.image.tag": "v0.93.7",
+          "chainloop.material.name": "material-1720782319034635257",
+          "chainloop.material.type": "CONTAINER_IMAGE"
+        },
+        "digest": {
+          "sha256": "571a5543151d651cbc62679c3f50c2e6cadfd2ff20279374c6d6106b3f70560f"
+        },
+        "name": "ghcr.io/chainloop-dev/chainloop/cli"
+      }
+    ],
+    "metadata": {
+      "finishedAt": "2024-07-12T11:05:19.808858785Z",
+      "initializedAt": "2024-07-12T11:04:48.604833219Z",
+      "name": "chainloop-vault-release",
+      "organization": "read-only-demo",
+      "project": "chainloop",
+      "team": "",
+      "workflowID": "2acc7ee5-21d1-4500-9ca4-2d25748a1ce0",
+      "workflowRunID": "37dd3d94-06e3-483f-83c2-18b1137e73ee"
+    },
+    "runnerType": "GITLAB",
+    "runnerURL": "https://github.com/chainloop-dev/chainloop/actions/runs/9906853011"
+  }
+}

--- a/pkg/policies/testdata/statement_missing_runner.json
+++ b/pkg/policies/testdata/statement_missing_runner.json
@@ -1,0 +1,245 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [
+    {
+      "name": "chainloop.workflow.chainloop-vault-release",
+      "digest": {
+        "sha256": "9ae495a85891eb1130fefc17bc89940c9aa96acb8355c26a3e0d73a5097d41d4"
+      }
+    },
+    {
+      "name": "git.head",
+      "digest": {
+        "sha1": "53f95f066b620172301e2a3879e7d593da05727e"
+      },
+      "annotations": {
+        "author.email": "devel@chainloop.dev",
+        "author.name": "Developer",
+        "date": "2024-07-12T10:16:04Z",
+        "message": "chore(vulns): fix CVEs in base image (#1088)\n\nSigned-off-by: Jose I. Paris <jiparis@chainloop.dev>",
+        "remotes": [
+          {
+            "name": "origin",
+            "url": "https://github.com/chainloop-dev/chainloop"
+          }
+        ]
+      }
+    }
+  ],
+  "predicateType": "chainloop.dev/attestation/v0.2",
+  "predicate": {
+    "buildType": "chainloop.dev/workflowrun/v0.1",
+    "builder": {
+      "id": "chainloop.dev/cli/0.90.1@sha256:431a0765636854095f0c78d01b61eb5558abe7c8de1608aa93eef1530deee0b6"
+    },
+    "env": {
+      "GITHUB_ACTOR": "jiparis",
+      "GITHUB_REF": "refs/tags/v0.93.7",
+      "GITHUB_REPOSITORY": "chainloop-dev/chainloop",
+      "GITHUB_REPOSITORY_OWNER": "chainloop-dev",
+      "GITHUB_RUN_ID": "9906853011",
+      "GITHUB_SHA": "53f95f066b620172301e2a3879e7d593da05727e",
+      "RUNNER_NAME": "GitHub Actions 193",
+      "RUNNER_OS": "Linux"
+    },
+    "materials": [
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782291120414953",
+          "chainloop.material.type": "SBOM_CYCLONEDX_JSON"
+        },
+        "digest": {
+          "sha256": "bc449b71c4a47f2f69b514f27e1d61250ff0af0cc554a68d331b40042d90a3da"
+        },
+        "name": "cas.cyclonedx.json"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782293352471920",
+          "chainloop.material.type": "ARTIFACT"
+        },
+        "digest": {
+          "sha256": "972ca204670aee23ed070619333fb04410ed996bf3c063ff88d35de0702fd478"
+        },
+        "name": "chainloop-cli-0.93.7-darwin-amd64.tar.gz"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782295934163620",
+          "chainloop.material.type": "ARTIFACT"
+        },
+        "digest": {
+          "sha256": "27e4efa094adef0dc5375da7bce70437dde9d35d1e20598240debfc318f374da"
+        },
+        "name": "chainloop-cli-0.93.7-darwin-amd64.tar.gz.sig"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782297645680131",
+          "chainloop.material.type": "ARTIFACT"
+        },
+        "digest": {
+          "sha256": "389ea065be2dd50d07b27619b8594d4738b2c86481db969f62dd549e579af1e2"
+        },
+        "name": "chainloop-cli-0.93.7-darwin-arm64.tar.gz"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782300158976415",
+          "chainloop.material.type": "ARTIFACT"
+        },
+        "digest": {
+          "sha256": "47d5c22ee0f56bf3e7eed5c283fe66e5f61a7a9e913b9af1550dd07e71ac09e1"
+        },
+        "name": "chainloop-cli-0.93.7-darwin-arm64.tar.gz.sig"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782301800977382",
+          "chainloop.material.type": "ARTIFACT"
+        },
+        "digest": {
+          "sha256": "a57b0b11a51b8ebbc9d421bd68e6e82fd021f4e87742780ef30f0aaca0bdd1c2"
+        },
+        "name": "chainloop-cli-0.93.7-linux-amd64.tar.gz"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782304541799505",
+          "chainloop.material.type": "ARTIFACT"
+        },
+        "digest": {
+          "sha256": "754dea96fc2addc0fdb70f725686fd4b5e01a1aa69a1ed0726e4d08866400d42"
+        },
+        "name": "chainloop-cli-0.93.7-linux-amd64.tar.gz.sig"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782306140039811",
+          "chainloop.material.type": "ARTIFACT"
+        },
+        "digest": {
+          "sha256": "c63ee103397001d2e9727d30d02a4ce4e55b7e32da55f042a414c7424b42b21d"
+        },
+        "name": "chainloop-cli-0.93.7-linux-arm64.tar.gz"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782308650938558",
+          "chainloop.material.type": "ARTIFACT"
+        },
+        "digest": {
+          "sha256": "b5c7c73c9d4cd325b8da64135c28685715e8e19f6b48357eaf1a02e693734f37"
+        },
+        "name": "chainloop-cli-0.93.7-linux-arm64.tar.gz.sig"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782309843066922",
+          "chainloop.material.type": "ARTIFACT"
+        },
+        "digest": {
+          "sha256": "897f1dfc64736dd66ea8881ab07689d59e1bc147c45da0baa1de416834a46a3d"
+        },
+        "name": "checksums.txt"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782311062937592",
+          "chainloop.material.type": "ARTIFACT"
+        },
+        "digest": {
+          "sha256": "2f804aa3b95a81802c24e384e5e87e86f02ec23d043c9c4d3aa9243ee866b60b"
+        },
+        "name": "checksums.txt.sig"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782311526704542",
+          "chainloop.material.type": "SBOM_CYCLONEDX_JSON"
+        },
+        "digest": {
+          "sha256": "8b53305ead21a9ede6e0e3aee2fcc04f04796716e1a2b566ce03f3f8cbc2b130"
+        },
+        "name": "controlplane.cyclonedx.json"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782313410977824",
+          "chainloop.material.type": "ARTIFACT"
+        },
+        "digest": {
+          "sha256": "91c0b92358109bfc31ea4c58902d9b7f4f582ff9c4782fb276a685e914d3cc82"
+        },
+        "name": "cosign.pub"
+      },
+      {
+        "annotations": {
+          "chainloop.material.cas": true,
+          "chainloop.material.name": "material-1720782315689903312",
+          "chainloop.material.type": "HELM_CHART"
+        },
+        "digest": {
+          "sha256": "7cbbda1e5ab71fef561c0f123f5f584c8e0de523d4da80379599ce7a05c04c1f"
+        },
+        "name": "chainloop-0.93.7.tar.gz"
+      },
+      {
+        "annotations": {
+          "chainloop.material.image.tag": "v0.93.7",
+          "chainloop.material.name": "material-1720782317669410353",
+          "chainloop.material.type": "CONTAINER_IMAGE"
+        },
+        "digest": {
+          "sha256": "4a8eb6f9ae76460b682e7e9eb5504df9f7f2b2250d9c5cb63204442e265e2c5a"
+        },
+        "name": "ghcr.io/chainloop-dev/chainloop/control-plane"
+      },
+      {
+        "annotations": {
+          "chainloop.material.image.tag": "v0.93.7",
+          "chainloop.material.name": "material-1720782318334142313",
+          "chainloop.material.type": "CONTAINER_IMAGE"
+        },
+        "digest": {
+          "sha256": "4d329b2aee79b35ec5e6c462be5d8000565d5ccd13602427cd889fc91c187fc8"
+        },
+        "name": "ghcr.io/chainloop-dev/chainloop/artifact-cas"
+      },
+      {
+        "annotations": {
+          "chainloop.material.image.tag": "v0.93.7",
+          "chainloop.material.name": "material-1720782319034635257",
+          "chainloop.material.type": "CONTAINER_IMAGE"
+        },
+        "digest": {
+          "sha256": "571a5543151d651cbc62679c3f50c2e6cadfd2ff20279374c6d6106b3f70560f"
+        },
+        "name": "ghcr.io/chainloop-dev/chainloop/cli"
+      }
+    ],
+    "metadata": {
+      "finishedAt": "2024-07-12T11:05:19.808858785Z",
+      "initializedAt": "2024-07-12T11:04:48.604833219Z",
+      "name": "chainloop-vault-release",
+      "organization": "read-only-demo",
+      "project": "chainloop",
+      "team": "",
+      "workflowID": "2acc7ee5-21d1-4500-9ca4-2d25748a1ce0",
+      "workflowRunID": "37dd3d94-06e3-483f-83c2-18b1137e73ee"
+    }
+  }
+}

--- a/pkg/policies/testdata/with_arguments.rego
+++ b/pkg/policies/testdata/with_arguments.rego
@@ -1,0 +1,49 @@
+package main
+
+import rego.v1
+
+################################
+# Common section do NOT change #
+################################
+
+result := {
+    "skipped": skipped,
+    "violations": violations,
+    "skip_reason": skip_reason,
+}
+
+default skip_reason := ""
+
+skip_reason := m if {
+    not valid_input
+    m := "invalid input"
+}
+
+default skipped := true
+
+skipped := false if valid_input
+
+########################################
+# EO Common section, custom code below #
+########################################
+
+# Validates if the input is valid and can be understood by this policy
+valid_input := true
+
+# If the input is valid, check for any policy violation here
+violations contains msg if {
+	valid_input
+	not valid_developer
+	msg := "Invalid developer"
+}
+
+valid_developer if {
+	some subject in input.subject
+	subject.annotations["author.email"] == input.args.email
+}
+
+
+valid_developer if {
+	some subject in input.subject
+	subject.annotations["author.email"] in input.args.email_array
+}

--- a/pkg/policies/testdata/with_arguments.yaml
+++ b/pkg/policies/testdata/with_arguments.yaml
@@ -1,0 +1,7 @@
+apiVersion: workflowcontract.chainloop.dev/v1
+kind: Policy
+metadata:
+  name: workflow
+spec:
+  type: ATTESTATION
+  path: with_arguments.rego

--- a/pkg/policies/testdata/workflow.rego
+++ b/pkg/policies/testdata/workflow.rego
@@ -1,0 +1,53 @@
+package main
+
+import rego.v1
+
+################################
+# Common section do NOT change #
+################################
+
+result := {
+    "skipped": skipped,
+    "violations": violations,
+    "skip_reason": skip_reason,
+}
+
+default skip_reason := ""
+
+skip_reason := m if {
+    not valid_input
+    m := "invalid input"
+}
+
+default skipped := true
+
+skipped := false if valid_input
+
+########################################
+# EO Common section, custom code below #
+########################################
+
+# Validates if the input is valid and can be understood by this policy
+valid_input := true
+
+# If the input is valid, check for any policy violation here
+violations contains msg if {
+    valid_input
+    not is_workflow
+    msg := "incorrect workflow"
+}
+
+violations contains msg if {
+    valid_input
+    not is_github
+    msg := "incorrect runner"
+}
+
+is_workflow if {
+    input.predicate.metadata.name == "chainloop-vault-release"
+}
+
+is_github if {
+    input.predicate.runnerType == "GITHUB_ACTION"
+    input.predicate.env.GITHUB_SHA
+}

--- a/pkg/policies/testdata/workflow.yaml
+++ b/pkg/policies/testdata/workflow.yaml
@@ -1,0 +1,7 @@
+apiVersion: workflowcontract.chainloop.dev/v1
+kind: Policy
+metadata:
+  name: workflow
+spec:
+  type: ATTESTATION
+  path: workflow.rego

--- a/pkg/policies/testdata/workflow_embedded.yaml
+++ b/pkg/policies/testdata/workflow_embedded.yaml
@@ -1,0 +1,61 @@
+apiVersion: workflowcontract.chainloop.dev/v1
+kind: Policy
+metadata:
+  name: workflow
+spec:
+  type: ATTESTATION
+  embedded: |
+    package main
+
+    import rego.v1
+
+    ################################
+    # Common section do NOT change #
+    ################################
+
+    result := {
+        "skipped": skipped,
+        "violations": violations,
+        "skip_reason": skip_reason,
+    }
+
+    default skip_reason := ""
+
+    skip_reason := m if {
+        not valid_input
+        m := "invalid input"
+    }
+
+    default skipped := true
+
+    skipped := false if valid_input
+
+    ########################################
+    # EO Common section, custom code below #
+    ########################################
+
+    # Validates if the input is valid and can be understood by this policy
+    valid_input := true
+
+    # If the input is valid, check for any policy violation here
+    violations contains msg if {
+        valid_input
+        not is_workflow
+        msg := "incorrect workflow"
+    }
+
+    violations contains msg if {
+        valid_input
+        not is_github
+        msg := "incorrect runner"
+    }
+
+    is_workflow if {
+        input.predicate.metadata.name == "chainloop-vault-release"
+    }
+
+    is_github if {
+        input.predicate.runnerType == "GITHUB_ACTION"
+        input.predicate.env.GITHUB_SHA
+    }
+

--- a/pkg/policies/testdata/wrong_policy.rego
+++ b/pkg/policies/testdata/wrong_policy.rego
@@ -1,0 +1,7 @@
+package main
+
+# wrong policy without a "violations" rule
+
+is_wrong {
+    true
+}

--- a/pkg/policies/testdata/wrong_policy.yaml
+++ b/pkg/policies/testdata/wrong_policy.yaml
@@ -1,0 +1,6 @@
+apiVersion: workflowcontract.chainloop.dev/v1
+kind: Policy
+metadata:
+  name: wrong_policy
+spec:
+  path: wrong_policy.rego


### PR DESCRIPTION
## Summary
Implemented automatic missing boilerplate injection for rego policies in the engine before policy evaluation.

### Changes
- Rego policy engine now detects missing required rules and injects them after `package` and `import` declarations.
- Removed boilerplate rules from policy template used in `policy devel init`.
- Updated `policy devel lint` since we no longer require `result` rule to be present in the policy.

### Example
Before policy required declaration of all rules used internally 
```
package main

import rego.v1

result := {
    "skipped": skipped,
    "violations": violations,
    "skip_reason": skip_reason,
}

default skip_reason := ""

skip_reason := m if {
    not valid_input
    m := "the file content is not recognized"
}

default skipped := true

skipped := false if valid_input

default valid_input := true

violations contains msg if {
    count(input.components) < 2
    msg := "SBOM must have at least 2 components"
}
```
Now these rules are injected into policy if they are missing, so above policy can be simplified to:
```
package main

import rego.v1

violations contains msg if {
    count(input.components) < 2
    msg := "SBOM must have at least 2 components"
}
```
