### PR TITLE
fix(ci): missing CHAINLOOP_PROJECT_NAME env var in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -168,6 +168,8 @@ jobs:
           chainloop attestation add --name source-code --value /tmp/source-code.tar.gz --kind ARTIFACT --attestation-id ${{ env.ATTESTATION_ID }}
 
       - name: Promote Chainloop Project Version
+        env:
+          CHAINLOOP_PROJECT_NAME: "chainloop"
         run: |
           current_version="$(cat .chainloop.yml | awk '/^projectVersion:/ {print $2}')"
           # Rename the existing pre-release into the actual release name


### PR DESCRIPTION
## Summary

Fixes missing environment variable in the release workflow that was causing the project version promotion step to fail during releases.

## Changes

- Added `CHAINLOOP_PROJECT_NAME: "chainloop"` environment variable to the "Promote Chainloop Project Version" step
- This variable was already defined in the `init_attestation` job but was not available in the `release` job where the project version update command runs

## Impact

Without this fix, the `chainloop project version update` command would fail because `${CHAINLOOP_PROJECT_NAME}` was undefined, preventing proper renaming of pre-release versions to actual release versions.