### PR TITLE
fix(crafter): handle invalid merge branch config during repo open

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -354,7 +354,7 @@ require (
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fsouza/fake-gcs-server v1.47.6
-	github.com/go-git/go-git/v5 v5.17.1
+	github.com/go-git/go-git/v5 v5.17.2
 	github.com/go-kratos/aegis v0.2.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -449,8 +449,8 @@ github.com/go-git/go-billy/v5 v5.8.0/go.mod h1:RpvI/rw4Vr5QA+Z60c6d6LXH0rYJo0uD5
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
 github.com/go-git/go-git/v5 v5.11.0/go.mod h1:6GFcX2P3NM7FPBfpePbpLd21XxsgdAt+lKqXmCUiUCY=
-github.com/go-git/go-git/v5 v5.17.1 h1:WnljyxIzSj9BRRUlnmAU35ohDsjRK0EKmL0evDqi5Jk=
-github.com/go-git/go-git/v5 v5.17.1/go.mod h1:pW/VmeqkanRFqR6AljLcs7EA7FbZaN5MQqO7oZADXpo=
+github.com/go-git/go-git/v5 v5.17.2 h1:B+nkdlxdYrvyFK4GPXVU8w1U+YkbsgciIR7f2sZJ104=
+github.com/go-git/go-git/v5 v5.17.2/go.mod h1:pW/VmeqkanRFqR6AljLcs7EA7FbZaN5MQqO7oZADXpo=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/pkg/attestation/crafter/crafter.go
+++ b/pkg/attestation/crafter/crafter.go
@@ -310,7 +310,12 @@ var errBranchInvalidMerge = errors.New("branch config: invalid merge")
 
 // Returns the current directory git commit hash if possible
 // If we are not in a git repo it will return an empty string
-func gracefulGitRepoHead(path string) (*HeadCommit, error) {
+func gracefulGitRepoHead(path string, logger *zerolog.Logger) (*HeadCommit, error) {
+	if logger == nil {
+		l := zerolog.Nop()
+		logger = &l
+	}
+
 	repo, err := git.PlainOpenWithOptions(path, &git.PlainOpenOptions{
 		// walk up the directory tree until we find a git repo
 		DetectDotGit: true,
@@ -326,6 +331,15 @@ func gracefulGitRepoHead(path string) (*HeadCommit, error) {
 			errors.Is(err, git.ErrUnsupportedExtensionRepositoryFormatVersion) ||
 			errors.Is(err, git.ErrUnknownExtension) ||
 			errors.Is(err, git.ErrUnsupportedRepositoryFormatVersion) {
+			return nil, nil
+		}
+
+		// Mitigate https://github.com/go-git/go-git/issues/331
+		// This error is not exposed by go-git so we do a string comparison.
+		// The upcoming go-git v6 no longer returns this error, so this
+		// workaround can be removed after upgrading.
+		if isBranchInvalidMergeError(err) {
+			logger.Warn().Err(err).Msg("branch is invalid merge, skipping commit")
 			return nil, nil
 		}
 
@@ -361,7 +375,8 @@ func gracefulGitRepoHead(path string) (*HeadCommit, error) {
 		// we do not care about that use-case, so we ignore the error
 		// we compare by error string because go-git does not expose the error type
 		// and errors.Is require the same instance of the error
-		if err.Error() == errBranchInvalidMerge.Error() {
+		if isBranchInvalidMergeError(err) {
+			logger.Warn().Err(err).Msg("branch is invalid merge, skipping remotes")
 			return c, nil
 		}
 
@@ -387,6 +402,10 @@ func gracefulGitRepoHead(path string) (*HeadCommit, error) {
 	return c, nil
 }
 
+func isBranchInvalidMergeError(err error) bool {
+	return err.Error() == errBranchInvalidMerge.Error()
+}
+
 // Clear any basic auth credentials from the remote URL
 func sanitizeRemoteURL(remoteURL string) (string, error) {
 	uri, err := url.Parse(remoteURL)
@@ -409,7 +428,7 @@ func initialCraftingState(cwd string, opts *InitOpts) (*api.CraftingState, error
 		return nil, errors.New("required init options not provided")
 	}
 	// Get git commit hash
-	headCommit, err := gracefulGitRepoHead(cwd)
+	headCommit, err := gracefulGitRepoHead(cwd, opts.Logger)
 	if err != nil {
 		return nil, fmt.Errorf("getting git commit hash: %w", err)
 	}

--- a/pkg/attestation/crafter/crafter_unit_test.go
+++ b/pkg/attestation/crafter/crafter_unit_test.go
@@ -190,7 +190,7 @@ func (s *crafterUnitSuite) TestGitRepoHead() {
 				require.NoError(s.T(), err)
 			}
 
-			got, err := gracefulGitRepoHead(path)
+			got, err := gracefulGitRepoHead(path, nil)
 			if tc.wantErr {
 				assert.Error(s.T(), err)
 				return
@@ -358,7 +358,7 @@ func (s *crafterUnitSuite) TestGitRepoHeadWorktree() {
 	out, err := cmd.CombinedOutput()
 	require.NoError(s.T(), err, "git worktree add: %s", out)
 
-	got, err := gracefulGitRepoHead(worktreePath)
+	got, err := gracefulGitRepoHead(worktreePath, nil)
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), got)
 


### PR DESCRIPTION
## Summary

- Upgrade go-git from v5.17.1 to v5.17.2
- Gracefully handle `branch config: invalid merge` errors from go-git when opening a repository, not just when listing remotes. This is a protective measure to prevent the crafter from crashing on repos with invalid merge references in their git config, similar to the existing protection we already had for the remote-listing path
- Extract `isBranchInvalidMergeError` helper to deduplicate the string-based error check

Closes #3031