### PR TITLE
feat(materials): add 'agent' config file kind to AI agent config

### DIFF
--- a/internal/aiagentconfig/aiagentconfig.go
+++ b/internal/aiagentconfig/aiagentconfig.go
@@ -25,6 +25,8 @@ const (
 	ConfigFileKindInstruction ConfigFileKind = "instruction"
 	// ConfigFileKindSkill is for skill definition files.
 	ConfigFileKindSkill ConfigFileKind = "skill"
+	// ConfigFileKindAgent is for agent definition files.
+	ConfigFileKindAgent ConfigFileKind = "agent"
 
 	// EvidenceID is the identifier for the AI agent config material type
 	EvidenceID = "CHAINLOOP_AI_AGENT_CONFIG"

--- a/internal/aiagentconfig/discover.go
+++ b/internal/aiagentconfig/discover.go
@@ -39,7 +39,7 @@ var agents = []agentDef{
 		{".claude/CLAUDE.md", ConfigFileKindInstruction},
 		{".claude/settings.json", ConfigFileKindConfiguration},
 		{".claude/rules/*.md", ConfigFileKindInstruction},
-		{".claude/agents/*.md", ConfigFileKindInstruction},
+		{".claude/agents/*.md", ConfigFileKindAgent},
 		{".claude/commands/*.md", ConfigFileKindInstruction},
 		{".claude/skills/*/SKILL.md", ConfigFileKindSkill},
 	}},
@@ -49,14 +49,14 @@ var agents = []agentDef{
 		{".cursor/rules/*/*.md", ConfigFileKindInstruction},
 		{".cursor/rules/*/*.mdc", ConfigFileKindInstruction},
 		{".cursor/skills/*/SKILL.md", ConfigFileKindSkill},
-		{".cursor/agents/*.md", ConfigFileKindInstruction},
+		{".cursor/agents/*.md", ConfigFileKindAgent},
 	}},
 }
 
 // sharedPatterns are file patterns not exclusive to any agent.
 // They are included in every agent's evidence when that agent has exclusive files.
 var sharedPatterns = []patternDef{
-	{"AGENTS.md", ConfigFileKindInstruction},
+	{"AGENTS.md", ConfigFileKindAgent},
 }
 
 // DiscoverAll searches basePath for AI agent configuration files and groups them by agent.

--- a/internal/aiagentconfig/discover_test.go
+++ b/internal/aiagentconfig/discover_test.go
@@ -60,7 +60,7 @@ func TestDiscoverAll(t *testing.T) {
 			files: []string{".cursor/rules/coding.md", ".cursor/agents/test.md"},
 			expected: map[string][]DiscoveredFile{
 				"cursor": {
-					{Path: ".cursor/agents/test.md", Kind: ConfigFileKindInstruction},
+					{Path: ".cursor/agents/test.md", Kind: ConfigFileKindAgent},
 					{Path: ".cursor/rules/coding.md", Kind: ConfigFileKindInstruction},
 				},
 			},
@@ -114,7 +114,7 @@ func TestDiscoverAll(t *testing.T) {
 					{Path: "CLAUDE.md", Kind: ConfigFileKindInstruction},
 				},
 				"cursor": {
-					{Path: ".cursor/agents/reviewer.md", Kind: ConfigFileKindInstruction},
+					{Path: ".cursor/agents/reviewer.md", Kind: ConfigFileKindAgent},
 					{Path: ".cursor/rules/coding.md", Kind: ConfigFileKindInstruction},
 				},
 			},
@@ -128,12 +128,12 @@ func TestDiscoverAll(t *testing.T) {
 			},
 			expected: map[string][]DiscoveredFile{
 				"claude": {
-					{Path: "AGENTS.md", Kind: ConfigFileKindInstruction},
+					{Path: "AGENTS.md", Kind: ConfigFileKindAgent},
 					{Path: "CLAUDE.md", Kind: ConfigFileKindInstruction},
 				},
 				"cursor": {
 					{Path: ".cursor/rules/coding.md", Kind: ConfigFileKindInstruction},
-					{Path: "AGENTS.md", Kind: ConfigFileKindInstruction},
+					{Path: "AGENTS.md", Kind: ConfigFileKindAgent},
 				},
 			},
 		},
@@ -159,13 +159,13 @@ func TestDiscoverAll(t *testing.T) {
 			expected: map[string][]DiscoveredFile{
 				"claude": {
 					{Path: ".claude/CLAUDE.md", Kind: ConfigFileKindInstruction},
-					{Path: ".claude/agents/reviewer.md", Kind: ConfigFileKindInstruction},
+					{Path: ".claude/agents/reviewer.md", Kind: ConfigFileKindAgent},
 					{Path: ".claude/commands/deploy.md", Kind: ConfigFileKindInstruction},
 					{Path: ".claude/rules/coding.md", Kind: ConfigFileKindInstruction},
 					{Path: ".claude/rules/testing.md", Kind: ConfigFileKindInstruction},
 					{Path: ".claude/settings.json", Kind: ConfigFileKindConfiguration},
 					{Path: ".claude/skills/search/SKILL.md", Kind: ConfigFileKindSkill},
-					{Path: "AGENTS.md", Kind: ConfigFileKindInstruction},
+					{Path: "AGENTS.md", Kind: ConfigFileKindAgent},
 					{Path: "CLAUDE.md", Kind: ConfigFileKindInstruction},
 				},
 			},

--- a/internal/schemavalidators/internal_schemas/aiagentconfig/ai-agent-config-0.1.schema.json
+++ b/internal/schemavalidators/internal_schemas/aiagentconfig/ai-agent-config-0.1.schema.json
@@ -62,7 +62,7 @@
           },
           "kind": {
             "type": "string",
-            "enum": ["configuration", "instruction", "skill"],
+            "enum": ["configuration", "instruction", "skill", "agent"],
             "description": "Classification of the file's purpose"
           },
           "sha256": {


### PR DESCRIPTION
## Summary

- Add a dedicated `agent` file kind to distinguish agent definition files from generic instructions in the AI agent config material
- Files matching `.claude/agents/*.md`, `.cursor/agents/*.md`, and `AGENTS.md` are now classified as `agent` instead of `instruction`
- JSON schema updated to accept the new kind

Closes #2928