### PR TITLE
Enable CORS for localhost in CAS dev config

### DIFF
--- a/app/artifact-cas/configs/config.devel.yaml
+++ b/app/artifact-cas/configs/config.devel.yaml
@@ -8,9 +8,9 @@ server:
     # Timeouts for http downloads
     # grpc downloads/uploads don't require this because they don't have timeouts
     timeout: 300s
-    # cors:
-    #   allow_origins:
-    #     - "http://localhost:3000"
+    cors:
+      allow_origins:
+        - "http://localhost:3000"
   grpc:
     addr: 0.0.0.0:9001
     # Some unary RPCs are slow, so we need to increase the timeout


### PR DESCRIPTION
## Summary
- Enable CORS configuration for `http://localhost:3000` in the artifact-cas development config by uncommenting the existing block.

Closes #2848