### PR TITLE
fix(cli): add line break before first violation in multi-policy output

### DIFF
--- a/app/cli/cmd/workflow_workflow_run_describe.go
+++ b/app/cli/cmd/workflow_workflow_run_describe.go
@@ -283,7 +283,7 @@ func policiesTable(evs []*action.PolicyEvaluation, mt table.Writer, debugMode bo
 				violations[i] = color.Sprint(v)
 			}
 
-			msg = strings.Join(violations, prefix)
+			msg = prefix + strings.Join(violations, prefix)
 		}
 
 		name := ev.Name


### PR DESCRIPTION
## Summary
- When a policy evaluation has multiple violations, the first violation was displayed inline with the policy name while subsequent ones were properly indented with `\n  - `. This adds the same line break before the first violation for consistent formatting.
- Single-violation policies remain inline as before.

```
┌───────────────────────────┬───────────────────────────────────────────────┐
│ Initialized At            │ 20 Mar 26 17:31 UTC                           │
├───────────────────────────┼───────────────────────────────────────────────┤
│ Attestation ID            │ e5ad061e-deb3-4d2f-a180-701ebb7490ac          │
│ Organization              │ my-org                                        │
│ Name                      │ aiworkflow2                                   │
│ Project                   │ my-project                                    │
│ Version                   │ v1.83.0+next (prerelease)                     │
│ Contract                  │ chainloop-platform-pr-validation (revision 2) │
│ Policy violation strategy │ ENFORCED                                      │
│ Policies                  │ ------                                        │
│                           │ test (gate):                                  │
│                           │   - violation1                                │
│                           │   - violation2                                │
│                           │   - violation3                                │
└───────────────────────────┴───────────────────────────────────────────────┘
```


Closes #2898