### PR TITLE
feat(backend): log version at boot

### DIFF
--- a/app/artifact-cas/cmd/main.go
+++ b/app/artifact-cas/cmd/main.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2024 The Chainloop Authors.
+// Copyright 2024-2026 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -117,6 +117,8 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+
+	_ = logger.Log(log.LevelInfo, "msg", "starting artifact-cas service", "version", Version)
 
 	flush, err := initSentry(&bc, logger)
 	defer flush()

--- a/app/controlplane/cmd/main.go
+++ b/app/controlplane/cmd/main.go
@@ -121,6 +121,8 @@ func main() {
 
 	logger = log.NewFilter(logger, log.FilterFunc(filterSensitiveArgs))
 
+	_ = logger.Log(log.LevelInfo, "msg", "starting control-plane service", "version", Version)
+
 	flush, err := initSentry(&bc, logger)
 	defer flush()
 	if err != nil {
@@ -177,17 +179,17 @@ func main() {
 	if app.casBackendChecker != nil {
 
 		go app.casBackendChecker.Start(ctx, &biz.CASBackendCheckerOpts{
-			CheckInterval: 30 * time.Minute,
-			InitialDelay:  initialDelay,
-			OnlyDefaultsOrFallbacks:  toPtr(true),
+			CheckInterval:           30 * time.Minute,
+			InitialDelay:            initialDelay,
+			OnlyDefaultsOrFallbacks: toPtr(true),
 		})
 
 		// Start the background CAS Backend checker for ALL backends (every 24 hours)
 		// Start around 24h mark to avoid overlap with default checker
 		go app.casBackendChecker.Start(ctx, &biz.CASBackendCheckerOpts{
-			CheckInterval: 24 * time.Hour,
-			InitialDelay:  (24 * time.Hour) + jitter,
-			OnlyDefaultsOrFallbacks:  toPtr(false),
+			CheckInterval:           24 * time.Hour,
+			InitialDelay:            (24 * time.Hour) + jitter,
+			OnlyDefaultsOrFallbacks: toPtr(false),
 		})
 	}
 


### PR DESCRIPTION
Log the application version immediately after logger initialization in both control-plane and artifact-cas services, making it available in logs even when the API is not yet reachable.

Closes #1070