### PR TITLE
test(controlplane): cover extractEnvVariables ordering and nil input

### DIFF
--- a/app/controlplane/internal/service/attestation_test.go
+++ b/app/controlplane/internal/service/attestation_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 The Chainloop Authors.
+// Copyright 2023-2026 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -95,6 +95,45 @@ func TestExtractMaterials(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := extractMaterials(tc.input)
 			assert.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestExtractEnvVariables(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input map[string]string
+		want  []*cpAPI.AttestationItem_EnvVariable
+	}{
+		{
+			name: "returns env vars sorted by name",
+			input: map[string]string{
+				"Z_VAR": "z",
+				"A_VAR": "a",
+				"M_VAR": "m",
+			},
+			want: []*cpAPI.AttestationItem_EnvVariable{
+				{Name: "A_VAR", Value: "a"},
+				{Name: "M_VAR", Value: "m"},
+				{Name: "Z_VAR", Value: "z"},
+			},
+		},
+		{
+			name:  "empty input",
+			input: map[string]string{},
+			want:  []*cpAPI.AttestationItem_EnvVariable{},
+		},
+		{
+			name:  "nil input",
+			input: nil,
+			want:  []*cpAPI.AttestationItem_EnvVariable{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractEnvVariables(tc.input)
 			assert.Equal(t, tc.want, got)
 		})
 	}


### PR DESCRIPTION
Add unit test for attestation env var extraction.

Might consider changing the original logic to `slices.SortFunc` (Go 1.21+) later on.