### PR TITLE
fix(policies): skip GetEvaluableContent when no policies apply

### DIFF
--- a/pkg/policies/policy_groups.go
+++ b/pkg/policies/policy_groups.go
@@ -77,6 +77,11 @@ func (pgv *PolicyGroupVerifier) VerifyMaterial(ctx context.Context, material *ap
 			return nil, NewPolicyError(err)
 		}
 
+		// Skip loading content if no policies apply to this material
+		if len(policyAtts) == 0 {
+			continue
+		}
+
 		// Load material content once for all policies in this group
 		subject, err := material.GetEvaluableContent(path)
 		if err != nil {


### PR DESCRIPTION
## Summary
- Guard `GetEvaluableContent` in `PolicyGroupVerifier.VerifyMaterial` with an early `continue` when no policies apply to a material, preventing JSON-decode failures on binary content (e.g. Helm charts, container images).

Closes #2963