### PR TITLE
Revert "chore(ci): migrate release workflow to GitHub keyless auth"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,8 @@ on:
       - "v*.*.*"
 
 # https://github.com/ossf/scorecard/blob/7ed886f1bd917d19cb9d6ce6c10e80e81fa31c39/docs/checks.md#token-permissions
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   release_gate:
@@ -27,17 +28,22 @@ jobs:
           chainloop attestation init --workflow release-gate --project chainloop
           chainloop attestation push
         env:
+          CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Mark attestation as failed
         if: ${{ failure() }}
         run: |
           chainloop attestation reset
+        env:
+          CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
 
       - name: Mark attestation as cancelled
         if: ${{ cancelled() }}
         run: |
           chainloop attestation reset --trigger cancellation
+        env:
+          CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
 
   test:
     uses: chainloop-dev/chainloop/.github/workflows/test.yml@d427768c0b07d50b485df0bcae87eb8ae8769e04
@@ -54,6 +60,7 @@ jobs:
       id-token: write # required for SLSA provenance
       attestations: write # required for SLSA provenance
     env:
+      CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:


### PR DESCRIPTION
Keyless attestations don't support calling remote functions in Rego. This means that the previous change I'm reverting caused the system to fail with the following error. I'm reverting it while we figure out a solution. 

```
ERR evaluating attestation policies: evaluating policies in statement: failed to execute policy: failed to evaluate policy: check-compliance-requirement:41: eval_builtin_error: chainloop.project_compliance: failed to call project compliance endpoint: permission_denied: federated accounts not allowed to perform this action

```