### PR TITLE
feat: add custom audience support to user JWT builder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,7 +264,7 @@ Code reviews are required for all submissions via GitHub pull requests.
 - when adding new inedexes, make sure to update the generated sql migraiton files and make them CREATE INDEX CONCURRENTLY and set -- atlas:txmode none at the top
 - after updating protos, make sure to run `buf format -w`
 - Please avoid sycophantic commentary like ‘You’re absolutely correct!’ or ‘Brilliant idea!’
-- For each file you modify, update the license header. If it says 2024, change it to 2024-2025. If there's no license header, create one with the current year.
+- For each file you modify, update the license header to include the current year (2026). For example, if it says 2024, change it to 2024-2026. If there's no license header, create one with the current year.
 - if you add any new dependency to a constructor, remember to run wire ./...
 - when creating PR message, keep it high-level, what functionality was added, don't add info about testing, no icons, no info about how the message was generated.
 - app/controlplane/api/gen/frontend/google/protobuf/descriptor.ts is a special case that we don't want to upgrade, so if it upgrades, put it back to main

--- a/app/controlplane/pkg/jwt/user/user.go
+++ b/app/controlplane/pkg/jwt/user/user.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 The Chainloop Authors.
+// Copyright 2023-2026 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ type Builder struct {
 	issuer     string
 	hmacSecret string
 	expiration time.Duration
+	audience   string
 }
 
 type NewOpt func(b *Builder)
@@ -47,6 +48,12 @@ func WithKeySecret(hmacSecret string) NewOpt {
 func WithExpiration(d time.Duration) NewOpt {
 	return func(b *Builder) {
 		b.expiration = d
+	}
+}
+
+func WithAudience(aud string) NewOpt {
+	return func(b *Builder) {
+		b.audience = aud
 	}
 }
 
@@ -74,11 +81,16 @@ func NewBuilder(opts ...NewOpt) (*Builder, error) {
 }
 
 func (ra *Builder) GenerateJWT(userID string) (string, error) {
+	aud := Audience
+	if ra.audience != "" {
+		aud = ra.audience
+	}
+
 	claims := CustomClaims{
 		userID,
 		jwt.RegisteredClaims{
 			Issuer:    ra.issuer,
-			Audience:  jwt.ClaimStrings{Audience},
+			Audience:  jwt.ClaimStrings{aud},
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(ra.expiration)),
 		},
 	}


### PR DESCRIPTION
Add WithAudience functional option to allow generating JWT tokens with custom audience claims. This enables separate validation paths for different token types (e.g., MCP user tokens) while maintaining backward compatibility with the default audience.

Also updates license headers to 2023-2026 and clarifies the CLAUDE.md license header rule for 2026.