### PR TITLE
fix(data): remove redundant user query in FindByOrg

### DIFF
--- a/app/controlplane/pkg/biz/membership_integration_test.go
+++ b/app/controlplane/pkg/biz/membership_integration_test.go
@@ -54,6 +54,7 @@ func (s *membershipIntegrationTestSuite) TestByOrg() {
 		s.Len(memberships, 1)
 		s.Equal(1, count)
 		s.Equal(memberships[0].OrganizationID.String(), userOrg.ID)
+		s.NotNil(memberships[0].User)
 		s.Equal(memberships[0].User.Email, user.Email)
 		s.Equal(memberships[0].Role, authz.RoleViewer)
 	})
@@ -63,6 +64,9 @@ func (s *membershipIntegrationTestSuite) TestByOrg() {
 		s.NoError(err)
 		s.Len(memberships, 2)
 		s.Equal(2, count)
+		for _, m := range memberships {
+			s.NotNil(m.User)
+		}
 	})
 
 	s.T().Run("non existing org", func(t *testing.T) {

--- a/app/controlplane/pkg/data/membership.go
+++ b/app/controlplane/pkg/data/membership.go
@@ -155,35 +155,7 @@ func (r *MembershipRepo) FindByOrg(ctx context.Context, orgID uuid.UUID, opts *b
 		return nil, 0, err
 	}
 
-	// Fetch all member IDs from the memberships, in this context they are user IDs
-	memberIDs := make([]uuid.UUID, 0, len(memberships))
-	for _, m := range memberships {
-		memberIDs = append(memberIDs, m.MemberID)
-	}
-
-	// Fetch user data for all the member IDs
-	users, err := r.data.DB.User.Query().Where(user.IDIn(memberIDs...)).All(ctx)
-	if err != nil {
-		return nil, 0, fmt.Errorf("failed to fetch user data: %w", err)
-	}
-
-	// Create a map of users by ID
-	userMap := make(map[uuid.UUID]*ent.User, len(users))
-	for _, u := range users {
-		userMap[u.ID] = u
-	}
-
-	// Convert to biz.Membership objects and attach user data manually
-	result := make([]*biz.Membership, 0, len(memberships))
-	for _, m := range memberships {
-		bizMembership := entMembershipToBiz(m)
-		if u, ok := userMap[m.MemberID]; ok {
-			bizMembership.User = entUserToBizUser(u)
-		}
-		result = append(result, bizMembership)
-	}
-
-	return result, count, nil
+	return entMembershipsToBiz(memberships), count, nil
 }
 
 // FindByOrgAndUser finds the membership for a given organization and user


### PR DESCRIPTION
**Summary**

`FindByOrg` was issuing a second `User.Query()` to fetch user data that had already been loaded via `.WithUser()` in the initial membership query. The extra round-trip and manual map-building were dead code — `entMembershipToBiz` already populates `User` from `m.Edges.User`.

Removed the redundant query and simplified the function to return `entMembershipsToBiz(memberships)` directly.

Added explicit `User != nil` assertions to `TestByOrg` to lock in the behavior.
