### PR TITLE
feat: standardize to chainloop.dev/v1 apiVersion for policies and policy groups

### DIFF
--- a/app/cli/internal/policydevel/templates/example-policy.yaml
+++ b/app/cli/internal/policydevel/templates/example-policy.yaml
@@ -2,7 +2,7 @@
 #
 # For policy examples and reference:
 # https://github.com/chainloop-dev/chainloop/tree/main/docs/examples/policies
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: {{.Name | sanitize}}

--- a/app/cli/internal/policydevel/testdata/embedded-policy.yaml
+++ b/app/cli/internal/policydevel/testdata/embedded-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: test-policy

--- a/app/cli/internal/policydevel/testdata/policy-test.yaml
+++ b/app/cli/internal/policydevel/testdata/policy-test.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: policy-test

--- a/app/cli/internal/policydevel/testdata/policy.yaml
+++ b/app/cli/internal/policydevel/testdata/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: test-policy

--- a/app/cli/internal/policydevel/testdata/sbom-metadata-component-policy.yaml
+++ b/app/cli/internal/policydevel/testdata/sbom-metadata-component-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: sbom-metadata-component

--- a/app/cli/internal/policydevel/testdata/sbom-min-components-policy.yaml
+++ b/app/cli/internal/policydevel/testdata/sbom-min-components-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: sbom-min-components

--- a/app/cli/internal/policydevel/testdata/sbom-multiple-checks-policy.yaml
+++ b/app/cli/internal/policydevel/testdata/sbom-multiple-checks-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: sbom-multiple-checks

--- a/app/cli/internal/policydevel/testdata/sbom-valid-cyclonedx-policy.yaml
+++ b/app/cli/internal/policydevel/testdata/sbom-valid-cyclonedx-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: sbom-valid-cyclonedx

--- a/app/cli/pkg/action/testdata/policy_group.yaml
+++ b/app/cli/pkg/action/testdata/policy_group.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: PolicyGroup
 metadata:
   name: sbom-quality

--- a/app/cli/pkg/action/testdata/policy_group_no_name.yaml
+++ b/app/cli/pkg/action/testdata/policy_group_no_name.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: PolicyGroup
 metadata:
   name: sbom-quality

--- a/app/cli/pkg/action/testdata/policy_group_with_arguments.yaml
+++ b/app/cli/pkg/action/testdata/policy_group_with_arguments.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: PolicyGroup
 metadata:
   name: sbom-quality

--- a/app/controlplane/api/gen/jsonschema/workflowcontract.v1.Policy.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/workflowcontract.v1.Policy.jsonschema.json
@@ -6,6 +6,7 @@
   "patternProperties": {
     "^(api_version)$": {
       "enum": [
+        "chainloop.dev/v1",
         "workflowcontract.chainloop.dev/v1"
       ],
       "type": "string"
@@ -14,6 +15,7 @@
   "properties": {
     "apiVersion": {
       "enum": [
+        "chainloop.dev/v1",
         "workflowcontract.chainloop.dev/v1"
       ],
       "type": "string"

--- a/app/controlplane/api/gen/jsonschema/workflowcontract.v1.Policy.schema.json
+++ b/app/controlplane/api/gen/jsonschema/workflowcontract.v1.Policy.schema.json
@@ -6,6 +6,7 @@
   "patternProperties": {
     "^(apiVersion)$": {
       "enum": [
+        "chainloop.dev/v1",
         "workflowcontract.chainloop.dev/v1"
       ],
       "type": "string"
@@ -14,6 +15,7 @@
   "properties": {
     "api_version": {
       "enum": [
+        "chainloop.dev/v1",
         "workflowcontract.chainloop.dev/v1"
       ],
       "type": "string"

--- a/app/controlplane/api/gen/jsonschema/workflowcontract.v1.PolicyGroup.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/workflowcontract.v1.PolicyGroup.jsonschema.json
@@ -6,6 +6,7 @@
   "patternProperties": {
     "^(api_version)$": {
       "enum": [
+        "chainloop.dev/v1",
         "workflowcontract.chainloop.dev/v1"
       ],
       "type": "string"
@@ -14,6 +15,7 @@
   "properties": {
     "apiVersion": {
       "enum": [
+        "chainloop.dev/v1",
         "workflowcontract.chainloop.dev/v1"
       ],
       "type": "string"

--- a/app/controlplane/api/gen/jsonschema/workflowcontract.v1.PolicyGroup.schema.json
+++ b/app/controlplane/api/gen/jsonschema/workflowcontract.v1.PolicyGroup.schema.json
@@ -6,6 +6,7 @@
   "patternProperties": {
     "^(apiVersion)$": {
       "enum": [
+        "chainloop.dev/v1",
         "workflowcontract.chainloop.dev/v1"
       ],
       "type": "string"
@@ -14,6 +15,7 @@
   "properties": {
     "api_version": {
       "enum": [
+        "chainloop.dev/v1",
         "workflowcontract.chainloop.dev/v1"
       ],
       "type": "string"

--- a/app/controlplane/api/workflowcontract/v1/crafting_schema.pb.go
+++ b/app/controlplane/api/workflowcontract/v1/crafting_schema.pb.go
@@ -2010,10 +2010,9 @@ const file_workflowcontract_v1_crafting_schema_proto_rawDesc = "" +
 	"\x10MaterialSelector\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04nameB\x0f\n" +
 	"\x06policy\x12\x05\xbaH\x02\b\x01B\a\n" +
-	"\x05_gate\"\xf6\x01\n" +
-	"\x06Policy\x12I\n" +
-	"\vapi_version\x18\x01 \x01(\tB(\xbaH%r#\n" +
-	"!workflowcontract.chainloop.dev/v1R\n" +
+	"\x05_gate\"\x88\x02\n" +
+	"\x06Policy\x12[\n" +
+	"\vapi_version\x18\x01 \x01(\tB:\xbaH7r5R\x10chainloop.dev/v1R!workflowcontract.chainloop.dev/v1R\n" +
 	"apiVersion\x12!\n" +
 	"\x04kind\x18\x02 \x01(\tB\r\xbaH\n" +
 	"r\b\n" +
@@ -2066,10 +2065,9 @@ const file_workflowcontract_v1_crafting_schema_proto_rawDesc = "" +
 	"\x04skip\x18\x03 \x03(\tR\x04skip\x1a7\n" +
 	"\tWithEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xb5\a\n" +
-	"\vPolicyGroup\x12I\n" +
-	"\vapi_version\x18\x01 \x01(\tB(\xbaH%r#\n" +
-	"!workflowcontract.chainloop.dev/v1R\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xc7\a\n" +
+	"\vPolicyGroup\x12[\n" +
+	"\vapi_version\x18\x01 \x01(\tB:\xbaH7r5R\x10chainloop.dev/v1R!workflowcontract.chainloop.dev/v1R\n" +
 	"apiVersion\x12&\n" +
 	"\x04kind\x18\x02 \x01(\tB\x12\xbaH\x0fr\r\n" +
 	"\vPolicyGroupR\x04kind\x12A\n" +

--- a/app/controlplane/api/workflowcontract/v1/crafting_schema.proto
+++ b/app/controlplane/api/workflowcontract/v1/crafting_schema.proto
@@ -252,7 +252,12 @@ message PolicyAttachment {
 
 // Represents a policy to be applied to a material or attestation
 message Policy {
-  string api_version = 1 [(buf.validate.field).string.const = "workflowcontract.chainloop.dev/v1"];
+  string api_version = 1 [(buf.validate.field).string = {
+    in: [
+      "chainloop.dev/v1",
+      "workflowcontract.chainloop.dev/v1"
+    ]
+  }];
   string kind = 2 [(buf.validate.field).string.const = "Policy"];
 
   Metadata metadata = 3 [(buf.validate.field).required = true];
@@ -388,7 +393,12 @@ message PolicyGroupAttachment {
 
 // Represents a group or policies
 message PolicyGroup {
-  string api_version = 1 [(buf.validate.field).string.const = "workflowcontract.chainloop.dev/v1"];
+  string api_version = 1 [(buf.validate.field).string = {
+    in: [
+      "chainloop.dev/v1",
+      "workflowcontract.chainloop.dev/v1"
+    ]
+  }];
   string kind = 2 [(buf.validate.field).string.const = "PolicyGroup"];
 
   Metadata metadata = 3 [(buf.validate.field).required = true];

--- a/app/controlplane/api/workflowcontract/v1/policy_test.go
+++ b/app/controlplane/api/workflowcontract/v1/policy_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 The Chainloop Authors.
+// Copyright 2023-2026 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,8 +11,6 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License.
-
 // limitations under the License.
 
 package v1_test
@@ -77,8 +75,14 @@ func TestValidatePolicy(t *testing.T) {
 			violation: "spec source or policies",
 		},
 		{
-			desc: "correct spec",
+			desc: "correct spec with legacy api version",
 			policy: &v1.Policy{ApiVersion: "workflowcontract.chainloop.dev/v1", Kind: "Policy",
+				Metadata: &v1.Metadata{Name: "my-policy"}, Spec: &v1.PolicySpec{Source: &v1.PolicySpec_Path{Path: "policy.rego"}}},
+			wantErr: false,
+		},
+		{
+			desc: "correct spec with new api version",
+			policy: &v1.Policy{ApiVersion: "chainloop.dev/v1", Kind: "Policy",
 				Metadata: &v1.Metadata{Name: "my-policy"}, Spec: &v1.PolicySpec{Source: &v1.PolicySpec_Path{Path: "policy.rego"}}},
 			wantErr: false,
 		},
@@ -103,6 +107,75 @@ func TestValidatePolicy(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			err := validator.Validate(tc.policy)
+			if tc.wantErr {
+				assert.Error(t, err)
+
+				if tc.violation != "" {
+					assert.Contains(t, err.Error(), tc.violation)
+				}
+				return
+			}
+
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestValidatePolicyGroup(t *testing.T) {
+	testCases := []struct {
+		desc      string
+		group     *v1.PolicyGroup
+		wantErr   bool
+		violation string
+	}{
+		{
+			desc:      "empty policy group",
+			group:     &v1.PolicyGroup{},
+			wantErr:   true,
+			violation: "api_version",
+		},
+		{
+			desc:      "wrong api version",
+			group:     &v1.PolicyGroup{ApiVersion: "wrong", Kind: "PolicyGroup"},
+			wantErr:   true,
+			violation: "api_version",
+		},
+		{
+			desc:    "legacy api version accepted",
+			group:   &v1.PolicyGroup{ApiVersion: "workflowcontract.chainloop.dev/v1", Kind: "PolicyGroup", Metadata: &v1.Metadata{Name: "my-group"}, Spec: &v1.PolicyGroup_PolicyGroupSpec{Policies: &v1.PolicyGroup_PolicyGroupPolicies{}}},
+			wantErr: false,
+		},
+		{
+			desc:    "new api version accepted",
+			group:   &v1.PolicyGroup{ApiVersion: "chainloop.dev/v1", Kind: "PolicyGroup", Metadata: &v1.Metadata{Name: "my-group"}, Spec: &v1.PolicyGroup_PolicyGroupSpec{Policies: &v1.PolicyGroup_PolicyGroupPolicies{}}},
+			wantErr: false,
+		},
+		{
+			desc:      "wrong kind",
+			group:     &v1.PolicyGroup{ApiVersion: "chainloop.dev/v1", Kind: "wrong"},
+			wantErr:   true,
+			violation: "kind",
+		},
+		{
+			desc:      "missing metadata",
+			group:     &v1.PolicyGroup{ApiVersion: "chainloop.dev/v1", Kind: "PolicyGroup"},
+			wantErr:   true,
+			violation: "metadata",
+		},
+		{
+			desc:      "missing spec",
+			group:     &v1.PolicyGroup{ApiVersion: "chainloop.dev/v1", Kind: "PolicyGroup", Metadata: &v1.Metadata{Name: "my-group"}},
+			wantErr:   true,
+			violation: "spec",
+		},
+	}
+
+	validator, err := protovalidate.New()
+	require.NoError(t, err)
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := validator.Validate(tc.group)
 			if tc.wantErr {
 				assert.Error(t, err)
 

--- a/app/controlplane/pkg/biz/testdata/policy_group_with_embedded.yaml
+++ b/app/controlplane/pkg/biz/testdata/policy_group_with_embedded.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: PolicyGroup
 metadata:
   name: test-policy-group

--- a/docs/examples/policies/chainloop-commit.yaml
+++ b/docs/examples/policies/chainloop-commit.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 The Chainloop Authors.
+# Copyright 2024-2026 The Chainloop Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: chainloop-commit

--- a/docs/examples/policies/chainloop-qa.yaml
+++ b/docs/examples/policies/chainloop-qa.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 The Chainloop Authors.
+# Copyright 2024-2026 The Chainloop Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 # Checks that there are is a container material with a custom annotation "chainloop-qa-approval=true"
 # chainloop att push
 # This can be used as a control gate to allow e.g. a production deployment
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: sarif-errors

--- a/docs/examples/policies/http-hostname-validation/policy.yaml
+++ b/docs/examples/policies/http-hostname-validation/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: http-hostname-validation

--- a/docs/examples/policies/json-field-validator/policy.yaml
+++ b/docs/examples/policies/json-field-validator/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: json-field-validator

--- a/docs/examples/policies/quickstart/cdx-fresh.yaml
+++ b/docs/examples/policies/quickstart/cdx-fresh.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: cdx-fresh

--- a/docs/examples/policies/sarif-errors.yaml
+++ b/docs/examples/policies/sarif-errors.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 The Chainloop Authors.
+# Copyright 2024-2026 The Chainloop Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Checks that there are no errors in the SARIF report
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: sarif-errors

--- a/docs/examples/policies/sbom-freshness/policy.yaml
+++ b/docs/examples/policies/sbom-freshness/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: sbom-freshness

--- a/docs/examples/policies/sbom/cyclonedx-banned-licenses.yaml
+++ b/docs/examples/policies/sbom/cyclonedx-banned-licenses.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 The Chainloop Authors.
+# Copyright 2024-2026 The Chainloop Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: cyclonedx-banned-licenses

--- a/docs/examples/policies/sbom/cyclonedx-banned-packages.yaml
+++ b/docs/examples/policies/sbom/cyclonedx-banned-packages.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 The Chainloop Authors.
+# Copyright 2024-2026 The Chainloop Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: cyclonedx-banned-packages

--- a/docs/examples/policies/sbom/cyclonedx-freshness.yaml
+++ b/docs/examples/policies/sbom/cyclonedx-freshness.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 The Chainloop Authors.
+# Copyright 2024-2026 The Chainloop Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: cyclonedx-required-packages

--- a/docs/examples/policies/sbom/cyclonedx-licenses.yaml
+++ b/docs/examples/policies/sbom/cyclonedx-licenses.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: cyclonedx-licenses

--- a/docs/examples/policies/sbom/cyclonedx-required-packages.yaml
+++ b/docs/examples/policies/sbom/cyclonedx-required-packages.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 The Chainloop Authors.
+# Copyright 2024-2026 The Chainloop Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: cyclonedx-required-packages

--- a/docs/examples/policies/sbom/sbom-present.yaml
+++ b/docs/examples/policies/sbom/sbom-present.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 The Chainloop Authors.
+# Copyright 2024-2026 The Chainloop Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: sbom-present

--- a/docs/examples/policies/sbom/spdx-sbom-syft.yaml
+++ b/docs/examples/policies/sbom/spdx-sbom-syft.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 The Chainloop Authors.
+# Copyright 2024-2026 The Chainloop Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: made-with-syft

--- a/docs/examples/policies/trivy-vulns.yaml
+++ b/docs/examples/policies/trivy-vulns.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 The Chainloop Authors.
+# Copyright 2024-2026 The Chainloop Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Checks that there are no MEDIUM or HIGH vulnerabilities in the CVE report
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: trivy-vulnerabilities

--- a/labs/wasm-policy-sdk/go/README.md
+++ b/labs/wasm-policy-sdk/go/README.md
@@ -557,7 +557,7 @@ replace github.com/chainloop-dev/chainloop/labs/wasm-policy-sdk/go => /path/to/c
 ### policy.yaml
 
 ```yaml
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: my-policy

--- a/labs/wasm-policy-sdk/go/examples/attestation/policy.yaml
+++ b/labs/wasm-policy-sdk/go/examples/attestation/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: git-commit-signature

--- a/labs/wasm-policy-sdk/go/examples/discover/policy.yaml
+++ b/labs/wasm-policy-sdk/go/examples/discover/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: policy-builtins

--- a/labs/wasm-policy-sdk/go/examples/http/policy.yaml
+++ b/labs/wasm-policy-sdk/go/examples/http/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: http-example

--- a/labs/wasm-policy-sdk/go/examples/sbom/policy.yaml
+++ b/labs/wasm-policy-sdk/go/examples/sbom/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: sbom-validation

--- a/labs/wasm-policy-sdk/go/examples/simple/policy.yaml
+++ b/labs/wasm-policy-sdk/go/examples/simple/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: simple-validation

--- a/labs/wasm-policy-sdk/js/README.md
+++ b/labs/wasm-policy-sdk/js/README.md
@@ -543,7 +543,7 @@ declare module "main" {
 ### policy.yaml
 
 ```yaml
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: my-policy

--- a/labs/wasm-policy-sdk/js/examples/attestation/policy.yaml
+++ b/labs/wasm-policy-sdk/js/examples/attestation/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: git-commit-signature

--- a/labs/wasm-policy-sdk/js/examples/discover/policy.yaml
+++ b/labs/wasm-policy-sdk/js/examples/discover/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: policy-builtins

--- a/labs/wasm-policy-sdk/js/examples/http/policy.yaml
+++ b/labs/wasm-policy-sdk/js/examples/http/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: http-example

--- a/labs/wasm-policy-sdk/js/examples/sbom/policy.yaml
+++ b/labs/wasm-policy-sdk/js/examples/sbom/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: sbom-validation

--- a/labs/wasm-policy-sdk/js/examples/simple/policy.yaml
+++ b/labs/wasm-policy-sdk/js/examples/simple/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: simple-js-example

--- a/pkg/attestation/crafter/testdata/policies/policy_embedded.yaml
+++ b/pkg/attestation/crafter/testdata/policies/policy_embedded.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: workflow

--- a/pkg/attestation/crafter/testdata/policies/policy_missing_rego.yaml
+++ b/pkg/attestation/crafter/testdata/policies/policy_missing_rego.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: workflow

--- a/pkg/attestation/crafter/testdata/policies/policy_rego.yaml
+++ b/pkg/attestation/crafter/testdata/policies/policy_rego.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: workflow

--- a/pkg/policies/policies_test.go
+++ b/pkg/policies/policies_test.go
@@ -618,20 +618,20 @@ func (s *testSuite) TestLoadPolicySpec() {
 			expectedCategory: "SBOM",
 			expectedRef: &PolicyDescriptor{
 				URI:    "file://testdata/sbom_syft.yaml",
-				Digest: "sha256:81b7fbe4c6ef2182fd042a28fa7f3b3971879d18994147cb812b8fe87a4e04e5",
+				Digest: "sha256:8337715eebbb27d498536bb4ac1adb090f63799e7a6ca6e15d22016368555c19",
 			},
 		},
 		{
 			name: "by file ref with valid digest",
 			attachment: &v12.PolicyAttachment{
 				Policy: &v12.PolicyAttachment_Ref{
-					Ref: "file://testdata/sbom_syft.yaml@sha256:81b7fbe4c6ef2182fd042a28fa7f3b3971879d18994147cb812b8fe87a4e04e5",
+					Ref: "file://testdata/sbom_syft.yaml@sha256:8337715eebbb27d498536bb4ac1adb090f63799e7a6ca6e15d22016368555c19",
 				},
 			},
 			expectedName: "made-with-syft",
 			expectedRef: &PolicyDescriptor{
 				URI:    "file://testdata/sbom_syft.yaml",
-				Digest: "sha256:81b7fbe4c6ef2182fd042a28fa7f3b3971879d18994147cb812b8fe87a4e04e5",
+				Digest: "sha256:8337715eebbb27d498536bb4ac1adb090f63799e7a6ca6e15d22016368555c19",
 			},
 		},
 		{

--- a/pkg/policies/policy_groups_test.go
+++ b/pkg/policies/policy_groups_test.go
@@ -72,7 +72,7 @@ func (s *groupsTestSuite) TestLoadGroupSpec() {
 		{
 			name: "with correct digest",
 			attachment: &v1.PolicyGroupAttachment{
-				Ref: "file://testdata/policy_group.yaml@sha256:e35d8effedf522b33a080168a69b0d56ca7d7e2779e2fe6e7d8c460509771f88",
+				Ref: "file://testdata/policy_group.yaml@sha256:3f27da0d40f194f760c68b99d93f405e135cb7be976b315688723cbdf1d07d90",
 			},
 			expectedName: "sbom-quality",
 		},

--- a/pkg/policies/testdata/container_policy.yaml
+++ b/pkg/policies/testdata/container_policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: container-policy

--- a/pkg/policies/testdata/group_with_inputs.yaml
+++ b/pkg/policies/testdata/group_with_inputs.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: PolicyGroup
 metadata:
   name: group-with-inputs

--- a/pkg/policies/testdata/group_with_interpolated_material.yaml
+++ b/pkg/policies/testdata/group_with_interpolated_material.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: PolicyGroup
 metadata:
   name: group-with-inputs

--- a/pkg/policies/testdata/materials.yaml
+++ b/pkg/policies/testdata/materials.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: materials

--- a/pkg/policies/testdata/missing_rego.yaml
+++ b/pkg/policies/testdata/missing_rego.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: missing-rego

--- a/pkg/policies/testdata/multi-kind.yaml
+++ b/pkg/policies/testdata/multi-kind.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: multikind

--- a/pkg/policies/testdata/policy_group.yaml
+++ b/pkg/policies/testdata/policy_group.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: PolicyGroup
 metadata:
   name: sbom-quality

--- a/pkg/policies/testdata/policy_group_multikind.yaml
+++ b/pkg/policies/testdata/policy_group_multikind.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: PolicyGroup
 metadata:
   name: sbom-quality

--- a/pkg/policies/testdata/policy_group_no_name.yaml
+++ b/pkg/policies/testdata/policy_group_no_name.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: PolicyGroup
 metadata:
   name: sbom-quality

--- a/pkg/policies/testdata/policy_group_push_only.yaml
+++ b/pkg/policies/testdata/policy_group_push_only.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: PolicyGroup
 metadata:
   name: push-only-group

--- a/pkg/policies/testdata/policy_group_wrong.yaml
+++ b/pkg/policies/testdata/policy_group_wrong.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: PolicyGroup
 metadata:
   name: sbom-quality

--- a/pkg/policies/testdata/policy_multi_kind_with_ignore.yaml
+++ b/pkg/policies/testdata/policy_multi_kind_with_ignore.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: multikindignore

--- a/pkg/policies/testdata/policy_openvex_no_ignore.yaml
+++ b/pkg/policies/testdata/policy_openvex_no_ignore.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: multikindignore

--- a/pkg/policies/testdata/policy_result_format.yaml
+++ b/pkg/policies/testdata/policy_result_format.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: policy-result-format

--- a/pkg/policies/testdata/policy_result_skipped.yaml
+++ b/pkg/policies/testdata/policy_result_skipped.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: policy-result-skipped

--- a/pkg/policies/testdata/policy_with_ignore.yaml
+++ b/pkg/policies/testdata/policy_with_ignore.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: policy-result-format

--- a/pkg/policies/testdata/policy_with_inputs.yaml
+++ b/pkg/policies/testdata/policy_with_inputs.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: policy-with-inputs

--- a/pkg/policies/testdata/sbom_syft.yaml
+++ b/pkg/policies/testdata/sbom_syft.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: made-with-syft

--- a/pkg/policies/testdata/sbom_syft_not_typed.yaml
+++ b/pkg/policies/testdata/sbom_syft_not_typed.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: made-with-syft

--- a/pkg/policies/testdata/with_arguments.yaml
+++ b/pkg/policies/testdata/with_arguments.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: workflow

--- a/pkg/policies/testdata/workflow.yaml
+++ b/pkg/policies/testdata/workflow.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: workflow

--- a/pkg/policies/testdata/workflow_embedded.yaml
+++ b/pkg/policies/testdata/workflow_embedded.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: workflow

--- a/pkg/policies/testdata/workflow_push_only.yaml
+++ b/pkg/policies/testdata/workflow_push_only.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: workflow-push-only

--- a/pkg/policies/testdata/wrong_policy.yaml
+++ b/pkg/policies/testdata/wrong_policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: workflowcontract.chainloop.dev/v1
+apiVersion: chainloop.dev/v1
 kind: Policy
 metadata:
   name: wrong_policy


### PR DESCRIPTION
## Summary

- Add support for `chainloop.dev/v1` as the apiVersion for Policy and PolicyGroup resources, standardizing them with the existing contract convention
- Maintain backward compatibility with the legacy `workflowcontract.chainloop.dev/v1` apiVersion
- Update all documentation examples, test fixtures, and SDK examples to use the new `chainloop.dev/v1` apiVersion

Closes https://github.com/chainloop-dev/chainloop/issues/2770
Related: PFM-4578