### PR TITLE
feat(cli): add restrict contract creation flag

### DIFF
--- a/app/cli/cmd/organization_update.go
+++ b/app/cli/cmd/organization_update.go
@@ -26,6 +26,7 @@ func newOrganizationUpdateCmd() *cobra.Command {
 		blockOnPolicyViolation          bool
 		policiesAllowedHostnames        []string
 		preventImplicitWorkflowCreation bool
+		restrictContractCreation        bool
 	)
 
 	cmd := &cobra.Command{
@@ -45,6 +46,10 @@ func newOrganizationUpdateCmd() *cobra.Command {
 				opts.PreventImplicitWorkflowCreation = &preventImplicitWorkflowCreation
 			}
 
+			if cmd.Flags().Changed("restrict-contract-creation") {
+				opts.RestrictContractCreation = &restrictContractCreation
+			}
+
 			_, err := action.NewOrgUpdate(ActionOpts).Run(cmd.Context(), orgName, opts)
 			if err != nil {
 				return err
@@ -62,5 +67,6 @@ func newOrganizationUpdateCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&blockOnPolicyViolation, "block", false, "set the default policy violation blocking strategy")
 	cmd.Flags().StringSliceVar(&policiesAllowedHostnames, "policies-allowed-hostnames", []string{}, "set the allowed hostnames for the policy engine")
 	cmd.Flags().BoolVar(&preventImplicitWorkflowCreation, "prevent-implicit-workflow-creation", false, "prevent workflows and projects from being created implicitly during attestation init")
+	cmd.Flags().BoolVar(&restrictContractCreation, "restrict-contract-creation", false, "restrict contract creation (org-level and project-level) to only organization admins (owner/admin roles)")
 	return cmd
 }

--- a/app/cli/documentation/cli-reference.mdx
+++ b/app/cli/documentation/cli-reference.mdx
@@ -2767,6 +2767,7 @@ Options
 --name string                          organization name
 --policies-allowed-hostnames strings   set the allowed hostnames for the policy engine
 --prevent-implicit-workflow-creation   prevent workflows and projects from being created implicitly during attestation init
+--restrict-contract-creation           restrict contract creation (org-level and project-level) to only organization admins (owner/admin roles)
 ```
 
 Options inherited from parent commands

--- a/app/cli/pkg/action/org_update.go
+++ b/app/cli/pkg/action/org_update.go
@@ -33,15 +33,17 @@ type NewOrgUpdateOpts struct {
 	BlockOnPolicyViolation          *bool
 	PoliciesAllowedHostnames        *[]string
 	PreventImplicitWorkflowCreation *bool
+	RestrictContractCreation        *bool
 }
 
 func (action *OrgUpdate) Run(ctx context.Context, name string, opts *NewOrgUpdateOpts) (*OrgItem, error) {
 	client := pb.NewOrganizationServiceClient(action.cfg.CPConnection)
 
 	payload := &pb.OrganizationServiceUpdateRequest{
-		Name:                            name,
-		BlockOnPolicyViolation:          opts.BlockOnPolicyViolation,
-		PreventImplicitWorkflowCreation: opts.PreventImplicitWorkflowCreation,
+		Name:                                name,
+		BlockOnPolicyViolation:              opts.BlockOnPolicyViolation,
+		PreventImplicitWorkflowCreation:     opts.PreventImplicitWorkflowCreation,
+		RestrictContractCreationToOrgAdmins: opts.RestrictContractCreation,
 	}
 
 	if opts.PoliciesAllowedHostnames != nil {


### PR DESCRIPTION
Adds `--restrict-contract-creation` flag to `org update` cli command. 

```
$ chainloop organization update --name myorg --restrict-contract-creation
```

Closes #2578 
