### PR TITLE
fix(policies): prevent binary content parsing for HELM_CHART materials

### DIFF
--- a/pkg/attestation/crafter/api/attestation/v1/crafting_state.go
+++ b/pkg/attestation/crafter/api/attestation/v1/crafting_state.go
@@ -96,9 +96,14 @@ func (m *Attestation_Material) GetEvaluableContent(value string) ([]byte, error)
 	if artifact != nil {
 		if m.InlineCas && m.MaterialType != v1.CraftingSchema_Material_HELM_CHART {
 			rawMaterial = artifact.GetContent()
-		} else if value == "" {
+		}
+
+		if !m.InlineCas && value == "" {
 			return nil, errors.New("artifact path required")
-		} else if m.MaterialType != v1.CraftingSchema_Material_HELM_CHART &&
+		}
+
+		if !m.InlineCas &&
+			m.MaterialType != v1.CraftingSchema_Material_HELM_CHART &&
 			m.MaterialType != v1.CraftingSchema_Material_JUNIT_XML {
 			// read content from local filesystem (except for tgz charts)
 			rawMaterial, err = os.ReadFile(value)


### PR DESCRIPTION
When using inline CAS storage, `HELM_CHART` materials containing binary data were incorrectly passed to JSON decoder, causing errors during policy evaluation.

Closes #2684 