### PR TITLE
chore(runners): use dynamic PR metadata material name

### DIFF
--- a/pkg/attestation/crafter/crafter.go
+++ b/pkg/attestation/crafter/crafter.go
@@ -536,7 +536,7 @@ func (c *Crafter) AutoCollectPRMetadata(ctx context.Context, attestationID strin
 
 	// Create a temporary file for the metadata
 	materialName := fmt.Sprintf("pr-metadata-%s", metadata.Number)
-	tmpFile, err := os.CreateTemp("", fmt.Sprintf("%s.json", materialName)
+	tmpFile, err := os.CreateTemp("", fmt.Sprintf("%s.json", materialName))
 	if err != nil {
 		return fmt.Errorf("failed to create temp file: %w", err)
 	}


### PR DESCRIPTION
This PR changes the default material name (`pr-metadata`) to a dynamic one that contains the PR number. This will prevent multiple attestations from different PRs to collide in the same "bucket" (for instance, material name might be used to calculate compliance).