### PR TITLE
fix(cli): allow equal signs in annotation values

### DIFF
--- a/app/cli/cmd/attestation.go
+++ b/app/cli/cmd/attestation.go
@@ -109,8 +109,8 @@ func orgFromLocalState(customPath string) string {
 func extractAnnotations(annotationsFlag []string) (map[string]string, error) {
 	var annotations = make(map[string]string)
 	for _, annotation := range annotationsFlag {
-		kv := strings.Split(annotation, "=")
-		if len(kv) != 2 {
+		kv := strings.SplitN(annotation, "=", 2)
+		if len(kv) < 2 {
 			return nil, fmt.Errorf("invalid annotation %q, the format must be key=value", annotation)
 		}
 		annotations[kv[0]] = kv[1]

--- a/app/cli/cmd/attestation_test.go
+++ b/app/cli/cmd/attestation_test.go
@@ -118,7 +118,20 @@ func TestExtractAnnotations(t *testing.T) {
 				"foo=bar",
 				"baz=qux=qux",
 			},
-			wantErr: true,
+			want: map[string]string{
+				"foo": "bar",
+				"baz": "qux=qux",
+			},
+			wantErr: false,
+		},
+		{
+			input: []string{
+				"url=https://example.com/path?id=123&foo=bar",
+			},
+			want: map[string]string{
+				"url": "https://example.com/path?id=123&foo=bar",
+			},
+			wantErr: false,
 		},
 	}
 


### PR DESCRIPTION
Split annotation strings on only the first '=' so values containing '=' (e.g. URLs with query parameters) are accepted.

Fixes #2866