### PR TITLE
feat(cli): Expose Chainloop CLI logger

### DIFF
--- a/app/cli/cmd/artifact.go
+++ b/app/cli/cmd/artifact.go
@@ -47,7 +47,7 @@ func wrappedArtifactConn(cpConn *grpc.ClientConn, role pb.CASCredentialsServiceG
 	}
 
 	if apiInsecure() {
-		logger.Warn().Msg("API contacted in insecure mode")
+		Logger.Warn().Msg("API contacted in insecure mode")
 	}
 
 	var opts = []grpcconn.Option{

--- a/app/cli/cmd/attached_integration_delete.go
+++ b/app/cli/cmd/attached_integration_delete.go
@@ -32,7 +32,7 @@ func newAttachedIntegrationDeleteCmd() *cobra.Command {
 				return err
 			}
 
-			logger.Info().Msg("integration detached!")
+			Logger.Info().Msg("integration detached!")
 			return nil
 		},
 	}

--- a/app/cli/cmd/attestation_add.go
+++ b/app/cli/cmd/attestation_add.go
@@ -112,7 +112,7 @@ func newAttestationAddCmd() *cobra.Command {
 						return err
 					}
 
-					logger.Info().Msg("material added to attestation")
+					Logger.Info().Msg("material added to attestation")
 
 					policies, err := a.GetPolicyEvaluations(cmd.Context(), attestationID)
 					if err != nil {

--- a/app/cli/cmd/attestation_init.go
+++ b/app/cli/cmd/attestation_init.go
@@ -54,11 +54,11 @@ func newAttestationInitCmd() *cobra.Command {
 				cfg, path, err := loadDotChainloopConfigWithParentTraversal()
 				// we do gracefully load, if not found, or any other error we continue
 				if err != nil {
-					logger.Debug().Msgf("failed to load chainloop config: %s", err)
+					Logger.Debug().Msgf("failed to load chainloop config: %s", err)
 					return nil
 				}
 
-				logger.Debug().Msgf("loaded version %s from config file %s", cfg.ProjectVersion, path)
+				Logger.Debug().Msgf("loaded version %s from config file %s", cfg.ProjectVersion, path)
 
 				projectVersion = cfg.ProjectVersion
 			}
@@ -109,7 +109,7 @@ func newAttestationInitCmd() *cobra.Command {
 				return newGracefulError(err)
 			}
 
-			logger.Info().Msg("Attestation initialized! now you can check its status or add materials to it")
+			Logger.Info().Msg("Attestation initialized! now you can check its status or add materials to it")
 
 			// Show the status information
 			statusAction, err := action.NewAttestationStatus(&action.AttestationStatusOpts{ActionsOpts: ActionOpts, UseAttestationRemoteState: useAttestationRemoteState, LocalStatePath: attestationLocalStatePath})
@@ -123,11 +123,11 @@ func newAttestationInitCmd() *cobra.Command {
 			}
 
 			if res.DryRun {
-				logger.Info().Msg("The attestation is being crafted in dry-run mode. It will not get stored once rendered")
+				Logger.Info().Msg("The attestation is being crafted in dry-run mode. It will not get stored once rendered")
 			}
 
 			if projectName == "" {
-				logger.Warn().Msg("DEPRECATION WARNING: --project not set, this will be required in the near future")
+				Logger.Warn().Msg("DEPRECATION WARNING: --project not set, this will be required in the near future")
 			}
 
 			return output.EncodeOutput(flagOutputFormat, res, fullStatusTable)

--- a/app/cli/cmd/attestation_push.go
+++ b/app/cli/cmd/attestation_push.go
@@ -126,7 +126,7 @@ func newAttestationPushCmd() *cobra.Command {
 			// and fail the command if needed
 			if res.Status.MustBlockOnPolicyViolations {
 				if bypassPolicyCheck {
-					logger.Warn().Msg(exceptionBypassPolicyCheck)
+					Logger.Warn().Msg(exceptionBypassPolicyCheck)
 					return nil
 				}
 

--- a/app/cli/cmd/attestation_reset.go
+++ b/app/cli/cmd/attestation_reset.go
@@ -55,7 +55,7 @@ func newAttestationResetCmd() *cobra.Command {
 				msg = "Attestation marked as failed"
 			}
 
-			logger.Info().Msg(msg)
+			Logger.Info().Msg(msg)
 
 			return nil
 		},

--- a/app/cli/cmd/auth_delete_account.go
+++ b/app/cli/cmd/auth_delete_account.go
@@ -54,7 +54,7 @@ func newAuthDeleteAccountCmd() *cobra.Command {
 				return err
 			}
 
-			logger.Info().Msg("Account deleted :(")
+			Logger.Info().Msg("Account deleted :(")
 			return nil
 		},
 	}

--- a/app/cli/cmd/auth_login.go
+++ b/app/cli/cmd/auth_login.go
@@ -81,7 +81,7 @@ func interactiveAuth(forceHeadless bool) error {
 
 	err = openbrowser(serverLoginURL.String())
 	if err != nil {
-		logger.Debug().Err(err).Msg("falling back to manual login")
+		Logger.Debug().Err(err).Msg("falling back to manual login")
 		return headlessAuth(serverLoginURL)
 	}
 
@@ -90,7 +90,7 @@ func interactiveAuth(forceHeadless bool) error {
 	// Run server in background
 	http.HandleFunc(callbackURL.Path, a.handleCallback)
 	go func() {
-		logger.Info().Msg("waiting for the authentication to be completed, please check your browser")
+		Logger.Info().Msg("waiting for the authentication to be completed, please check your browser")
 
 		server := &http.Server{ReadHeaderTimeout: time.Second}
 
@@ -132,7 +132,7 @@ func headlessAuth(loginURL *url.URL) error {
 	}
 
 	fmt.Println("")
-	logger.Info().Msg("login successful!")
+	Logger.Info().Msg("login successful!")
 
 	return nil
 }
@@ -160,7 +160,7 @@ func (a *app) handleCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	logger.Info().Msg("login successful!")
+	Logger.Info().Msg("login successful!")
 	fmt.Fprintln(w, "login successful, you can now close this window and go back to the terminal")
 }
 

--- a/app/cli/cmd/casbackend_delete.go
+++ b/app/cli/cmd/casbackend_delete.go
@@ -40,7 +40,7 @@ func newCASBackendDeleteCmd() *cobra.Command {
 				return err
 			}
 
-			logger.Info().Msg("Backend deleted")
+			Logger.Info().Msg("Backend deleted")
 
 			return nil
 		},

--- a/app/cli/cmd/config.go
+++ b/app/cli/cmd/config.go
@@ -87,7 +87,7 @@ var (
 // It supports both .yaml and .yml extensions
 func loadDotChainloopConfigWithParentTraversal() (*DotChainloopConfig, string, error) {
 	searchPaths := getConfigSearchPaths()
-	logger.Debug().Msgf("searching %s.[yaml|yml] file in %q", dotChainloopConfigFilename, searchPaths)
+	Logger.Debug().Msgf("searching %s.[yaml|yml] file in %q", dotChainloopConfigFilename, searchPaths)
 
 	for _, currentDir := range searchPaths {
 		for _, ext := range []string{".yaml", ".yml"} {

--- a/app/cli/cmd/config_reset.go
+++ b/app/cli/cmd/config_reset.go
@@ -30,7 +30,7 @@ func newConfigResetCmd() *cobra.Command {
 			configFile := viper.ConfigFileUsed()
 			err := os.Remove(configFile)
 			cobra.CheckErr(err)
-			logger.Info().Str("file", configFile).Msg("Config file removed")
+			Logger.Info().Str("file", configFile).Msg("Config file removed")
 		},
 	}
 

--- a/app/cli/cmd/errors.go
+++ b/app/cli/cmd/errors.go
@@ -87,6 +87,6 @@ func runWithBackoffRetry(fn func() error) error {
 		},
 		backoff.NewExponentialBackOff(backoff.WithMaxElapsedTime(3*time.Minute)),
 		func(err error, delay time.Duration) {
-			logger.Err(err).Msgf("retrying in %s", delay)
+			Logger.Err(err).Msgf("retrying in %s", delay)
 		})
 }

--- a/app/cli/cmd/organization_apitoken_revoke.go
+++ b/app/cli/cmd/organization_apitoken_revoke.go
@@ -34,7 +34,7 @@ func newAPITokenRevokeCmd() *cobra.Command {
 				return fmt.Errorf("revoking API token: %w", err)
 			}
 
-			logger.Info().Msg("API token revoked!")
+			Logger.Info().Msg("API token revoked!")
 			return nil
 		},
 	}

--- a/app/cli/cmd/organization_create.go
+++ b/app/cli/cmd/organization_create.go
@@ -40,7 +40,7 @@ func newOrganizationCreateCmd() *cobra.Command {
 				return fmt.Errorf("writing config file: %w", err)
 			}
 
-			logger.Info().Msgf("Organization %q created!", org.Name)
+			Logger.Info().Msgf("Organization %q created!", org.Name)
 			return nil
 		},
 	}

--- a/app/cli/cmd/organization_delete.go
+++ b/app/cli/cmd/organization_delete.go
@@ -48,7 +48,7 @@ func newOrganizationDeleteCmd() *cobra.Command {
 				return fmt.Errorf("writing config file: %w", err)
 			}
 
-			logger.Info().Str("organization", orgName).Msg("Organization deleted")
+			Logger.Info().Str("organization", orgName).Msg("Organization deleted")
 			return nil
 		},
 	}

--- a/app/cli/cmd/organization_invitation_revoke.go
+++ b/app/cli/cmd/organization_invitation_revoke.go
@@ -32,7 +32,7 @@ func newOrganizationInvitationRevokeCmd() *cobra.Command {
 				return err
 			}
 
-			logger.Info().Msg("Invitation Revoked!")
+			Logger.Info().Msg("Invitation Revoked!")
 			return nil
 		},
 	}

--- a/app/cli/cmd/organization_leave.go
+++ b/app/cli/cmd/organization_leave.go
@@ -71,7 +71,7 @@ func newOrganizationLeaveCmd() *cobra.Command {
 				return fmt.Errorf("writing config file: %w", err)
 			}
 
-			logger.Info().Msg("Membership deleted")
+			Logger.Info().Msg("Membership deleted")
 			return nil
 		},
 	}

--- a/app/cli/cmd/organization_member_delete.go
+++ b/app/cli/cmd/organization_member_delete.go
@@ -63,7 +63,7 @@ func newOrganizationMemberDeleteCmd() *cobra.Command {
 				return err
 			}
 
-			logger.Info().Msg("Member deleted")
+			Logger.Info().Msg("Member deleted")
 			return nil
 		},
 	}

--- a/app/cli/cmd/organization_member_list.go
+++ b/app/cli/cmd/organization_member_list.go
@@ -93,11 +93,11 @@ func newOrganizationMemberList() *cobra.Command {
 			if pgResponse.TotalPages >= paginationOpts.Page {
 				inPage := min(paginationOpts.Limit, len(res.Memberships))
 				lowerBound := (paginationOpts.Page - 1) * paginationOpts.Limit
-				logger.Info().Msg(fmt.Sprintf("Showing [%d-%d] out of %d", lowerBound+1, lowerBound+inPage, pgResponse.TotalCount))
+				Logger.Info().Msg(fmt.Sprintf("Showing [%d-%d] out of %d", lowerBound+1, lowerBound+inPage, pgResponse.TotalCount))
 			}
 
 			if pgResponse.TotalCount > pgResponse.Page*pgResponse.PageSize {
-				logger.Info().Msg(fmt.Sprintf("Next page available: %d", pgResponse.Page+1))
+				Logger.Info().Msg(fmt.Sprintf("Next page available: %d", pgResponse.Page+1))
 			}
 
 			return nil

--- a/app/cli/cmd/organization_set.go
+++ b/app/cli/cmd/organization_set.go
@@ -61,7 +61,7 @@ func newOrganizationSet() *cobra.Command {
 				}
 			}
 
-			logger.Info().Msg("Organization switched!")
+			Logger.Info().Msg("Organization switched!")
 			return output.EncodeOutput(flagOutputFormat, []*action.MembershipItem{membership}, orgMembershipTableOutput)
 		},
 	}

--- a/app/cli/cmd/organization_update.go
+++ b/app/cli/cmd/organization_update.go
@@ -45,7 +45,7 @@ func newOrganizationUpdateCmd() *cobra.Command {
 				return err
 			}
 
-			logger.Info().Msg("Organization updated!")
+			Logger.Info().Msg("Organization updated!")
 			return nil
 		},
 	}

--- a/app/cli/cmd/policy_develop_init.go
+++ b/app/cli/cmd/policy_develop_init.go
@@ -63,7 +63,7 @@ By default, it creates chainloop-policy.yaml and chainloop-policy.rego files.`,
 				return newGracefulError(err)
 			}
 
-			logger.Info().Msg("Initialized policy files")
+			Logger.Info().Msg("Initialized policy files")
 
 			return nil
 		},

--- a/app/cli/cmd/policy_develop_lint.go
+++ b/app/cli/cmd/policy_develop_lint.go
@@ -54,7 +54,7 @@ func newPolicyDevelopLintCmd() *cobra.Command {
 			}
 
 			if result.Valid {
-				logger.Info().Msg("policy is valid!")
+				Logger.Info().Msg("policy is valid!")
 				return nil
 			}
 

--- a/app/cli/cmd/registered_integration_delete.go
+++ b/app/cli/cmd/registered_integration_delete.go
@@ -30,7 +30,7 @@ func newRegisteredIntegrationDeleteCmd() *cobra.Command {
 				return err
 			}
 
-			logger.Info().Msg("Integration deregistered!")
+			Logger.Info().Msg("Integration deregistered!")
 			return nil
 		},
 	}

--- a/app/cli/cmd/workflow_contract_apply.go
+++ b/app/cli/cmd/workflow_contract_apply.go
@@ -53,7 +53,7 @@ or update it if it already exists.`,
 				return err
 			}
 
-			logger.Info().Msg("Contract applied!")
+			Logger.Info().Msg("Contract applied!")
 			return output.EncodeOutput(flagOutputFormat, res, contractItemTableOutput)
 		},
 	}

--- a/app/cli/cmd/workflow_contract_create.go
+++ b/app/cli/cmd/workflow_contract_create.go
@@ -48,7 +48,7 @@ func newWorkflowContractCreateCmd() *cobra.Command {
 				return err
 			}
 
-			logger.Info().Msg("Contract created!")
+			Logger.Info().Msg("Contract created!")
 			return output.EncodeOutput(flagOutputFormat, res, contractItemTableOutput)
 		},
 	}

--- a/app/cli/cmd/workflow_contract_delete.go
+++ b/app/cli/cmd/workflow_contract_delete.go
@@ -30,7 +30,7 @@ func newWorkflowContractDeleteCmd() *cobra.Command {
 			if err := action.NewWorkflowContractDelete(ActionOpts).Run(name); err != nil {
 				return err
 			}
-			logger.Info().Msg("contract deleted!")
+			Logger.Info().Msg("contract deleted!")
 			return nil
 		},
 	}

--- a/app/cli/cmd/workflow_contract_describe.go
+++ b/app/cli/cmd/workflow_contract_describe.go
@@ -62,7 +62,7 @@ func newWorkflowContractDescribeCmd() *cobra.Command {
 
 func encodeContractOutput(run *action.WorkflowContractWithVersionItem) error {
 	if flagOutputFormat != formatContract {
-		logger.Info().Msg("To download the contract, run the command with the \"--output schema\" option")
+		Logger.Info().Msg("To download the contract, run the command with the \"--output schema\" option")
 	}
 
 	err := output.EncodeOutput(flagOutputFormat, run, contractDescribeTableOutput)

--- a/app/cli/cmd/workflow_contract_update.go
+++ b/app/cli/cmd/workflow_contract_update.go
@@ -49,7 +49,7 @@ func newWorkflowContractUpdateCmd() *cobra.Command {
 				return err
 			}
 
-			logger.Info().Msg("Contract updated!")
+			Logger.Info().Msg("Contract updated!")
 			return output.EncodeOutput(flagOutputFormat, res, contractDescribeTableOutput)
 		},
 	}

--- a/app/cli/cmd/workflow_create.go
+++ b/app/cli/cmd/workflow_create.go
@@ -65,7 +65,7 @@ func newWorkflowCreateCmd() *cobra.Command {
 				if s, ok := status.FromError(err); ok {
 					if s.Code() == codes.AlreadyExists {
 						if skipIfExists {
-							logger.Info().Msg("Workflow already exists")
+							Logger.Info().Msg("Workflow already exists")
 							return nil
 						}
 					}
@@ -79,7 +79,7 @@ func newWorkflowCreateCmd() *cobra.Command {
 				return fmt.Errorf("failed to print workflow: %w", err)
 			}
 
-			logger.Info().Msg("To Attest this workflow you'll need to provide an API token. See \"chainloop organization api-token\" command for more information.\n")
+			Logger.Info().Msg("To Attest this workflow you'll need to provide an API token. See \"chainloop organization api-token\" command for more information.\n")
 
 			return nil
 		},

--- a/app/cli/cmd/workflow_delete.go
+++ b/app/cli/cmd/workflow_delete.go
@@ -29,7 +29,7 @@ func newWorkflowDeleteCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := action.NewWorkflowDelete(ActionOpts).Run(name, projectName)
 			if err == nil {
-				logger.Info().Msg("Workflow deleted!")
+				Logger.Info().Msg("Workflow deleted!")
 			}
 			return err
 		},

--- a/app/cli/cmd/workflow_list.go
+++ b/app/cli/cmd/workflow_list.go
@@ -70,11 +70,11 @@ func newWorkflowListCmd() *cobra.Command {
 			if pgResponse.TotalPages >= paginationOpts.Page {
 				inPage := min(paginationOpts.Limit, len(res.Workflows))
 				lowerBound := (paginationOpts.Page - 1) * paginationOpts.Limit
-				logger.Info().Msg(fmt.Sprintf("Showing [%d-%d] out of %d", lowerBound+1, lowerBound+inPage, pgResponse.TotalCount))
+				Logger.Info().Msg(fmt.Sprintf("Showing [%d-%d] out of %d", lowerBound+1, lowerBound+inPage, pgResponse.TotalCount))
 			}
 
 			if pgResponse.TotalCount > pgResponse.Page*pgResponse.PageSize {
-				logger.Info().Msg(fmt.Sprintf("Next page available: %d", pgResponse.Page+1))
+				Logger.Info().Msg(fmt.Sprintf("Next page available: %d", pgResponse.Page+1))
 			}
 
 			return nil

--- a/app/cli/cmd/workflow_update.go
+++ b/app/cli/cmd/workflow_update.go
@@ -52,7 +52,7 @@ func newWorkflowUpdateCmd() *cobra.Command {
 				return err
 			}
 
-			logger.Info().Msg("Workflow updated!")
+			Logger.Info().Msg("Workflow updated!")
 			return output.EncodeOutput(flagOutputFormat, &action.WorkflowListResult{Workflows: []*action.WorkflowItem{res}}, WorkflowListTableOutput)
 		},
 	}

--- a/app/cli/cmd/workflow_workflow_run_describe.go
+++ b/app/cli/cmd/workflow_workflow_run_describe.go
@@ -132,14 +132,14 @@ func workflowRunDescribeTableOutput(run *action.WorkflowRunItemFull) error {
 
 	if run.WorkflowRun.FinishedAt == nil {
 		gt.Render()
-		logger.Info().Msg("the attestation crafting process is in progress, it has not been received yet")
+		Logger.Info().Msg("the attestation crafting process is in progress, it has not been received yet")
 		return nil
 	}
 
 	att := run.Attestation
 	if att == nil {
 		gt.Render()
-		logger.Warn().Msg("there was an issue retrieving the attestation")
+		Logger.Warn().Msg("there was an issue retrieving the attestation")
 		return nil
 	}
 
@@ -174,7 +174,7 @@ func workflowRunDescribeTableOutput(run *action.WorkflowRunItemFull) error {
 	gt.Render()
 
 	predicateV1Table(att)
-	logger.Info().Msg("you can use the flag \"--output statement\" to see the full in-toto statement")
+	Logger.Info().Msg("you can use the flag \"--output statement\" to see the full in-toto statement")
 	return nil
 }
 
@@ -286,7 +286,7 @@ func encodeAttestationOutput(run *action.WorkflowRunItemFull, writer io.Writer) 
 
 	// Try to encode the output using some additional custom formats
 	if run.Attestation == nil {
-		logger.Info().Msg("This run doesn't have an attestation, noop")
+		Logger.Info().Msg("This run doesn't have an attestation, noop")
 		return nil
 	}
 

--- a/app/cli/cmd/workflow_workflow_run_list.go
+++ b/app/cli/cmd/workflow_workflow_run_list.go
@@ -71,10 +71,10 @@ func newWorkflowWorkflowRunListCmd() *cobra.Command {
 				return nil
 			}
 
-			logger.Info().Msg("Pagination options \n")
+			Logger.Info().Msg("Pagination options \n")
 
 			if next != "" {
-				logger.Info().Msgf("--next %s\n", next)
+				Logger.Info().Msgf("--next %s\n", next)
 			}
 
 			return nil


### PR DESCRIPTION
This patch exposes the Chainloop's CLI logger so other extensions of the CLI can use the same logger in their commands and operations.