### PR TITLE
feat(org): allow chainloop as a valid organization name

### DIFF
--- a/app/controlplane/pkg/biz/organization.go
+++ b/app/controlplane/pkg/biz/organization.go
@@ -110,7 +110,7 @@ func NewOrganizationUseCase(repo OrganizationRepo, repoUC *CASBackendUseCase, au
 
 const RandomNameMaxTries = 10
 
-var reservedOrgNames = []string{"chainloop", "admin", "default"}
+var reservedOrgNames = []string{"admin", "default"}
 
 type createOptions struct {
 	createInlineBackend bool

--- a/app/controlplane/pkg/biz/organization_integration_test.go
+++ b/app/controlplane/pkg/biz/organization_integration_test.go
@@ -67,9 +67,9 @@ func (s *OrgIntegrationTestSuite) TestCreate() {
 		// over the max size
 		{"aabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk", true},
 		// reserved names
-		{"chainloop", true},
 		{"admin", true},
 		{"default", true},
+		{"chainloop", false},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Remove `chainloop` from the reserved organization names list, allowing it to be used as a regular organization name.

There is no an obvious reason why this one should be restricted, `admin`, and `default` paths are different though