### PR TITLE
chore: pin go releaser version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -112,7 +112,7 @@ jobs:
         uses: goreleaser/goreleaser-action@b508e2e3ef3b19d4e4146d4f8fb3ba9db644a757 # v3.2.0
         with:
           distribution: goreleaser
-          version: latest
+          version: "v2.14.3"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Latest version introduces changes in how checksums are generated. Pinning to previous one.

fixes #2957
