### PR TITLE
fix(workflow): respect contract name from schema v2

### DIFF
--- a/app/controlplane/pkg/data/referrer.go
+++ b/app/controlplane/pkg/data/referrer.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2023-2026 The Chainloop Authors.
+// Copyright 2023 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -89,10 +89,10 @@ func (r *ReferrerRepo) Save(ctx context.Context, referrers []*biz.Referrer, work
 		// Iterate on the items it refer to (references)
 		var references []uuid.UUID
 		for _, ref := range parentRef.References {
-			// and find it in the DB
+			// amd find it in the DB
 			storedReference, ok := storedMap[ref.MapID()]
 			if !ok {
-				return fmt.Errorf("an artifact or piece of evidence with digest %s (kind: %s) can't be found", ref.Digest, ref.Kind)
+				return fmt.Errorf("referrer %v not found", ref)
 			}
 
 			references = append(references, storedReference)


### PR DESCRIPTION
When running `attestation init` with a contract in schema v2, the contract is now created with the name defined in metadata.name instead of the default one.

```
piVersion: chainloop.dev/v1
kind: Contract
metadata:
  name: different-name
  description: Contract for CSAF advisories and VEX
spec:
  materials:
    # Refs: https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#45-profile-5-vex
    - type: CSAF_VEX
      name: vex-disclosure
    # Refs: https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#43-profile-3-informational-advisory
    - type: CSAF_INFORMATIONAL_ADVISORY
      name: informational-advisory
    # Refs: https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#44-profile-4-security-advisory
    - type: CSAF_SECURITY_ADVISORY
      name: security-advisory
    # Refs: https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#42-profile-2-security-incident-response
    - type: CSAF_SECURITY_INCIDENT_RESPONSE
      name: security-incident-response
```

```
$ chainloop att init --project myproject --workflow respects-name --contract contract.yml
WRN API contacted in insecure mode
WRN User-attended mode detected. This is intended for local testing only. For CI/CD or automated workflows, please use an API token.
This command will run against the organization "myorg"
Please confirm to continue y/N
y
INF Attestation initialized! now you can check its status or add materials to it
┌───────────────────────────┬──────────────────────────────────────┐
│ Initialized At            │ 13 Feb 26 12:13 UTC                  │
├───────────────────────────┼──────────────────────────────────────┤
│ Attestation ID            │ be0c970c-b7cf-4a86-98c7-ef772c3cb590 │
│ Organization              │ myorg                                │
│ Name                      │ respects-name                        │
│ Project                   │ myproject                            │
│ Version                   │ v1.19.1+next (prerelease)            │
│ Contract                  │ different-name (revision 1)          │
│ Policy violation strategy │ ADVISORY                             │
└───────────────────────────┴──────────────────────────────────────┘
┌────────────────────────────────────────────┐
│ Materials                                  │
├──────────┬─────────────────────────────────┤
│ Name     │ informational-advisory          │
│ Type     │ CSAF_INFORMATIONAL_ADVISORY     │
│ Set      │ No                              │
│ Required │ Yes                             │
├──────────┼─────────────────────────────────┤
│ Name     │ security-advisory               │
│ Type     │ CSAF_SECURITY_ADVISORY          │
│ Set      │ No                              │
│ Required │ Yes                             │
├──────────┼─────────────────────────────────┤
│ Name     │ security-incident-response      │
│ Type     │ CSAF_SECURITY_INCIDENT_RESPONSE │
│ Set      │ No                              │
│ Required │ Yes                             │
├──────────┼─────────────────────────────────┤
│ Name     │ vex-disclosure                  │
│ Type     │ CSAF_VEX                        │
│ Set      │ No                              │
│ Required │ Yes                             │
└──────────┴─────────────────────────────────┘
```