### PR TITLE
docs: update install commands now that EE is the default edition

### DIFF
--- a/.github/workflows/author_verification.yml
+++ b/.github/workflows/author_verification.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Install Chainloop
         run: |
-          curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s -- --ee
+          curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s
 
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Install Chainloop
         run: |
-          curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s -- --ee
+          curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s
 
       - name: Run Release Gate Attestation
         run: |
@@ -65,8 +65,7 @@ jobs:
 
       - name: Install Chainloop
         run: |
-          # Need the ee CLI to have access to project management capabilities
-          curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s -- --ee
+          curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s
 
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/scm_configuration_check.yaml
+++ b/.github/workflows/scm_configuration_check.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install Chainloop
         run: |
-          curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s -- --ee
+          curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s
 
       - name: Initialize Attestation
         run: |

--- a/.github/workflows/secrets-scan-daily.yml
+++ b/.github/workflows/secrets-scan-daily.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install Chainloop
         run: |
-          curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s -- --ee
+          curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s
 
       - name: Initialize Attestation
         run: |

--- a/README.md
+++ b/README.md
@@ -97,25 +97,25 @@ Follow the [quickstart](https://docs.chainloop.dev/quickstart) or the [getting s
 To **install the latest version** for macOS, Linux or Windows (using [WSL](https://learn.microsoft.com/en-us/windows/wsl/install)) just choose one of the following installation methods.
 
 ```bash
-curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s
+curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s now -- --oss
 ```
 
 you can retrieve a specific version with
 
 ```bash
-curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s -- --version v1.7.0
+curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s now -- --oss --version v1.7.0
 ```
 
 and customize the install path (default to /usr/local/bin)
 
 ```bash
-curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s -- --path /my-path
+curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s now -- --oss --path /my-path
 ```
 
 if [`cosign`](https://docs.sigstore.dev/cosign) is present in your system, in addition to the checksum check, a signature verification will be performed. This behavior can be enforced via the `--force-verification` flag.
 
 ```bash
-curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s -- --force-verification
+curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s now -- --oss --force-verification
 ```
 
 ### Deploy Chainloop (optional)

--- a/README.md
+++ b/README.md
@@ -97,25 +97,25 @@ Follow the [quickstart](https://docs.chainloop.dev/quickstart) or the [getting s
 To **install the latest version** for macOS, Linux or Windows (using [WSL](https://learn.microsoft.com/en-us/windows/wsl/install)) just choose one of the following installation methods.
 
 ```bash
-curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s now -- --oss
+curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s -- --oss
 ```
 
 you can retrieve a specific version with
 
 ```bash
-curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s now -- --oss --version v1.7.0
+curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s -- --oss --version v1.7.0
 ```
 
 and customize the install path (default to /usr/local/bin)
 
 ```bash
-curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s now -- --oss --path /my-path
+curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s -- --oss --path /my-path
 ```
 
 if [`cosign`](https://docs.sigstore.dev/cosign) is present in your system, in addition to the checksum check, a signature verification will be performed. This behavior can be enforced via the `--force-verification` flag.
 
 ```bash
-curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s now -- --oss --force-verification
+curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s -- --oss --force-verification
 ```
 
 ### Deploy Chainloop (optional)

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ To **install the latest version** for macOS, Linux or Windows (using [WSL](https
 curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s -- --oss
 ```
 
+> To install the **enterprise edition** instead, omit the `--oss` flag.
+
 you can retrieve a specific version with
 
 ```bash


### PR DESCRIPTION
The Chainloop install script now defaults to the enterprise edition.

- Updated README installation commands to include `--oss` for installing the OSS edition
- Removed `--ee` flag from all CI workflow install steps since EE is now the default