### PR TITLE
fix(controlplane): use request context for CAS backend lookup in attestation init

### DIFF
--- a/app/controlplane/internal/service/attestation.go
+++ b/app/controlplane/internal/service/attestation.go
@@ -179,7 +179,7 @@ func (s *AttestationService) Init(ctx context.Context, req *cpAPI.AttestationSer
 	}
 
 	// Find the default or fallback CAS backend to associate the workflow
-	backend, err := s.casUC.FindDefaultOrFallbackBackend(context.Background(), robotAccount.OrgID)
+	backend, err := s.casUC.FindDefaultOrFallbackBackend(ctx, robotAccount.OrgID)
 	if err != nil {
 		if biz.IsNotFound(err) {
 			return nil, cpAPI.ErrorCasBackendErrorReasonRequired("no CAS backend configured for organization")


### PR DESCRIPTION
**Summary**

- Update `AttestationService.Init` to pass the incoming request context to CAS backend resolution.
- Keep CAS backend selection behavior unchanged while preserving request-scoped cancellation, deadlines, and metadata propagation.
- Improve consistency with the rest of the service layer by avoiding detached context usage in request handling.