### PR TITLE
chore: upgrade atlas docker image to canary v1.1.7

### DIFF
--- a/app/controlplane/Dockerfile.migrations
+++ b/app/controlplane/Dockerfile.migrations
@@ -1,6 +1,6 @@
 # Container image built by go-releaser that's used to run migrations against the database during deployment
 # See https://atlasgo.io/guides/deploying/image
-# from: arigaio/atlas:latest
+# from: arigaio/atlas:v1.1.7-0f00ade-canary
 # docker run arigaio/atlas@sha256:cbeb45f5342e8e614a60a7ffa355973e5c45f8a8529651c36b9a8ec7e9337d02 version
 # atlas version v1.1.7-0f00ade-canary
 FROM arigaio/atlas@sha256:cbeb45f5342e8e614a60a7ffa355973e5c45f8a8529651c36b9a8ec7e9337d02 as base


### PR DESCRIPTION
Upgrades the Atlas Docker image used for running database migrations from stable v1.1.6 to canary v1.1.7-0f00ade-canary (digest `sha256:cbeb45f5342e8e614a60a7ffa355973e5c45f8a8529651c36b9a8ec7e9337d02`).

Only `Dockerfile.migrations` is updated; `common.mk` and the CI test workflow retain v1.1.6 since the release is not yet done..