### PR TITLE
fix(controlplane): upgrade Atlas image to fix critical gRPC CVE

### DIFF
--- a/app/controlplane/Dockerfile.migrations
+++ b/app/controlplane/Dockerfile.migrations
@@ -1,9 +1,9 @@
 # Container image built by go-releaser that's used to run migrations against the database during deployment
 # See https://atlasgo.io/guides/deploying/image
-# from: arigaio/atlas:v1.1.7-0f00ade-canary
-# docker run arigaio/atlas@sha256:cbeb45f5342e8e614a60a7ffa355973e5c45f8a8529651c36b9a8ec7e9337d02 version
-# atlas version v1.1.7-0f00ade-canary
-FROM arigaio/atlas@sha256:cbeb45f5342e8e614a60a7ffa355973e5c45f8a8529651c36b9a8ec7e9337d02 as base
+# from: arigaio/atlas:v1.1.7-2e53571-canary
+# docker run arigaio/atlas@sha256:7f36d26819623b7a52b6e9c0aebf40891623baf349e1b1c38580dd6ebf2b32c3 version
+# atlas version v1.1.7-2e53571-canary
+FROM arigaio/atlas@sha256:7f36d26819623b7a52b6e9c0aebf40891623baf349e1b1c38580dd6ebf2b32c3 as base
 
 FROM scratch
 # Update permissions to make it readable by the user


### PR DESCRIPTION
## Summary

- Upgrade Atlas from v1.1.7-0f00ade-canary to v1.1.7-2e53571-canary which ships google.golang.org/grpc v1.79.3+
- Fixes GHSA-p77j-4mvh-x3m3 (Critical, CVSS 9.1) — gRPC-Go authorization bypass via missing leading slash in `:path` header
- Resolves `no-vulnerabilities-high` policy failure for the `control-plane-migrations` image

Closes #2941