### PR TITLE
fix: handle go-git extension validation errors gracefully

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -353,10 +353,7 @@ require (
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fsouza/fake-gcs-server v1.47.6
-	// Pinned to v5.16.5: v5.17.x has a case-sensitivity bug in extension validation
-	// that breaks PlainOpen on repos using git worktree.
-	// https://github.com/chainloop-dev/chainloop/issues/2966
-	github.com/go-git/go-git/v5 v5.16.5
+	github.com/go-git/go-git/v5 v5.17.1
 	github.com/go-kratos/aegis v0.2.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -449,8 +449,8 @@ github.com/go-git/go-billy/v5 v5.8.0/go.mod h1:RpvI/rw4Vr5QA+Z60c6d6LXH0rYJo0uD5
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
 github.com/go-git/go-git/v5 v5.11.0/go.mod h1:6GFcX2P3NM7FPBfpePbpLd21XxsgdAt+lKqXmCUiUCY=
-github.com/go-git/go-git/v5 v5.16.5 h1:mdkuqblwr57kVfXri5TTH+nMFLNUxIj9Z7F5ykFbw5s=
-github.com/go-git/go-git/v5 v5.16.5/go.mod h1:QOMLpNf1qxuSY4StA/ArOdfFR2TrKEjJiye2kel2m+M=
+github.com/go-git/go-git/v5 v5.17.1 h1:WnljyxIzSj9BRRUlnmAU35ohDsjRK0EKmL0evDqi5Jk=
+github.com/go-git/go-git/v5 v5.17.1/go.mod h1:pW/VmeqkanRFqR6AljLcs7EA7FbZaN5MQqO7oZADXpo=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/pkg/attestation/crafter/crafter.go
+++ b/pkg/attestation/crafter/crafter.go
@@ -312,20 +312,6 @@ type CommitRemote struct {
 // This error is not exposed by go-git
 var errBranchInvalidMerge = errors.New("branch config: invalid merge")
 
-// isGitExtensionError returns true if the error is related to unsupported git
-// repository format extensions (e.g. worktreeConfig). go-git v5.17.0 introduced
-// strict validation that rejects repos with extensions it doesn't support.
-// See https://github.com/go-git/go-git/pull/1861
-func isGitExtensionError(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := err.Error()
-	return strings.Contains(msg, "does not support extension") ||
-		strings.Contains(msg, "unknown extension") ||
-		strings.Contains(msg, "repositoryformatversion not supported")
-}
-
 // Returns the current directory git commit hash if possible
 // If we are not in a git repo it will return an empty string
 func gracefulGitRepoHead(path string) (*HeadCommit, error) {
@@ -335,8 +321,13 @@ func gracefulGitRepoHead(path string) (*HeadCommit, error) {
 	})
 
 	if err != nil {
+		// go-git v5.17.0 introduced strict extension validation (go-git/go-git#1861)
+		// that rejects repos with extensions it doesn't fully support (e.g. worktreeConfig).
+		// Degrade gracefully instead of failing the attestation.
 		if errors.Is(err, git.ErrRepositoryNotExists) ||
-			isGitExtensionError(err) {
+			errors.Is(err, git.ErrUnsupportedExtensionRepositoryFormatVersion) ||
+			errors.Is(err, git.ErrUnknownExtension) ||
+			errors.Is(err, git.ErrUnsupportedRepositoryFormatVersion) {
 			return nil, nil
 		}
 


### PR DESCRIPTION
## Summary

- Handle go-git v5.17.x extension validation errors gracefully in `gracefulGitRepoHead` so attestation init doesn't fail in repos using git worktree
- Keeps go-git at v5.17.1 for its security fixes; the worktreeConfig incompatibility is worked around on our side until upstream fixes the case-sensitivity bug in their extension validation ([go-git/go-git#1861](https://github.com/go-git/go-git/pull/1861))

Closes #2966