### PR TITLE
feat: add material size annotation to attestations

### DIFF
--- a/pkg/attestation/crafter/materials/artifact_test.go
+++ b/pkg/attestation/crafter/materials/artifact_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2023-2025 The Chainloop Authors.
+// Copyright 2023-2026 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -96,6 +96,9 @@ func TestArtifactCraft(t *testing.T) {
 	assert.Equal(got.GetArtifact(), &attestationApi.Attestation_Material_Artifact{
 		Id: "test", Digest: "sha256:54181dfe59340b318253e59f7695f547c5c10d071cb75001170a389061349918", Name: "simple.txt",
 	})
+
+	// The result includes the size annotation
+	assert.Equal("8", got.Annotations[materials.AnnotationMaterialSize])
 }
 
 func TestArtifactCraftInline(t *testing.T) {
@@ -153,4 +156,6 @@ func assertMaterial(t *testing.T, got *attestationApi.Attestation_Material) {
 		// Inline content
 		Content: []byte("txt file"),
 	})
+	// The result includes the size annotation
+	assert.Equal("8", got.Annotations[materials.AnnotationMaterialSize])
 }

--- a/pkg/attestation/crafter/materials/evidence_test.go
+++ b/pkg/attestation/crafter/materials/evidence_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2024-2025 The Chainloop Authors.
+// Copyright 2024-2026 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -171,6 +171,7 @@ func TestEvidenceCraftWithJSONAnnotations(t *testing.T) {
 			expectedAnnotations: map[string]string{
 				"chainloop.material.evidence.id":     "custom-evidence-123",
 				"chainloop.material.evidence.schema": "https://example.com/schema/v1",
+				materials.AnnotationMaterialSize:     "297",
 			},
 		},
 		{
@@ -178,6 +179,7 @@ func TestEvidenceCraftWithJSONAnnotations(t *testing.T) {
 			filePath: "./testdata/evidence-with-id-data-no-schema.json",
 			expectedAnnotations: map[string]string{
 				"chainloop.material.evidence.id": "custom-evidence-456",
+				materials.AnnotationMaterialSize: "158",
 			},
 		},
 		{
@@ -186,17 +188,22 @@ func TestEvidenceCraftWithJSONAnnotations(t *testing.T) {
 			expectedAnnotations: map[string]string{
 				"chainloop.material.evidence.id":     "custom-evidence-123",
 				"chainloop.material.evidence.schema": "https://example.com/schema/v1",
+				materials.AnnotationMaterialSize:     "325",
 			},
 		},
 		{
-			name:                "JSON without required structure does not extract annotations",
-			filePath:            "./testdata/evidence-invalid-structure.json",
-			expectedAnnotations: nil,
+			name:     "JSON without required structure does not extract annotations",
+			filePath: "./testdata/evidence-invalid-structure.json",
+			expectedAnnotations: map[string]string{
+				materials.AnnotationMaterialSize: "90",
+			},
 		},
 		{
-			name:                "Non-JSON file does not extract annotations",
-			filePath:            "./testdata/simple.txt",
-			expectedAnnotations: nil,
+			name:     "Non-JSON file does not extract annotations",
+			filePath: "./testdata/simple.txt",
+			expectedAnnotations: map[string]string{
+				materials.AnnotationMaterialSize: "8",
+			},
 		},
 	}
 

--- a/pkg/attestation/crafter/materials/materials.go
+++ b/pkg/attestation/crafter/materials/materials.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2024-2025 The Chainloop Authors.
+// Copyright 2024-2026 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"time"
 
 	"buf.build/go/protovalidate"
@@ -39,6 +40,7 @@ const (
 	AnnotationToolNameKey    = "chainloop.material.tool.name"
 	AnnotationToolVersionKey = "chainloop.material.tool.version"
 	AnnotationToolsKey       = "chainloop.material.tools"
+	AnnotationMaterialSize   = "chainloop.material.size"
 )
 
 // IsLegacyAnnotation returns true if the annotation key is a legacy annotation
@@ -163,6 +165,10 @@ func uploadAndCraft(ctx context.Context, input *schemaapi.CraftingSchema_Materia
 
 		material.InlineCas = true
 		material.GetArtifact().Content = content
+	}
+
+	material.Annotations = map[string]string{
+		AnnotationMaterialSize: strconv.FormatInt(result.size, 10),
 	}
 
 	return material, nil

--- a/pkg/attestation/crafter/materials/materials_test.go
+++ b/pkg/attestation/crafter/materials/materials_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 The Chainloop Authors.
+// Copyright 2023-2026 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -51,5 +51,5 @@ func TestCraft(t *testing.T) {
 	// Timestamp
 	assert.WithinDuration(time.Now(), got.AddedAt.AsTime(), 5*time.Second)
 	// Annotations
-	assert.Equal(map[string]string{"test": "test"}, got.Annotations)
+	assert.Equal(map[string]string{"test": "test", "chainloop.material.size": "10"}, got.Annotations)
 }

--- a/pkg/attestation/crafter/materials/string.go
+++ b/pkg/attestation/crafter/materials/string.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 The Chainloop Authors.
+// Copyright 2023-2026 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package materials
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	schemaapi "github.com/chainloop-dev/chainloop/app/controlplane/api/workflowcontract/v1"
@@ -52,6 +53,9 @@ func (i *StringCrafter) Craft(_ context.Context, value string) (*api.Attestation
 				Id:    i.input.Name,
 				Value: value, Digest: hash.String(),
 			},
+		},
+		Annotations: map[string]string{
+			AnnotationMaterialSize: strconv.Itoa(len(value)),
 		},
 	}, nil
 }


### PR DESCRIPTION
## Summary
- Add `chainloop.material.size` built-in annotation that records the material size in bytes
- Applies to all file-based material types (artifacts, SBOMs, SARIF, etc.) and STRING materials
- Follows existing `chainloop.material.*` annotation naming convention

Example output after adding a material:

```
┌─────────────┬─────────────────────────────────────────────────────────────────────────┐
│ Name        │ artifact                                                                │
├─────────────┼─────────────────────────────────────────────────────────────────────────┤
│ Type        │ ARTIFACT                                                                │
├─────────────┼─────────────────────────────────────────────────────────────────────────┤
│ Required    │ No                                                                      │
├─────────────┼─────────────────────────────────────────────────────────────────────────┤
│ Value       │ 20240415_123801.jpg                                                     │
├─────────────┼─────────────────────────────────────────────────────────────────────────┤
│ Digest      │ sha256:d7f73a24a4bfe62d0024db940db13fca9bcf17040151b9607e6e52ec75b03f97 │
├─────────────┼─────────────────────────────────────────────────────────────────────────┤
│ Annotations │ ------                                                                  │
├─────────────┼─────────────────────────────────────────────────────────────────────────┤
│             │ chainloop.material.size: 1023852                                        │
└─────────────┴─────────────────────────────────────────────────────────────────────────┘
```

In the final in-toto attestation:

```json
"materials": [
   {
      "annotations": {
         "chainloop.material.cas": true,
         "chainloop.material.name": "artifact",
         "chainloop.material.size": "1023852",
         "chainloop.material.type": "ARTIFACT"
      },
      "digest": {
         "sha256": "d7f73a24a4bfe62d0024db940db13fca9bcf17040151b9607e6e52ec75b03f97"
      },
      "name": "20240415_123801.jpg"
   }
]
```

Closes #2847