### PR TITLE
chore: enable chainloop trace for AI coding sessions

### DIFF
--- a/.chainloop.yml
+++ b/.chainloop.yml
@@ -1,3 +1,5 @@
+organization: chainloop
+projectName: chainloop
 # This indicates the [current version]+next
 # to indicate that we are building a new version of the project
 projectVersion: v1.93.3+next

--- a/.chainloop.yml
+++ b/.chainloop.yml
@@ -1,3 +1,5 @@
+# organization and projectName are used for Chainloop Trace
+# https://docs.chainloop.dev/reference/operator/trace
 organization: chainloop
 projectName: chainloop
 # This indicates the [current version]+next

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,11 +2,51 @@
   "hooks": {
     "PostToolUse": [
       {
-        "matcher": "Edit|Write",
         "hooks": [
           {
-            "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/format-and-lint.sh"
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/format-and-lint.sh",
+            "type": "command"
+          }
+        ],
+        "matcher": "Edit|Write"
+      },
+      {
+        "hooks": [
+          {
+            "command": "chainloop trace hook claude post-tool-use",
+            "type": "command"
+          }
+        ],
+        "matcher": "Edit|Write|MultiEdit"
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "chainloop trace hook claude pre-tool-use",
+            "type": "command"
+          }
+        ],
+        "matcher": "Edit|Write|MultiEdit"
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "command": "chainloop trace hook claude session-end",
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "chainloop trace hook claude session-start",
+            "type": "command"
           }
         ]
       }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,10 @@ use GitHub pull requests for this purpose. Consult
 [GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
 information on using pull requests.
 
+## Chainloop Trace
+
+This repository has [Chainloop Trace](https://docs.chainloop.dev/reference/operator/trace) enabled. This means that AI coding sessions can optionally be tracked as part of the software supply chain. See [`.chainloop.yml`](./.chainloop.yml) for the configuration.
+
 ## Development
 
 To learn more about how to run the project locally refer to our development [guide](./devel/README.md).


### PR DESCRIPTION
## Summary
- Enable `chainloop trace` to automatically capture and attest AI-assisted coding sessions on every push
- Adds Claude Code hooks (SessionStart, PreToolUse, PostToolUse, SessionEnd) and Git hooks (post-commit, pre-push)
- Pins organization and project name in `.chainloop.yml`

More info: https://docs.chainloop.dev/guides/chainloop-trace