### PR TITLE
fix(authz): add WorkflowContractService/Apply to ServerOperationsMap

### DIFF
--- a/app/controlplane/pkg/authz/authz.go
+++ b/app/controlplane/pkg/authz/authz.go
@@ -406,6 +406,7 @@ var ServerOperationsMap = map[string]*OperationPolicy{
 	"/controlplane.v1.WorkflowContractService/Update":   {Policies: []*Policy{PolicyWorkflowContractUpdate}},
 	"/controlplane.v1.WorkflowContractService/Create":   {Policies: []*Policy{PolicyWorkflowContractCreate}},
 	"/controlplane.v1.WorkflowContractService/Delete":   {Policies: []*Policy{PolicyWorkflowContractDelete}},
+	"/controlplane.v1.WorkflowContractService/Apply":    {Policies: []*Policy{PolicyWorkflowContractCreate, PolicyWorkflowContractUpdate}},
 	// Get current information about an organization
 	"/controlplane.v1.ContextService/Current": {Policies: []*Policy{PolicyOrganizationRead}},
 	// Listing, create or selecting an organization does not have any required permissions,

--- a/app/controlplane/pkg/authz/middleware/middleware_test.go
+++ b/app/controlplane/pkg/authz/middleware/middleware_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2024-2025 The Chainloop Authors.
+// Copyright 2024-2026 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -210,6 +210,10 @@ func TestPoliciesLookup(t *testing.T) {
 			operation: "/controlplane.v1.OrgMetricsService",
 			wantErr:   true,
 		},
+		{
+			name:      "contract apply operation found",
+			operation: "/controlplane.v1.WorkflowContractService/Apply",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -223,4 +227,10 @@ func TestPoliciesLookup(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPoliciesLookupContractApply(t *testing.T) {
+	policies, err := policiesLookup("/controlplane.v1.WorkflowContractService/Apply")
+	assert.NoError(t, err)
+	assert.Equal(t, []*authz.Policy{authz.PolicyWorkflowContractCreate, authz.PolicyWorkflowContractUpdate}, policies)
 }


### PR DESCRIPTION
The Apply endpoint was missing from the authorization map, causing "operation not allowed" errors for non-admin users running `chainloop apply -f <contract>`. Both Create and Update policies are required since Apply is a create-or-update operation.