### PR TITLE
feat(gatherer): Use GitHub app instead of PAT for gatherer

### DIFF
--- a/.github/workflows/scm_configuration_check.yaml
+++ b/.github/workflows/scm_configuration_check.yaml
@@ -33,7 +33,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.GATHERER_APP_ID }}
+          app-id: ${{ vars.CHAINLOOP_GATHERER_APP_ID }}
           private-key: ${{ secrets.GATHERER_APP_PRIVATE_KEY }}
 
       - name: Gather runner context data


### PR DESCRIPTION
This PR makes changes on the gatherer so it uses the Chainloop's Gatherer GitHub action rather than the personal access token.
