### PR TITLE
chore(ci): migrate release workflow to GitHub keyless auth

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,8 +6,7 @@ on:
       - "v*.*.*"
 
 # https://github.com/ossf/scorecard/blob/7ed886f1bd917d19cb9d6ce6c10e80e81fa31c39/docs/checks.md#token-permissions
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
   release_gate:
@@ -28,22 +27,17 @@ jobs:
           chainloop attestation init --workflow release-gate --project chainloop
           chainloop attestation push
         env:
-          CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Mark attestation as failed
         if: ${{ failure() }}
         run: |
           chainloop attestation reset
-        env:
-          CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
 
       - name: Mark attestation as cancelled
         if: ${{ cancelled() }}
         run: |
           chainloop attestation reset --trigger cancellation
-        env:
-          CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
 
   test:
     uses: chainloop-dev/chainloop/.github/workflows/test.yml@d427768c0b07d50b485df0bcae87eb8ae8769e04
@@ -60,7 +54,6 @@ jobs:
       id-token: write # required for SLSA provenance
       attestations: write # required for SLSA provenance
     env:
-      CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:


### PR DESCRIPTION
## Summary

Migrate `release` workflow to use [GitHub keyless attestation](https://docs.chainloop.dev/guides/github-keyless).