### PR TITLE
chore: use ee CLI for project renaming

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Install Chainloop
         run: |
-          curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s
+          curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s -- --ee
 
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION
Fixes 
<img width="1720" height="1078" alt="image" src="https://github.com/user-attachments/assets/d6560f0c-1bb8-488f-b246-a4a69eb12e7e" />
