### PR TITLE
chore: update chainloop.yaml method

### DIFF
--- a/.chainloop.yml
+++ b/.chainloop.yml
@@ -1,5 +1,6 @@
-# This can indicate the next version and by default it will be marked as pre-release
-projectVersion: v1.56.0
+# This indicates the [current version]+next
+# to indicate that we are building a new version of the project
+projectVersion: v1.55.0+next
 
 # Experimental feature used by Chainloop labs shared workflow https://github.com/chainloop-dev/labs
 # It maps the material names with location in disk so they get automatically attested

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -164,7 +164,7 @@ jobs:
       - name: Bump Chart and Dagger Version
         run: .github/workflows/utils/bump-chart-and-dagger-version.sh deployment/chainloop extras/dagger ${{ github.ref_name }}
       - name: Bump Project Version
-        run: .github/workflows/utils/bump-project-version.sh
+        run: .github/workflows/utils/bump-project-version.sh ${{ github.ref_name }}
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5.0.2

--- a/.github/workflows/utils/bump-project-version.sh
+++ b/.github/workflows/utils/bump-project-version.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-# Bump the Chainloop project version to the next minor version to the version defined .chainloop.yml
+# Update the Chainloop project version in .chainloop.yml to the provided version + "+next"
 
 set -e
 
 die () {
    echo >&2 "$@"
-   echo "usage: bump-project-version.sh [configFile]"
+   echo "usage: bump-project-version.sh <version> [configFile]"
    exit 1
 }
 
@@ -15,35 +15,18 @@ if [[ -n "${DEBUG}" ]]; then
    set -x
 fi
 
+[ "$#" -ge 1 ] || die "Version argument is required"
+
+version="${1}"
 project_yaml=".chainloop.yml"
 # manual override
-if [[ -n "${1}" ]]; then
-   project_yaml="${1}"
+if [[ -n "${2}" ]]; then
+   project_yaml="${2}"
 fi
 
-if [[ -n "$GITHUB_REF_NAME" ]]; then
-  # Bump from provided version tag
-  version=$(echo $GITHUB_REF_NAME | awk -F'[ .]' '{print $1"."$2+1"."0}')
-else
-  # Load the previous version and bump appropriately
-  version=$(cat "${project_yaml}" | awk '/^projectVersion:/ {
-      version = $2;
-      if (version ~ /-rc/) {
-          # Handle release candidate versions (e.g., v1.0.0-rc.1 -> v1.0.0-rc.2)
-          split(version, parts, /-rc\./);
-          rc_num = parts[2] + 1;
-          print parts[1] "-rc." rc_num;
-      }
-      else {
-          # Load the previous version and BUMP THE MINOR
-          # Handle minor version bumps (e.g., v1.0.0 -> v1.1.0)
-          split(version, ver_parts, /\./);
-          ver_parts[2] = ver_parts[2] + 1;
-          print ver_parts[1] "." ver_parts[2] ".0";
-      }
-  }')
-fi
+# Append "+next" to the version
+version_with_next="${version}+next"
 
 # Update the project yaml file
-sed -i "s#^projectVersion:.*#projectVersion: ${version}#g" "${project_yaml}"
+sed -i "s#^projectVersion:.*#projectVersion: ${version_with_next}#g" "${project_yaml}"
 


### PR DESCRIPTION
Since we don't know what the next version will be and this is causing confusion, we're going to indicate in the script the current version plus the next suffix. 

This, in tandem with #2541 will make sure we do not record invalid versions