### PR TITLE
feat(cli): improve user-attended attestation mode warning

### DIFF
--- a/app/cli/cmd/root.go
+++ b/app/cli/cmd/root.go
@@ -153,7 +153,7 @@ func NewRootCmd(l zerolog.Logger) *cobra.Command {
 
 			// Warn users when the session is interactive, and the operation is supposed to use an API token instead
 			if shouldAskForConfirmation(cmd) && isUserToken && !flagYes {
-logger.Warn().Msg("User-attended mode detected. This is intended for local testing only. For CI/CD or automated workflows, please use an API token.")
+				logger.Warn().Msg("User-attended mode detected. This is intended for local testing only. For CI/CD or automated workflows, please use an API token.")
 				if !confirmationPrompt(fmt.Sprintf("This command will run against the organization %q", orgName)) {
 					return errors.New("command canceled by user")
 				}


### PR DESCRIPTION
This PR adds a warning to `attestation init` when running with user authentication instead of API tokens.

User token:
```
$ chainloop att init --project myproject --workflow multipolicy
WRN API contacted in insecure mode
WRN You are running in user-attended mode. For automated workflows, use an API token instead.
This command will run against the organization "myorg"
Please confirm to continue y/N
y
INF Attestation initialized! now you can check its status or add materials to it
┌───────────────────────────┬──────────────────────────────────────┐
│ Initialized At            │ 18 Dec 25 13:22 UTC                  │
├───────────────────────────┼──────────────────────────────────────┤
│ Attestation ID            │ 7597e05f-157a-48ac-98fe-3876cc39133f │
│ Organization              │ myorg                                │
│ Name                      │ multipolicy                          │
│ Project                   │ myproject                            │
│ Version                   │ v1.64.0+next (prerelease)            │
│ Contract                  │ myproject-multipolicy (revision 4)   │
│ Annotations               │ ------                               │
│                           │ environment: [NOT SET]               │
│ Policy violation strategy │ ADVISORY                             │
└───────────────────────────┴──────────────────────────────────────┘
```

Api token: 
```
$ chainloop att init --project myproject --workflow multipolicy --token eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
WRN API contacted in insecure mode
INF Attestation initialized! now you can check its status or add materials to it
┌───────────────────────────┬──────────────────────────────────────┐
│ Initialized At            │ 18 Dec 25 13:27 UTC                  │
├───────────────────────────┼──────────────────────────────────────┤
│ Attestation ID            │ a2e648e4-056e-4e02-889a-63099dc66a4b │
│ Organization              │ myorg                                │
│ Name                      │ multipolicy                          │
│ Project                   │ myproject                            │
│ Version                   │ v1.64.0+next (prerelease)            │
│ Contract                  │ myproject-multipolicy (revision 4)   │
│ Annotations               │ ------                               │
│                           │ environment: [NOT SET]               │
│ Policy violation strategy │ ADVISORY                             │
└───────────────────────────┴──────────────────────────────────────┘
```

Closes #2627 