### PR TITLE
chore(ci): migrate scm_configuration_check workflow to GitHub keyless auth

### DIFF
--- a/.github/workflows/scm_configuration_check.yaml
+++ b/.github/workflows/scm_configuration_check.yaml
@@ -6,6 +6,8 @@ on:
     - cron: "0 9 * * *"
   workflow_dispatch: # Allow manual triggering
 
+permissions: read-all
+
 jobs:
   scm-configuration-check:
     runs-on: ubuntu-latest
@@ -14,7 +16,6 @@ jobs:
       id-token: write
 
     env:
-      CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
       CHAINLOOP_WORKFLOW_NAME: scm-configuration-check
       CHAINLOOP_PROJECT_NAME: chainloop
       GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Migrate `scm_configuration_check` workflow to use [GitHub keyless attestation](https://docs.chainloop.dev/guides/github-keyless).