### PR TITLE
fix: remove captured_at from AI agent config material

### DIFF
--- a/internal/aiagentconfig/aiagentconfig.go
+++ b/internal/aiagentconfig/aiagentconfig.go
@@ -74,7 +74,6 @@ type MCPServer struct {
 type Data struct {
 	Agent       Agent        `json:"agent"`
 	ConfigHash  string       `json:"config_hash"`
-	CapturedAt  string       `json:"captured_at"`
 	GitContext  *GitContext  `json:"git_context,omitempty"`
 	ConfigFiles []ConfigFile `json:"config_files"`
 	// Future fields for richer analysis

--- a/internal/aiagentconfig/builder.go
+++ b/internal/aiagentconfig/builder.go
@@ -24,7 +24,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/rs/zerolog/log"
 )
@@ -33,12 +32,7 @@ import (
 // basePath is the base directory, discovered contains files relative to basePath with their kinds.
 // agentName identifies the AI agent (e.g. "claude", "cursor").
 // gitCtx may be nil if not in a git repository.
-// capturedAt is the timestamp to record in the output; pass time.Time{} to use the current time.
-func Build(basePath string, discovered []DiscoveredFile, agentName string, gitCtx *GitContext, capturedAt time.Time) (*Data, error) {
-	if capturedAt.IsZero() {
-		capturedAt = time.Now().UTC()
-	}
-
+func Build(basePath string, discovered []DiscoveredFile, agentName string, gitCtx *GitContext) (*Data, error) {
 	// Resolve basePath to its real path so symlink comparisons are reliable
 	realRoot, err := filepath.EvalSymlinks(basePath)
 	if err != nil {
@@ -54,14 +48,9 @@ func Build(basePath string, discovered []DiscoveredFile, agentName string, gitCt
 		relPath := df.Path
 		absPath := filepath.Join(basePath, relPath)
 
-		content, realPath, err := safeReadFile(absPath, realRoot)
+		content, _, err := safeReadFile(absPath, realRoot)
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", relPath, err)
-		}
-
-		info, err := os.Stat(realPath)
-		if err != nil {
-			return nil, fmt.Errorf("stat %s: %w", relPath, err)
 		}
 
 		hash := sha256.Sum256(content)
@@ -72,7 +61,7 @@ func Build(basePath string, discovered []DiscoveredFile, agentName string, gitCt
 			Path:    relPath,
 			Kind:    df.Kind,
 			SHA256:  hexHash,
-			Size:    info.Size(),
+			Size:    int64(len(content)),
 			Content: base64.StdEncoding.EncodeToString(content),
 		})
 
@@ -87,7 +76,6 @@ func Build(basePath string, discovered []DiscoveredFile, agentName string, gitCt
 	data := Data{
 		Agent:       Agent{Name: agentName},
 		ConfigHash:  computeCombinedHash(hashes),
-		CapturedAt:  capturedAt.Format(time.RFC3339),
 		GitContext:  gitCtx,
 		ConfigFiles: configFiles,
 		MCPServers:  mcpServers,

--- a/internal/aiagentconfig/builder_test.go
+++ b/internal/aiagentconfig/builder_test.go
@@ -26,7 +26,6 @@ import (
 	"sort"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -51,11 +50,10 @@ func TestBuild(t *testing.T) {
 	data, err := Build(rootDir, []DiscoveredFile{
 		{Path: "CLAUDE.md", Kind: ConfigFileKindInstruction},
 		{Path: ".claude/settings.json", Kind: ConfigFileKindConfiguration},
-	}, "claude", gitCtx, time.Time{})
+	}, "claude", gitCtx)
 	require.NoError(t, err)
 
 	assert.Equal(t, "claude", data.Agent.Name)
-	assert.NotEmpty(t, data.CapturedAt)
 	assert.NotEmpty(t, data.ConfigHash)
 
 	// Verify git context
@@ -98,7 +96,7 @@ func TestBuildWithCursorAgent(t *testing.T) {
 
 	data, err := Build(rootDir, []DiscoveredFile{
 		{Path: ".cursor/rules/coding.md", Kind: ConfigFileKindInstruction},
-	}, "cursor", nil, time.Time{})
+	}, "cursor", nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, "cursor", data.Agent.Name)
@@ -113,7 +111,7 @@ func TestBuildWithoutGitContext(t *testing.T) {
 
 	data, err := Build(rootDir, []DiscoveredFile{
 		{Path: "CLAUDE.md", Kind: ConfigFileKindInstruction},
-	}, "claude", nil, time.Time{})
+	}, "claude", nil)
 	require.NoError(t, err)
 
 	assert.Nil(t, data.GitContext)
@@ -126,7 +124,7 @@ func TestBuildJSONFormat(t *testing.T) {
 
 	data, err := Build(rootDir, []DiscoveredFile{
 		{Path: "CLAUDE.md", Kind: ConfigFileKindInstruction},
-	}, "claude", nil, time.Time{})
+	}, "claude", nil)
 	require.NoError(t, err)
 
 	// Verify it marshals to valid JSON with top-level fields (no envelope)
@@ -138,7 +136,6 @@ func TestBuildJSONFormat(t *testing.T) {
 
 	assert.NotNil(t, raw["agent"])
 	assert.NotNil(t, raw["config_hash"])
-	assert.NotNil(t, raw["captured_at"])
 	assert.NotNil(t, raw["config_files"])
 	// Ensure no envelope fields
 	assert.Nil(t, raw["chainloop.material.evidence.id"])
@@ -161,7 +158,7 @@ func TestBuildRejectsSymlinksEscapingRoot(t *testing.T) {
 
 	_, err := Build(rootDir, []DiscoveredFile{
 		{Path: "CLAUDE.md", Kind: ConfigFileKindInstruction},
-	}, "claude", nil, time.Time{})
+	}, "claude", nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "path escapes root directory via symlink")
 }
@@ -180,7 +177,7 @@ func TestBuildRejectsSymlinkedParentDir(t *testing.T) {
 
 	_, err := Build(rootDir, []DiscoveredFile{
 		{Path: ".claude/settings.json", Kind: ConfigFileKindConfiguration},
-	}, "claude", nil, time.Time{})
+	}, "claude", nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "path escapes root directory via symlink")
 }
@@ -188,17 +185,16 @@ func TestBuildRejectsSymlinkedParentDir(t *testing.T) {
 func TestBuildEmptyFileList(t *testing.T) {
 	rootDir := t.TempDir()
 
-	data, err := Build(rootDir, []DiscoveredFile{}, "claude", nil, time.Time{})
+	data, err := Build(rootDir, []DiscoveredFile{}, "claude", nil)
 	require.NoError(t, err)
 	assert.Empty(t, data.ConfigFiles)
 	assert.NotEmpty(t, data.ConfigHash)
-	assert.NotEmpty(t, data.CapturedAt)
 }
 
 func TestBuildNilFileList(t *testing.T) {
 	rootDir := t.TempDir()
 
-	data, err := Build(rootDir, nil, "claude", nil, time.Time{})
+	data, err := Build(rootDir, nil, "claude", nil)
 	require.NoError(t, err)
 	assert.Empty(t, data.ConfigFiles)
 }
@@ -209,7 +205,7 @@ func TestBuildAllowsRegularFilesInRoot(t *testing.T) {
 
 	data, err := Build(rootDir, []DiscoveredFile{
 		{Path: "CLAUDE.md", Kind: ConfigFileKindInstruction},
-	}, "claude", nil, time.Time{})
+	}, "claude", nil)
 	require.NoError(t, err)
 	assert.Len(t, data.ConfigFiles, 1)
 }

--- a/internal/schemavalidators/internal_schemas/aiagentconfig/ai-agent-config-0.1.schema.json
+++ b/internal/schemavalidators/internal_schemas/aiagentconfig/ai-agent-config-0.1.schema.json
@@ -7,7 +7,6 @@
   "required": [
     "agent",
     "config_hash",
-    "captured_at",
     "config_files"
   ],
   "properties": {
@@ -30,11 +29,6 @@
     "config_hash": {
       "type": "string",
       "description": "SHA-256 hash of combined config for drift detection"
-    },
-    "captured_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Timestamp of config snapshot"
     },
     "git_context": {
       "type": "object",

--- a/internal/schemavalidators/testdata/ai_agent_config_empty_config_files.json
+++ b/internal/schemavalidators/testdata/ai_agent_config_empty_config_files.json
@@ -3,6 +3,5 @@
     "name": "claude"
   },
   "config_hash": "abc123",
-  "captured_at": "2026-03-13T10:00:00Z",
   "config_files": []
 }

--- a/internal/schemavalidators/testdata/ai_agent_config_extra_fields.json
+++ b/internal/schemavalidators/testdata/ai_agent_config_extra_fields.json
@@ -3,7 +3,6 @@
     "name": "claude"
   },
   "config_hash": "abc123",
-  "captured_at": "2026-03-13T10:00:00Z",
   "config_files": [
     {
       "path": "CLAUDE.md",

--- a/internal/schemavalidators/testdata/ai_agent_config_minimal.json
+++ b/internal/schemavalidators/testdata/ai_agent_config_minimal.json
@@ -3,7 +3,6 @@
     "name": "claude"
   },
   "config_hash": "abc123",
-  "captured_at": "2026-03-13T10:00:00Z",
   "config_files": [
     {
       "path": "CLAUDE.md",

--- a/internal/schemavalidators/testdata/ai_agent_config_missing_agent.json
+++ b/internal/schemavalidators/testdata/ai_agent_config_missing_agent.json
@@ -1,7 +1,6 @@
 {
   "schema_version": "0.1",
   "config_hash": "abc123",
-  "captured_at": "2026-03-13T10:00:00Z",
   "config_files": [
     {
       "path": "CLAUDE.md",

--- a/internal/schemavalidators/testdata/ai_agent_config_missing_config_file_fields.json
+++ b/internal/schemavalidators/testdata/ai_agent_config_missing_config_file_fields.json
@@ -4,7 +4,6 @@
     "name": "claude"
   },
   "config_hash": "abc123",
-  "captured_at": "2026-03-13T10:00:00Z",
   "config_files": [
     {
       "path": "CLAUDE.md"

--- a/internal/schemavalidators/testdata/ai_agent_config_valid.json
+++ b/internal/schemavalidators/testdata/ai_agent_config_valid.json
@@ -4,7 +4,6 @@
     "version": "4.0"
   },
   "config_hash": "abc123def456",
-  "captured_at": "2026-03-13T10:00:00Z",
   "git_context": {
     "repository": "https://github.com/org/repo",
     "branch": "main",

--- a/pkg/attestation/crafter/collector_aiagentconfig.go
+++ b/pkg/attestation/crafter/collector_aiagentconfig.go
@@ -88,7 +88,7 @@ func (c *AIAgentConfigCollector) uploadAgentConfig(
 	ctx context.Context, cr *Crafter, attestationID string,
 	casBackend *casclient.CASBackend, agentName string, files []aiagentconfig.DiscoveredFile, gitCtx *aiagentconfig.GitContext,
 ) error {
-	data, err := aiagentconfig.Build(cr.WorkingDir(), files, agentName, gitCtx, cr.CraftingState.GetAttestation().GetInitializedAt().AsTime())
+	data, err := aiagentconfig.Build(cr.WorkingDir(), files, agentName, gitCtx)
 	if err != nil {
 		return fmt.Errorf("building AI agent config for %s: %w", agentName, err)
 	}

--- a/pkg/attestation/crafter/materials/chainloop_ai_agent_config_test.go
+++ b/pkg/attestation/crafter/materials/chainloop_ai_agent_config_test.go
@@ -67,7 +67,6 @@ func TestChainloopAIAgentConfigCrafter_Validation(t *testing.T) {
 			data: &aiagentconfig.Data{
 				Agent:      aiagentconfig.Agent{Name: "claude", Version: "4.0"},
 				ConfigHash: "abc123",
-				CapturedAt: "2026-03-13T10:00:00Z",
 				GitContext: &aiagentconfig.GitContext{
 					Repository: "https://github.com/org/repo",
 					Branch:     "main",
@@ -90,7 +89,6 @@ func TestChainloopAIAgentConfigCrafter_Validation(t *testing.T) {
 			data: &aiagentconfig.Data{
 				Agent:      aiagentconfig.Agent{Name: "claude"},
 				ConfigHash: "abc123",
-				CapturedAt: "2026-03-13T10:00:00Z",
 				ConfigFiles: []aiagentconfig.ConfigFile{
 					{
 						Path:    "CLAUDE.md",
@@ -108,7 +106,6 @@ func TestChainloopAIAgentConfigCrafter_Validation(t *testing.T) {
 			data: &aiagentconfig.Data{
 				Agent:      aiagentconfig.Agent{Name: "cursor"},
 				ConfigHash: "def456",
-				CapturedAt: "2026-03-13T10:00:00Z",
 				ConfigFiles: []aiagentconfig.ConfigFile{
 					{
 						Path:    ".cursor/rules/coding.md",
@@ -126,7 +123,6 @@ func TestChainloopAIAgentConfigCrafter_Validation(t *testing.T) {
 			data: &aiagentconfig.Data{
 				Agent:      aiagentconfig.Agent{Name: "cursor"},
 				ConfigHash: "ghi789",
-				CapturedAt: "2026-03-13T10:00:00Z",
 				ConfigFiles: []aiagentconfig.ConfigFile{
 					{
 						Path:    ".cursor/rules/react.mdc",
@@ -163,7 +159,6 @@ func TestChainloopAIAgentConfigCrafter_Validation(t *testing.T) {
 			data: &aiagentconfig.Data{
 				Agent:       aiagentconfig.Agent{Name: "claude"},
 				ConfigHash:  "abc123",
-				CapturedAt:  "2026-03-13T10:00:00Z",
 				ConfigFiles: []aiagentconfig.ConfigFile{},
 			},
 			wantErr: false,
@@ -253,7 +248,6 @@ func TestChainloopAIAgentConfigCrafter_RejectsExtraFields(t *testing.T) {
 		"data": {
 			"agent": {"name": "claude"},
 			"config_hash": "abc",
-			"captured_at": "2026-03-13T10:00:00Z",
 			"config_files": [{"path": "CLAUDE.md", "kind": "instruction", "sha256": "abc", "size": 1, "content": "Yg=="}],
 			"unknown_field": "should fail"
 		}

--- a/pkg/attestation/crafter/materials/testdata/ai-agent-config-claude.json
+++ b/pkg/attestation/crafter/materials/testdata/ai-agent-config-claude.json
@@ -4,7 +4,6 @@
   "data": {
     "agent": {"name": "claude"},
     "config_hash": "abc123",
-    "captured_at": "2026-03-13T10:00:00Z",
     "config_files": [
       {
         "path": "CLAUDE.md",

--- a/pkg/attestation/crafter/materials/testdata/ai-agent-config-cursor.json
+++ b/pkg/attestation/crafter/materials/testdata/ai-agent-config-cursor.json
@@ -4,7 +4,6 @@
   "data": {
     "agent": {"name": "cursor"},
     "config_hash": "def456",
-    "captured_at": "2026-03-13T10:00:00Z",
     "config_files": [
       {
         "path": ".cursor/rules/coding.md",


### PR DESCRIPTION
Remove the `captured_at` field from the AI agent config material so that successive attestations produce identical output when the agent configuration has not changed. This ensures the `config_hash` remains stable for drift detection.

Also replaced a redundant `os.Stat` call with `len(content)` in the builder since the file bytes are already in memory from `os.ReadFile`.

Fixes https://github.com/chainloop-dev/chainloop/issues/2907