### PR TITLE
fix(contracts): run check-compliance-requirement only at INIT phase

### DIFF
--- a/.github/workflows/contracts/chainloop-vault-release.yaml
+++ b/.github/workflows/contracts/chainloop-vault-release.yaml
@@ -11,6 +11,8 @@ spec:
         with:
           requirement_name: sbom-compliance
         gate: true
+        attestation_phases:
+          - INIT
       - ref: source-commit
         with:
           check_signature: yes


### PR DESCRIPTION
## Summary
- Restrict the `check-compliance-requirement` policy in the vault release contract to run only during the INIT attestation phase, preventing unnecessary evaluation at push time.

Fixes #2798