### PR TITLE
chore(ci): update cli ee flag

### DIFF
--- a/.github/workflows/scm_configuration_check.yaml
+++ b/.github/workflows/scm_configuration_check.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install Chainloop
         run: |
-          curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s -- -ee
+          curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s -- --ee
 
       - name: Initialize Attestation
         run: |


### PR DESCRIPTION
Updates flag used to install CLI EE from `-ee` to `--ee`.
Requires `install.sh` to be updated before merge.