### PR TITLE
feat: gated attestation add

### DIFF
--- a/app/cli/cmd/attestation_add.go
+++ b/app/cli/cmd/attestation_add.go
@@ -119,6 +119,12 @@ func newAttestationAddCmd() *cobra.Command {
 						return err
 					}
 
+					if err := output.EncodeOutput(flagOutputFormat, resp, func(s *action.AttestationStatusMaterial) error {
+						return displayMaterialInfo(s, policies[resp.Name])
+					}); err != nil {
+						return err
+					}
+
 					// Check for gated policy violations
 					for _, evaluations := range policies {
 						for _, eval := range evaluations {
@@ -128,9 +134,7 @@ func newAttestationAddCmd() *cobra.Command {
 						}
 					}
 
-					return output.EncodeOutput(flagOutputFormat, resp, func(s *action.AttestationStatusMaterial) error {
-						return displayMaterialInfo(s, policies[resp.Name])
-					})
+					return nil
 				},
 			)
 		},


### PR DESCRIPTION
Checks whether any of evaluations performed during `att add` contain violations and exits with code reserved for gate errors when that happens.


Example contract:
```yaml
apiVersion: chainloop.dev/v1
kind: Contract
metadata:
  name: gate-contract
  description: Test contract with gate
spec:
  materials:
  - type: SBOM_CYCLONEDX_JSON
    name: skynet-sbom
  policies:
    materials:
    - selector:
        name: skynet-sbom 
      ref: policy-gate
      gate: true
```

Example policy:
```yaml
apiVersion: workflowcontract.chainloop.dev/v1
kind: Policy
metadata:
  name: policy-gate
spec:
  policies:
    - kind: SBOM_CYCLONEDX_JSON
      embedded: |
        package main
        import rego.v1
        
        result := {"violations": ["Gated policy violation"]}
```

Attestation process:
```
$ chainloop att init --project myproject --workflow gateadd --contract contractgate.yaml --replace
WRN API contacted in insecure mode
This command will run against the organization "myorg"
Please confirm to continue y/N
y
INF Attestation initialized! now you can check its status or add materials to it
┌───────────────────────────┬──────────────────────────────────────┐
│ Initialized At            │ 17 Dec 25 11:43 UTC                  │
├───────────────────────────┼──────────────────────────────────────┤
│ Attestation ID            │ 2c154d14-b3f4-4127-993c-0b0fd6e7881c │
│ Organization              │ myorg                                │
│ Name                      │ gateadd                              │
│ Project                   │ myproject                            │
│ Version                   │ v1.63.0+next (prerelease)            │
│ Contract                  │ myproject-gateadd (revision 1)       │
│ Policy violation strategy │ ADVISORY                             │
└───────────────────────────┴──────────────────────────────────────┘


$ chainloop att add --value sbom.json --name skynet-sbom
WRN API contacted in insecure mode
INF uploading sbom.json - sha256:bfbb8312c63447567e65f128ac05ddaebf562d072532b37fb412f47bfc32a421
INF material added to attestation
┌────────────────────┬─────────────────────────────────────────────────────────────────────────┐
│ Name               │ skynet-sbom                                                             │
├────────────────────┼─────────────────────────────────────────────────────────────────────────┤
│ Type               │ SBOM_CYCLONEDX_JSON                                                     │
├────────────────────┼─────────────────────────────────────────────────────────────────────────┤
│ Required           │ Yes                                                                     │
├────────────────────┼─────────────────────────────────────────────────────────────────────────┤
│ Value              │ sbom.json                                                               │
├────────────────────┼─────────────────────────────────────────────────────────────────────────┤
│ Digest             │ sha256:bfbb8312c63447567e65f128ac05ddaebf562d072532b37fb412f47bfc32a421 │
├────────────────────┼─────────────────────────────────────────────────────────────────────────┤
│ Policy evaluations │ ------                                                                  │
├────────────────────┼─────────────────────────────────────────────────────────────────────────┤
│                    │ policy-gate (gate): Gated policy violation                              │
└────────────────────┴─────────────────────────────────────────────────────────────────────────┘

ERR the policy "policy-gate" is configured as a gate and has violations
exit status 4

```
