### PR TITLE
fix(crafter): resolve commit info in git worktrees

### DIFF
--- a/pkg/attestation/crafter/crafter.go
+++ b/pkg/attestation/crafter/crafter.go
@@ -314,6 +314,8 @@ func gracefulGitRepoHead(path string) (*HeadCommit, error) {
 	repo, err := git.PlainOpenWithOptions(path, &git.PlainOpenOptions{
 		// walk up the directory tree until we find a git repo
 		DetectDotGit: true,
+		// enable .git/commondir support so worktrees can resolve HEAD
+		EnableDotGitCommonDir: true,
 	})
 
 	if err != nil {

--- a/pkg/attestation/crafter/crafter_unit_test.go
+++ b/pkg/attestation/crafter/crafter_unit_test.go
@@ -17,6 +17,7 @@ package crafter
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"testing"
@@ -313,6 +314,63 @@ func (s *crafterUnitSuite) TestPolicyEvaluationDedup() {
 			s.Len(filtered, tc.wantCount, tc.description)
 		})
 	}
+}
+
+func (s *crafterUnitSuite) TestGitRepoHeadWorktree() {
+	// go-git cannot create worktrees, so use the git CLI
+	if _, err := exec.LookPath("git"); err != nil {
+		s.T().Skip("git not found in PATH")
+	}
+
+	repoPath := s.T().TempDir()
+
+	// Initialize a repo and create a commit using go-git
+	repo, err := git.PlainInit(repoPath, false)
+	require.NoError(s.T(), err)
+
+	_, err = repo.CreateRemote(&config.RemoteConfig{
+		Name: "origin",
+		URLs: []string{"git@cyberdyne.com:skynet.git"},
+	})
+	require.NoError(s.T(), err)
+
+	wt, err := repo.Worktree()
+	require.NoError(s.T(), err)
+
+	filename := filepath.Join(repoPath, "example-git-file")
+	require.NoError(s.T(), os.WriteFile(filename, []byte("hello world!"), 0o600))
+
+	_, err = wt.Add("example-git-file")
+	require.NoError(s.T(), err)
+
+	h, err := wt.Commit("test commit", &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  "John Doe",
+			Email: "john@doe.org",
+			When:  time.Now(),
+		},
+	})
+	require.NoError(s.T(), err)
+
+	// Create a worktree using git CLI (go-git doesn't support this)
+	worktreePath := filepath.Join(s.T().TempDir(), "test-worktree")
+	cmd := exec.Command("git", "-C", repoPath, "worktree", "add", worktreePath)
+	out, err := cmd.CombinedOutput()
+	require.NoError(s.T(), err, "git worktree add: %s", out)
+
+	got, err := gracefulGitRepoHead(worktreePath)
+	require.NoError(s.T(), err)
+	require.NotNil(s.T(), got)
+
+	assert.Equal(s.T(), h.String(), got.Hash)
+	assert.Equal(s.T(), "john@doe.org", got.AuthorEmail)
+	assert.Equal(s.T(), "John Doe", got.AuthorName)
+	assert.NotEmpty(s.T(), got.Remotes)
+	assert.Equal(s.T(), &CommitRemote{
+		Name: "origin",
+		URL:  "git@cyberdyne.com:skynet.git",
+	}, got.Remotes[0])
+	assert.NotEmpty(s.T(), got.Date)
 }
 
 func TestSuite(t *testing.T) {


### PR DESCRIPTION
## Summary

- Enable `EnableDotGitCommonDir` in go-git's `PlainOpenOptions` so that git worktrees can properly resolve HEAD via `.git/commondir`
- Previously, running `chainloop att init` from a worktree returned no commit info because go-git couldn't follow the commondir reference to resolve HEAD

```
[in a worktree ...]
./chainloop att init --workflow mywf --project myproject --replace
WRN User-attended mode detected. This is intended for local testing only. For CI/CD or automated workflows, please use an API token.
This command will run against the organization "silly-greider-943"
Please confirm to continue y/N
y
INF discovered AI agent config files agent=claude files=7
INF uploading ai-agent-config-claude-3750200425.json - sha256:6b3ef54d6edfada4b2b1e5294c8946b7842a258af960008b42d5fc591c0038e8
INF successfully collected AI agent configuration agent=claude
INF Attestation initialized! now you can check its status or add materials to it
┌───────────────────────────┬──────────────────────────────────────┐
│ Initialized At            │ 09 Apr 26 21:47 UTC                  │
├───────────────────────────┼──────────────────────────────────────┤
│ Attestation ID            │ 9cf70434-5352-492e-b12e-6a6b79c894cd │
│ Organization              │ silly-greider-943                    │
│ Name                      │ mywf                                 │
│ Project                   │ myproject                            │
│ Version                   │ v1.89.11+next (prerelease)           │
│ Contract                  │ myproject-mywf (revision 4)          │
│ Timestamp Authority       │ http://timestamp.digicert.com        │
│ Policy violation strategy │ ADVISORY                             │
│ Policies                  │ ------                               │
│                           │ source-commit: Ok                    │
└───────────────────────────┴──────────────────────────────────────┘
```

Closes #3018