### PR TITLE
fix(cli): remove ResourceExhausted from retriable gRPC codes

### DIFF
--- a/app/cli/cmd/errors.go
+++ b/app/cli/cmd/errors.go
@@ -63,7 +63,6 @@ func isRetriableAPIError(err error) bool {
 	retriableCodes := []codes.Code{
 		codes.Unavailable,
 		codes.Internal,
-		codes.ResourceExhausted,
 		codes.DeadlineExceeded,
 	}
 


### PR DESCRIPTION
## Summary

Removes `codes.ResourceExhausted` from the CLI's set of retriable gRPC error codes in `app/cli/cmd/errors.go`.

`ResourceExhausted` typically signals rate limiting or quota exhaustion. Blanket-retrying it can waste work against hard quotas that will not self-recover within the retry window, and can amplify load on an already overloaded server. Standard gRPC guidance is to only retry `ResourceExhausted` when the server explicitly signals it is safe via `RetryInfo` metadata.

Retries remain for `Unavailable`, `Internal`, and `DeadlineExceeded`.

Closes #3053