### PR TITLE
fix(migrations): upgrade atlas image to v1.2.0

### DIFF
--- a/app/controlplane/Dockerfile.migrations
+++ b/app/controlplane/Dockerfile.migrations
@@ -1,9 +1,9 @@
 # Container image built by go-releaser that's used to run migrations against the database during deployment
 # See https://atlasgo.io/guides/deploying/image
-# from: arigaio/atlas:v1.1.7-2e53571-canary
-# docker run arigaio/atlas@sha256:7f36d26819623b7a52b6e9c0aebf40891623baf349e1b1c38580dd6ebf2b32c3 version
-# atlas version v1.1.7-2e53571-canary
-FROM arigaio/atlas@sha256:7f36d26819623b7a52b6e9c0aebf40891623baf349e1b1c38580dd6ebf2b32c3 as base
+# from: arigaio/atlas:1.2.0
+# docker run arigaio/atlas@sha256:69fef5b506378439771fc70e052471780336552dbf35da397f5a7a729da8f7e3 version
+# atlas version v1.2.0
+FROM arigaio/atlas@sha256:69fef5b506378439771fc70e052471780336552dbf35da397f5a7a729da8f7e3 as base
 
 FROM scratch
 # Update permissions to make it readable by the user


### PR DESCRIPTION
## Summary

- Upgrades the atlas base image in `app/controlplane/Dockerfile.migrations` from `v1.1.7-2e53571-canary` to `1.2.0`.
- Fixes the following vulnerabilities reported against the `/atlas` binary in the `control-plane-migrations` image:
  - GHSA-78h2-9frx-2jm8 (High) — `github.com/go-jose/go-jose/v4` v4.1.3 → 4.1.4
  - GHSA-hfvc-g4fc-pqhx (High) — `go.opentelemetry.io/otel/sdk` v1.40.0 → 1.43.0
  - GHSA-xmrv-pmrh-hhx2 (Medium) — `github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream` v1.6.10 → 1.7.8
  - GHSA-xmrv-pmrh-hhx2 (Medium) — `github.com/aws/aws-sdk-go-v2/service/s3` v1.78.2 → 1.97.3
- Image continues to be pinned by SHA256 digest.