### PR TITLE
test(signer): unit tests for signserver signer package

### DIFF
--- a/pkg/attestation/signer/signserver/signserver_test.go
+++ b/pkg/attestation/signer/signserver/signserver_test.go
@@ -237,7 +237,7 @@ func TestSignMessage_Non200Status(t *testing.T) {
 }
 
 func TestSignMessage_NetworkError(t *testing.T) {
-	srv, caPath := tlsServerWithCA(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+	srv, caPath := tlsServerWithCA(t, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
 	host := strings.TrimPrefix(srv.URL, "https://")
 	srv.Close() // closed before the call
 
@@ -293,7 +293,7 @@ func TestPrivateKeyFromPem(t *testing.T) {
 	}{
 		{
 			name:     "unencrypted PKCS8 key with empty password",
-			pemBytes: func(t *testing.T) []byte { return generatePrivateKeyPEM(t) },
+			pemBytes: generatePrivateKeyPEM,
 			password: "",
 		},
 		{
@@ -315,7 +315,7 @@ func TestPrivateKeyFromPem(t *testing.T) {
 		},
 		{
 			name:     "certificate block only — no key",
-			pemBytes: func(t *testing.T) []byte { return generateSelfSignedCertPEM(t) },
+			pemBytes: generateSelfSignedCertPEM,
 			password: "",
 			wantErr:  true,
 		},


### PR DESCRIPTION
**Summary**

Adds unit tests for `pkg/attestation/signer/signserver`, bringing coverage from 0% to 75.2%.

All pure functions (`ParseKeyReference`, `certFromPem`, `privateKeyFromPem`) and option constructors are fully covered. `SignMessage` is tested via `httptest.NewTLSServer` for the success path, non-200 responses, network errors, and missing CA file.

The mTLS client-cert path in `SignMessage` is intentionally excluded — it requires a full mutual TLS handshake and is a better fit for an integration test.

One behavioral note documented in tests: `ParseKeyReference` does not validate the scheme prefix; that responsibility belongs to the caller (`GetSigner`).
