### PR TITLE
build: upgrade Go from 1.26.1 to 1.26.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,7 @@ make migration_lint         # Lint migration files
 
 ## Key Technologies
 
-- **Language**: Go 1.26.1
+- **Language**: Go 1.26.2
 - **API**: gRPC with HTTP/JSON gateway, Protocol Buffers with buf
 - **Database**: PostgreSQL with Ent ORM, Atlas for migrations
 - **Authentication**: OIDC, JWT tokens

--- a/app/artifact-cas/Dockerfile.goreleaser
+++ b/app/artifact-cas/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-FROM golang:1.26.1@sha256:c7e98cc0fd4dfb71ee7465fee6c9a5f079163307e4bf141b336bb9dae00159a5 AS builder
+FROM golang:1.26.2@sha256:2a2b4b5791cea8ae09caecba7bad0bd9631def96e5fe362e4a5e67009fe4ae61 AS builder
 
 FROM scratch
 

--- a/app/cli/Dockerfile.goreleaser
+++ b/app/cli/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-FROM golang:1.26.1@sha256:c7e98cc0fd4dfb71ee7465fee6c9a5f079163307e4bf141b336bb9dae00159a5 AS builder
+FROM golang:1.26.2@sha256:2a2b4b5791cea8ae09caecba7bad0bd9631def96e5fe362e4a5e67009fe4ae61 AS builder
 RUN mkdir -p /.config/chainloop
 
 FROM scratch

--- a/app/controlplane/Dockerfile.goreleaser
+++ b/app/controlplane/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-FROM golang:1.26.1@sha256:c7e98cc0fd4dfb71ee7465fee6c9a5f079163307e4bf141b336bb9dae00159a5 AS builder
+FROM golang:1.26.2@sha256:2a2b4b5791cea8ae09caecba7bad0bd9631def96e5fe362e4a5e67009fe4ae61 AS builder
 
 FROM scratch
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chainloop-dev/chainloop
 
-go 1.26.1
+go 1.26.2
 
 require (
 	cloud.google.com/go/secretmanager v1.16.0


### PR DESCRIPTION
## Summary
- Upgrade Go from 1.26.1 to 1.26.2 across go.mod, Dockerfiles, and documentation
- Docker image digests updated for all goreleaser Dockerfiles