### PR TITLE
fix(ci): extract attestation digest from push output

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -225,8 +225,7 @@ jobs:
         env:
           ATTESTATION_ID: ${{ steps.init_attestation.outputs.attestation_id }}
         run: |
-          chainloop attestation push --attestation-id ${{ env.ATTESTATION_ID }}
-          attestation_sha=$(chainloop wf run describe --id ${{ env.ATTESTATION_ID }} -o json | jq -r '.attestation.digest')
+          attestation_sha=$(chainloop attestation push --attestation-id ${{ env.ATTESTATION_ID }} -o json | jq -r '.digest')
           # check that the command succeeded
           if [ -n "$attestation_sha" ]; then
             echo "attestation_sha=$attestation_sha" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- Extract the attestation digest directly from `attestation push -o json` output instead of calling `wf run describe`, which lacks authentication and causes the release workflow to fail.

Fixes [PFM-4991](https://linear.app/chainloop/issue/PFM-4991)