### PR TITLE
refactor(authz): replace admin role check with policy-based authorization for default backend access

### DIFF
--- a/app/controlplane/pkg/authz/authz.go
+++ b/app/controlplane/pkg/authz/authz.go
@@ -63,6 +63,7 @@ const (
 	ResourceAPIToken                = "api_token"
 	ResourceProjectMembership       = "project_membership"
 	ResourceOrganizationInvitations = "organization_invitations"
+	ResourceDefaultBackend          = "default_backend"
 
 	// Top level instance admin role
 	// this is used to know if an user is a super admin of the chainloop instance
@@ -107,6 +108,8 @@ var (
 	// Artifact
 	PolicyArtifactDownload = &Policy{ResourceCASArtifact, ActionRead}
 	PolicyArtifactUpload   = &Policy{ResourceCASArtifact, ActionCreate}
+	// Being able to read from the default backend
+	PolicyDefaultBackendArtifactRead = &Policy{ResourceDefaultBackend, ActionRead}
 	// CAS backend
 	PolicyCASBackendList   = &Policy{ResourceCASBackend, ActionList}
 	PolicyCASBackendUpdate = &Policy{ResourceCASBackend, ActionUpdate}
@@ -198,6 +201,8 @@ var RolesMap = map[Role][]*Policy{
 		PolicyArtifactUpload,
 		// We manually check this policy to be able to know if the user can invite users to the system
 		PolicyOrganizationInvitationsCreate,
+		// Being able to read from the default backend
+		PolicyDefaultBackendArtifactRead,
 		// + all the policies from the viewer role inherited automatically
 	},
 	// RoleViewer is an org-scoped role that provides read-only access to all resources


### PR DESCRIPTION
## Summary
Replace hardcoded admin role check with proper policy-based authorization when falling back to the default CAS backend for artifact downloads.

## Motivation
This change improves the authorization model by:
1. Using the authorization framework consistently instead of hardcoded role checks
2. Making the permission explicit and auditable through policies
3. Allowing for future policy customization without code changes