### PR TITLE
fix(nats): honor replicas for audit stream and tune attestation bundle cache

### DIFF
--- a/app/controlplane/pkg/auditor/nats.go
+++ b/app/controlplane/pkg/auditor/nats.go
@@ -71,11 +71,12 @@ func (p *AuditLogPublisher) initJetStream() error {
 	if _, err := js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{
 		Name:     streamName,
 		Subjects: []string{subjectName},
+		Replicas: p.rc.Replicas,
 	}); err != nil {
 		return fmt.Errorf("creating stream: %w", err)
 	}
 
-	p.logger.Infow("msg", "stream created or updated", "name", streamName, "subject", subjectName)
+	p.logger.Infow("msg", "stream created or updated", "name", streamName, "subject", subjectName, "replicas", p.rc.Replicas)
 
 	return nil
 }

--- a/pkg/cache/attestationbundle/attestationbundle.go
+++ b/pkg/cache/attestationbundle/attestationbundle.go
@@ -26,8 +26,8 @@ import (
 )
 
 const (
-	ttl         = 5 * 24 * time.Hour
-	maxBytes    = 100 * 1024 * 1024 // 100 MB
+	ttl         = 48 * time.Hour
+	maxBytes    = 200 * 1024 * 1024 // 200 MB
 	bucket      = "chainloop-attestation-bundles"
 	description = "Cache for attestation bundles"
 )

--- a/pkg/cache/natskv.go
+++ b/pkg/cache/natskv.go
@@ -52,7 +52,7 @@ func newNATSKV[T any](cfg *config) (*natsKVCache[T], error) {
 		go c.watchReconnect(cfg.reconnCh)
 	}
 
-	cfg.logger.Infow("msg", "cache: using NATS KV backend", "bucket", cfg.bucketName, "ttl", cfg.ttl)
+	cfg.logger.Infow("msg", "cache: using NATS KV backend", "bucket", cfg.bucketName, "ttl", cfg.ttl, "replicas", cfg.replicas)
 	return c, nil
 }
 


### PR DESCRIPTION
## Summary

- The `chainloop-audit` JetStream stream was created without a `Replicas` field, so it stayed at 1 replica regardless of the `nats_server.replicas` config. It now uses the configured replica count from the NATS connection.
- The NATS KV cache startup log (`chainloop-attestation-bundles`, `chainloop-policy-eval-bundles`) now includes the `replicas` value so operators can confirm what the controlplane is requesting at bucket create/update time.
- Tune the attestation bundle cache: TTL 5d → 48h, max size 100MB → 200MB.