### PR TITLE
fix: add missing GITHUB_TOKEN for chainloop to gather runner data

### DIFF
--- a/.github/workflows/scm_configuration_check.yaml
+++ b/.github/workflows/scm_configuration_check.yaml
@@ -17,6 +17,7 @@ jobs:
       CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
       CHAINLOOP_WORKFLOW_NAME: scm-configuration-check
       CHAINLOOP_PROJECT_NAME: chainloop
+      GITHUB_TOKEN: ${{ github.token }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/secrets-scan-daily.yml
+++ b/.github/workflows/secrets-scan-daily.yml
@@ -28,6 +28,7 @@ jobs:
       CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
       CHAINLOOP_WORKFLOW_NAME: ${{ needs.onboard_workflow.outputs.workflow_name }}
       CHAINLOOP_PROJECT_NAME: ${{ needs.onboard_workflow.outputs.project_name }}
+      GITHUB_TOKEN: ${{ github.token }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Fixes missing verification information in chainloop attestations as this one https://github.com/chainloop-dev/platform/actions/runs/22662954302


