### PR TITLE
fix(artifact-cas): return ResourceExhausted for oversized uploads

### DIFF
--- a/pkg/blobmanager/errors.go
+++ b/pkg/blobmanager/errors.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 The Chainloop Authors.
+// Copyright 2023-2026 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -34,4 +34,21 @@ func (e ErrNotFound) Error() string {
 
 func IsNotFound(err error) bool {
 	return errors.As(err, &ErrNotFound{})
+}
+
+type ErrUploadSizeExceeded struct {
+	want int64
+	max  int64
+}
+
+func NewErrUploadSizeExceeded(want, maxSize int64) ErrUploadSizeExceeded {
+	return ErrUploadSizeExceeded{want: want, max: maxSize}
+}
+
+func (e ErrUploadSizeExceeded) Error() string {
+	return fmt.Sprintf("max size of upload exceeded: want=%d, max=%d", e.want, e.max)
+}
+
+func IsUploadSizeExceeded(err error) bool {
+	return errors.As(err, &ErrUploadSizeExceeded{})
 }


### PR DESCRIPTION
For #2582 

This PR improves artifact upload error semantics in `artifact-cas` when a file exceeds the configured maximum size.

It introduces a typed domain error for upload size overflow in `pkg/blobmanager` and updates the `bytestream` write path to detect that condition explicitly. Instead of masking it as a generic internal server error, the service now returns a client-visible gRPC `ResourceExhausted` status.

The `bytestream` test suite was updated to validate the new overflow classification and the expected status code for max-size rejection.

Also replaced `backend` with `storageBackend` in `bytestream.go` to avoid name shadowing (`backend`: blobmanager package utilities and types, `storageBackend`: runtime backend implementation)/ 

**Note:** I've observed that we use `ResourceExhausted` to signal request retries in `attestation_push.go` and other places but this doesn't affect `pkg/casclient/uploader.go` (and artifact uploads from CLI) in particular.

**Before this change:**
```
% chainloop artifact upload --file random-20mb.bin 
WRN API contacted in insecure mode
WRN API contacted in insecure mode
INF uploading random-20mb.bin - sha256:922af4fb71fc691abd17a5f91d4bbeb663ea8ea66e6de2e7e4eb1c6511c08b26
 ... done! [13.63MB in 13ms; 1.05GB/s]
ERR server error
```

**After this change:**
```
% chainloop artifact upload --file random-20mb.bin
WRN API contacted in insecure mode
WRN API contacted in insecure mode
INF uploading random-20mb.bin - sha256:922af4fb71fc691abd17a5f91d4bbeb663ea8ea66e6de2e7e4eb1c6511c08b26
 ... done! [13.63MB in 11ms; 1.20GB/s]
ERR max size of upload exceeded: want=11534336, max=10485760
```

Some points:
1. Do we want to send these errors to Sentry (e.g. use `LogAndMaskErr`)?
2. I've added want/max to the error so we inform the user about the limit and expected size. Is this ok?
3. We can tackle CLI changes in another PR and avoid showing "done!" in these cases. Also propose a friendlier message if we implement the above.