### PR TITLE
fix(release): use EE CLI in finish_attestation to support project_compliance

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -215,7 +215,7 @@ jobs:
     steps:
       - name: Install Chainloop
         run: |
-          curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s
+          curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s -- --ee
 
       - name: Finish and Record Attestation
         id: attestation_push


### PR DESCRIPTION
The finish_attestation job in the release workflow was installing the OSS CLI, which lacks the `chainloop.project_compliance` Rego built-in function required during policy evaluation. This caused attestation push to fail when policies reference project compliance checks. Now it installs the EE CLI, consistent with init_attestation and release jobs.