### PR TITLE
feat(contract): Modify codeql contract to include sast policy group

### DIFF
--- a/.github/workflows/contracts/chainloop-vault-codeql.yml
+++ b/.github/workflows/contracts/chainloop-vault-codeql.yml
@@ -22,3 +22,4 @@ spec:
     - ref: slsa-checks
       with:
         runner: GITHUB_ACTION
+    - ref: sast


### PR DESCRIPTION
Updates the CodeQL contract to use the new `sast` policy group. Do not merge until the policy group is live.