### PR TITLE
fix(attestation): base64 encode inline helm charts

### DIFF
--- a/app/controlplane/internal/service/attestation.go
+++ b/app/controlplane/internal/service/attestation.go
@@ -17,6 +17,7 @@ package service
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -652,10 +653,16 @@ func extractMaterials(in []*chainloop.NormalizedMaterial) ([]*cpAPI.AttestationI
 			Type:           m.Type,
 			Filename:       m.Filename,
 			Annotations:    m.Annotations,
-			Value:          m.Value,
 			UploadedToCas:  m.UploadedToCAS,
 			EmbeddedInline: m.EmbeddedInline,
 			Tag:            m.Tag,
+		}
+
+		if m.Type == "HELM_CHART" {
+			// Base64 encoding for binary content
+			materialItem.Value = base64.StdEncoding.EncodeToString([]byte(m.Value))
+		} else {
+			materialItem.Value = m.Value
 		}
 
 		if m.Hash != nil {


### PR DESCRIPTION
Helm chart tarballs stored inline within attestation now are encoded with base64, this fixes issue with UTF-8 validation.

Part of the returned attestation
```
      "casBackend": {
         "casBackendID": "75c78473-902e-4169-b39e-4770d08200c4",
         "casBackendName": "default-inline",
         "fallback": false
      },
      "materials": [
         {
            "annotations": {
               "chainloop.material.cas.inline": true,
               "chainloop.material.name": "material-1769176887389113820",
               "chainloop.material.type": "HELM_CHART"
            },
            "content": "H4sIFAAAAAAA/ykAK2FIUjBjSE02THk5NWIzVjBkU ... # base64 encoded helm chart",
            "digest": {
               "sha256": "95c7b1d8b26d5f8f59ad5d1a142b6f6b8603ffc9f0f2d9647ff75f8c025f129c"
            },
            "name": "chainloop-1.324.0.tgz"
         }
      ],
      "metadata": {
         "contractName": "myproject-helmcharttest",
         "contractVersion": "2",
         "finishedAt": "2026-01-23T14:01:38.991811223Z",
         "initializedAt": "2026-01-23T14:01:17.906261472Z",
         "name": "helmcharttest",
         "organization": "myorg",
         "project": "myproject",
         "projectVersion": "v1.12.5+next",
         "projectVersionPrerelease": true,
         "team": "",
         "workflowID": "c2b2d61e-d23f-4ea0-8406-2a1ae388e0aa",
         "workflowName": "helmcharttest",
         "workflowRunID": "f0b6f85b-7e12-4102-ae43-7993356bb968"
      },
```

Closes https://github.com/chainloop-dev/chainloop/issues/2685