### PR TITLE
fix(ci): inject token for renaming

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -172,6 +172,7 @@ jobs:
       - name: Promote Chainloop Project Version
         env:
           CHAINLOOP_PROJECT_NAME: "chainloop"
+          CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
         run: |
           current_version="$(cat .chainloop.yml | awk '/^projectVersion:/ {print $2}')"
           # Rename the existing pre-release into the actual release name


### PR DESCRIPTION
Fixes the not found error thrown by the rename step

https://github.com/chainloop-dev/chainloop/actions/runs/21134227441/job/60773073848

<img width="820" height="276" alt="image" src="https://github.com/user-attachments/assets/993cdcc8-e920-4492-b387-bc8283155e7b" />
