### PR TITLE
docs(slsa): update slsa example contract

### DIFF
--- a/docs/examples/contracts/slsa/source-code.yaml
+++ b/docs/examples/contracts/slsa/source-code.yaml
@@ -1,13 +1,17 @@
 # SLSA source track validation contract
 # Validates repository security configuration including branch protection,
-# code review requirements, and commit signing policies
+# code review requirements, identity management, and commit signing policies
 schemaVersion: v1
 policies:
   attestation:
     - ref: runner-automated
       with:
         runner: "GITHUB_ACTION" # or GITLAB_PIPELINE
+    - ref: runner-authenticated
   materials:
+    - ref: pr-code-owner-review-required
+      with:
+        branches: "main"
     - ref: commits-signed-required
       with:
         branches: "main"


### PR DESCRIPTION
Updates SLSA example contract to include the policies related to SMC authentication enabled and allowed approvers in code reviews.

refs #2675