### PR TITLE
fix(cli): demote retry log messages to debug level

### DIFF
--- a/app/cli/cmd/errors.go
+++ b/app/cli/cmd/errors.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 The Chainloop Authors.
+// Copyright 2023-2026 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -87,6 +87,11 @@ func runWithBackoffRetry(fn func() error) error {
 		},
 		backoff.NewExponentialBackOff(backoff.WithMaxElapsedTime(3*time.Minute)),
 		func(err error, delay time.Duration) {
-			logger.Err(err).Msgf("retrying in %s", delay)
+			l := logger.Debug().Err(err)
+			if v1.IsAttestationStateErrorConflict(err) {
+				l.Msgf("concurrent state update detected, retrying in %s", delay)
+			} else {
+				l.Msgf("retrying in %s", delay)
+			}
 		})
 }


### PR DESCRIPTION
## Summary

- Demote transient retry log messages from error to debug level so they are hidden by default
- Preserve the "concurrent state update detected" message for attestation state conflicts

Fixes chainloop-dev/chainloop#2905