### PR TITLE
fix(config): allow commands to run without valid connection

### DIFF
--- a/app/cli/cmd/config_reset.go
+++ b/app/cli/cmd/config_reset.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 The Chainloop Authors.
+// Copyright 2023-2025 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,6 +26,9 @@ func newConfigResetCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "reset",
 		Short: "Reset the CLI configuration",
+		Annotations: map[string]string{
+			skipActionOptsInit: trueString,
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			configFile := viper.ConfigFileUsed()
 			err := os.Remove(configFile)

--- a/app/cli/cmd/config_save.go
+++ b/app/cli/cmd/config_save.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 The Chainloop Authors.
+// Copyright 2023-2025 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,6 +25,9 @@ func newConfigSaveCmd() *cobra.Command {
 		Use:     "save",
 		Short:   "Persist the current settings to the config file",
 		Example: "chainloop config save --control-plane localhost:1234 --artifact-cas localhost:1235",
+		Annotations: map[string]string{
+			skipActionOptsInit: trueString,
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return viper.WriteConfig()
 		},

--- a/app/cli/cmd/config_view.go
+++ b/app/cli/cmd/config_view.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 The Chainloop Authors.
+// Copyright 2023-2025 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,6 +26,9 @@ func newConfigViewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "view",
 		Short: "View the current CLI configuration",
+		Annotations: map[string]string{
+			skipActionOptsInit: trueString,
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Printf("Config file: %s\n", viper.ConfigFileUsed())
 


### PR DESCRIPTION
Fixes an issue where `chainloop config reset` and other config management commands would fail when certificates couldn't be loaded, creating situation where users couldn't fix broken configurations.