### PR TITLE
fix(log-message): Update CAS credentials logging message

### DIFF
--- a/app/cli/pkg/action/action.go
+++ b/app/cli/pkg/action/action.go
@@ -108,7 +108,7 @@ func getCASBackend(ctx context.Context, client pb.AttestationServiceClient, work
 	})
 	if err != nil {
 		// Log warning but don't fail - will fall back to inline storage
-		logger.Warn().Err(err).Msg("failed to get CAS credentials for PR metadata, will store inline")
+		logger.Warn().Err(err).Msg("failed to get CAS credentials, will store inline")
 		return nil, nil, fmt.Errorf("getting upload creds: %w", err)
 	}
 


### PR DESCRIPTION
This pull request makes a minor change to the warning message in the `getCASBackend` function to clarify the context when failing to get CAS credentials. The updated message is now more general and no longer mentions "PR metadata".

- Improved warning log message in `getCASBackend` to remove the reference to "PR metadata" and clarify that inline storage will be used if CAS credentials can't be obtained.

PFM-768, #2809 