### PR TITLE
chore: re-enable previously disabled buf lint checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,7 +56,6 @@ jobs:
           token: ${{ secrets.buf_api_token }}
           breaking: true
           pr_comment: false
-          exclude_imports: true
 
   lint-dagger-module:
     runs-on: ubuntu-latest

--- a/buf.yaml
+++ b/buf.yaml
@@ -49,7 +49,6 @@ modules:
       except:
         - EXTENSION_NO_DELETE
         - FIELD_SAME_DEFAULT
-        - FIELD_SAME_CARDINALITY
   - path: app/controlplane/internal/conf
     lint:
       use:


### PR DESCRIPTION
## Summary

This PR restores the `buf` lint checks that were temporarily disabled for #2769 (PR #2777)

It brings `buf.yaml` and the lint workflow configuration back to the standard validation behavior so protobuf checks run as expected in CI.