### PR TITLE
chore(ci): Activate breaking check on Buf linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           version: 1.49.0
           token: ${{ secrets.buf_api_token }}
-          breaking: false
+          breaking: true
           pr_comment: false
 
   lint-dagger-module:


### PR DESCRIPTION
This pull request updates the lint workflow configuration to enable breaking change detection during the Buf linting process. This ensures that any breaking changes in protobuf definitions will be flagged during CI runs.

* CI/CD pipeline update:
  * [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2L56-R56): Set the `breaking` option to `true` in the Buf lint step to detect and report breaking changes in protobuf files.