### PR TITLE
feat(cli): send CLI version on every request and forward it to policy providers

### DIFF
--- a/app/cli/cmd/artifact.go
+++ b/app/cli/cmd/artifact.go
@@ -53,7 +53,7 @@ func wrappedArtifactConn(cpConn *grpc.ClientConn, role pb.CASCredentialsServiceG
 
 	var opts = []grpcconn.Option{
 		grpcconn.WithInsecure(apiInsecure()),
-		grpcconn.WithCLIVersion(FullVersion()),
+		grpcconn.WithCLIVersion(fullVersion()),
 	}
 
 	if caValue := viper.GetString(confOptions.CASCA.viperKey); caValue != "" {

--- a/app/cli/cmd/artifact.go
+++ b/app/cli/cmd/artifact.go
@@ -53,6 +53,7 @@ func wrappedArtifactConn(cpConn *grpc.ClientConn, role pb.CASCredentialsServiceG
 
 	var opts = []grpcconn.Option{
 		grpcconn.WithInsecure(apiInsecure()),
+		grpcconn.WithCLIVersion(FullVersion()),
 	}
 
 	if caValue := viper.GetString(confOptions.CASCA.viperKey); caValue != "" {

--- a/app/cli/cmd/root.go
+++ b/app/cli/cmd/root.go
@@ -134,7 +134,7 @@ func NewRootCmd(l zerolog.Logger) *cobra.Command {
 
 			var opts = []grpcconn.Option{
 				grpcconn.WithInsecure(apiInsecure()),
-				grpcconn.WithCLIVersion(FullVersion()),
+				grpcconn.WithCLIVersion(fullVersion()),
 			}
 
 			if caValue := viper.GetString(confOptions.controlplaneCA.viperKey); caValue != "" {
@@ -370,7 +370,7 @@ func initConfigFile() {
 }
 
 func newActionOpts(logger zerolog.Logger, conn *grpc.ClientConn, token string) *action.ActionsOpts {
-	return &action.ActionsOpts{CPConnection: conn, Logger: logger, AuthTokenRaw: token, OutputFormat: flagOutputFormat, CLIVersion: FullVersion()}
+	return &action.ActionsOpts{CPConnection: conn, Logger: logger, AuthTokenRaw: token, OutputFormat: flagOutputFormat, CLIVersion: fullVersion()}
 }
 
 func cleanup(conn *grpc.ClientConn) error {

--- a/app/cli/cmd/root.go
+++ b/app/cli/cmd/root.go
@@ -134,6 +134,7 @@ func NewRootCmd(l zerolog.Logger) *cobra.Command {
 
 			var opts = []grpcconn.Option{
 				grpcconn.WithInsecure(apiInsecure()),
+				grpcconn.WithCLIVersion(FullVersion()),
 			}
 
 			if caValue := viper.GetString(confOptions.controlplaneCA.viperKey); caValue != "" {
@@ -369,7 +370,7 @@ func initConfigFile() {
 }
 
 func newActionOpts(logger zerolog.Logger, conn *grpc.ClientConn, token string) *action.ActionsOpts {
-	return &action.ActionsOpts{CPConnection: conn, Logger: logger, AuthTokenRaw: token, OutputFormat: flagOutputFormat}
+	return &action.ActionsOpts{CPConnection: conn, Logger: logger, AuthTokenRaw: token, OutputFormat: flagOutputFormat, CLIVersion: FullVersion()}
 }
 
 func cleanup(conn *grpc.ClientConn) error {

--- a/app/cli/cmd/version.go
+++ b/app/cli/cmd/version.go
@@ -36,10 +36,10 @@ var (
 	Edition = ossEdition
 )
 
-// FullVersion returns the CLI version annotated with its edition flavor,
+// fullVersion returns the CLI version annotated with its edition flavor,
 // e.g. "v1.94.2-oss" or "dev-ee". Used as the value of the Chainloop-Cli-Version
 // header sent on every request to the Control Plane and CAS.
-func FullVersion() string {
+func fullVersion() string {
 	return Version + "-" + Edition
 }
 

--- a/app/cli/cmd/version.go
+++ b/app/cli/cmd/version.go
@@ -36,6 +36,13 @@ var (
 	Edition = ossEdition
 )
 
+// FullVersion returns the CLI version annotated with its edition flavor,
+// e.g. "v1.94.2-oss" or "dev-ee". Used as the value of the Chainloop-Cli-Version
+// header sent on every request to the Control Plane and CAS.
+func FullVersion() string {
+	return Version + "-" + Edition
+}
+
 type info struct {
 	Version string
 	Digest  string

--- a/app/cli/pkg/action/action.go
+++ b/app/cli/pkg/action/action.go
@@ -59,6 +59,7 @@ type ActionsOpts struct {
 	Logger       zerolog.Logger
 	AuthTokenRaw string
 	OutputFormat string
+	CLIVersion   string
 }
 
 type OffsetPagination struct {
@@ -113,7 +114,7 @@ func newCrafter(stateOpts *newCrafterStateOpts, conn *grpc.ClientConn, opts ...c
 }
 
 // getCASBackend tries to get CAS upload credentials and set up a CAS client
-func getCASBackend(ctx context.Context, client pb.AttestationServiceClient, workflowRunID, casCAPath, casURI string, casConnectionInsecure bool, logger zerolog.Logger, casBackend *casclient.CASBackend) (*clientAPI.Attestation_CASBackend, func() error, error) {
+func getCASBackend(ctx context.Context, client pb.AttestationServiceClient, workflowRunID, casCAPath, casURI string, casConnectionInsecure bool, logger zerolog.Logger, casBackend *casclient.CASBackend, cliVersion string) (*clientAPI.Attestation_CASBackend, func() error, error) {
 	credsResp, err := client.GetUploadCreds(ctx, &pb.AttestationServiceGetUploadCredsRequest{
 		WorkflowRunId: workflowRunID,
 	})
@@ -151,7 +152,10 @@ func getCASBackend(ctx context.Context, client pb.AttestationServiceClient, work
 		return casBackendInfo, nil, nil
 	}
 
-	opts := []grpcconn.Option{grpcconn.WithInsecure(casConnectionInsecure)}
+	opts := []grpcconn.Option{
+		grpcconn.WithInsecure(casConnectionInsecure),
+		grpcconn.WithCLIVersion(cliVersion),
+	}
 	if casCAPath != "" {
 		// Check if it's a file path or content. If it's a file path, it should exist. If not, treat it as content.
 		if _, err := os.Stat(casCAPath); err == nil {

--- a/app/cli/pkg/action/attestation_add.go
+++ b/app/cli/pkg/action/attestation_add.go
@@ -104,7 +104,7 @@ func (action *AttestationAdd) Run(ctx context.Context, attestationID, materialNa
 	if !crafter.CraftingState.GetDryRun() {
 		client := pb.NewAttestationServiceClient(action.CPConnection)
 		workflowRunID := crafter.CraftingState.GetAttestation().GetWorkflow().GetWorkflowRunId()
-		_, connectionCloserFn, getCASBackendErr := getCASBackend(ctx, client, workflowRunID, action.casCAPath, action.casURI, action.connectionInsecure, action.Logger, casBackend)
+		_, connectionCloserFn, getCASBackendErr := getCASBackend(ctx, client, workflowRunID, action.casCAPath, action.casURI, action.connectionInsecure, action.Logger, casBackend, action.CLIVersion)
 		if getCASBackendErr != nil {
 			return nil, fmt.Errorf("failed to get CAS backend: %w", getCASBackendErr)
 		}

--- a/app/cli/pkg/action/attestation_init.go
+++ b/app/cli/pkg/action/attestation_init.go
@@ -250,7 +250,7 @@ func (action *AttestationInit) Run(ctx context.Context, opts *AttestationInitRun
 	var casBackendInfo *clientAPI.Attestation_CASBackend
 	if !action.dryRun && attestationID != "" {
 		var connectionCloserFn func() error
-		casBackendInfo, connectionCloserFn, err = getCASBackend(ctx, client, attestationID, action.casCAPath, action.casURI, action.connectionInsecure, action.Logger, casBackend)
+		casBackendInfo, connectionCloserFn, err = getCASBackend(ctx, client, attestationID, action.casCAPath, action.casURI, action.connectionInsecure, action.Logger, casBackend, action.CLIVersion)
 		if err != nil {
 			// We don't want to fail the attestation initialization if CAS setup fails, it's a best-effort feature for PR/MR metadata
 			action.Logger.Warn().Err(err).Msg("unexpected error getting CAS backend")

--- a/app/cli/pkg/action/attestation_push.go
+++ b/app/cli/pkg/action/attestation_push.go
@@ -222,7 +222,7 @@ func (action *AttestationPush) Run(ctx context.Context, attestationID string, ru
 	if evaluations := crafter.CraftingState.GetAttestation().GetPolicyEvaluations(); !crafter.CraftingState.DryRun && len(evaluations) > 0 {
 		casBackend := &casclient.CASBackend{Name: "not-set"}
 		workflowRunID := crafter.CraftingState.GetAttestation().GetWorkflow().GetWorkflowRunId()
-		_, connectionCloserFn, getCASErr := getCASBackend(ctx, attClient, workflowRunID, action.casCAPath, action.casURI, action.connectionInsecure, action.Logger, casBackend)
+		_, connectionCloserFn, getCASErr := getCASBackend(ctx, attClient, workflowRunID, action.casCAPath, action.casURI, action.connectionInsecure, action.Logger, casBackend, action.CLIVersion)
 		if connectionCloserFn != nil {
 			// nolint: errcheck
 			defer connectionCloserFn()

--- a/app/controlplane/internal/service/attestation.go
+++ b/app/controlplane/internal/service/attestation.go
@@ -492,7 +492,7 @@ func (s *AttestationService) GetPolicy(ctx context.Context, req *cpAPI.Attestati
 		return nil, errors.Forbidden("forbidden", "organization not found")
 	}
 
-	remotePolicy, err := s.workflowContractUseCase.GetPolicy(req.GetProvider(), req.GetPolicyName(), req.GetOrgName(), org.Name, token.Token)
+	remotePolicy, err := s.workflowContractUseCase.GetPolicy(ctx, req.GetProvider(), req.GetPolicyName(), req.GetOrgName(), org.Name, token.Token)
 	if err != nil {
 		return nil, handleUseCaseErr(err, s.log)
 	}
@@ -514,7 +514,7 @@ func (s *AttestationService) GetPolicyGroup(ctx context.Context, req *cpAPI.Atte
 		return nil, errors.Forbidden("forbidden", "organization not found")
 	}
 
-	remoteGroup, err := s.workflowContractUseCase.GetPolicyGroup(req.GetProvider(), req.GetGroupName(), req.GetOrgName(), org.Name, token.Token)
+	remoteGroup, err := s.workflowContractUseCase.GetPolicyGroup(ctx, req.GetProvider(), req.GetGroupName(), req.GetOrgName(), org.Name, token.Token)
 	if err != nil {
 		return nil, handleUseCaseErr(err, s.log)
 	}
@@ -732,7 +732,7 @@ func (s *AttestationService) FindOrCreateWorkflow(ctx context.Context, req *cpAP
 
 	// contract validation
 	if req.GetContractBytes() != nil {
-		if err = s.workflowContractUseCase.ValidateContractPolicies(req.GetContractBytes(), token); err != nil {
+		if err = s.workflowContractUseCase.ValidateContractPolicies(ctx, req.GetContractBytes(), token); err != nil {
 			return nil, handleUseCaseErr(err, s.log)
 		}
 	}

--- a/app/controlplane/internal/service/workflowcontract.go
+++ b/app/controlplane/internal/service/workflowcontract.go
@@ -146,7 +146,7 @@ func (s *WorkflowContractService) Create(ctx context.Context, req *pb.WorkflowCo
 	}
 
 	if len(req.RawContract) != 0 {
-		if err = s.contractUseCase.ValidateContractPolicies(req.RawContract, token); err != nil {
+		if err = s.contractUseCase.ValidateContractPolicies(ctx, req.RawContract, token); err != nil {
 			return nil, handleUseCaseErr(err, s.log)
 		}
 	}
@@ -212,7 +212,7 @@ func (s *WorkflowContractService) Update(ctx context.Context, req *pb.WorkflowCo
 
 	// Validate the contract policies if the raw contract is provided
 	if len(req.RawContract) != 0 {
-		if err = s.contractUseCase.ValidateContractPolicies(req.RawContract, token); err != nil {
+		if err = s.contractUseCase.ValidateContractPolicies(ctx, req.RawContract, token); err != nil {
 			return nil, handleUseCaseErr(err, s.log)
 		}
 	}
@@ -251,7 +251,7 @@ func (s *WorkflowContractService) Apply(ctx context.Context, req *pb.WorkflowCon
 		return nil, err
 	}
 
-	if err = s.contractUseCase.ValidateContractPolicies(req.RawSchema, token); err != nil {
+	if err = s.contractUseCase.ValidateContractPolicies(ctx, req.RawSchema, token); err != nil {
 		return nil, handleUseCaseErr(err, s.log)
 	}
 

--- a/app/controlplane/internal/usercontext/entities/entitites.go
+++ b/app/controlplane/internal/usercontext/entities/entitites.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2025 The Chainloop Authors.
+// Copyright 2025-2026 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/chainloop-dev/chainloop/pkg/grpcconn"
 	"github.com/go-kratos/kratos/v2/middleware/auth/jwt"
 	"github.com/go-kratos/kratos/v2/transport"
 )
@@ -45,4 +46,16 @@ func GetOrganizationNameFromHeader(ctx context.Context) (string, error) {
 	}
 
 	return "", nil
+}
+
+// GetCLIVersionFromHeader returns the CLI version advertised by the caller in
+// the Chainloop-Cli-Version request header. The value format is
+// "<version>-<edition>", e.g. "v1.94.2-oss". Returns an empty string when the
+// header is absent or there is no transport in the context.
+func GetCLIVersionFromHeader(ctx context.Context) string {
+	header, ok := transport.FromServerContext(ctx)
+	if !ok {
+		return ""
+	}
+	return header.RequestHeader().Get(grpcconn.CLIVersionHeader)
 }

--- a/app/controlplane/internal/usercontext/entities/entitites_test.go
+++ b/app/controlplane/internal/usercontext/entities/entitites_test.go
@@ -1,0 +1,72 @@
+//
+// Copyright 2026 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package entities
+
+import (
+	"context"
+	"testing"
+
+	"github.com/chainloop-dev/chainloop/pkg/grpcconn"
+	"github.com/go-kratos/kratos/v2/transport"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockHeader map[string]string
+
+func (h mockHeader) Get(key string) string { return h[key] }
+func (h mockHeader) Set(key, value string) { h[key] = value }
+func (h mockHeader) Add(key, value string) { h[key] = value }
+func (h mockHeader) Keys() []string {
+	keys := make([]string, 0, len(h))
+	for k := range h {
+		keys = append(keys, k)
+	}
+	return keys
+}
+func (h mockHeader) Values(key string) []string {
+	if v, ok := h[key]; ok {
+		return []string{v}
+	}
+	return nil
+}
+
+type mockTransport struct {
+	header transport.Header
+}
+
+func (tr *mockTransport) Kind() transport.Kind            { return transport.KindGRPC }
+func (tr *mockTransport) Endpoint() string                { return "" }
+func (tr *mockTransport) Operation() string               { return "" }
+func (tr *mockTransport) RequestHeader() transport.Header { return tr.header }
+func (tr *mockTransport) ReplyHeader() transport.Header   { return tr.header }
+
+func TestGetCLIVersionFromHeader(t *testing.T) {
+	t.Run("returns the header value when present", func(t *testing.T) {
+		ctx := transport.NewServerContext(context.Background(), &mockTransport{
+			header: mockHeader{grpcconn.CLIVersionHeader: "v1.94.2-oss"},
+		})
+		assert.Equal(t, "v1.94.2-oss", GetCLIVersionFromHeader(ctx))
+	})
+
+	t.Run("returns empty when header is absent", func(t *testing.T) {
+		ctx := transport.NewServerContext(context.Background(), &mockTransport{header: mockHeader{}})
+		assert.Equal(t, "", GetCLIVersionFromHeader(ctx))
+	})
+
+	t.Run("returns empty when there is no transport in context", func(t *testing.T) {
+		assert.Equal(t, "", GetCLIVersionFromHeader(context.Background()))
+	})
+}

--- a/app/controlplane/pkg/biz/workflowcontract.go
+++ b/app/controlplane/pkg/biz/workflowcontract.go
@@ -26,6 +26,7 @@ import (
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/auditor/events"
 
 	schemav1 "github.com/chainloop-dev/chainloop/app/controlplane/api/workflowcontract/v1"
+	"github.com/chainloop-dev/chainloop/app/controlplane/internal/usercontext/entities"
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/policies"
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/unmarshal"
 	loader "github.com/chainloop-dev/chainloop/pkg/policies"
@@ -439,7 +440,7 @@ func (uc *WorkflowContractUseCase) Update(ctx context.Context, orgID, name strin
 	return c, nil
 }
 
-func (uc *WorkflowContractUseCase) ValidateContractPolicies(rawSchema []byte, token string) error {
+func (uc *WorkflowContractUseCase) ValidateContractPolicies(ctx context.Context, rawSchema []byte, token string) error {
 	// Validate that externally provided policies exist
 	c, err := identifyUnMarshalAndValidateRawContract(rawSchema)
 	if err != nil {
@@ -452,17 +453,17 @@ func (uc *WorkflowContractUseCase) ValidateContractPolicies(rawSchema []byte, to
 		// DEPRECATED: v1 schema is deprecated, use v2 Contract format instead
 		schema := c.Schema
 		for _, att := range schema.GetPolicies().GetAttestation() {
-			if _, err := uc.findAndValidatePolicy(att, token); err != nil {
+			if _, err := uc.findAndValidatePolicy(ctx, att, token); err != nil {
 				return NewErrValidation(err)
 			}
 		}
 		for _, att := range schema.GetPolicies().GetMaterials() {
-			if _, err := uc.findAndValidatePolicy(att, token); err != nil {
+			if _, err := uc.findAndValidatePolicy(ctx, att, token); err != nil {
 				return NewErrValidation(err)
 			}
 		}
 		for _, gatt := range schema.GetPolicyGroups() {
-			if _, err := uc.findAndValidatePolicyGroup(gatt, token); err != nil {
+			if _, err := uc.findAndValidatePolicyGroup(ctx, gatt, token); err != nil {
 				return NewErrValidation(err)
 			}
 		}
@@ -471,18 +472,18 @@ func (uc *WorkflowContractUseCase) ValidateContractPolicies(rawSchema []byte, to
 		spec := c.Schemav2.GetSpec()
 		if spec.GetPolicies() != nil {
 			for _, att := range spec.GetPolicies().GetAttestation() {
-				if _, err := uc.findAndValidatePolicy(att, token); err != nil {
+				if _, err := uc.findAndValidatePolicy(ctx, att, token); err != nil {
 					return NewErrValidation(err)
 				}
 			}
 			for _, att := range spec.GetPolicies().GetMaterials() {
-				if _, err := uc.findAndValidatePolicy(att, token); err != nil {
+				if _, err := uc.findAndValidatePolicy(ctx, att, token); err != nil {
 					return NewErrValidation(err)
 				}
 			}
 		}
 		for _, gatt := range spec.GetPolicyGroups() {
-			if _, err := uc.findAndValidatePolicyGroup(gatt, token); err != nil {
+			if _, err := uc.findAndValidatePolicyGroup(ctx, gatt, token); err != nil {
 				return NewErrValidation(err)
 			}
 		}
@@ -493,13 +494,13 @@ func (uc *WorkflowContractUseCase) ValidateContractPolicies(rawSchema []byte, to
 	return nil
 }
 
-func (uc *WorkflowContractUseCase) ValidatePolicyAttachment(providerName string, att *schemav1.PolicyAttachment, token string) error {
+func (uc *WorkflowContractUseCase) ValidatePolicyAttachment(ctx context.Context, providerName string, att *schemav1.PolicyAttachment, token string) error {
 	provider, err := uc.findProvider(providerName)
 	if err != nil {
 		return err
 	}
 
-	if err = provider.ValidateAttachment(att, token); err != nil {
+	if err = provider.ValidateAttachment(att, providerAuthOpts(ctx, token, "")); err != nil {
 		if errors.Is(err, policies.ErrUnauthorized) {
 			return NewErrUnauthorized(fmt.Errorf("invalid attachment: %w", err))
 		}
@@ -509,7 +510,7 @@ func (uc *WorkflowContractUseCase) ValidatePolicyAttachment(providerName string,
 	return nil
 }
 
-func (uc *WorkflowContractUseCase) findAndValidatePolicy(att *schemav1.PolicyAttachment, token string) (*schemav1.Policy, error) {
+func (uc *WorkflowContractUseCase) findAndValidatePolicy(ctx context.Context, att *schemav1.PolicyAttachment, token string) (*schemav1.Policy, error) {
 	var policy *schemav1.Policy
 
 	if att.GetEmbedded() != nil {
@@ -521,11 +522,11 @@ func (uc *WorkflowContractUseCase) findAndValidatePolicy(att *schemav1.PolicyAtt
 	if loader.IsProviderScheme(att.GetRef()) {
 		pr := loader.ProviderParts(att.GetRef())
 		// Validate attachment
-		if err := uc.ValidatePolicyAttachment(pr.Provider, att, token); err != nil {
+		if err := uc.ValidatePolicyAttachment(ctx, pr.Provider, att, token); err != nil {
 			return nil, err
 		}
 
-		remotePolicy, err := uc.GetPolicy(pr.Provider, pr.Name, pr.OrgName, "", token)
+		remotePolicy, err := uc.GetPolicy(ctx, pr.Provider, pr.Name, pr.OrgName, "", token)
 		if err != nil {
 			return nil, err
 		}
@@ -547,7 +548,7 @@ func (uc *WorkflowContractUseCase) findAndValidatePolicy(att *schemav1.PolicyAtt
 	return policy, nil
 }
 
-func (uc *WorkflowContractUseCase) findAndValidatePolicyGroup(att *schemav1.PolicyGroupAttachment, token string) (*schemav1.PolicyGroup, error) {
+func (uc *WorkflowContractUseCase) findAndValidatePolicyGroup(ctx context.Context, att *schemav1.PolicyGroupAttachment, token string) (*schemav1.PolicyGroup, error) {
 	if !loader.IsProviderScheme(att.GetRef()) {
 		// Otherwise, don't return an error, as it might consist of a local policy, not available in this context
 		return nil, nil
@@ -556,7 +557,7 @@ func (uc *WorkflowContractUseCase) findAndValidatePolicyGroup(att *schemav1.Poli
 	// if it should come from a provider, check that it's available
 	// [chainloop://][provider/]name
 	pr := loader.ProviderParts(att.GetRef())
-	remoteGroup, err := uc.GetPolicyGroup(pr.Provider, pr.Name, pr.OrgName, "", token)
+	remoteGroup, err := uc.GetPolicyGroup(ctx, pr.Provider, pr.Name, pr.OrgName, "", token)
 	if err != nil {
 		return nil, NewErrValidation(fmt.Errorf("failed to get policy group: %w", err))
 	}
@@ -577,7 +578,7 @@ func (uc *WorkflowContractUseCase) findAndValidatePolicyGroup(att *schemav1.Poli
 	}
 
 	// Validate skip list
-	if err := uc.validateSkipList(remoteGroup.PolicyGroup, att, token); err != nil {
+	if err := uc.validateSkipList(ctx, remoteGroup.PolicyGroup, att, token); err != nil {
 		return nil, fmt.Errorf("failed to validate skip list: %w", err)
 	}
 
@@ -586,7 +587,7 @@ func (uc *WorkflowContractUseCase) findAndValidatePolicyGroup(att *schemav1.Poli
 
 // validateSkipList checks if policy names in the skip list exist in the group
 // and returns an error if any unknown policy names are found
-func (uc *WorkflowContractUseCase) validateSkipList(group *schemav1.PolicyGroup, groupAtt *schemav1.PolicyGroupAttachment, token string) error {
+func (uc *WorkflowContractUseCase) validateSkipList(ctx context.Context, group *schemav1.PolicyGroup, groupAtt *schemav1.PolicyGroupAttachment, token string) error {
 	if len(groupAtt.GetSkip()) == 0 {
 		return nil
 	}
@@ -598,7 +599,7 @@ func (uc *WorkflowContractUseCase) validateSkipList(group *schemav1.PolicyGroup,
 	// Collect material policy names
 	for _, groupMaterial := range policies.GetMaterials() {
 		for _, policyAtt := range groupMaterial.GetPolicies() {
-			policy, err := uc.findAndValidatePolicy(policyAtt, token)
+			policy, err := uc.findAndValidatePolicy(ctx, policyAtt, token)
 			if err != nil {
 				return fmt.Errorf("failed to get policy name during skip list validation: %w", err)
 			}
@@ -608,7 +609,7 @@ func (uc *WorkflowContractUseCase) validateSkipList(group *schemav1.PolicyGroup,
 
 	// Collect attestation policy names
 	for _, policyAtt := range policies.GetAttestation() {
-		policy, err := uc.findAndValidatePolicy(policyAtt, token)
+		policy, err := uc.findAndValidatePolicy(ctx, policyAtt, token)
 		if err != nil {
 			return fmt.Errorf("failed to get policy name during skip list validation: %w", err)
 		}
@@ -683,17 +684,25 @@ type RemotePolicyGroup struct {
 	PolicyGroup *schemav1.PolicyGroup
 }
 
+// providerAuthOpts forwards the originating CLI's version (read from the
+// inbound gRPC metadata) to the policy provider so the provider can correlate
+// requests with the CLI release that triggered them.
+func providerAuthOpts(ctx context.Context, token, currentOrgName string) policies.ProviderAuthOpts {
+	return policies.ProviderAuthOpts{
+		Token:      token,
+		OrgName:    currentOrgName,
+		CLIVersion: entities.GetCLIVersionFromHeader(ctx),
+	}
+}
+
 // GetPolicy retrieves a policy from a policy provider
-func (uc *WorkflowContractUseCase) GetPolicy(providerName, policyName, policyOrgName, currentOrgName, token string) (*RemotePolicy, error) {
+func (uc *WorkflowContractUseCase) GetPolicy(ctx context.Context, providerName, policyName, policyOrgName, currentOrgName, token string) (*RemotePolicy, error) {
 	provider, err := uc.findProvider(providerName)
 	if err != nil {
 		return nil, err
 	}
 
-	policy, ref, err := provider.Resolve(policyName, policyOrgName, policies.ProviderAuthOpts{
-		Token:   token,
-		OrgName: currentOrgName,
-	})
+	policy, ref, err := provider.Resolve(policyName, policyOrgName, providerAuthOpts(ctx, token, currentOrgName))
 	if err != nil {
 		if errors.Is(err, policies.ErrNotFound) {
 			return nil, NewErrNotFound(fmt.Sprintf("policy %q", policyName))
@@ -708,16 +717,13 @@ func (uc *WorkflowContractUseCase) GetPolicy(providerName, policyName, policyOrg
 	return &RemotePolicy{Policy: policy, ProviderRef: ref}, nil
 }
 
-func (uc *WorkflowContractUseCase) GetPolicyGroup(providerName, groupName, groupOrgName, currentOrgName, token string) (*RemotePolicyGroup, error) {
+func (uc *WorkflowContractUseCase) GetPolicyGroup(ctx context.Context, providerName, groupName, groupOrgName, currentOrgName, token string) (*RemotePolicyGroup, error) {
 	provider, err := uc.findProvider(providerName)
 	if err != nil {
 		return nil, err
 	}
 
-	group, ref, err := provider.ResolveGroup(groupName, groupOrgName, policies.ProviderAuthOpts{
-		Token:   token,
-		OrgName: currentOrgName,
-	})
+	group, ref, err := provider.ResolveGroup(groupName, groupOrgName, providerAuthOpts(ctx, token, currentOrgName))
 	if err != nil {
 		if errors.Is(err, policies.ErrNotFound) {
 			return nil, NewErrNotFound(fmt.Sprintf("policy group %q", groupName))

--- a/app/controlplane/pkg/policies/policyprovider.go
+++ b/app/controlplane/pkg/policies/policyprovider.go
@@ -25,6 +25,7 @@ import (
 
 	schemaapi "github.com/chainloop-dev/chainloop/app/controlplane/api/workflowcontract/v1"
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/unmarshal"
+	"github.com/chainloop-dev/chainloop/pkg/grpcconn"
 	"github.com/chainloop-dev/chainloop/pkg/policies"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
@@ -76,6 +77,10 @@ type PolicyReference struct {
 type ProviderAuthOpts struct {
 	Token   string
 	OrgName string
+	// CLIVersion, when non-empty, is forwarded to the policy provider as the
+	// Chainloop-Cli-Version header. It carries the version+edition string of
+	// the CLI that originated the request.
+	CLIVersion string
 }
 
 var (
@@ -111,7 +116,7 @@ func (p *PolicyProvider) Resolve(policyName, policyOrgName string, authOpts Prov
 	return &policy, createRef(url, policyName, providerDigest, orgName), nil
 }
 
-func (p *PolicyProvider) ValidateAttachment(att *schemaapi.PolicyAttachment, token string) error {
+func (p *PolicyProvider) ValidateAttachment(att *schemaapi.PolicyAttachment, authOpts ProviderAuthOpts) error {
 	endpoint, err := url.JoinPath(p.url, policiesEndpoint, validateAction)
 	if err != nil {
 		return fmt.Errorf("invalid url: %w", err)
@@ -140,8 +145,11 @@ func (p *PolicyProvider) ValidateAttachment(att *schemaapi.PolicyAttachment, tok
 		return fmt.Errorf("error creating policy request: %w", err)
 	}
 
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", authOpts.Token))
 	req.Header.Set("Content-Type", "application/json")
+	if authOpts.CLIVersion != "" {
+		req.Header.Set(grpcconn.CLIVersionHeader, authOpts.CLIVersion)
+	}
 
 	// make the request
 	resp, err := http.DefaultClient.Do(req)
@@ -230,6 +238,9 @@ func (p *PolicyProvider) queryProvider(url *url.URL, digest, orgName string, aut
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", authOpts.Token))
 	if authOpts.OrgName != "" {
 		req.Header.Set(organizationHeader, authOpts.OrgName)
+	}
+	if authOpts.CLIVersion != "" {
+		req.Header.Set(grpcconn.CLIVersionHeader, authOpts.CLIVersion)
 	}
 
 	// make the request

--- a/app/controlplane/pkg/policies/policyprovider_http_test.go
+++ b/app/controlplane/pkg/policies/policyprovider_http_test.go
@@ -19,8 +19,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
+	schemaapi "github.com/chainloop-dev/chainloop/app/controlplane/api/workflowcontract/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -159,6 +161,59 @@ func TestResolveGroupHTTPStatusHandling(t *testing.T) {
 	}
 }
 
+func TestProviderForwardsCLIVersionHeader(t *testing.T) {
+	testCases := []struct {
+		name       string
+		cliVersion string
+		wantHeader string
+	}{
+		{
+			name:       "header forwarded when set",
+			cliVersion: "v1.94.2-oss",
+			wantHeader: "v1.94.2-oss",
+		},
+		{
+			name:       "header omitted when empty",
+			cliVersion: "",
+			wantHeader: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				resolveHeader, groupHeader, validateHeader string
+			)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				got := r.Header.Get("Chainloop-Cli-Version")
+				switch {
+				case strings.Contains(r.URL.Path, "/policies/validate"):
+					validateHeader = got
+				case strings.Contains(r.URL.Path, "/groups/"):
+					groupHeader = got
+				default:
+					resolveHeader = got
+				}
+				// minimal valid response
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{}`))
+			}))
+			defer server.Close()
+
+			provider := &PolicyProvider{name: "test", url: server.URL}
+			authOpts := ProviderAuthOpts{Token: "test-token", CLIVersion: tc.cliVersion}
+
+			_, _, _ = provider.Resolve("p1", "", authOpts)
+			_, _, _ = provider.ResolveGroup("g1", "", authOpts)
+			_ = provider.ValidateAttachment(&schemaapi.PolicyAttachment{}, authOpts)
+
+			assert.Equal(t, tc.wantHeader, resolveHeader, "Resolve")
+			assert.Equal(t, tc.wantHeader, groupHeader, "ResolveGroup")
+			assert.Equal(t, tc.wantHeader, validateHeader, "ValidateAttachment")
+		})
+	}
+}
+
 func TestValidateAttachmentHTTPStatusHandling(t *testing.T) {
 	testCases := []struct {
 		name       string
@@ -214,7 +269,7 @@ func TestValidateAttachmentHTTPStatusHandling(t *testing.T) {
 				url:  server.URL,
 			}
 
-			err := provider.ValidateAttachment(nil, "test-token")
+			err := provider.ValidateAttachment(nil, ProviderAuthOpts{Token: "test-token"})
 			if tc.errNil {
 				assert.NoError(t, err)
 				return

--- a/pkg/grpcconn/grpcconn.go
+++ b/pkg/grpcconn/grpcconn.go
@@ -26,13 +26,22 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	grpc_insecure "google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 )
+
+// CLIVersionHeader is the request header key the CLI uses to advertise its
+// version (and edition flavor) on every request to the Control Plane and CAS.
+// Both gRPC and HTTP treat header keys as case-insensitive, so the same
+// canonical name is reused when the Control Plane forwards the value to
+// downstream policy providers over HTTP.
+const CLIVersionHeader = "Chainloop-Cli-Version"
 
 type newOptionalArg struct {
 	caFilePath string
 	caContent  string
 	insecure   bool
 	orgName    string
+	cliVersion string
 }
 
 type Option func(*newOptionalArg)
@@ -62,6 +71,28 @@ func WithOrgName(orgName string) Option {
 	}
 }
 
+// WithCLIVersion attaches the given CLI version (e.g. "v1.94.2-oss") to every
+// outgoing request as the chainloop-cli-version header.
+func WithCLIVersion(version string) Option {
+	return func(opt *newOptionalArg) {
+		opt.cliVersion = version
+	}
+}
+
+func cliVersionUnaryInterceptor(version string) grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		ctx = metadata.AppendToOutgoingContext(ctx, CLIVersionHeader, version)
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+}
+
+func cliVersionStreamInterceptor(version string) grpc.StreamClientInterceptor {
+	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		ctx = metadata.AppendToOutgoingContext(ctx, CLIVersionHeader, version)
+		return streamer(ctx, desc, cc, method, opts...)
+	}
+}
+
 // Simple wrapper around grpc.Dial that returns a grpc.ClientConn
 // It sets up the connection with the correct credentials headers
 func New(uri, authToken string, opt ...Option) (*grpc.ClientConn, error) {
@@ -71,14 +102,25 @@ func New(uri, authToken string, opt ...Option) (*grpc.ClientConn, error) {
 	}
 
 	var opts []grpc.DialOption
+	unaryInterceptors := []grpc.UnaryClientInterceptor{}
+	streamInterceptors := []grpc.StreamClientInterceptor{}
+
 	if authToken != "" {
 		grpcCreds := newTokenAuth(authToken, optionalArgs.insecure, optionalArgs.orgName)
+		opts = append(opts, grpc.WithPerRPCCredentials(grpcCreds))
+		unaryInterceptors = append(unaryInterceptors, grpc_retry.UnaryClientInterceptor())
+	}
 
-		opts = []grpc.DialOption{
-			grpc.WithPerRPCCredentials(grpcCreds),
-			// Retry using default configuration
-			grpc.WithUnaryInterceptor(grpc_retry.UnaryClientInterceptor()),
-		}
+	if optionalArgs.cliVersion != "" {
+		unaryInterceptors = append(unaryInterceptors, cliVersionUnaryInterceptor(optionalArgs.cliVersion))
+		streamInterceptors = append(streamInterceptors, cliVersionStreamInterceptor(optionalArgs.cliVersion))
+	}
+
+	if len(unaryInterceptors) > 0 {
+		opts = append(opts, grpc.WithChainUnaryInterceptor(unaryInterceptors...))
+	}
+	if len(streamInterceptors) > 0 {
+		opts = append(opts, grpc.WithChainStreamInterceptor(streamInterceptors...))
 	}
 
 	// Currently we only support system tls certs

--- a/pkg/grpcconn/grpcconn_test.go
+++ b/pkg/grpcconn/grpcconn_test.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
 const caPath = "../../devel/devkeys/selfsigned/rootCA.crt"
@@ -185,6 +187,44 @@ func TestBackwardCompatibility_NewClientOldConfig(t *testing.T) {
 	opts[0](optArg)
 	assert.Equal(t, caPath, optArg.caFilePath, "should use file path method for old config")
 	assert.Empty(t, optArg.caContent, "should not use content method for old config")
+}
+
+func TestWithCLIVersion(t *testing.T) {
+	opt := &newOptionalArg{}
+	WithCLIVersion("v1.94.2-oss")(opt)
+	assert.Equal(t, "v1.94.2-oss", opt.cliVersion)
+}
+
+func TestCLIVersionUnaryInterceptorAttachesHeader(t *testing.T) {
+	const want = "v1.94.2-oss"
+	intercept := cliVersionUnaryInterceptor(want)
+
+	var captured metadata.MD
+	invoker := func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+		md, _ := metadata.FromOutgoingContext(ctx)
+		captured = md
+		return nil
+	}
+
+	err := intercept(context.Background(), "/svc/Method", nil, nil, nil, invoker)
+	require.NoError(t, err)
+	assert.Equal(t, []string{want}, captured.Get(CLIVersionHeader))
+}
+
+func TestCLIVersionStreamInterceptorAttachesHeader(t *testing.T) {
+	const want = "v1.94.2-ee"
+	intercept := cliVersionStreamInterceptor(want)
+
+	var captured metadata.MD
+	streamer := func(ctx context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn, _ string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
+		md, _ := metadata.FromOutgoingContext(ctx)
+		captured = md
+		return nil, nil
+	}
+
+	_, err := intercept(context.Background(), &grpc.StreamDesc{}, nil, "/svc/Method", streamer)
+	require.NoError(t, err)
+	assert.Equal(t, []string{want}, captured.Get(CLIVersionHeader))
 }
 
 func TestBackwardCompatibility_OldClientNewConfig(t *testing.T) {


### PR DESCRIPTION
## Summary

- The CLI attaches a `Chainloop-Cli-Version` header (formatted as `<version>-<edition>`, e.g. `v1.94.2-oss`) on every gRPC request to the Control Plane and CAS via unary/stream client interceptors in `pkg/grpcconn`.
- The Control Plane reads the header and forwards it on outbound HTTP calls to policy providers (`Resolve`, `ResolveGroup`, `ValidateAttachment`).
- Biz-layer methods that reach policy providers now accept a `context.Context`; `ValidateAttachment` adopts `ProviderAuthOpts` for parity with `Resolve`/`ResolveGroup`.