### PR TITLE
feat(.claude): add dependabot-pr-automation skill

### DIFF
--- a/.claude/skills/dependabot-pr-automation/SKILL.md
+++ b/.claude/skills/dependabot-pr-automation/SKILL.md
@@ -52,7 +52,7 @@ Dependabot PR titles follow the pattern: `Bump <package> from <old-version> to <
 
 ### 2b. Check CI / Check Status
 
-Use `mcp__github__get_pull_request` to get details for each PR. Check the `mergeable_state` and status checks.
+Use `mcp__github__get_pull_request_status` to retrieve the CI check status for each PR. A PR is considered CI-passing only if all checks have concluded with a success state.
 
 ### 2c. Inspect the Diff
 


### PR DESCRIPTION
Adds a new Claude skill that automates the review and merging of Dependabot pull requests. The skill lists open Dependabot PRs, assesses risk based on version bump type (patch/minor/major), CI status, and file scope, then auto-approves and merges eligible low-risk PRs while flagging high-risk ones for manual review.

Closes #2780