### PR TITLE
fix(cli): handle GitHub federated OIDC tokens in attestation auth parsing

### DIFF
--- a/app/cli/internal/token/token.go
+++ b/app/cli/internal/token/token.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2024-2025 The Chainloop Authors.
+// Copyright 2024-2026 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ const (
 	//nolint:gosec
 	apiTokenAudience       = "api-token-auth.chainloop"
 	federatedTokenAudience = "chainloop"
+	githubFederatedIssuer  = "https://token.actions.githubusercontent.com"
 )
 
 // Parse the token and return the type of token. At the moment in Chainloop we have 3 types of tokens:
@@ -111,13 +112,26 @@ func Parse(token string) (*ParsedToken, error) {
 			pToken.ID = userID
 		}
 	case federatedTokenAudience:
-		if isGitLabFederatedToken(claims) {
+		// Federated tokens require a known provider format.
+		switch {
+		case isGitLabFederatedToken(claims):
 			pToken.TokenType = v1.Attestation_Auth_AUTH_TYPE_FEDERATED
-			if issuer, ok := claims["iss"].(string); ok {
-				pToken.ID = issuer
-			}
+		case isGitHubFederatedToken(claims):
+			pToken.TokenType = v1.Attestation_Auth_AUTH_TYPE_FEDERATED
+		default:
+			return nil, nil
+		}
+
+		if issuer, ok := claims["iss"].(string); ok {
+			pToken.ID = issuer
 		}
 	default:
+		return nil, nil
+	}
+
+	// Avoid returning partially filled tokens that would create invalid auth metadata
+	// in crafting state (e.g. type=UNSPECIFIED or empty ID).
+	if pToken.TokenType == v1.Attestation_Auth_AUTH_TYPE_UNSPECIFIED || pToken.ID == "" {
 		return nil, nil
 	}
 
@@ -171,4 +185,15 @@ func isGitLabFederatedToken(claims jwt.MapClaims) bool {
 	}
 
 	return found >= requiredClaims
+}
+
+// TODO: Evaluate adding claim-structure validation for GitHub tokens, similar to
+// the GitLab heuristic above, once we stabilize the expected claim set.
+func isGitHubFederatedToken(claims jwt.MapClaims) bool {
+	iss, ok := claims["iss"].(string)
+	if !ok {
+		return false
+	}
+
+	return iss == githubFederatedIssuer
 }

--- a/app/cli/internal/token/token_test.go
+++ b/app/cli/internal/token/token_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2024 The Chainloop Authors.
+// Copyright 2024-2026 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -54,6 +54,18 @@ func TestParse(t *testing.T) {
 				ID:        "https://chainloop.gitlab.com",
 				TokenType: v1.Attestation_Auth_AUTH_TYPE_FEDERATED,
 			},
+		},
+		{
+			name:  "federated github token",
+			token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL3Rva2VuLmFjdGlvbnMuZ2l0aHVidXNlcmNvbnRlbnQuY29tIiwiYXVkIjoiY2hhaW5sb29wIiwicmVwb3NpdG9yeSI6Im1hdGlhc2luc2F1cnJhbGRlL3Byb2plY3QiLCJzdWIiOiJyZXBvOm1hdGlhc2luc2F1cnJhbGRlL3Byb2plY3Q6cmVmOnJlZnMvaGVhZHMvbWFpbiJ9.signature",
+			want: &ParsedToken{
+				ID:        "https://token.actions.githubusercontent.com",
+				TokenType: v1.Attestation_Auth_AUTH_TYPE_FEDERATED,
+			},
+		},
+		{
+			name:  "federated token without issuer",
+			token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJjaGFpbmxvb3AifQ.signature",
 		},
 		{
 			name:  "old api token (without orgID)",
@@ -199,6 +211,41 @@ func TestIsGitLabFederatedToken(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := isGitLabFederatedToken(tt.claims)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIsGitHubFederatedToken(t *testing.T) {
+	tests := []struct {
+		name   string
+		claims jwt.MapClaims
+		want   bool
+	}{
+		{
+			name: "github issuer",
+			claims: jwt.MapClaims{
+				"iss": "https://token.actions.githubusercontent.com",
+			},
+			want: true,
+		},
+		{
+			name: "different issuer",
+			claims: jwt.MapClaims{
+				"iss": "https://gitlab.com",
+			},
+			want: false,
+		},
+		{
+			name:   "missing issuer",
+			claims: jwt.MapClaims{},
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isGitHubFederatedToken(tt.claims)
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION

## Summary
This change fixes a CLI federated-auth parsing issue that affected GitHub OIDC flows.  
In the failing scenario, `att init` and `att add` succeeded, but `att push` failed because crafting state contained invalid `attestation.auth` values (`type=0`, empty `id`).

## What changed
- Added explicit GitHub federated token recognition via issuer `https://token.actions.githubusercontent.com`.
- Kept federated classification for GitLab tokens.
- Added a guard to avoid returning partially filled parsed tokens that would result in invalid crafting-state auth metadata.
- Extended token parsing tests to cover:
  - GitHub federated token parsing
  - Federated token missing issuer
  - GitHub issuer detection helper behavior

## Why
Issue analysis showed the CLI parser handled federated tokens with a GitLab-specific claim heuristic, so valid GitHub OIDC tokens could bypass proper classification and still produce a non-nil parsed token with zero-value auth fields. Those invalid auth fields were then rejected later by strict push-time crafting-state validation.

## Context
This is related to **GitHub support** for keyless/federated CLI workflows, ensuring GitHub OIDC users can complete the expected attestation flow without deferred validation errors.