### PR TITLE
feat(gatherer): Scope SCM gatherer to only main branch

### DIFF
--- a/.github/workflows/scm_configuration_check.yaml
+++ b/.github/workflows/scm_configuration_check.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Gather runner context data
         run: |
-          chainloop gather-runner-context --runner-token ${{ steps.generate-token.outputs.token }}
+          chainloop gather-runner-context --runner-token ${{ steps.generate-token.outputs.token }} --branches=main
 
       - name: Add runner context material to attestation
         run: |


### PR DESCRIPTION
Modifies the SCM configuration job to only fetch information about the `main` branch.