### PR TITLE
feat(gatherer): Update json schema response for gatherer

### DIFF
--- a/internal/schemavalidators/external_schemas/runnercontext/runner-context-response-0.1.schema.json
+++ b/internal/schemavalidators/external_schemas/runnercontext/runner-context-response-0.1.schema.json
@@ -8,6 +8,10 @@
                     "type": "string",
                     "description": "Unique identifier for the runner context schema version"
                 },
+                "generated_at": {
+                    "type": "string",
+                    "description": "Timestamp when the runner context was generated (RFC3339 format)"
+                },
                 "errors": {
                     "items": {
                         "properties": {


### PR DESCRIPTION
Updates the JSON schema response for runner context to include the new field, `generated_at`.