### PR TITLE
chore: update skill for vulnerability remediation

### DIFF
--- a/.claude/skills/vulnerability-remediation/SKILL.md
+++ b/.claude/skills/vulnerability-remediation/SKILL.md
@@ -80,8 +80,8 @@ The binary path (e.g. `/atlas`, `/app`) tells you which binary inside the image 
 **Source file**: `app/controlplane/Dockerfile.migrations`
 
 **Fix procedure**:
-1. Check the current atlas version in the comment at the top of the Dockerfile (e.g. `# atlas version v1.1.0`)
-2. Find the latest available version:
+1. Check the current atlas version in the comment at the top of the Dockerfile (e.g. `# atlas version v1.2.0`)
+2. Find the latest available stable version:
    ```bash
    curl -s "https://registry.hub.docker.com/v2/repositories/arigaio/atlas/tags?page_size=20&ordering=last_updated" \
      | python3 -c "import json,sys; [print(t['name']) for t in json.load(sys.stdin)['results'] if t['name'][0].isdigit() and '-' not in t['name']]"
@@ -92,18 +92,28 @@ The binary path (e.g. `/atlas`, `/app`) tells you which binary inside the image 
    grype arigaio/atlas:<new-version> --only-fixed 2>&1
    ```
    A clean run has only the header line and no CVE rows.
-4. Once a clean version is confirmed, pull it and get its digest:
+4. **If the latest stable tag still has CVEs**, also check the `latest` tag — atlas rebuilds it frequently with updated Go toolchain and dependencies:
+   ```bash
+   docker pull arigaio/atlas:latest
+   grype arigaio/atlas:latest --only-fixed 2>&1
+   docker run --rm arigaio/atlas:latest version
+   ```
+   If `latest` is clean and the version is a reasonable increment (e.g. canary of the next patch), it is acceptable since the image is pinned by digest.
+5. Once a clean version is confirmed, pull it and get its digest:
    ```bash
    docker pull arigaio/atlas:<new-version>
    docker inspect --format='{{index .RepoDigests 0}}' arigaio/atlas:<new-version>
    ```
-5. Update `app/controlplane/Dockerfile.migrations`:
+6. Update `app/controlplane/Dockerfile.migrations`:
    ```dockerfile
    # from: arigaio/atlas:<NEW_VERSION>
    # docker run arigaio/atlas@sha256:<NEW_DIGEST> version
    # atlas version v<NEW_VERSION>
    FROM arigaio/atlas@sha256:<NEW_DIGEST> as base
    ```
+7. Update `ATLAS_VERSION` in the following files to match the latest **stable** version (used for CLI tool installation, not the Docker image):
+   - `common.mk` — the `ATLAS_VERSION=vX.X.X` in the `init` target
+   - `.github/workflows/test.yml` — the `ATLAS_VERSION: vX.X.X` env variable
 
 ### 4b. Go stdlib / Go module vulnerabilities (backend)
 
@@ -184,6 +194,8 @@ Summarise the findings and changes in this format:
 
 ### Files Changed
 - `app/controlplane/Dockerfile.migrations` — atlas vX.X.X → vX.X.X
+- `common.mk` — ATLAS_VERSION vX.X.X → vX.X.X (if upgraded)
+- `.github/workflows/test.yml` — ATLAS_VERSION vX.X.X → vX.X.X (if upgraded)
 
 ### PR
 <GitHub PR URL>
@@ -198,6 +210,8 @@ Summarise the findings and changes in this format:
 | chainloop-best-practices framework ID | `0ceef195-6900-4166-8407-77eb84954ed3` |
 | Continuous-scanning workflow ID | `c506a425-d307-4a59-9132-659ffd417b57` |
 | Migrations Dockerfile | `app/controlplane/Dockerfile.migrations` |
+| Atlas CLI version (Makefile) | `common.mk` — `ATLAS_VERSION=vX.X.X` in `init` target |
+| Atlas CLI version (CI) | `.github/workflows/test.yml` — `ATLAS_VERSION: vX.X.X` env |
 | Backend go.mod | `go.mod` (root) |
 
 ## Important Notes


### PR DESCRIPTION
This is a follow up of #3028 to include automated upgrade of Atlas in the skill.
