### PR TITLE
chore: add chainloop token to project update call

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -237,6 +237,7 @@ jobs:
       - name: Promote Chainloop Project Version
         if: ${{ success() }}
         env:
+          CHAINLOOP_TOKEN: ${{ secrets.CHAINLOOP_TOKEN }}
           CURRENT_VERSION: ${{ steps.project_version.outputs.current_version }}
           TARGET_VERSION: ${{ github.ref_name }}
         run: |


### PR DESCRIPTION
The call is missing the proper authentication token.
This fixes failed failed promotions in releases like https://github.com/chainloop-dev/chainloop/actions/runs/23435688296/job/68173916586

```
...
ERR describe project version: unauthenticated: JWT token is missing
```
