### PR TITLE
chore(integration): expose integration registered output render functions

### DIFF
--- a/app/cli/cmd/registered_integration_add.go
+++ b/app/cli/cmd/registered_integration_add.go
@@ -63,7 +63,7 @@ func newRegisteredIntegrationAddCmd() *cobra.Command {
 				return err
 			}
 
-			return output.EncodeOutput(flagOutputFormat, res, RegisteredIntegrationItemTableOutput)
+			return output.EncodeOutput(flagOutputFormat, res, registeredIntegrationItemTableOutput)
 		},
 	}
 

--- a/app/cli/cmd/registered_integration_list.go
+++ b/app/cli/cmd/registered_integration_list.go
@@ -37,18 +37,18 @@ func newRegisteredIntegrationListCmd() *cobra.Command {
 				return err
 			}
 
-			return output.EncodeOutput(flagOutputFormat, res, RegisteredIntegrationListTableOutput)
+			return output.EncodeOutput(flagOutputFormat, res, registeredIntegrationListTableOutput)
 		},
 	}
 
 	return cmd
 }
 
-func RegisteredIntegrationItemTableOutput(item *action.RegisteredIntegrationItem) error {
-	return RegisteredIntegrationListTableOutput([]*action.RegisteredIntegrationItem{item})
+func registeredIntegrationItemTableOutput(item *action.RegisteredIntegrationItem) error {
+	return registeredIntegrationListTableOutput([]*action.RegisteredIntegrationItem{item})
 }
 
-func RegisteredIntegrationListTableOutput(items []*action.RegisteredIntegrationItem) error {
+func registeredIntegrationListTableOutput(items []*action.RegisteredIntegrationItem) error {
 	switch n := len(items); {
 	case n == 0:
 		fmt.Println("there are no third party integrations configured in your organization yet")


### PR DESCRIPTION
Expose `ParseAndValidateOpts` and `ParseKeyValOpts` functions from cmd package to allow reuse by downstream consumers.