### PR TITLE
fix(migrations): upgrade atlas image to fix CVE vulnerabilities

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Generate migrations
         if: ${{ matrix.app == 'controlplane' }}
         env:
-          ATLAS_VERSION: v1.1.6
+          ATLAS_VERSION: v1.2.0
         run: |
           wget -q https://release.ariga.io/atlas/atlas-linux-amd64-$ATLAS_VERSION -O /tmp/atlas
           sudo install /tmp/atlas /usr/local/bin/atlas

--- a/app/controlplane/Dockerfile.migrations
+++ b/app/controlplane/Dockerfile.migrations
@@ -1,9 +1,9 @@
 # Container image built by go-releaser that's used to run migrations against the database during deployment
 # See https://atlasgo.io/guides/deploying/image
-# from: arigaio/atlas:1.2.0
-# docker run arigaio/atlas@sha256:69fef5b506378439771fc70e052471780336552dbf35da397f5a7a729da8f7e3 version
-# atlas version v1.2.0
-FROM arigaio/atlas@sha256:69fef5b506378439771fc70e052471780336552dbf35da397f5a7a729da8f7e3 as base
+# from: arigaio/atlas:latest (v1.2.1-29c7cc3-canary)
+# docker run arigaio/atlas@sha256:c9a0e6135c1f9c2761f5ef08b1db7a033ee37eb23a68173fd3909e231fdc2919 version
+# atlas version v1.2.1-29c7cc3-canary
+FROM arigaio/atlas@sha256:c9a0e6135c1f9c2761f5ef08b1db7a033ee37eb23a68173fd3909e231fdc2919 as base
 
 FROM scratch
 # Update permissions to make it readable by the user

--- a/common.mk
+++ b/common.mk
@@ -9,7 +9,7 @@ init: init-api-tools
 	# in the community version anymore https://github.com/ariga/atlas/issues/2388#issuecomment-1864287189
 	# install golangci-lint with Go 1.25 support
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v2.4.0
-	curl -sSf https://atlasgo.sh | ATLAS_VERSION=v1.1.6 sh -s -- -y
+	curl -sSf https://atlasgo.sh | ATLAS_VERSION=v1.2.0 sh -s -- -y
 
 # initialize API tooling
 .PHONY: init-api-tools


### PR DESCRIPTION
## Summary

- Upgrade atlas base image from v1.2.0 (Go 1.26.1) to latest build (Go 1.26.2) in Dockerfile.migrations
- Update ATLAS_VERSION from v1.1.6 to v1.2.0 in common.mk and .github/workflows/test.yml
- Fixes GHSA-78h2-9frx-2jm8 (High) in go-jose/go-jose/v4, GHSA-hfvc-g4fc-pqhx (High) in otel/sdk, GHSA-xmrv-pmrh-hhx2 (Medium) in aws-sdk-go-v2, and multiple Go stdlib CVEs
- Docker image pinned by SHA256 digest for reproducibility
- Grype scan of new image shows zero fixable vulnerabilities