### PR TITLE
feat: add configurable initial delay with jitter to CAS backend validation

### DIFF
--- a/app/controlplane/cmd/main.go
+++ b/app/controlplane/cmd/main.go
@@ -186,9 +186,9 @@ func main() {
 		// Start the background CAS Backend checker for ALL backends (every 24 hours)
 		// Start around 24h mark to avoid overlap with default checker
 		go app.casBackendChecker.Start(ctx, &biz.CASBackendCheckerOpts{
-			CheckInterval:  24 * time.Hour,
-			SkipFirstCheck: true,
-			OnlyDefaults:   toPtr(false),
+			CheckInterval: 24 * time.Hour,
+			InitialDelay:  24 * time.Hour,
+			OnlyDefaults:  toPtr(false),
 		})
 	}
 

--- a/app/controlplane/pkg/biz/casbackend_checker.go
+++ b/app/controlplane/pkg/biz/casbackend_checker.go
@@ -45,8 +45,7 @@ type CASBackendCheckerOpts struct {
 	// Timeout for each individual backend validation, defaults to 10 seconds
 	ValidationTimeout time.Duration
 	// Initial delay before first validation (includes jitter). If not set, runs immediately.
-	InitialDelay   time.Duration
-	SkipFirstCheck bool
+	InitialDelay time.Duration
 }
 
 // NewCASBackendChecker creates a new CAS backend checker that will periodically validate
@@ -79,11 +78,11 @@ func (c *CASBackendChecker) Start(ctx context.Context, opts *CASBackendCheckerOp
 
 	// Apply initial delay from options if provided
 	var initialDelay = 0 * time.Second
-	if opts != nil && !opts.SkipFirstCheck && opts.InitialDelay > 0 {
+	if opts != nil && opts.InitialDelay > 0 {
 		initialDelay = opts.InitialDelay
 	}
 
-	c.logger.Infow("msg", "CAS backend checker configured", "skipFirstCheck", opts.SkipFirstCheck, "initialDelay", initialDelay, "interval", interval, "allBackends", !onlyDefaults, "timeout", c.validationTimeout)
+	c.logger.Infow("msg", "CAS backend checker configured", "initialDelay", initialDelay, "interval", interval, "allBackends", !onlyDefaults, "timeout", c.validationTimeout)
 
 	select {
 	case <-ctx.Done():
@@ -93,11 +92,9 @@ func (c *CASBackendChecker) Start(ctx context.Context, opts *CASBackendCheckerOp
 		// Continue to first check
 	}
 
-	if opts != nil && !opts.SkipFirstCheck {
-		// Run first check
-		if err := c.checkBackends(ctx, onlyDefaults); err != nil {
-			c.logger.Errorf("initial CAS backend check failed: %v", err)
-		}
+	// Run first check
+	if err := c.checkBackends(ctx, onlyDefaults); err != nil {
+		c.logger.Errorf("initial CAS backend check failed: %v", err)
 	}
 
 	// Start periodic checks


### PR DESCRIPTION
## Summary

- Implement dual CAS backend validation with different frequencies
- Default backends validated every 30 minutes with startup jitter
- All backends validated every 24 hours without initial check overhead

Before, we were validating all the CAS backends at boot; now, we only validate the default ones with some jitter.

Additionally, the check for all backends happen at a 24 hours interval now. 


Fixes #2516