### PR TITLE
fix(cli): stop masking auth errors as token expiry

### DIFF
--- a/app/cli/main.go
+++ b/app/cli/main.go
@@ -16,6 +16,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/chainloop-dev/chainloop/app/cli/cmd"
@@ -87,13 +88,24 @@ func errorInfo(err error, logger zerolog.Logger) (string, int) {
 	case v1.IsCasBackendErrorReasonInvalid(err):
 		msg = "the CAS backend you provided is invalid. Refer to `chainloop cas-backend update` command or contact your administrator."
 	case isWrappedErr(st, jwtMiddleware.ErrTokenExpired):
-		msg = "your authentication token has expired, please run chainloop auth login again"
+		msg = "your authentication token has expired, please run \"chainloop auth login\" again"
+	case isWrappedErr(st, jwtMiddleware.ErrTokenInvalid):
+		msg = "your authentication token is invalid, please run \"chainloop auth login\" again"
+	case isWrappedErr(st, jwtMiddleware.ErrTokenParseFail):
+		msg = "failed to parse authentication token, please run \"chainloop auth login\" again"
 	case isWrappedErr(st, jwtMiddleware.ErrMissingJwtToken):
 		msg = "authentication required, please run \"chainloop auth login\""
 	case v1.IsUserNotMemberOfOrgErrorNotInOrg(err):
 		msg = "the organization you are trying to access does not exist or you are not part of it, please run \"chainloop auth login\""
 	case v1.IsUserWithNoMembershipErrorNotInOrg(err):
 		msg = "you are not part of any organization, please run \"chainloop organization create --name ORG_NAME\" to create one"
+	case isUnmatchedAuthErr(st):
+		// Fallback for any other 401/Unauthenticated errors not matched above.
+		// Org-membership errors (IsUserNotMemberOfOrgErrorNotInOrg,
+		// IsUserWithNoMembershipErrorNotInOrg) use gRPC code 7 (PermissionDenied),
+		// not code 16 (Unauthenticated), so shadowing is structurally impossible.
+		// We keep this case ordered after them purely for readability/clarity.
+		msg = fmt.Sprintf("authentication error: %s", st.Message())
 	case errors.As(err, &cmd.GracefulError{}):
 		// Graceful recovery if the flag is set and the received error is marked as recoverable
 		if cmd.GracefulExit {
@@ -110,12 +122,21 @@ func errorInfo(err error, logger zerolog.Logger) (string, int) {
 
 // target is the expected error
 // grpcStatus is the actual error that might be wrapped in both the status and the error
+//
+// NOTE: We intentionally do NOT use kratos errors.Is() here because it only
+// compares Code and Reason. Since all JWT errors share the same Code (401) and
+// Reason ("UNAUTHORIZED"), errors.Is() would match any 401 error against any
+// JWT sentinel — causing e.g. "token invalid" to be reported as "token expired".
+// Instead we compare Code and Message, which carry the distinguishing text.
 func isWrappedErr(grpcStatus *status.Status, target *errors.Error) bool {
 	err := errors.FromError(grpcStatus.Err())
-	// The error might be wrapped since the CLI sometimes returns a wrapped error
-	if errors.Is(err, target) {
-		return true
-	}
-
 	return target.Code == err.Code && err.Message == target.Message
+}
+
+// isUnmatchedAuthErr returns true when the gRPC status represents an
+// Unauthenticated (401-equivalent) error that was not matched by any of the
+// specific JWT sentinel checks above. This lets us surface the server's
+// original message instead of silently dropping it.
+func isUnmatchedAuthErr(grpcStatus *status.Status) bool {
+	return grpcStatus.Code() == codes.Unauthenticated
 }

--- a/app/cli/main_test.go
+++ b/app/cli/main_test.go
@@ -1,0 +1,246 @@
+//
+// Copyright 2023-2026 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	kratosErrors "github.com/go-kratos/kratos/v2/errors"
+	jwtMiddleware "github.com/go-kratos/kratos/v2/middleware/auth/jwt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// toGRPCStatus converts a Kratos *errors.Error into a *status.Status the same
+// way it would travel over the wire: Kratos Error -> GRPCStatus() -> gRPC Status.
+func toGRPCStatus(err *kratosErrors.Error) *status.Status {
+	return err.GRPCStatus()
+}
+
+func TestIsWrappedErr(t *testing.T) {
+	tests := []struct {
+		name   string
+		actual *kratosErrors.Error // the error that "came over the wire"
+		target *kratosErrors.Error // the sentinel we are checking against
+		want   bool
+	}{
+		{
+			name:   "ErrTokenExpired matches itself",
+			actual: jwtMiddleware.ErrTokenExpired,
+			target: jwtMiddleware.ErrTokenExpired,
+			want:   true,
+		},
+		{
+			name:   "ErrTokenInvalid matches itself",
+			actual: jwtMiddleware.ErrTokenInvalid,
+			target: jwtMiddleware.ErrTokenInvalid,
+			want:   true,
+		},
+		{
+			name:   "ErrTokenParseFail matches itself",
+			actual: jwtMiddleware.ErrTokenParseFail,
+			target: jwtMiddleware.ErrTokenParseFail,
+			want:   true,
+		},
+		{
+			name:   "ErrMissingJwtToken matches itself",
+			actual: jwtMiddleware.ErrMissingJwtToken,
+			target: jwtMiddleware.ErrMissingJwtToken,
+			want:   true,
+		},
+		{
+			name:   "ErrTokenExpired does NOT match ErrTokenInvalid",
+			actual: jwtMiddleware.ErrTokenExpired,
+			target: jwtMiddleware.ErrTokenInvalid,
+			want:   false,
+		},
+		{
+			name:   "ErrTokenInvalid does NOT match ErrTokenExpired",
+			actual: jwtMiddleware.ErrTokenInvalid,
+			target: jwtMiddleware.ErrTokenExpired,
+			want:   false,
+		},
+		{
+			name:   "ErrTokenParseFail does NOT match ErrTokenExpired",
+			actual: jwtMiddleware.ErrTokenParseFail,
+			target: jwtMiddleware.ErrTokenExpired,
+			want:   false,
+		},
+		{
+			name:   "ErrTokenExpired does NOT match ErrMissingJwtToken",
+			actual: jwtMiddleware.ErrTokenExpired,
+			target: jwtMiddleware.ErrMissingJwtToken,
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st := toGRPCStatus(tt.actual)
+			got := isWrappedErr(st, tt.target)
+			assert.Equal(t, tt.want, got, "isWrappedErr(%v, %v)", tt.actual.Message, tt.target.Message)
+		})
+	}
+}
+
+func TestIsUnmatchedAuthErr(t *testing.T) {
+	tests := []struct {
+		name string
+		st   *status.Status
+		want bool
+	}{
+		{
+			name: "generic 401/Unauthenticated error is caught",
+			st:   status.New(codes.Unauthenticated, "some auth error"),
+			want: true,
+		},
+		{
+			name: "JWT token expired (Unauthenticated) is caught",
+			st:   toGRPCStatus(jwtMiddleware.ErrTokenExpired),
+			want: true,
+		},
+		{
+			name: "PermissionDenied is NOT caught",
+			st:   status.New(codes.PermissionDenied, "forbidden"),
+			want: false,
+		},
+		{
+			name: "OK status is NOT caught",
+			st:   status.New(codes.OK, ""),
+			want: false,
+		},
+		{
+			name: "Internal error is NOT caught",
+			st:   status.New(codes.Internal, "internal server error"),
+			want: false,
+		},
+		{
+			name: "NotFound is NOT caught",
+			st:   status.New(codes.NotFound, "not found"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isUnmatchedAuthErr(tt.st)
+			assert.Equal(t, tt.want, got, "isUnmatchedAuthErr()")
+		})
+	}
+}
+
+// TestKratosErrorsIsMasksJWTErrors demonstrates the bug that motivates our
+// Message-based comparison: Kratos errors.Is() only compares Code and Reason.
+// Since all JWT errors share Code=401 and Reason="UNAUTHORIZED", errors.Is()
+// incorrectly matches ANY JWT error against ANY other JWT sentinel.
+func TestKratosErrorsIsMasksJWTErrors(t *testing.T) {
+	// This test proves that the naive errors.Is approach is broken:
+	// ErrTokenExpired would incorrectly match ErrTokenInvalid via Kratos errors.Is.
+	if !kratosErrors.Is(jwtMiddleware.ErrTokenExpired, jwtMiddleware.ErrTokenInvalid) {
+		t.Skip("Kratos errors.Is behavior has changed; this test documents the original masking bug")
+	}
+
+	// Now verify that our isWrappedErr correctly distinguishes them
+	st := toGRPCStatus(jwtMiddleware.ErrTokenExpired)
+	assert.False(t, isWrappedErr(st, jwtMiddleware.ErrTokenInvalid),
+		"isWrappedErr should NOT match ErrTokenExpired against ErrTokenInvalid")
+	assert.True(t, isWrappedErr(st, jwtMiddleware.ErrTokenExpired),
+		"isWrappedErr should match ErrTokenExpired against itself")
+}
+
+// TestIsWrappedErrGRPCWireRoundTrip verifies that isWrappedErr works after a
+// full gRPC wire round-trip: KratosError -> GRPCStatus -> proto bytes -> gRPC
+// status.FromError -> isWrappedErr. This simulates the actual path an error
+// takes from the server through a gRPC transport to the CLI client.
+func TestIsWrappedErrGRPCWireRoundTrip(t *testing.T) {
+	sentinels := []*kratosErrors.Error{
+		jwtMiddleware.ErrTokenExpired,
+		jwtMiddleware.ErrTokenInvalid,
+		jwtMiddleware.ErrTokenParseFail,
+		jwtMiddleware.ErrMissingJwtToken,
+	}
+
+	for _, sentinel := range sentinels {
+		t.Run(sentinel.Message, func(t *testing.T) {
+			// Step 1: Convert Kratos error to gRPC status (server side)
+			grpcSt := sentinel.GRPCStatus()
+
+			// Step 2: Serialize to the wire format (proto bytes)
+			proto := grpcSt.Proto()
+			require.NotNil(t, proto, "gRPC status proto should not be nil")
+
+			// Step 3: Deserialize from proto back into a gRPC status (client side)
+			roundTripped := status.FromProto(proto)
+			require.NotNil(t, roundTripped, "round-tripped status should not be nil")
+
+			// Step 4: Verify isWrappedErr still matches after the full round-trip
+			assert.True(t, isWrappedErr(roundTripped, sentinel),
+				"isWrappedErr should match %q after gRPC wire round-trip", sentinel.Message)
+
+			// Step 5: Verify it does NOT match a different sentinel after round-trip
+			for _, other := range sentinels {
+				if other == sentinel {
+					continue
+				}
+				assert.False(t, isWrappedErr(roundTripped, other),
+					"isWrappedErr should NOT match %q against %q after round-trip",
+					sentinel.Message, other.Message)
+			}
+		})
+	}
+}
+
+// TestJWTSentinelMessageCanary asserts the exact Message strings of the JWT
+// sentinel errors we depend on. If a Kratos update changes these strings
+// (e.g. ErrTokenParseFail's trailing space), this test will fail and alert us
+// that our Message-based matching in isWrappedErr needs updating.
+func TestJWTSentinelMessageCanary(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     *kratosErrors.Error
+		wantMsg string
+	}{
+		{
+			name:    "ErrTokenExpired",
+			err:     jwtMiddleware.ErrTokenExpired,
+			wantMsg: "JWT token has expired",
+		},
+		{
+			name:    "ErrTokenInvalid",
+			err:     jwtMiddleware.ErrTokenInvalid,
+			wantMsg: "Token is invalid",
+		},
+		{
+			name:    "ErrTokenParseFail (note trailing space)",
+			err:     jwtMiddleware.ErrTokenParseFail,
+			wantMsg: "Fail to parse JWT token ", // trailing space is intentional
+		},
+		{
+			name:    "ErrMissingJwtToken",
+			err:     jwtMiddleware.ErrMissingJwtToken,
+			wantMsg: "JWT token is missing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.wantMsg, tt.err.Message,
+				"Kratos sentinel %s Message has changed — update isWrappedErr matching and case branches in errorInfo", tt.name)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Fix all 401/UNAUTHORIZED auth errors being incorrectly displayed as "your authentication token has expired"
- Reorder switch cases so `isUnmatchedAuthErr` fallback does not shadow org-membership error cases
- Add unit tests for `isWrappedErr` and `isUnmatchedAuthErr` helper functions

## Root Cause Analysis
The Kratos `errors.Is()` implementation only compares `Code` and `Reason` fields:

```go
func (e *Error) Is(err error) bool {
    if se := new(Error); errors.As(err, &se) {
        return se.Code == e.Code && se.Reason == e.Reason
    }
    return false
}
```

All JWT middleware errors (`ErrTokenExpired`, `ErrTokenInvalid`, `ErrTokenParseFail`, `ErrMissingJwtToken`) are created with `errors.Unauthorized("UNAUTHORIZED", "<message>")`, giving them identical `Code: 401` and `Reason: "UNAUTHORIZED"` fields. Only the `Message` field differs. This caused `errors.Is()` to match **any** auth error against `ErrTokenExpired` first in the switch statement, masking the real error type.

## Changes
- **Remove the `errors.Is()` short-circuit** in `isWrappedErr` — keep only the `Code + Message` comparison, which correctly distinguishes between different JWT error types
- **Add explicit case branches** for `ErrTokenInvalid` ("token is invalid") and `ErrTokenParseFail` ("failed to parse token") so users see accurate error messages
- **Add a fallback** (`isUnmatchedAuthErr`) for unmatched 401 errors that surfaces the server's original message instead of silently dropping it
- **Reorder switch cases** so org-membership checks (`IsUserNotMemberOfOrgErrorNotInOrg`, `IsUserWithNoMembershipErrorNotInOrg`) come BEFORE the generic `isUnmatchedAuthErr` fallback. Note: org-membership errors use gRPC code 7 (PermissionDenied), not code 16 (Unauthenticated), so shadowing is structurally impossible — but the ordering is kept for readability/clarity
- **Add explanatory comment** on `isWrappedErr` documenting why we use Message comparison instead of Kratos `errors.Is()`
- **Add unit tests** covering:
  - `isWrappedErr` correctly matches each JWT error sentinel against itself
  - `isWrappedErr` does NOT cross-match different JWT error types
  - `isUnmatchedAuthErr` catches generic 401/Unauthenticated errors
  - `isUnmatchedAuthErr` does NOT catch non-401 errors (PermissionDenied, Internal, NotFound, OK)
  - Regression test demonstrating the Kratos `errors.Is()` masking bug and proving our fix avoids it
  - **gRPC wire round-trip test** — serializes each JWT sentinel to gRPC status proto bytes, deserializes back, and verifies `isWrappedErr` still works correctly (tests the full server-to-client error path)
  - **Sentinel message canary assertions** — asserts the exact `Message` strings of all four JWT sentinels (including `ErrTokenParseFail`'s trailing space). If Kratos updates and changes these strings, the test fails immediately and alerts us to update our matching

## Test Plan
- [x] `go test ./app/cli/ -v` — all 23 test cases pass (5 test functions)
- [x] `go vet ./app/cli/...` passes
- [ ] Test with an expired JWT token: confirms "token has expired" message
- [ ] Test with an invalid/revoked JWT token: confirms "token is invalid" message (previously showed "token has expired")
- [ ] Test with a malformed JWT token: confirms "failed to parse" message
- [ ] Test with missing JWT token: confirms "authentication required" message
- [ ] Test with an unrecognized 401 error: confirms server's original message is shown

Fixes #2922