### PR TITLE
fix(ci): add least-privilege permissions to workflow files

### DIFF
--- a/.github/workflows/build_external_container_images.yaml
+++ b/.github/workflows/build_external_container_images.yaml
@@ -5,12 +5,14 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   build_and_push_images:
     name: Build and Push ${{ matrix.image.name }} Image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         image:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write # required for SLSA attestation
 
 jobs:
   analyze:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,6 +5,10 @@ on:
     - cron: '30 1 * * *'
   workflow_dispatch:
 
+# Job-level permissions completely replace workflow-level defaults, so the
+# token only receives the job's issues: write + pull-requests: write grants.
+permissions: {}
+
 jobs:
   close-issues:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add top-level `permissions` blocks to workflow files following the two-tier permission pattern recommended by [OpenSSF Scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions). This tightens the default GITHUB_TOKEN scope so that each job only receives the permissions it explicitly declares.

### Changes

- **`stale.yml`**: added `permissions: {}` at workflow level (job-level `issues: write` + `pull-requests: write` already correct)
- **`build_external_container_images.yaml`**: moved `packages: write` from workflow level to job level; set workflow level to `permissions: { contents: read }`
- **`codeql.yml`**: removed `id-token: write` from workflow level (kept `contents: read`); job level already has `id-token: write`

## Full 12-Workflow Audit

| # | Workflow file | Workflow-level permissions | Status |
|---|---|---|---|
| 1 | `author_verification.yml` | `read-all` | Already compliant |
| 2 | `build_external_container_images.yaml` | `contents: read` (was also `packages: write`) | **Fixed** - moved `packages: write` to job level |
| 3 | `codeql.yml` | `contents: read` (was also `id-token: write`) | **Fixed** - removed `id-token: write`; job already declares it |
| 4 | `lint.yml` | `contents: read`, `pull-requests: read` | Already compliant (read-only) |
| 5 | `package_chart.yaml` | `read-all` | Already compliant (job has `packages: write` + `id-token: write`) |
| 6 | `release.yaml` | `read-all` | Already compliant (jobs declare write perms as needed) |
| 7 | `scm_configuration_check.yaml` | `read-all` | Already compliant |
| 8 | `scorecards.yml` | `read-all` | Already compliant |
| 9 | `secrets-scan-daily.yml` | `read-all` | Already compliant |
| 10 | `stale.yml` | `{}` (was missing entirely) | **Fixed** - added empty block with comment; job has `issues: write` + `pull-requests: write` |
| 11 | `sync_contracts.yml` | `read-all` | Already compliant |
| 12 | `test.yml` | `contents: read` | Already compliant (read-only) |

**Result**: 3 workflows fixed, 9 were already compliant. All 12 workflow files now follow the least-privilege two-tier pattern.

## Test Plan

- [ ] Verify `stale.yml` workflow runs correctly (cron or manual dispatch) with the new top-level `permissions: {}`
- [ ] Verify `build_external_container_images.yaml` workflow can still build and push container images with `packages: write` now at job level
- [ ] Verify `codeql.yml` workflow still generates SLSA provenance with `id-token: write` only at job level
- [ ] Re-run [OpenSSF Scorecard](https://securityscorecards.dev/) to confirm the **Token-Permissions** check score improves (currently flagged in issue #2841)

Fixes #2841