### PR TITLE
fix(policy-engine): Preserve escaped patterns on policy args

### DIFF
--- a/pkg/policies/policies_test.go
+++ b/pkg/policies/policies_test.go
@@ -807,6 +807,31 @@ func (s *testSuite) TestGetInputArguments() {
 			inputs:   map[string]string{"foo": "bar1,bar2,bar3", "bar": "baz", "foos": "bar1\nbar2\nbar3\n"},
 			expected: map[string]any{"foo": []string{"bar1", "bar2", "bar3"}, "bar": "baz", "foos": []string{"bar1", "bar2", "bar3"}},
 		},
+		{
+			name:     "regex with escaped parameters",
+			inputs:   map[string]string{"pattern": "[A-Z][A-Z0-9_]+-\\d+"},
+			expected: map[string]any{"pattern": `[A-Z][A-Z0-9_]+-\d+`},
+		},
+		{
+			name:     "regex with multiple backslashes",
+			inputs:   map[string]string{"pattern": "\\d+\\s+\\w+"},
+			expected: map[string]any{"pattern": `\d+\s+\w+`},
+		},
+		{
+			name:     "mixed escaped comma and regex",
+			inputs:   map[string]string{"patterns": "\\d+\\,test,\\w+"},
+			expected: map[string]any{"patterns": []string{`\d+,test`, `\w+`}},
+		},
+		{
+			name:     "backslash at end",
+			inputs:   map[string]string{"foo": "bar\\"},
+			expected: map[string]any{"foo": `bar\`},
+		},
+		{
+			name:     "double backslash",
+			inputs:   map[string]string{"foo": "bar\\\\baz"},
+			expected: map[string]any{"foo": `bar\\baz`},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
This PR is a follow up of https://github.com/chainloop-dev/chainloop/pull/2306.

The `getInputArguments` function was incorrectly handling escaped characters in input parameters. The original implementation treated ANY character following a backslash as an escape sequence, which caused issues with regex patterns containing backslashes (e.g., `\d+`, `\s+`, `\w+`).

The special case that needed to continue working
- Escaped commas: `bar1\,bar2,bar3` should parse as `["bar1,bar2", "bar3"]`

However, regex patterns like `[A-Z]+-\d+` or `\w+` were being incorrectly parsed, losing the backslash and becoming `[A-Z][A-Z0-9_]+-d+` or `w+`.

I've updated it with a more readable approach that consist of:
1. Replace all `\,` with a unique placeholder
2. Split on unescaped commas
3. Restore placeholders back to commas
4. Trim whitespace and filter empty strings