### PR TITLE
feat(contracts): remove requirements mapping to enable automatching

### DIFF
--- a/.github/workflows/contracts/chainloop-vault-codeql.yaml
+++ b/.github/workflows/contracts/chainloop-vault-codeql.yaml
@@ -17,8 +17,6 @@ spec:
         with:
           check_signature: yes
           check_author_verified: yes
-        requirements:
-          - chainloop-best-practices/commit-signed
   policyGroups:
     - ref: slsa-checks
       with:

--- a/.github/workflows/contracts/chainloop-vault-helm-package.yaml
+++ b/.github/workflows/contracts/chainloop-vault-helm-package.yaml
@@ -23,13 +23,8 @@ spec:
         with:
           check_signature: yes
           check_author_verified: yes
-        requirements:
-          - chainloop-best-practices/commit-signed
     materials:
       - ref: artifact-signed
-        requirements:
-          - chainloop-best-practices/container-signed
-          - chainloop-best-practices/helm-chart-signed
   policyGroups:
     - ref: slsa-checks
       with:

--- a/.github/workflows/contracts/chainloop-vault-release.yaml
+++ b/.github/workflows/contracts/chainloop-vault-release.yaml
@@ -15,13 +15,9 @@ spec:
         with:
           check_signature: yes
           check_author_verified: yes
-        requirements:
-          - chainloop-best-practices/commit-signed
       - ref: containers-with-sbom
     materials:
       - ref: artifact-signed
-        requirements:
-          - chainloop-best-practices/container-signed
   policyGroups:
     - ref: sbom-quality
       with:

--- a/.github/workflows/contracts/chainloop-vault-scorecards.yaml
+++ b/.github/workflows/contracts/chainloop-vault-scorecards.yaml
@@ -16,5 +16,3 @@ spec:
       - ref: source-commit
         with:
           check_signature: yes
-        requirements:
-          - chainloop-best-practices/commit-signed


### PR DESCRIPTION
This PR removes the explicit mapping of a policy to a requirement leaving the mapping the automatching [feature in Chainloop Platform](https://docs.chainloop.dev/concepts/compliance-frameworks#requirements-auto-matching). 

refs #2790