### PR TITLE
feat(source-commit): Update source-commit to enforce signature verification

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,6 +44,9 @@ jobs:
         if: ${{ github.event_name != 'pull_request' }}
         run: |
           chainloop attestation init --workflow $CHAINLOOP_WORKFLOW_NAME --project $CHAINLOOP_PROJECT
+        env:
+          # Needed for commit signature verification: https://docs.chainloop.dev/concepts/attestations#commit-verification
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Go
         uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3.6.1

--- a/.github/workflows/contracts/chainloop-vault-codeql.yml
+++ b/.github/workflows/contracts/chainloop-vault-codeql.yml
@@ -16,6 +16,7 @@ spec:
       - ref: source-commit
         with:
           check_signature: yes
+          check_author_verified: yes
         requirements:
           - chainloop-best-practices/commit-signed
   policyGroups:

--- a/.github/workflows/contracts/chainloop-vault-helm-package.yml
+++ b/.github/workflows/contracts/chainloop-vault-helm-package.yml
@@ -22,6 +22,7 @@ spec:
       - ref: source-commit
         with:
           check_signature: yes
+          check_author_verified: yes
         requirements:
           - chainloop-best-practices/commit-signed
     materials:

--- a/.github/workflows/contracts/chainloop-vault-release.yml
+++ b/.github/workflows/contracts/chainloop-vault-release.yml
@@ -10,6 +10,7 @@ spec:
       - ref: source-commit
         with:
           check_signature: yes
+          check_author_verified: yes
         requirements:
           - chainloop-best-practices/commit-signed
       - ref: containers-with-sbom

--- a/.github/workflows/package_chart.yaml
+++ b/.github/workflows/package_chart.yaml
@@ -90,6 +90,8 @@ jobs:
         env:
           COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_KEY}}
           COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
+          # Needed for commit signature verification: https://docs.chainloop.dev/concepts/attestations#commit-verification
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Finish and Record Attestation
         if: ${{ success() }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,8 @@ jobs:
           CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
           CHAINLOOP_WORKFLOW_NAME: "release"
           CHAINLOOP_PROJECT_NAME: "chainloop"
+          # Needed for commit signature verification: https://docs.chainloop.dev/concepts/attestations#commit-verification
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release:
     name: Release CLI and control-plane/artifact-cas container images


### PR DESCRIPTION
This PR updates some contracts of the workflows present on the repository to enforce author's commit signature verification by using the policy `source-commit`.

This enforcement will check if the commit's author has a signature that has been verified, in this case by GitHub.

More information what commit verification is, can be found on this [link](https://docs.chainloop.dev/concepts/attestations#commit-verification) to the documentation.