### PR TITLE
feat(materials): add skill kind to AI agent config discovery

### DIFF
--- a/internal/aiagentconfig/aiagentconfig.go
+++ b/internal/aiagentconfig/aiagentconfig.go
@@ -23,6 +23,8 @@ const (
 	ConfigFileKindConfiguration ConfigFileKind = "configuration"
 	// ConfigFileKindInstruction is for markdown instruction/rules files.
 	ConfigFileKindInstruction ConfigFileKind = "instruction"
+	// ConfigFileKindSkill is for skill definition files.
+	ConfigFileKindSkill ConfigFileKind = "skill"
 
 	// EvidenceID is the identifier for the AI agent config material type
 	EvidenceID = "CHAINLOOP_AI_AGENT_CONFIG"

--- a/internal/aiagentconfig/discover.go
+++ b/internal/aiagentconfig/discover.go
@@ -41,14 +41,14 @@ var agents = []agentDef{
 		{".claude/rules/*.md", ConfigFileKindInstruction},
 		{".claude/agents/*.md", ConfigFileKindInstruction},
 		{".claude/commands/*.md", ConfigFileKindInstruction},
-		{".claude/skills/*/SKILL.md", ConfigFileKindInstruction},
+		{".claude/skills/*/SKILL.md", ConfigFileKindSkill},
 	}},
 	{name: "cursor", patterns: []patternDef{
 		{".cursor/rules/*.md", ConfigFileKindInstruction},
 		{".cursor/rules/*.mdc", ConfigFileKindInstruction},
 		{".cursor/rules/*/*.md", ConfigFileKindInstruction},
 		{".cursor/rules/*/*.mdc", ConfigFileKindInstruction},
-		{".cursor/skills/*/SKILL.md", ConfigFileKindInstruction},
+		{".cursor/skills/*/SKILL.md", ConfigFileKindSkill},
 		{".cursor/agents/*.md", ConfigFileKindInstruction},
 	}},
 }

--- a/internal/aiagentconfig/discover_test.go
+++ b/internal/aiagentconfig/discover_test.go
@@ -96,7 +96,7 @@ func TestDiscoverAll(t *testing.T) {
 			files: []string{".cursor/skills/search/SKILL.md"},
 			expected: map[string][]DiscoveredFile{
 				"cursor": {
-					{Path: ".cursor/skills/search/SKILL.md", Kind: ConfigFileKindInstruction},
+					{Path: ".cursor/skills/search/SKILL.md", Kind: ConfigFileKindSkill},
 				},
 			},
 		},
@@ -167,7 +167,7 @@ func TestDiscoverAll(t *testing.T) {
 					{Path: ".claude/rules/coding.md", Kind: ConfigFileKindInstruction},
 					{Path: ".claude/rules/testing.md", Kind: ConfigFileKindInstruction},
 					{Path: ".claude/settings.json", Kind: ConfigFileKindConfiguration},
-					{Path: ".claude/skills/search/SKILL.md", Kind: ConfigFileKindInstruction},
+					{Path: ".claude/skills/search/SKILL.md", Kind: ConfigFileKindSkill},
 					{Path: ".mcp.json", Kind: ConfigFileKindConfiguration},
 					{Path: "AGENTS.md", Kind: ConfigFileKindInstruction},
 					{Path: "CLAUDE.md", Kind: ConfigFileKindInstruction},

--- a/internal/schemavalidators/internal_schemas/aiagentconfig/ai-agent-config-0.1.schema.json
+++ b/internal/schemavalidators/internal_schemas/aiagentconfig/ai-agent-config-0.1.schema.json
@@ -68,7 +68,7 @@
           },
           "kind": {
             "type": "string",
-            "enum": ["configuration", "instruction"],
+            "enum": ["configuration", "instruction", "skill"],
             "description": "Classification of the file's purpose"
           },
           "sha256": {


### PR DESCRIPTION
## Summary
- Add a dedicated `"skill"` kind for skill definition files (e.g. `.claude/skills/*/SKILL.md`, `.cursor/skills/*/SKILL.md`) in the AI agent config collector, previously classified as `"instruction"`
- Update the JSON schema to accept the new kind value