### PR TITLE
chore: upgrade atlas to v1.1.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Generate migrations
         if: ${{ matrix.app == 'controlplane' }}
         env:
-          ATLAS_VERSION: v1.1.0
+          ATLAS_VERSION: v1.1.6
         run: |
           wget -q https://release.ariga.io/atlas/atlas-linux-amd64-$ATLAS_VERSION -O /tmp/atlas
           sudo install /tmp/atlas /usr/local/bin/atlas

--- a/app/controlplane/Dockerfile.migrations
+++ b/app/controlplane/Dockerfile.migrations
@@ -1,9 +1,9 @@
 # Container image built by go-releaser that's used to run migrations against the database during deployment
 # See https://atlasgo.io/guides/deploying/image
-# from: arigaio/atlas:1.1.3
-# docker run arigaio/atlas@sha256:f0a0022a34e5ddffb634e75dfece214a86dfc1bb15151927c20cf3e6a84bac76 version
-# atlas version v1.1.3
-FROM arigaio/atlas@sha256:f0a0022a34e5ddffb634e75dfece214a86dfc1bb15151927c20cf3e6a84bac76 as base
+# from: arigaio/atlas:1.1.6
+# docker run arigaio/atlas@sha256:f05f62d9797e305e4cd891dcc7047919bb23f5f1186827792036cb4e4a816ee9 version
+# atlas version v1.1.6
+FROM arigaio/atlas@sha256:f05f62d9797e305e4cd891dcc7047919bb23f5f1186827792036cb4e4a816ee9 as base
 
 FROM scratch
 # Update permissions to make it readable by the user

--- a/common.mk
+++ b/common.mk
@@ -9,7 +9,7 @@ init: init-api-tools
 	# in the community version anymore https://github.com/ariga/atlas/issues/2388#issuecomment-1864287189
 	# install golangci-lint with Go 1.25 support
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v2.4.0
-	curl -sSf https://atlasgo.sh | ATLAS_VERSION=v1.1.3 sh -s -- -y
+	curl -sSf https://atlasgo.sh | ATLAS_VERSION=v1.1.6 sh -s -- -y
 
 # initialize API tooling
 .PHONY: init-api-tools


### PR DESCRIPTION
## Summary
- Upgrade Atlas database migration tool from v1.1.0/v1.1.3 to v1.1.6 across all usage points: CI workflow, local dev tooling, and migrations Docker image