### PR TITLE
chore(ci): migrate secrets-scan-daily workflow to GitHub keyless auth

### DIFF
--- a/.github/workflows/secrets-scan-daily.yml
+++ b/.github/workflows/secrets-scan-daily.yml
@@ -6,29 +6,18 @@ on:
     - cron: '0 9 * * *'
   workflow_dispatch: # Allow manual triggering
 
-permissions:
-  contents: read
-  id-token: write # Required for SLSA attestation
+permissions: read-all
 
 jobs:
-  onboard_workflow:
-    name: Onboard Chainloop Workflow
-    uses: chainloop-dev/labs/.github/workflows/chainloop_onboard.yml@6bbd1c2b3022e48ae60afa0c2b90f3b6d31bcf11
-    with:
-      project: "chainloop"
-      workflow_name: "daily-secrets-detection"
-    secrets:
-      api_token: ${{ secrets.CHAINLOOP_TOKEN }}
-
   daily-secrets-scan:
     name: Daily Secrets Scan
-    needs: onboard_workflow
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     env:
-      CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
-      CHAINLOOP_WORKFLOW_NAME: ${{ needs.onboard_workflow.outputs.workflow_name }}
-      CHAINLOOP_PROJECT_NAME: ${{ needs.onboard_workflow.outputs.project_name }}
-      GITHUB_TOKEN: ${{ github.token }}
+      CHAINLOOP_WORKFLOW_NAME: "daily-secrets-detection"
+      CHAINLOOP_PROJECT_NAME: "chainloop"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Migrate secrets-scan-daily workflow to use [GitHub keyless attestation](https://docs.chainloop.dev/guides/github-keyless).