### PR TITLE
fix(ci): Use Chainloop CLI EE everywhere

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Chainloop
         if: ${{ github.event_name != 'pull_request' }}
         run: |
-          curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s
+          curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s -- --ee
 
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/github_release.yaml
+++ b/.github/workflows/github_release.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install Chainloop
         run: |
-          curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s
+          curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s -- --ee
 
       - name: Initialize Attestation
         run: |

--- a/.github/workflows/package_chart.yaml
+++ b/.github/workflows/package_chart.yaml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: Install Chainloop
         run: |
-          curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s
+          curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s -- --ee
 
       - name: Docker login to Github Packages
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -215,7 +215,7 @@ jobs:
     steps:
       - name: Install Chainloop
         run: |
-          curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s
+          curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s -- --ee
 
       - name: Finish and Record Attestation
         id: attestation_push

--- a/.github/workflows/sync_contracts.yml
+++ b/.github/workflows/sync_contracts.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Chainloop
         run: |
-          curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s
+          curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s -- --ee
       - name: Update contract definitions
         run: |
           for file in .github/workflows/contracts/*.yaml; do


### PR DESCRIPTION
This patch introduces the `--ee` option to all workflows in the CI pipeline, ensuring that we consistently use the enterprise version.

This patch was necessary to resolve the failure of this particular release: https://github.com/chainloop-dev/chainloop/actions/runs/22134861837/job/63986563330

The introduction of this option was made in [this pull request](https://github.com/chainloop-dev/chainloop/pull/2731) when we implemented the corresponding policy. By adding it to all workflows, we ensure that this important configuration is never overlooked.