### PR TITLE
feat(chart): Add Gateway API support and merge HTTP + GRPC traffic

### DIFF
--- a/deployment/chainloop/charts/dex/templates/_helpers.tpl
+++ b/deployment/chainloop/charts/dex/templates/_helpers.tpl
@@ -43,13 +43,16 @@ Figure out the external URL for Dex service
 {{- define "chainloop.dex.external_url" -}}
 {{- $service := .Values.dex.service }}
 {{- $ingress := .Values.dex.ingress }}
+{{- $httpRoute := .Values.dex.httpRoute }}
 
 {{- if (and $ingress $ingress.enabled $ingress.hostname) }}
 {{- printf "%s://%s/dex" (ternary "https" "http" $ingress.tls ) $ingress.hostname }}
+{{- else if (and $httpRoute $httpRoute.enabled $httpRoute.hostnames ) }}
+{{- printf "%s://%s/dex" (ternary "https" "http" $httpRoute.tls ) (index $httpRoute.hostnames 0) }}
 {{- else if (and (eq $service.type "NodePort") $service.nodePorts (not (empty $service.nodePorts.http))) }}
 {{- printf "http://localhost:%s" $service.nodePorts.http }}
 {{- else -}}
-{{- printf "http://%s-dex:%d/dex" ( include "chainloop.dex.fullname" . ) ( int $service.ports.http ) }}
+{{- printf "http://%s:%d/dex" ( include "chainloop.dex.fullname" . ) ( int $service.ports.http ) }}
 {{- end -}}
 {{- end -}}
 

--- a/deployment/chainloop/charts/dex/templates/httproute.yaml
+++ b/deployment/chainloop/charts/dex/templates/httproute.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.dex.httpRoute.enabled }}
+{{- /*
+Copyright Chainloop, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+{{- $fullName := include "chainloop.dex.fullname" . -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "chainloop.dex.labels" . | nindent 4 }}
+    {{- if .Values.dex.httpRoute.labels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.dex.httpRoute.labels "context" $) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.dex.httpRoute.annotations }}
+  annotations:
+    {{- include "common.tplvalues.render" ( dict "value" .Values.dex.httpRoute.annotations "context" $) | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+  {{- if .Values.dex.httpRoute.parentRefs }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.dex.httpRoute.parentRefs "context" .) | nindent 4 }}
+  {{- else }}
+    - name: gateway
+      namespace: {{ include "common.names.namespace" . | quote }}
+  {{- end }}
+  hostnames: {{- include "common.tplvalues.render" (dict "value" .Values.dex.httpRoute.hostnames "context" .) | nindent 4 }}
+  rules:
+    {{- $port := coalesce .Values.dex.service.port .Values.dex.service.ports.http }}
+    - backendRefs:
+        - name: {{ include "chainloop.dex.fullname" . }}
+          port: {{ $port }}
+      {{- if .Values.dex.httpRoute.matches }}
+      matches: {{- include "common.tplvalues.render" (dict "value" .Values.dex.httpRoute.matches "context" .) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.dex.httpRoute.filters }}
+      filters: {{- include "common.tplvalues.render" (dict "value" .Values.dex.httpRoute.filters "context" .) | nindent 8 }}
+      {{- end }}
+  {{- if .Values.dex.httpRoute.extraRules }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.dex.httpRoute.extraRules "context" .) | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deployment/chainloop/charts/dex/values.yaml
+++ b/deployment/chainloop/charts/dex/values.yaml
@@ -675,3 +675,60 @@ dex:
     ##             name: http
     ##
     extraRules: []
+  ## Gateway API HTTP routing parameters
+  ## ref: https://gateway-api.sigs.k8s.io/guides/http-routing/
+  ##
+  httpRoute:
+    ## @param dex.httpRoute.enabled Enable HTTPRoute generation for dex
+    ##
+    enabled: false
+    ## @param controlplane.httpRoute.tls Indicate if tls is active for this route
+    ##
+    tls: false
+    ## @param dex.httpRoute.annotations Additional annotations for the HTTPRoute resource
+    ##
+    annotations: {}
+    ## @param dex.httpRoute.labels Additional labels for the HTTPRoute resource
+    ##
+    labels: {}
+    ## @param dex.httpRoute.parentRefs Gateways the HTTPRoute is attached to. If unspecified, it'll be attached to Gateway named 'gateway' in the same namespace.
+    ## e.g:
+    ## parentRefs:
+    ##   - name: my-gateway
+    ##     sectionName: http
+    ##     namespace: default
+    ##
+    parentRefs: []
+    ## @param dex.httpRoute.hostnames [array] List of hostnames matching HTTP header
+    ##
+    hostnames:
+      - dex.dev.local
+    ## @param dex.httpRoute.matches [array] List of match rules applied to the HTTPRoute for the default svc backend reference
+    ##
+    matches:
+      - path:
+          type: PathPrefix
+          value: /
+    ## @param dex.httpRoute.filters List of filter rules applied to the HTTPRoute for the default svc backend reference
+    ##
+    filters: []
+    ## @param dex.httpRoute.extraRules List of extra rules applied to the HTTPRoute
+    ## e.g:
+    ## extraRules:
+    ##   - matches:
+    ##       - path:
+    ##           type: PathPrefix
+    ##           value: /login
+    ##     filters:
+    ##       - type: RequestHeaderModifier
+    ##         requestHeaderModifier:
+    ##           set:
+    ##             - name: My-Overwrite-Header
+    ##               value: this-is-the-only-value
+    ##           remove:
+    ##             - User-Agent
+    ##     backendRefs:
+    ##       - name: chainloop-dex
+    ##         port: 80
+    ##
+    extraRules: []

--- a/deployment/chainloop/templates/NOTES.txt
+++ b/deployment/chainloop/templates/NOTES.txt
@@ -5,19 +5,6 @@ APP VERSION: {{ .Chart.AppVersion  }}
 ** Please be patient while the chart is being deployed **
 
 ###########################################################################
-  CONFIGURE CLI
-###########################################################################
-
-Configure the CLI to point to this instance, for example
-
-  chainloop --insecure config save \
-    --control-plane my-controlplane.acme.com:80 \
-    --artifact-cas cas.acme.com:80
-
-Refer to this link for more information
-https://docs.chainloop.dev/get-started/setup
-
-###########################################################################
   USEFUL LINKS
 ###########################################################################
 
@@ -30,3 +17,19 @@ https://docs.chainloop.dev/get-started/setup
 {{- include "common.warnings.rollingTag" .Values.controlplane.migration.image }}
 {{- include "chainloop.validateValues" . }}
 {{- include "common.warnings.modifiedImages" (dict "images" (list .Values.controlplane.image .Values.cas.image .Values.controlplane.migration.image) "context" $) }}
+
+###########################################################################
+  CONFIGURE CLI
+###########################################################################
+
+Configure the CLI to point to this instance, for example:
+
+  chainloop{{ ternary "" " --insecure" ( or .Values.controlplane.ingressAPI.tls .Values.controlplane.httpRoute.tls )  }} config save \
+    --control-plane {{ include "chainloop.controlplane.external_hostname" . }}:{{ ternary "443" "80" ( or .Values.controlplane.ingressAPI.tls .Values.controlplane.httpRoute.tls )  }} \
+    --artifact-cas {{ include "chainloop.cas.external_hostname" . }}:{{ ternary "443" "80" ( or .Values.cas.ingressAPI.tls .Values.cas.httpRoute.tls )  }} \
+
+Refer to this link for more information
+https://docs.chainloop.dev/getting-started/installation#configure-cli-optional
+
+Refer to this link for more information
+https://docs.chainloop.dev/get-started/setup

--- a/deployment/chainloop/templates/_helpers.tpl
+++ b/deployment/chainloop/templates/_helpers.tpl
@@ -316,13 +316,34 @@ NOTE: Load balancer service type is not supported
 {{- define "chainloop.controlplane.external_url" -}}
 {{- $service := .Values.controlplane.service }}
 {{- $ingress := .Values.controlplane.ingress }}
+{{- $httpRoute := .Values.controlplane.httpRoute }}
 
 {{- if .Values.controlplane.auth.oidc.externalURL }}
 {{- .Values.controlplane.auth.oidc.externalURL }}
 {{- else if (and $ingress $ingress.enabled $ingress.hostname) }}
 {{- printf "%s://%s" (ternary "https" "http" $ingress.tls ) $ingress.hostname }}
+{{- else if (and $httpRoute $httpRoute.enabled $httpRoute.hostnames ) }}
+{{- printf "%s://%s" (ternary "https" "http" $httpRoute.tls ) ( index $httpRoute.hostnames 0) }}
 {{- else if (and (eq $service.type "NodePort") $service.nodePorts (not (empty $service.nodePorts.http))) }}
 {{- printf "http://localhost:%s" $service.nodePorts.http }}
+{{- else -}}
+null
+{{- end -}}
+{{- end -}}
+
+{{- define "chainloop.controlplane.external_hostname" -}}
+{{- $service := .Values.controlplane.service }}
+{{- $ingress := .Values.controlplane.ingress }}
+{{- $httpRoute := .Values.controlplane.httpRoute }}
+
+{{- if .Values.controlplane.auth.oidc.externalURL }}
+{{- .Values.controlplane.auth.oidc.externalURL }}
+{{- else if (and $ingress $ingress.enabled $ingress.hostname) }}
+{{- printf "%s" $ingress.hostname }}
+{{- else if (and $httpRoute $httpRoute.enabled $httpRoute.hostnames ) }}
+{{- printf "%s" ( index $httpRoute.hostnames 0) }}
+{{- else if (and (eq $service.type "NodePort") $service.nodePorts (not (empty $service.nodePorts.http))) }}
+{{- printf "localhost:%s" $service.nodePorts.http }}
 {{- else -}}
 null
 {{- end -}}
@@ -407,13 +428,32 @@ NOTE: Load balancer service type is not supported
 {{- define "chainloop.cas.external_url" -}}
 {{- $service := .Values.cas.service }}
 {{- $ingress := .Values.cas.ingress }}
+{{- $httpRoute := .Values.cas.httpRoute }}
 
 {{- if .Values.cas.externalURL }}
 {{- .Values.cas.externalURL }}
 {{- else if (and $ingress $ingress.enabled $ingress.hostname) }}
 {{- printf "%s://%s" (ternary "https" "http" $ingress.tls ) $ingress.hostname }}
+{{- else if (and $httpRoute $httpRoute.enabled $httpRoute.hostnames) }}
+{{- printf "%s://%s" (ternary "https" "http" $httpRoute.tls ) (index $httpRoute.hostnames 0) }}
 {{- else if (and (eq $service.type "NodePort") $service.nodePorts (not (empty $service.nodePorts.http))) }}
 {{- printf "http://localhost:%s" $service.nodePorts.http }}
+{{- end -}}
+{{- end -}}
+
+{{- define "chainloop.cas.external_hostname" -}}
+{{- $service := .Values.cas.service }}
+{{- $ingress := .Values.cas.ingress }}
+{{- $httpRoute := .Values.cas.httpRoute }}
+
+{{- if .Values.cas.externalURL }}
+{{- .Values.cas.externalURL }}
+{{- else if (and $ingress $ingress.enabled $ingress.hostname) }}
+{{- printf "%s" $ingress.hostname }}
+{{- else if (and $httpRoute $httpRoute.enabled $httpRoute.hostnames) }}
+{{- printf "%s" (index $httpRoute.hostnames 0) }}
+{{- else if (and (eq $service.type "NodePort") $service.nodePorts (not (empty $service.nodePorts.http))) }}
+{{- printf "localhost:%s" $service.nodePorts.http }}
 {{- end -}}
 {{- end -}}
 
@@ -435,6 +475,23 @@ Compile all warning messages into a single one
 {{- $messages := without $messages "" -}}
 {{- $message := join "\n" $messages -}}
 
+{{- if and (or (.Values.controlplane.ingress.enabled | default false)  (.Values.controlplane.ingressAPI.enabled | default false))  (.Values.controlplane.httpRoute.enabled | default false) -}}
+{{- fail "Invalid values: controlplane.ingress.enabled or controlplane.ingressAPI.enabled and controlplane.httpRoute.enabled cannot both be true." -}}
+{{- end -}}
+
+{{- if and (or (.Values.cas.ingress.enabled | default false)  (.Values.cas.ingressAPI.enabled | default false))  (.Values.cas.httpRoute.enabled | default false) -}}
+{{- fail "Invalid values: cas.ingress.enabled or cas.ingressAPI.enabled and cas.httpRoute.enabled cannot both be true." -}}
+{{- end -}}
+
+
+{{- if and (.Values.cas.httpRoute.enabled | default false)  ( gt (len .Values.cas.httpRoute.hostnames) 1 ) -}}
+{{- fail "Invalid values: .Values.cas.httpRoute.hostnames can only have one hostname" -}}
+{{- end -}}
+
+{{- if and (.Values.controlplane.httpRoute.enabled | default false)  ( gt (len .Values.controlplane.httpRoute.hostnames) 1 ) -}}
+{{- fail "Invalid values: .Values.controlplane.httpRoute.hostnames can only have one hostname" -}}
+{{- end -}}
+
 {{- if $message -}}
 {{-   printf "\n\nVALUES VALIDATION:\n%s" $message -}}
 {{- end -}}
@@ -449,4 +506,3 @@ Return the Nats connection string
 {{- $port := required "nats server port not set" .Values.controlplane.nats.port }}
 {{- printf "nats://%s:%d" $host ($port | int) }}
 {{- end -}}
-

--- a/deployment/chainloop/templates/cas/httproute.yaml
+++ b/deployment/chainloop/templates/cas/httproute.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.cas.httpRoute.enabled }}
+{{- /*
+Copyright Chainloop, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+{{- $fullName := include "chainloop.cas.fullname" . -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "chainloop.cas.labels" . | nindent 4 }}
+    {{- if .Values.cas.httpRoute.labels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.cas.httpRoute.labels "context" $) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.cas.httpRoute.annotations }}
+  annotations:
+    {{- include "common.tplvalues.render" ( dict "value" .Values.cas.httpRoute.annotations "context" $) | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+  {{- if .Values.cas.httpRoute.parentRefs }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.cas.httpRoute.parentRefs "context" .) | nindent 4 }}
+  {{- else }}
+    - name: gateway
+      namespace: {{ include "common.names.namespace" . | quote }}
+  {{- end }}
+  hostnames: {{- include "common.tplvalues.render" (dict "value" .Values.cas.httpRoute.hostnames "context" .) | nindent 4 }}
+  rules:
+    {{- $port := coalesce .Values.cas.service.port .Values.cas.service.ports.http }}
+    - backendRefs:
+        - name: {{ include "chainloop.cas.fullname" . }}
+          port: {{ $port }}
+      {{- if .Values.cas.httpRoute.matches }}
+      matches: {{- include "common.tplvalues.render" (dict "value" .Values.cas.httpRoute.matches "context" .) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.cas.httpRoute.filters }}
+      filters: {{- include "common.tplvalues.render" (dict "value" .Values.cas.httpRoute.filters "context" .) | nindent 8 }}
+      {{- end }}
+    - matches:
+        - headers:
+            - name: content-type
+              value: "^application/grpc"
+              type: RegularExpression
+      {{- $portAPI := coalesce .Values.cas.serviceAPI.port .Values.cas.serviceAPI.ports.http }}
+      backendRefs:
+        - name: {{ include "chainloop.cas.fullname" . }}-api
+          kind: Service
+          namespace: {{ include "common.names.namespace" . | quote }}
+          port: {{ $portAPI }}
+  {{- if .Values.cas.httpRoute.extraRules }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.cas.httpRoute.extraRules "context" .) | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deployment/chainloop/templates/cas/service-grpc.yaml
+++ b/deployment/chainloop/templates/cas/service-grpc.yaml
@@ -40,6 +40,7 @@ spec:
       {{- if not (eq $port .Values.cas.containerPorts.grpc) }}
       targetPort: {{ .Values.cas.containerPorts.grpc }}
       {{- end }}
+      appProtocol: kubernetes.io/h2c
       protocol: TCP
       {{- if and (or (eq .Values.cas.serviceAPI.type "NodePort") (eq .Values.cas.serviceAPI.type "LoadBalancer")) (not (empty .Values.cas.serviceAPI.nodePorts.http)) }}
       nodePort: {{ .Values.cas.serviceAPI.nodePorts.http }}

--- a/deployment/chainloop/templates/controlplane/httproute.yaml
+++ b/deployment/chainloop/templates/controlplane/httproute.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.controlplane.httpRoute.enabled }}
+{{- /*
+Copyright Chainloop, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+{{- $fullName := include "chainloop.controlplane.fullname" . -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "chainloop.controlplane.labels" . | nindent 4 }}
+    {{- if .Values.controlplane.httpRoute.labels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.controlplane.httpRoute.labels "context" $) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.controlplane.httpRoute.annotations }}
+  annotations:
+    {{- include "common.tplvalues.render" ( dict "value" .Values.controlplane.httpRoute.annotations "context" $) | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+  {{- if .Values.controlplane.httpRoute.parentRefs }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.controlplane.httpRoute.parentRefs "context" .) | nindent 4 }}
+  {{- else }}
+    - name: gateway
+      namespace: {{ include "common.names.namespace" . | quote }}
+  {{- end }}
+  hostnames: {{- include "common.tplvalues.render" (dict "value" .Values.controlplane.httpRoute.hostnames "context" .) | nindent 4 }}
+  rules:
+    {{- $port := coalesce .Values.controlplane.service.port .Values.controlplane.service.ports.http }}
+    - backendRefs:
+        - name: {{ include "chainloop.controlplane.fullname" . }}
+          port: {{ $port }}
+      {{- if .Values.controlplane.httpRoute.matches }}
+      matches: {{- include "common.tplvalues.render" (dict "value" .Values.controlplane.httpRoute.matches "context" .) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.controlplane.httpRoute.filters }}
+      filters: {{- include "common.tplvalues.render" (dict "value" .Values.controlplane.httpRoute.filters "context" .) | nindent 8 }}
+      {{- end }}
+    - matches:
+        - headers:
+            - name: content-type
+              value: "^application/grpc"
+              type: RegularExpression
+      {{- $portAPI := coalesce .Values.controlplane.serviceAPI.port .Values.controlplane.serviceAPI.ports.http }}
+      backendRefs:
+        - name: {{ include "chainloop.controlplane.fullname" . }}-api
+          kind: Service
+          namespace: {{ include "common.names.namespace" . | quote }}
+          port: {{ $portAPI }}
+  {{- if .Values.controlplane.httpRoute.extraRules }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.controlplane.httpRoute.extraRules "context" .) | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deployment/chainloop/templates/controlplane/service-grpc.yaml
+++ b/deployment/chainloop/templates/controlplane/service-grpc.yaml
@@ -41,6 +41,7 @@ spec:
       targetPort: {{ .Values.controlplane.containerPorts.grpc }}
       {{- end }}
       protocol: TCP
+      appProtocol: kubernetes.io/h2c
       {{- if and (or (eq .Values.controlplane.serviceAPI.type "NodePort") (eq .Values.controlplane.serviceAPI.type "LoadBalancer")) (not (empty .Values.controlplane.serviceAPI.nodePorts.http)) }}
       nodePort: {{ .Values.controlplane.serviceAPI.nodePorts.http }}
       {{- else if eq .Values.controlplane.serviceAPI.type "ClusterIP" }}

--- a/deployment/chainloop/values.yaml
+++ b/deployment/chainloop/values.yaml
@@ -604,6 +604,63 @@ controlplane:
     ##             name: http
     ##
     extraRules: []
+  ## Gateway API HTTP routing parameters
+  ## ref: https://gateway-api.sigs.k8s.io/guides/http-routing/
+  ##
+  httpRoute:
+    ## @param controlplane.httpRoute.enabled Enable HTTPRoute generation for controlplane
+    ##
+    enabled: false
+    ## @param controlplane.httpRoute.tls Indicate if tls is active for this route
+    ##
+    tls: false
+    ## @param controlplane.httpRoute.annotations Additional annotations for the HTTPRoute resource
+    ##
+    annotations: {}
+    ## @param controlplane.httpRoute.labels Additional labels for the HTTPRoute resource
+    ##
+    labels: {}
+    ## @param controlplane.httpRoute.parentRefs Gateways the HTTPRoute is attached to. If unspecified, it'll be attached to Gateway named 'gateway' in the same namespace.
+    ## e.g:
+    ## parentRefs:
+    ##   - name: my-gateway
+    ##     sectionName: http
+    ##     namespace: default
+    ##
+    parentRefs: []
+    ## @param controlplane.httpRoute.hostnames [array] List of hostnames matching HTTP header
+    ##
+    hostnames:
+      - cp.dev.local
+    ## @param controlplane.httpRoute.matches [array] List of match rules applied to the HTTPRoute for the default svc backend reference
+    ##
+    matches:
+      - path:
+          type: PathPrefix
+          value: /
+    ## @param controlplane.httpRoute.filters List of filter rules applied to the HTTPRoute for the default svc backend reference
+    ##
+    filters: []
+    ## @param controlplane.httpRoute.extraRules List of extra rules applied to the HTTPRoute
+    ## e.g:
+    ## extraRules:
+    ##   - matches:
+    ##       - path:
+    ##           type: PathPrefix
+    ##           value: /login
+    ##     filters:
+    ##       - type: RequestHeaderModifier
+    ##         requestHeaderModifier:
+    ##           set:
+    ##             - name: My-Overwrite-Header
+    ##               value: this-is-the-only-value
+    ##           remove:
+    ##             - User-Agent
+    ##     backendRefs:
+    ##       - name: chainloop-controlplane
+    ##         port: 80
+    ##
+    extraRules: []
 
   ## @section Controlplane Misc
 
@@ -1352,7 +1409,63 @@ cas:
     ##             name: http
     ##
     extraRules: []
-
+  ## Gateway API HTTP routing parameters
+  ## ref: https://gateway-api.sigs.k8s.io/guides/http-routing/
+  ##
+  httpRoute:
+    ## @param cas.httpRoute.enabled Enable HTTPRoute generation for CAS
+    ##
+    enabled: false
+    ## @param cas.httpRoute.tls Indicate if tls is active for this route
+    ##
+    tls: false
+    ## @param cas.httpRoute.annotations Additional annotations for the HTTPRoute resource
+    ##
+    annotations: {}
+    ## @param cas.httpRoute.labels Additional labels for the HTTPRoute resource
+    ##
+    labels: {}
+    ## @param cas.httpRoute.parentRefs Gateways the HTTPRoute is attached to. If unspecified, it'll be attached to Gateway named 'gateway' in the same namespace.
+    ## e.g:
+    ## parentRefs:
+    ##   - name: my-gateway
+    ##     sectionName: http
+    ##     namespace: default
+    ##
+    parentRefs: []
+    ## @param cas.httpRoute.hostnames [array] List of hostnames matching HTTP header
+    ##
+    hostnames:
+      - cas.dev.local
+    ## @param cas.httpRoute.matches [array] List of match rules applied to the HTTPRoute for the default svc backend reference
+    ##
+    matches:
+      - path:
+          type: PathPrefix
+          value: /
+    ## @param cas.httpRoute.filters List of filter rules applied to the HTTPRoute for the default svc backend reference
+    ##
+    filters: []
+    ## @param cas.httpRoute.extraRules List of extra rules applied to the HTTPRoute
+    ## e.g:
+    ## extraRules:
+    ##   - matches:
+    ##       - path:
+    ##           type: PathPrefix
+    ##           value: /login
+    ##     filters:
+    ##       - type: RequestHeaderModifier
+    ##         requestHeaderModifier:
+    ##           set:
+    ##             - name: My-Overwrite-Header
+    ##               value: this-is-the-only-value
+    ##           remove:
+    ##             - User-Agent
+    ##     backendRefs:
+    ##       - name: chainloop-cas
+    ##         port: 80
+    ##
+    extraRules: []
   ## @section CAS Misc
   ## @param cas.sentry.enabled Enable sentry.io alerting
   ## @param cas.sentry.dsn DSN endpoint
@@ -1686,12 +1799,16 @@ postgresql:
 
 ## Bitnami Hashicorp Vault chart configuration
 ## ref: https://github.com/bitnami/charts/blob/main/bitnami/vault/values.yaml
-## @param vault.server.args Arguments to pass to the vault server. This is useful for setting the server in development mode
-## @param vault.server.config Configuration for the vault server. Small override of default Bitnami configuration
-## @param vault.server.extraEnvVars[0].name Root token for the vault server
-## @param vault.server.extraEnvVars[0].value The value of the root token. Default: notasecret
-## @param vault.server.extraEnvVars[1].name Address to listen on development mode
-## @param vault.server.extraEnvVars[1].value The address to listen on. Default: [::]:8200
+## @skip vault.extraDeploy Array of extra objects to deploy with Vault (evaluated as a template)
+## @param vault.server.command Override default container command
+## @param vault.server.args Override default container args
+## @skip vault.server.config Configuration for the vault server
+## @param vault.server.extraVolumes[0].name Name of the extra volume
+## @param vault.server.extraVolumes[0].configMap.name Name of the ConfigMap to mount
+## @param vault.server.extraVolumes[0].configMap.defaultMode Default mode for the ConfigMap files
+## @param vault.server.extraVolumeMounts[0].name Name of the volume to mount
+## @param vault.server.extraVolumeMounts[0].mountPath Path where the volume should be mounted
+## @param vault.server.extraVolumeMounts[0].subPath Subpath within the volume to mount
 vault:
   extraDeploy:
     - |
@@ -1784,3 +1901,36 @@ vault:
       - name: vault-init
         mountPath: /vault-init.sh
         subPath: vault-init.sh
+
+## Dex chart configuration
+## @param dex.dex.redirectURL Control Plane URL where Dex will redirect after a successful login
+## @extra dex.dex.ingress Configuration for the Dex ingress record
+## @param dex.dex.ingress.enabled Enable ingress record generation for Dex
+## @param dex.dex.ingress.tls Enable TLS for the Dex ingress record
+## @param dex.dex.ingress.hostname Hostname for the Dex ingress record
+## @param dex.dex.ingress.ingressClassName IngressClass that will be be used to implement the Dex Ingress (Kubernetes 1.18+)
+## @param dex.dex.httpRoute.enabled Enable HTTPRoute generation for controlplane
+## @param dex.dex.httpRoute.hostnames List of hostnames to match for this route WARNING: Please use only one domain
+## @param dex.dex.httpRoute.parentRefs Gateways the HTTPRoute is attached to. If unspecified, it'll be attached to Gateway named 'gateway' in the same namespace.
+
+## Used only if .Values.development is true
+## Yes, dex.dex, since we are overriding the dex section in the dex subchart
+dex:
+  dex:
+    # Point to the [controlplane http ingress]/auth/callback
+    redirectURL: http(s)://[controlplane http ingress]/auth/callback
+    httpRoute:
+      enabled: false
+      tls: false
+      hostnames:
+        - dex.[domain]
+      parentRefs: []
+      #    - name: your-gateway
+      #      sectionName: http
+      #      namespace: your-namespace
+    # Expose the dex instance to the outside world
+    ingress:
+      enabled: false
+      tls: false
+      hostname: ""
+      ingressClassName: ""


### PR DESCRIPTION
This PR adds support for Gateway API and exposing both HTTP and gRPC traffic through a single Gateway API HTTPRoute in the Helm chart. 
Additionaly i had to fix problems with readme-generator by fixing vault params. 

Dex changes:
 - I had to add httproutes to dex subchart otherwise users who want to use only gateway api could not have used development mode. 
```yaml
## Used only if .Values.development is true
## Yes, dex.dex, since we are overriding the dex section in the dex subchart
dex:
  dex:
    # Point to the [controlplane http ingress]/auth/callback
    redirectURL: http(s)://[controlplane http ingress]/auth/callback
    httpRoute:
      enabled: false
      hostnames:
        - dex.[domain]
      parentRefs: []
      #    - name: your-gateway
      #      sectionName: http
      #      namespace: your-namespace
    # Expose the dex instance to the outside world
    ingress:
      enabled: false
      tls: false
      hostname: ""
      ingressClassName: ""
```

Also I have updated helpers with httpRoute configurations.
Example:
```
{{/*
External URL the CAS can be reached at
This endpoint is used for the cas to redirect downloads
NOTE: Load balancer service type is not supported
*/}}
{{- define "chainloop.cas.external_url" -}}
{{- $service := .Values.cas.service }}
{{- $ingress := .Values.cas.ingress }}
{{- $httpRoute := .Values.cas.httpRoute }}

{{- if .Values.cas.externalURL }}
{{- .Values.cas.externalURL }}
{{- else if (and $ingress $ingress.enabled $ingress.hostname) }}
{{- printf "%s://%s" (ternary "https" "http" $ingress.tls ) $ingress.hostname }}
{{- else if (and $httpRoute $httpRoute.enabled $httpRoute.hostnames) }}
{{- printf "%s://%s" (ternary "https" "http" $httpRoute.tls ) (index $httpRoute.hostnames 0) }}
{{- else if (and (eq $service.type "NodePort") $service.nodePorts (not (empty $service.nodePorts.http))) }}
{{- printf "http://localhost:%s" $service.nodePorts.http }}
{{- end -}}
{{- end -}}
```
Configuration is made up to bitnami standards

Params added in values.yaml
```yaml
  ## Gateway API HTTP routing parameters
  ## ref: https://gateway-api.sigs.k8s.io/guides/http-routing/
  ## We dont have to create two http routes for HTTP and API because when we use Gateway API, we can use the same HTTPRoute for both.
  ##
  httpRoute:
    ## @param cas.httpRoute.enabled Enable HTTPRoute generation for CAS
    ##
    enabled: false
    ## @param controlplane.httpRoute.tls Indicate if tls is active for this route
    tls: false
    ## @param cas.httpRoute.annotations Additional annotations for the HTTPRoute resource
    ##
    annotations: {}
    ## @param cas.httpRoute.labels Additional labels for the HTTPRoute resource
    ##
    labels: {}
    ## @param cas.httpRoute.parentRefs Gateways the HTTPRoute is attached to. If unspecified, it'll be attached to Gateway named 'gateway' in the same namespace.
    ## e.g:
    ## parentRefs:
    ##   - name: my-gateway
    ##     sectionName: http
    ##     namespace: default
    ##
    parentRefs: []
    ## @param cas.httpRoute.hostnames [array] List of hostnames matching HTTP header
    ##
    hostnames:
      - cas.dev.local
    ## @param cas.httpRoute.matches [array] List of match rules applied to the HTTPRoute for the default svc backend reference
    ##
    matches:
      - path:
          type: PathPrefix
          value: /
    ## @param cas.httpRoute.filters List of filter rules applied to the HTTPRoute for the default svc backend reference
    ##
    filters: []
    ## @param cas.httpRoute.extraRules List of extra rules applied to the HTTPRoute
    ## e.g:
    ## extraRules:
    ##   - matches:
    ##       - path:
    ##           type: PathPrefix
    ##           value: /login
    ##     filters:
    ##       - type: RequestHeaderModifier
    ##         requestHeaderModifier:
    ##           set:
    ##             - name: My-Overwrite-Header
    ##               value: this-is-the-only-value
    ##           remove:
    ##             - User-Agent
    ##     backendRefs:
    ##       - name: chainloop-cas
    ##         port: 80
    ##
    extraRules: []
```

There are also validators added that check if user didnt enable both ingress and httproute and if httproute is enabled if there is no more than one hostname per service. 

TODO:
- [x] Http - > HTTPS redirection
- [x]  NOTES.txt
- [x] Configuration when in development mode (dex)

Changes are connected with:
#2641 #2642 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chainloop-dev/chainloop/pull/2643" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
