### PR TITLE
feat: add project name filtering to workflow run list

### DIFF
--- a/app/controlplane/cmd/wire_gen.go
+++ b/app/controlplane/cmd/wire_gen.go
@@ -167,6 +167,7 @@ func wireApp(bootstrap *conf.Bootstrap, readerWriter credentials.ReaderWriter, l
 		WorkflowRunUC:      workflowRunUseCase,
 		WorkflowUC:         workflowUseCase,
 		WorkflowContractUC: workflowContractUseCase,
+		ProjectUC:          projectUseCase,
 		CredsReader:        readerWriter,
 		Opts:               v5,
 	}


### PR DESCRIPTION
## Summary

Adds support for filtering workflow runs by project name alone in the `WorkflowRunServiceListRequest`, without requiring a workflow name to be specified.

## Changes

- Added `ProjectUseCase` to `WorkflowRunService` to enable project lookup by name
- Implemented `validateAndGetProjectID` helper method that validates project access against RBAC permissions
- Updated `WorkflowRunService.List` to handle filtering by project name when only `project_name` is provided
- Wire configuration automatically updated to inject `ProjectUseCase` dependency

## Implementation Details

The implementation ensures RBAC compliance by:
1. Looking up the project by name using `FindProjectByReference`
2. Verifying the project ID exists in the user's visible projects list
3. Only returning workflow runs from authorized projects