### PR TITLE
ci: fix goreleaser build cache misses on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,6 +55,7 @@ jobs:
       attestations: write # required for SLSA provenance
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CGO_ENABLED: "0"
 
     steps:
       - name: Install Cosign


### PR DESCRIPTION
**Summary**

The release job was doing a full recompile of all binaries on every run despite `actions/setup-go` reporting a cache hit. The root cause: `CGO_ENABLED=0` was only set inside `.goreleaser.yml`, not at the job level, so the build cache was saved and restored with `CGO_ENABLED=1` (the Linux default). Goreleaser then built with `CGO_ENABLED=0`, producing different build cache keys for every package in the tree.

Setting `CGO_ENABLED=0` at the job level aligns the cache key with what goreleaser uses. On warm cache runs, only packages whose source actually changed will recompile. 
