### PR TITLE
chore(chart): disable Vault Kubernetes Injector

### DIFF
--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -7,7 +7,7 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.325.0
+version: 1.325.1
 # Do not update appVersion, this is handled automatically by the release process
 appVersion: v1.73.1
 

--- a/deployment/chainloop/charts/vault/values.yaml
+++ b/deployment/chainloop/charts/vault/values.yaml
@@ -1316,7 +1316,7 @@ csiProvider:
 injector:
   ## @param injector.enabled Enable Vault Kubernetes Injector
   ##
-  enabled: true
+  enabled: false
   ## Bitnami Vault Kubernetes Injector image
   ## ref: https://hub.docker.com/r/bitnami/vault-k8s/tags/
   ## @param injector.image.registry [default: REGISTRY_NAME] Vault Kubernetes Injector image registry


### PR DESCRIPTION
Disabling vault injector in development as we are not using it and it can cause problems because of mutatingwebhook resource.
In case that injector has problems communicating with vault it can stop all new pods (in whole cluster) from being deployed.
By default its better to disable it and if someone want to use it then he has to explicitly enable it.