### PR TITLE
chore(ci): migrate CodeQL workflow to GitHub keyless auth

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write # required for SLSA attestation
 
 jobs:
   analyze:
@@ -22,7 +23,6 @@ jobs:
       security-events: write
       id-token: write # required for SLSA provenance - https://docs.chainloop.dev/guides/slsa/
     env:
-      CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
       CHAINLOOP_WORKFLOW_NAME: "codeql"
       CHAINLOOP_PROJECT: "chainloop"
 


### PR DESCRIPTION
## Summary

- Migrate CodeQL GH workflow to use [GitHub keyless attestation](https://docs.chainloop.dev/guides/github-keyless).