### PR TITLE
chore: replace buf DEFAULT lint category with STANDARD

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -83,7 +83,7 @@ modules:
   - path: app/controlplane/plugins/sdk/v1/plugin/api
     lint:
       use:
-        - DEFAULT
+        - STANDARD
       except:
         - FIELD_NOT_REQUIRED
         - PACKAGE_NO_IMPORT_CYCLE
@@ -102,7 +102,7 @@ modules:
   - path: pkg/attestation/crafter/api
     lint:
       use:
-        - DEFAULT
+        - STANDARD
       except:
         - FIELD_NOT_REQUIRED
         - PACKAGE_NO_IMPORT_CYCLE
@@ -119,7 +119,7 @@ modules:
   - path: pkg/credentials/api
     lint:
       use:
-        - DEFAULT
+        - STANDARD
       except:
         - FIELD_NOT_REQUIRED
         - PACKAGE_NO_IMPORT_CYCLE


### PR DESCRIPTION
## Summary
- Update `buf.yaml` to use `STANDARD` instead of the deprecated `DEFAULT` lint category.
- Keep the effective linting behavior unchanged while aligning with current Buf terminology.
- Remove deprecation warnings and improve forward compatibility of the Buf configuration.

This triggered a warning in buf lint, the change is mentioned here: https://github.com/bufbuild/buf/blob/main/CHANGELOG.md#v1400---2024-09-04