### PR TITLE
feat(policies): add assessment annotation to policy finding schemas

### DIFF
--- a/app/cli/cmd/attestation_push.go
+++ b/app/cli/cmd/attestation_push.go
@@ -186,11 +186,25 @@ func (e *GateError) Error() string {
 	return fmt.Sprintf("the policy %q is configured as a gate and has violations", e.PolicyName)
 }
 
+// hasGatingViolation reports whether any of the supplied violations should
+// count toward the policy gate. Entries flagged Suppress (typically because
+// an assessment renders the finding NOT_AFFECTED) are excluded.
+func hasGatingViolation(violations []*action.PolicyViolation) bool {
+	for _, v := range violations {
+		if !v.Suppress {
+			return true
+		}
+	}
+	return false
+}
+
 func validatePolicyEnforcement(status *action.AttestationStatusResult, bypassPolicyCheck bool) error {
-	// Block if any of the policies has been configured as a gate.
+	// Block if any of the policies has been configured as a gate. Entries
+	// flagged Suppress are excluded from the gate count but remain in
+	// eval.Violations for CAS storage and ingestion (audit trail preserved).
 	for _, evaluations := range status.PolicyEvaluations {
 		for _, eval := range evaluations {
-			if len(eval.Violations) > 0 && eval.Gate {
+			if eval.Gate && hasGatingViolation(eval.Violations) {
 				if bypassPolicyCheck {
 					logger.Warn().Msg(exceptionBypassPolicyCheck)
 					continue

--- a/app/cli/cmd/attestation_push_test.go
+++ b/app/cli/cmd/attestation_push_test.go
@@ -88,4 +88,51 @@ func TestValidatePolicyEnforcement(t *testing.T) {
 		err := validatePolicyEnforcement(status, false)
 		require.NoError(t, err)
 	})
+
+	t.Run("does not block when every violation on a gated policy is suppressed", func(t *testing.T) {
+		status := &action.AttestationStatusResult{
+			PolicyEvaluations: map[string][]*action.PolicyEvaluation{
+				"materials": {
+					{
+						Name: "cdx-fresh",
+						Gate: true,
+						Violations: []*action.PolicyViolation{
+							{Message: "CVE-2024-1 NOT_AFFECTED", Suppress: true},
+							{Message: "CVE-2024-2 NOT_AFFECTED", Suppress: true},
+						},
+					},
+				},
+			},
+			HasPolicyViolations:         true,
+			MustBlockOnPolicyViolations: false,
+		}
+
+		err := validatePolicyEnforcement(status, false)
+		require.NoError(t, err)
+	})
+
+	t.Run("blocks when at least one violation on a gated policy is not suppressed", func(t *testing.T) {
+		status := &action.AttestationStatusResult{
+			PolicyEvaluations: map[string][]*action.PolicyEvaluation{
+				"materials": {
+					{
+						Name: "cdx-fresh",
+						Gate: true,
+						Violations: []*action.PolicyViolation{
+							{Message: "CVE-2024-1 NOT_AFFECTED", Suppress: true},
+							{Message: "CVE-2024-2 active", Suppress: false},
+						},
+					},
+				},
+			},
+			HasPolicyViolations:         true,
+			MustBlockOnPolicyViolations: false,
+		}
+
+		err := validatePolicyEnforcement(status, false)
+		require.Error(t, err)
+		var gateErr *GateError
+		require.ErrorAs(t, err, &gateErr)
+		require.Equal(t, "cdx-fresh", gateErr.PolicyName)
+	})
 }

--- a/app/cli/pkg/action/attestation_status.go
+++ b/app/cli/pkg/action/attestation_status.go
@@ -367,8 +367,9 @@ func policyEvaluationStateToActionForStatus(in *v1.PolicyEvaluation) *PolicyEval
 	violations := make([]*PolicyViolation, 0, len(in.Violations))
 	for _, v := range in.Violations {
 		violations = append(violations, &PolicyViolation{
-			Subject: v.Subject,
-			Message: v.Message,
+			Subject:  v.Subject,
+			Message:  v.Message,
+			Suppress: v.GetSuppress(),
 		})
 	}
 

--- a/app/cli/pkg/action/workflow_run_describe.go
+++ b/app/cli/pkg/action/workflow_run_describe.go
@@ -115,6 +115,10 @@ type PolicyEvaluation struct {
 type PolicyViolation struct {
 	Subject string `json:"subject"`
 	Message string `json:"message"`
+	// Suppress, when true, excludes this entry from the gate count while
+	// keeping it in the CAS-stored bundle (audit trail preserved). Set by
+	// the policy author via the rego "suppress" key.
+	Suppress bool `json:"suppress,omitempty"`
 }
 
 type PolicyReference struct {

--- a/app/controlplane/api/gen/frontend/attestation/v1/crafting_state.ts
+++ b/app/controlplane/api/gen/frontend/attestation/v1/crafting_state.ts
@@ -313,7 +313,17 @@ export interface PolicyEvaluation_Violation {
   message: string;
   vulnerability?: PolicyVulnerabilityFinding | undefined;
   sast?: PolicySASTFinding | undefined;
-  licenseViolation?: PolicyLicenseViolationFinding | undefined;
+  licenseViolation?:
+    | PolicyLicenseViolationFinding
+    | undefined;
+  /**
+   * Suppression hint set by the policy. When true the gate count
+   * excludes this entry, but it is still stored in CAS and ingested
+   * (audit trail preserved). Set by the policy author (typically based
+   * on `assessment.effective_status`) — the engine reads the bool
+   * without interpreting why.
+   */
+  suppress: boolean;
 }
 
 export interface PolicyEvaluation_Reference {
@@ -2916,7 +2926,14 @@ export const PolicyEvaluation_WithEntry = {
 };
 
 function createBasePolicyEvaluation_Violation(): PolicyEvaluation_Violation {
-  return { subject: "", message: "", vulnerability: undefined, sast: undefined, licenseViolation: undefined };
+  return {
+    subject: "",
+    message: "",
+    vulnerability: undefined,
+    sast: undefined,
+    licenseViolation: undefined,
+    suppress: false,
+  };
 }
 
 export const PolicyEvaluation_Violation = {
@@ -2935,6 +2952,9 @@ export const PolicyEvaluation_Violation = {
     }
     if (message.licenseViolation !== undefined) {
       PolicyLicenseViolationFinding.encode(message.licenseViolation, writer.uint32(42).fork()).ldelim();
+    }
+    if (message.suppress === true) {
+      writer.uint32(48).bool(message.suppress);
     }
     return writer;
   },
@@ -2981,6 +3001,13 @@ export const PolicyEvaluation_Violation = {
 
           message.licenseViolation = PolicyLicenseViolationFinding.decode(reader, reader.uint32());
           continue;
+        case 6:
+          if (tag !== 48) {
+            break;
+          }
+
+          message.suppress = reader.bool();
+          continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -3001,6 +3028,7 @@ export const PolicyEvaluation_Violation = {
       licenseViolation: isSet(object.licenseViolation)
         ? PolicyLicenseViolationFinding.fromJSON(object.licenseViolation)
         : undefined,
+      suppress: isSet(object.suppress) ? Boolean(object.suppress) : false,
     };
   },
 
@@ -3016,6 +3044,7 @@ export const PolicyEvaluation_Violation = {
     message.licenseViolation !== undefined && (obj.licenseViolation = message.licenseViolation
       ? PolicyLicenseViolationFinding.toJSON(message.licenseViolation)
       : undefined);
+    message.suppress !== undefined && (obj.suppress = message.suppress);
     return obj;
   },
 
@@ -3036,6 +3065,7 @@ export const PolicyEvaluation_Violation = {
     message.licenseViolation = (object.licenseViolation !== undefined && object.licenseViolation !== null)
       ? PolicyLicenseViolationFinding.fromPartial(object.licenseViolation)
       : undefined;
+    message.suppress = object.suppress ?? false;
     return message;
   },
 };

--- a/app/controlplane/api/gen/frontend/attestation/v1/crafting_state.ts
+++ b/app/controlplane/api/gen/frontend/attestation/v1/crafting_state.ts
@@ -358,6 +358,8 @@ export interface PolicyVulnerabilityFinding {
   description: string;
   /** Version that fixes the vulnerability (e.g., "2.0.1", "1.3.4-patch1") */
   fixedVersion: string;
+  /** Optional assessment context. See PolicyAssessmentResult. */
+  assessmentResult?: PolicyAssessmentResult | undefined;
 }
 
 /**
@@ -380,7 +382,11 @@ export interface PolicySASTFinding {
   /** Suggested fix */
   recommendation: string;
   /** Optional numeric severity score from the scanner (scale is tool-defined) */
-  severityScore?: number | undefined;
+  severityScore?:
+    | number
+    | undefined;
+  /** Optional assessment context. See PolicyAssessmentResult. */
+  assessmentResult?: PolicyAssessmentResult | undefined;
 }
 
 /**
@@ -402,6 +408,37 @@ export interface PolicyLicenseViolationFinding {
   componentVersion: string;
   /** Suggested fix */
   recommendation: string;
+  /** Optional assessment context. See PolicyAssessmentResult. */
+  assessmentResult?: PolicyAssessmentResult | undefined;
+}
+
+/**
+ * Assessment context attached to a policy finding by the policy engine via
+ * the chainloop.effective_assessments builtin. Sent to CAS as part of the
+ * PolicyEvaluationBundle.
+ */
+export interface PolicyAssessmentResult {
+  /**
+   * Precedence-resolved status across `assessments`. Values use the
+   * platform's AssessmentStatus enum names, e.g.
+   * "ASSESSMENT_STATUS_NOT_AFFECTED".
+   */
+  effectiveStatus: string;
+  /** Assessments matching the finding's identity tuple. */
+  assessments: PolicyAssessment[];
+}
+
+/**
+ * Audit-critical subset of an assessment. Full record is reachable via
+ * AssessmentService.Get on the platform using `id`.
+ */
+export interface PolicyAssessment {
+  /** Platform assessment UUID. */
+  id: string;
+  /** Platform AssessmentStatus enum name, e.g. "ASSESSMENT_STATUS_NOT_AFFECTED". */
+  status: string;
+  /** Platform AssessmentScope enum name, e.g. "ASSESSMENT_SCOPE_PROJECT". */
+  scope: string;
 }
 
 export interface Commit {
@@ -3248,6 +3285,7 @@ function createBasePolicyVulnerabilityFinding(): PolicyVulnerabilityFinding {
     recommendation: "",
     description: "",
     fixedVersion: "",
+    assessmentResult: undefined,
   };
 }
 
@@ -3279,6 +3317,9 @@ export const PolicyVulnerabilityFinding = {
     }
     if (message.fixedVersion !== "") {
       writer.uint32(74).string(message.fixedVersion);
+    }
+    if (message.assessmentResult !== undefined) {
+      PolicyAssessmentResult.encode(message.assessmentResult, writer.uint32(82).fork()).ldelim();
     }
     return writer;
   },
@@ -3353,6 +3394,13 @@ export const PolicyVulnerabilityFinding = {
 
           message.fixedVersion = reader.string();
           continue;
+        case 10:
+          if (tag !== 82) {
+            break;
+          }
+
+          message.assessmentResult = PolicyAssessmentResult.decode(reader, reader.uint32());
+          continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -3373,6 +3421,9 @@ export const PolicyVulnerabilityFinding = {
       recommendation: isSet(object.recommendation) ? String(object.recommendation) : "",
       description: isSet(object.description) ? String(object.description) : "",
       fixedVersion: isSet(object.fixedVersion) ? String(object.fixedVersion) : "",
+      assessmentResult: isSet(object.assessmentResult)
+        ? PolicyAssessmentResult.fromJSON(object.assessmentResult)
+        : undefined,
     };
   },
 
@@ -3391,6 +3442,9 @@ export const PolicyVulnerabilityFinding = {
     message.recommendation !== undefined && (obj.recommendation = message.recommendation);
     message.description !== undefined && (obj.description = message.description);
     message.fixedVersion !== undefined && (obj.fixedVersion = message.fixedVersion);
+    message.assessmentResult !== undefined && (obj.assessmentResult = message.assessmentResult
+      ? PolicyAssessmentResult.toJSON(message.assessmentResult)
+      : undefined);
     return obj;
   },
 
@@ -3409,6 +3463,9 @@ export const PolicyVulnerabilityFinding = {
     message.recommendation = object.recommendation ?? "";
     message.description = object.description ?? "";
     message.fixedVersion = object.fixedVersion ?? "";
+    message.assessmentResult = (object.assessmentResult !== undefined && object.assessmentResult !== null)
+      ? PolicyAssessmentResult.fromPartial(object.assessmentResult)
+      : undefined;
     return message;
   },
 };
@@ -3423,6 +3480,7 @@ function createBasePolicySASTFinding(): PolicySASTFinding {
     codeSnippet: "",
     recommendation: "",
     severityScore: undefined,
+    assessmentResult: undefined,
   };
 }
 
@@ -3451,6 +3509,9 @@ export const PolicySASTFinding = {
     }
     if (message.severityScore !== undefined) {
       writer.uint32(65).double(message.severityScore);
+    }
+    if (message.assessmentResult !== undefined) {
+      PolicyAssessmentResult.encode(message.assessmentResult, writer.uint32(74).fork()).ldelim();
     }
     return writer;
   },
@@ -3518,6 +3579,13 @@ export const PolicySASTFinding = {
 
           message.severityScore = reader.double();
           continue;
+        case 9:
+          if (tag !== 74) {
+            break;
+          }
+
+          message.assessmentResult = PolicyAssessmentResult.decode(reader, reader.uint32());
+          continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -3537,6 +3605,9 @@ export const PolicySASTFinding = {
       codeSnippet: isSet(object.codeSnippet) ? String(object.codeSnippet) : "",
       recommendation: isSet(object.recommendation) ? String(object.recommendation) : "",
       severityScore: isSet(object.severityScore) ? Number(object.severityScore) : undefined,
+      assessmentResult: isSet(object.assessmentResult)
+        ? PolicyAssessmentResult.fromJSON(object.assessmentResult)
+        : undefined,
     };
   },
 
@@ -3550,6 +3621,9 @@ export const PolicySASTFinding = {
     message.codeSnippet !== undefined && (obj.codeSnippet = message.codeSnippet);
     message.recommendation !== undefined && (obj.recommendation = message.recommendation);
     message.severityScore !== undefined && (obj.severityScore = message.severityScore);
+    message.assessmentResult !== undefined && (obj.assessmentResult = message.assessmentResult
+      ? PolicyAssessmentResult.toJSON(message.assessmentResult)
+      : undefined);
     return obj;
   },
 
@@ -3567,6 +3641,9 @@ export const PolicySASTFinding = {
     message.codeSnippet = object.codeSnippet ?? "";
     message.recommendation = object.recommendation ?? "";
     message.severityScore = object.severityScore ?? undefined;
+    message.assessmentResult = (object.assessmentResult !== undefined && object.assessmentResult !== null)
+      ? PolicyAssessmentResult.fromPartial(object.assessmentResult)
+      : undefined;
     return message;
   },
 };
@@ -3580,6 +3657,7 @@ function createBasePolicyLicenseViolationFinding(): PolicyLicenseViolationFindin
     licenseName: "",
     componentVersion: "",
     recommendation: "",
+    assessmentResult: undefined,
   };
 }
 
@@ -3605,6 +3683,9 @@ export const PolicyLicenseViolationFinding = {
     }
     if (message.recommendation !== "") {
       writer.uint32(58).string(message.recommendation);
+    }
+    if (message.assessmentResult !== undefined) {
+      PolicyAssessmentResult.encode(message.assessmentResult, writer.uint32(66).fork()).ldelim();
     }
     return writer;
   },
@@ -3665,6 +3746,13 @@ export const PolicyLicenseViolationFinding = {
 
           message.recommendation = reader.string();
           continue;
+        case 8:
+          if (tag !== 66) {
+            break;
+          }
+
+          message.assessmentResult = PolicyAssessmentResult.decode(reader, reader.uint32());
+          continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -3683,6 +3771,9 @@ export const PolicyLicenseViolationFinding = {
       licenseName: isSet(object.licenseName) ? String(object.licenseName) : "",
       componentVersion: isSet(object.componentVersion) ? String(object.componentVersion) : "",
       recommendation: isSet(object.recommendation) ? String(object.recommendation) : "",
+      assessmentResult: isSet(object.assessmentResult)
+        ? PolicyAssessmentResult.fromJSON(object.assessmentResult)
+        : undefined,
     };
   },
 
@@ -3695,6 +3786,9 @@ export const PolicyLicenseViolationFinding = {
     message.licenseName !== undefined && (obj.licenseName = message.licenseName);
     message.componentVersion !== undefined && (obj.componentVersion = message.componentVersion);
     message.recommendation !== undefined && (obj.recommendation = message.recommendation);
+    message.assessmentResult !== undefined && (obj.assessmentResult = message.assessmentResult
+      ? PolicyAssessmentResult.toJSON(message.assessmentResult)
+      : undefined);
     return obj;
   },
 
@@ -3713,6 +3807,170 @@ export const PolicyLicenseViolationFinding = {
     message.licenseName = object.licenseName ?? "";
     message.componentVersion = object.componentVersion ?? "";
     message.recommendation = object.recommendation ?? "";
+    message.assessmentResult = (object.assessmentResult !== undefined && object.assessmentResult !== null)
+      ? PolicyAssessmentResult.fromPartial(object.assessmentResult)
+      : undefined;
+    return message;
+  },
+};
+
+function createBasePolicyAssessmentResult(): PolicyAssessmentResult {
+  return { effectiveStatus: "", assessments: [] };
+}
+
+export const PolicyAssessmentResult = {
+  encode(message: PolicyAssessmentResult, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.effectiveStatus !== "") {
+      writer.uint32(10).string(message.effectiveStatus);
+    }
+    for (const v of message.assessments) {
+      PolicyAssessment.encode(v!, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): PolicyAssessmentResult {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBasePolicyAssessmentResult();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag !== 10) {
+            break;
+          }
+
+          message.effectiveStatus = reader.string();
+          continue;
+        case 2:
+          if (tag !== 18) {
+            break;
+          }
+
+          message.assessments.push(PolicyAssessment.decode(reader, reader.uint32()));
+          continue;
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): PolicyAssessmentResult {
+    return {
+      effectiveStatus: isSet(object.effectiveStatus) ? String(object.effectiveStatus) : "",
+      assessments: Array.isArray(object?.assessments)
+        ? object.assessments.map((e: any) => PolicyAssessment.fromJSON(e))
+        : [],
+    };
+  },
+
+  toJSON(message: PolicyAssessmentResult): unknown {
+    const obj: any = {};
+    message.effectiveStatus !== undefined && (obj.effectiveStatus = message.effectiveStatus);
+    if (message.assessments) {
+      obj.assessments = message.assessments.map((e) => e ? PolicyAssessment.toJSON(e) : undefined);
+    } else {
+      obj.assessments = [];
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<PolicyAssessmentResult>, I>>(base?: I): PolicyAssessmentResult {
+    return PolicyAssessmentResult.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<PolicyAssessmentResult>, I>>(object: I): PolicyAssessmentResult {
+    const message = createBasePolicyAssessmentResult();
+    message.effectiveStatus = object.effectiveStatus ?? "";
+    message.assessments = object.assessments?.map((e) => PolicyAssessment.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+function createBasePolicyAssessment(): PolicyAssessment {
+  return { id: "", status: "", scope: "" };
+}
+
+export const PolicyAssessment = {
+  encode(message: PolicyAssessment, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.id !== "") {
+      writer.uint32(10).string(message.id);
+    }
+    if (message.status !== "") {
+      writer.uint32(18).string(message.status);
+    }
+    if (message.scope !== "") {
+      writer.uint32(26).string(message.scope);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): PolicyAssessment {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBasePolicyAssessment();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag !== 10) {
+            break;
+          }
+
+          message.id = reader.string();
+          continue;
+        case 2:
+          if (tag !== 18) {
+            break;
+          }
+
+          message.status = reader.string();
+          continue;
+        case 3:
+          if (tag !== 26) {
+            break;
+          }
+
+          message.scope = reader.string();
+          continue;
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): PolicyAssessment {
+    return {
+      id: isSet(object.id) ? String(object.id) : "",
+      status: isSet(object.status) ? String(object.status) : "",
+      scope: isSet(object.scope) ? String(object.scope) : "",
+    };
+  },
+
+  toJSON(message: PolicyAssessment): unknown {
+    const obj: any = {};
+    message.id !== undefined && (obj.id = message.id);
+    message.status !== undefined && (obj.status = message.status);
+    message.scope !== undefined && (obj.scope = message.scope);
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<PolicyAssessment>, I>>(base?: I): PolicyAssessment {
+    return PolicyAssessment.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<PolicyAssessment>, I>>(object: I): PolicyAssessment {
+    const message = createBasePolicyAssessment();
+    message.id = object.id ?? "";
+    message.status = object.status ?? "";
+    message.scope = object.scope ?? "";
     return message;
   },
 };

--- a/app/controlplane/api/gen/frontend/attestation/v1/crafting_state.ts
+++ b/app/controlplane/api/gen/frontend/attestation/v1/crafting_state.ts
@@ -359,7 +359,7 @@ export interface PolicyVulnerabilityFinding {
   /** Version that fixes the vulnerability (e.g., "2.0.1", "1.3.4-patch1") */
   fixedVersion: string;
   /** Optional assessment context. See PolicyAssessmentResult. */
-  assessmentResult?: PolicyAssessmentResult | undefined;
+  assessment?: PolicyAssessmentResult | undefined;
 }
 
 /**
@@ -386,7 +386,7 @@ export interface PolicySASTFinding {
     | number
     | undefined;
   /** Optional assessment context. See PolicyAssessmentResult. */
-  assessmentResult?: PolicyAssessmentResult | undefined;
+  assessment?: PolicyAssessmentResult | undefined;
 }
 
 /**
@@ -409,7 +409,7 @@ export interface PolicyLicenseViolationFinding {
   /** Suggested fix */
   recommendation: string;
   /** Optional assessment context. See PolicyAssessmentResult. */
-  assessmentResult?: PolicyAssessmentResult | undefined;
+  assessment?: PolicyAssessmentResult | undefined;
 }
 
 /**
@@ -3285,7 +3285,7 @@ function createBasePolicyVulnerabilityFinding(): PolicyVulnerabilityFinding {
     recommendation: "",
     description: "",
     fixedVersion: "",
-    assessmentResult: undefined,
+    assessment: undefined,
   };
 }
 
@@ -3318,8 +3318,8 @@ export const PolicyVulnerabilityFinding = {
     if (message.fixedVersion !== "") {
       writer.uint32(74).string(message.fixedVersion);
     }
-    if (message.assessmentResult !== undefined) {
-      PolicyAssessmentResult.encode(message.assessmentResult, writer.uint32(82).fork()).ldelim();
+    if (message.assessment !== undefined) {
+      PolicyAssessmentResult.encode(message.assessment, writer.uint32(82).fork()).ldelim();
     }
     return writer;
   },
@@ -3399,7 +3399,7 @@ export const PolicyVulnerabilityFinding = {
             break;
           }
 
-          message.assessmentResult = PolicyAssessmentResult.decode(reader, reader.uint32());
+          message.assessment = PolicyAssessmentResult.decode(reader, reader.uint32());
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -3421,9 +3421,7 @@ export const PolicyVulnerabilityFinding = {
       recommendation: isSet(object.recommendation) ? String(object.recommendation) : "",
       description: isSet(object.description) ? String(object.description) : "",
       fixedVersion: isSet(object.fixedVersion) ? String(object.fixedVersion) : "",
-      assessmentResult: isSet(object.assessmentResult)
-        ? PolicyAssessmentResult.fromJSON(object.assessmentResult)
-        : undefined,
+      assessment: isSet(object.assessment) ? PolicyAssessmentResult.fromJSON(object.assessment) : undefined,
     };
   },
 
@@ -3442,9 +3440,8 @@ export const PolicyVulnerabilityFinding = {
     message.recommendation !== undefined && (obj.recommendation = message.recommendation);
     message.description !== undefined && (obj.description = message.description);
     message.fixedVersion !== undefined && (obj.fixedVersion = message.fixedVersion);
-    message.assessmentResult !== undefined && (obj.assessmentResult = message.assessmentResult
-      ? PolicyAssessmentResult.toJSON(message.assessmentResult)
-      : undefined);
+    message.assessment !== undefined &&
+      (obj.assessment = message.assessment ? PolicyAssessmentResult.toJSON(message.assessment) : undefined);
     return obj;
   },
 
@@ -3463,8 +3460,8 @@ export const PolicyVulnerabilityFinding = {
     message.recommendation = object.recommendation ?? "";
     message.description = object.description ?? "";
     message.fixedVersion = object.fixedVersion ?? "";
-    message.assessmentResult = (object.assessmentResult !== undefined && object.assessmentResult !== null)
-      ? PolicyAssessmentResult.fromPartial(object.assessmentResult)
+    message.assessment = (object.assessment !== undefined && object.assessment !== null)
+      ? PolicyAssessmentResult.fromPartial(object.assessment)
       : undefined;
     return message;
   },
@@ -3480,7 +3477,7 @@ function createBasePolicySASTFinding(): PolicySASTFinding {
     codeSnippet: "",
     recommendation: "",
     severityScore: undefined,
-    assessmentResult: undefined,
+    assessment: undefined,
   };
 }
 
@@ -3510,8 +3507,8 @@ export const PolicySASTFinding = {
     if (message.severityScore !== undefined) {
       writer.uint32(65).double(message.severityScore);
     }
-    if (message.assessmentResult !== undefined) {
-      PolicyAssessmentResult.encode(message.assessmentResult, writer.uint32(74).fork()).ldelim();
+    if (message.assessment !== undefined) {
+      PolicyAssessmentResult.encode(message.assessment, writer.uint32(74).fork()).ldelim();
     }
     return writer;
   },
@@ -3584,7 +3581,7 @@ export const PolicySASTFinding = {
             break;
           }
 
-          message.assessmentResult = PolicyAssessmentResult.decode(reader, reader.uint32());
+          message.assessment = PolicyAssessmentResult.decode(reader, reader.uint32());
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -3605,9 +3602,7 @@ export const PolicySASTFinding = {
       codeSnippet: isSet(object.codeSnippet) ? String(object.codeSnippet) : "",
       recommendation: isSet(object.recommendation) ? String(object.recommendation) : "",
       severityScore: isSet(object.severityScore) ? Number(object.severityScore) : undefined,
-      assessmentResult: isSet(object.assessmentResult)
-        ? PolicyAssessmentResult.fromJSON(object.assessmentResult)
-        : undefined,
+      assessment: isSet(object.assessment) ? PolicyAssessmentResult.fromJSON(object.assessment) : undefined,
     };
   },
 
@@ -3621,9 +3616,8 @@ export const PolicySASTFinding = {
     message.codeSnippet !== undefined && (obj.codeSnippet = message.codeSnippet);
     message.recommendation !== undefined && (obj.recommendation = message.recommendation);
     message.severityScore !== undefined && (obj.severityScore = message.severityScore);
-    message.assessmentResult !== undefined && (obj.assessmentResult = message.assessmentResult
-      ? PolicyAssessmentResult.toJSON(message.assessmentResult)
-      : undefined);
+    message.assessment !== undefined &&
+      (obj.assessment = message.assessment ? PolicyAssessmentResult.toJSON(message.assessment) : undefined);
     return obj;
   },
 
@@ -3641,8 +3635,8 @@ export const PolicySASTFinding = {
     message.codeSnippet = object.codeSnippet ?? "";
     message.recommendation = object.recommendation ?? "";
     message.severityScore = object.severityScore ?? undefined;
-    message.assessmentResult = (object.assessmentResult !== undefined && object.assessmentResult !== null)
-      ? PolicyAssessmentResult.fromPartial(object.assessmentResult)
+    message.assessment = (object.assessment !== undefined && object.assessment !== null)
+      ? PolicyAssessmentResult.fromPartial(object.assessment)
       : undefined;
     return message;
   },
@@ -3657,7 +3651,7 @@ function createBasePolicyLicenseViolationFinding(): PolicyLicenseViolationFindin
     licenseName: "",
     componentVersion: "",
     recommendation: "",
-    assessmentResult: undefined,
+    assessment: undefined,
   };
 }
 
@@ -3684,8 +3678,8 @@ export const PolicyLicenseViolationFinding = {
     if (message.recommendation !== "") {
       writer.uint32(58).string(message.recommendation);
     }
-    if (message.assessmentResult !== undefined) {
-      PolicyAssessmentResult.encode(message.assessmentResult, writer.uint32(66).fork()).ldelim();
+    if (message.assessment !== undefined) {
+      PolicyAssessmentResult.encode(message.assessment, writer.uint32(66).fork()).ldelim();
     }
     return writer;
   },
@@ -3751,7 +3745,7 @@ export const PolicyLicenseViolationFinding = {
             break;
           }
 
-          message.assessmentResult = PolicyAssessmentResult.decode(reader, reader.uint32());
+          message.assessment = PolicyAssessmentResult.decode(reader, reader.uint32());
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -3771,9 +3765,7 @@ export const PolicyLicenseViolationFinding = {
       licenseName: isSet(object.licenseName) ? String(object.licenseName) : "",
       componentVersion: isSet(object.componentVersion) ? String(object.componentVersion) : "",
       recommendation: isSet(object.recommendation) ? String(object.recommendation) : "",
-      assessmentResult: isSet(object.assessmentResult)
-        ? PolicyAssessmentResult.fromJSON(object.assessmentResult)
-        : undefined,
+      assessment: isSet(object.assessment) ? PolicyAssessmentResult.fromJSON(object.assessment) : undefined,
     };
   },
 
@@ -3786,9 +3778,8 @@ export const PolicyLicenseViolationFinding = {
     message.licenseName !== undefined && (obj.licenseName = message.licenseName);
     message.componentVersion !== undefined && (obj.componentVersion = message.componentVersion);
     message.recommendation !== undefined && (obj.recommendation = message.recommendation);
-    message.assessmentResult !== undefined && (obj.assessmentResult = message.assessmentResult
-      ? PolicyAssessmentResult.toJSON(message.assessmentResult)
-      : undefined);
+    message.assessment !== undefined &&
+      (obj.assessment = message.assessment ? PolicyAssessmentResult.toJSON(message.assessment) : undefined);
     return obj;
   },
 
@@ -3807,8 +3798,8 @@ export const PolicyLicenseViolationFinding = {
     message.licenseName = object.licenseName ?? "";
     message.componentVersion = object.componentVersion ?? "";
     message.recommendation = object.recommendation ?? "";
-    message.assessmentResult = (object.assessmentResult !== undefined && object.assessmentResult !== null)
-      ? PolicyAssessmentResult.fromPartial(object.assessmentResult)
+    message.assessment = (object.assessment !== undefined && object.assessment !== null)
+      ? PolicyAssessmentResult.fromPartial(object.assessment)
       : undefined;
     return message;
   },

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyAssessment.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyAssessment.jsonschema.json
@@ -1,0 +1,23 @@
+{
+  "$id": "attestation.v1.PolicyAssessment.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Audit-critical subset of an assessment. Full record is reachable via\n AssessmentService.Get on the platform using `id`.",
+  "properties": {
+    "id": {
+      "description": "Platform assessment UUID.",
+      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+      "type": "string"
+    },
+    "scope": {
+      "description": "Platform AssessmentScope enum name, e.g. \"ASSESSMENT_SCOPE_PROJECT\".",
+      "type": "string"
+    },
+    "status": {
+      "description": "Platform AssessmentStatus enum name, e.g. \"ASSESSMENT_STATUS_NOT_AFFECTED\".",
+      "type": "string"
+    }
+  },
+  "title": "Policy Assessment",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyAssessment.schema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyAssessment.schema.json
@@ -1,0 +1,23 @@
+{
+  "$id": "attestation.v1.PolicyAssessment.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Audit-critical subset of an assessment. Full record is reachable via\n AssessmentService.Get on the platform using `id`.",
+  "properties": {
+    "id": {
+      "description": "Platform assessment UUID.",
+      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+      "type": "string"
+    },
+    "scope": {
+      "description": "Platform AssessmentScope enum name, e.g. \"ASSESSMENT_SCOPE_PROJECT\".",
+      "type": "string"
+    },
+    "status": {
+      "description": "Platform AssessmentStatus enum name, e.g. \"ASSESSMENT_STATUS_NOT_AFFECTED\".",
+      "type": "string"
+    }
+  },
+  "title": "Policy Assessment",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyAssessmentResult.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyAssessmentResult.jsonschema.json
@@ -1,0 +1,27 @@
+{
+  "$id": "attestation.v1.PolicyAssessmentResult.jsonschema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Assessment context attached to a policy finding by the policy engine via\n the chainloop.effective_assessments builtin. Sent to CAS as part of the\n PolicyEvaluationBundle.",
+  "patternProperties": {
+    "^(effective_status)$": {
+      "description": "Precedence-resolved status across `assessments`. Values use the\n platform's AssessmentStatus enum names, e.g.\n \"ASSESSMENT_STATUS_NOT_AFFECTED\".",
+      "type": "string"
+    }
+  },
+  "properties": {
+    "assessments": {
+      "description": "Assessments matching the finding's identity tuple.",
+      "items": {
+        "$ref": "attestation.v1.PolicyAssessment.jsonschema.json"
+      },
+      "type": "array"
+    },
+    "effectiveStatus": {
+      "description": "Precedence-resolved status across `assessments`. Values use the\n platform's AssessmentStatus enum names, e.g.\n \"ASSESSMENT_STATUS_NOT_AFFECTED\".",
+      "type": "string"
+    }
+  },
+  "title": "Policy Assessment Result",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyAssessmentResult.schema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyAssessmentResult.schema.json
@@ -1,0 +1,27 @@
+{
+  "$id": "attestation.v1.PolicyAssessmentResult.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Assessment context attached to a policy finding by the policy engine via\n the chainloop.effective_assessments builtin. Sent to CAS as part of the\n PolicyEvaluationBundle.",
+  "patternProperties": {
+    "^(effectiveStatus)$": {
+      "description": "Precedence-resolved status across `assessments`. Values use the\n platform's AssessmentStatus enum names, e.g.\n \"ASSESSMENT_STATUS_NOT_AFFECTED\".",
+      "type": "string"
+    }
+  },
+  "properties": {
+    "assessments": {
+      "description": "Assessments matching the finding's identity tuple.",
+      "items": {
+        "$ref": "attestation.v1.PolicyAssessment.schema.json"
+      },
+      "type": "array"
+    },
+    "effective_status": {
+      "description": "Precedence-resolved status across `assessments`. Values use the\n platform's AssessmentStatus enum names, e.g.\n \"ASSESSMENT_STATUS_NOT_AFFECTED\".",
+      "type": "string"
+    }
+  },
+  "title": "Policy Assessment Result",
+  "type": "object"
+}

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyEvaluation.Violation.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyEvaluation.Violation.jsonschema.json
@@ -20,6 +20,10 @@
     "subject": {
       "type": "string"
     },
+    "suppress": {
+      "description": "Suppression hint set by the policy. When true the gate count\n excludes this entry, but it is still stored in CAS and ingested\n (audit trail preserved). Set by the policy author (typically based\n on `assessment.effective_status`) — the engine reads the bool\n without interpreting why.",
+      "type": "boolean"
+    },
     "vulnerability": {
       "$ref": "attestation.v1.PolicyVulnerabilityFinding.jsonschema.json"
     }

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyEvaluation.Violation.schema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyEvaluation.Violation.schema.json
@@ -20,6 +20,10 @@
     "subject": {
       "type": "string"
     },
+    "suppress": {
+      "description": "Suppression hint set by the policy. When true the gate count\n excludes this entry, but it is still stored in CAS and ingested\n (audit trail preserved). Set by the policy author (typically based\n on `assessment.effective_status`) — the engine reads the bool\n without interpreting why.",
+      "type": "boolean"
+    },
     "vulnerability": {
       "$ref": "attestation.v1.PolicyVulnerabilityFinding.schema.json"
     }

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyLicenseViolationFinding.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyLicenseViolationFinding.jsonschema.json
@@ -4,6 +4,10 @@
   "additionalProperties": false,
   "description": "Output schema for license violation findings from policy evaluation.\n Used when a policy declares finding_type: LICENSE_VIOLATION.",
   "patternProperties": {
+    "^(assessment_result)$": {
+      "$ref": "attestation.v1.PolicyAssessmentResult.jsonschema.json",
+      "description": "Optional assessment context. See PolicyAssessmentResult."
+    },
     "^(component_name)$": {
       "description": "Component name (e.g., \"lodash\")",
       "type": "string"
@@ -26,6 +30,10 @@
     }
   },
   "properties": {
+    "assessmentResult": {
+      "$ref": "attestation.v1.PolicyAssessmentResult.jsonschema.json",
+      "description": "Optional assessment context. See PolicyAssessmentResult."
+    },
     "componentName": {
       "description": "Component name (e.g., \"lodash\")",
       "type": "string"

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyLicenseViolationFinding.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyLicenseViolationFinding.jsonschema.json
@@ -4,10 +4,6 @@
   "additionalProperties": false,
   "description": "Output schema for license violation findings from policy evaluation.\n Used when a policy declares finding_type: LICENSE_VIOLATION.",
   "patternProperties": {
-    "^(assessment_result)$": {
-      "$ref": "attestation.v1.PolicyAssessmentResult.jsonschema.json",
-      "description": "Optional assessment context. See PolicyAssessmentResult."
-    },
     "^(component_name)$": {
       "description": "Component name (e.g., \"lodash\")",
       "type": "string"
@@ -30,7 +26,7 @@
     }
   },
   "properties": {
-    "assessmentResult": {
+    "assessment": {
       "$ref": "attestation.v1.PolicyAssessmentResult.jsonschema.json",
       "description": "Optional assessment context. See PolicyAssessmentResult."
     },

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyLicenseViolationFinding.schema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyLicenseViolationFinding.schema.json
@@ -4,10 +4,6 @@
   "additionalProperties": false,
   "description": "Output schema for license violation findings from policy evaluation.\n Used when a policy declares finding_type: LICENSE_VIOLATION.",
   "patternProperties": {
-    "^(assessmentResult)$": {
-      "$ref": "attestation.v1.PolicyAssessmentResult.schema.json",
-      "description": "Optional assessment context. See PolicyAssessmentResult."
-    },
     "^(componentName)$": {
       "description": "Component name (e.g., \"lodash\")",
       "type": "string"
@@ -30,7 +26,7 @@
     }
   },
   "properties": {
-    "assessment_result": {
+    "assessment": {
       "$ref": "attestation.v1.PolicyAssessmentResult.schema.json",
       "description": "Optional assessment context. See PolicyAssessmentResult."
     },

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyLicenseViolationFinding.schema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyLicenseViolationFinding.schema.json
@@ -4,6 +4,10 @@
   "additionalProperties": false,
   "description": "Output schema for license violation findings from policy evaluation.\n Used when a policy declares finding_type: LICENSE_VIOLATION.",
   "patternProperties": {
+    "^(assessmentResult)$": {
+      "$ref": "attestation.v1.PolicyAssessmentResult.schema.json",
+      "description": "Optional assessment context. See PolicyAssessmentResult."
+    },
     "^(componentName)$": {
       "description": "Component name (e.g., \"lodash\")",
       "type": "string"
@@ -26,6 +30,10 @@
     }
   },
   "properties": {
+    "assessment_result": {
+      "$ref": "attestation.v1.PolicyAssessmentResult.schema.json",
+      "description": "Optional assessment context. See PolicyAssessmentResult."
+    },
     "component_name": {
       "description": "Component name (e.g., \"lodash\")",
       "type": "string"

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.PolicySASTFinding.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.PolicySASTFinding.jsonschema.json
@@ -4,6 +4,10 @@
   "additionalProperties": false,
   "description": "Output schema for SAST findings from policy evaluation.\n Used when a policy declares finding_type: SAST.",
   "patternProperties": {
+    "^(assessment_result)$": {
+      "$ref": "attestation.v1.PolicyAssessmentResult.jsonschema.json",
+      "description": "Optional assessment context. See PolicyAssessmentResult."
+    },
     "^(code_snippet)$": {
       "description": "Code snippet showing the issue",
       "type": "string"
@@ -39,6 +43,10 @@
     }
   },
   "properties": {
+    "assessmentResult": {
+      "$ref": "attestation.v1.PolicyAssessmentResult.jsonschema.json",
+      "description": "Optional assessment context. See PolicyAssessmentResult."
+    },
     "codeSnippet": {
       "description": "Code snippet showing the issue",
       "type": "string"

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.PolicySASTFinding.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.PolicySASTFinding.jsonschema.json
@@ -4,10 +4,6 @@
   "additionalProperties": false,
   "description": "Output schema for SAST findings from policy evaluation.\n Used when a policy declares finding_type: SAST.",
   "patternProperties": {
-    "^(assessment_result)$": {
-      "$ref": "attestation.v1.PolicyAssessmentResult.jsonschema.json",
-      "description": "Optional assessment context. See PolicyAssessmentResult."
-    },
     "^(code_snippet)$": {
       "description": "Code snippet showing the issue",
       "type": "string"
@@ -43,7 +39,7 @@
     }
   },
   "properties": {
-    "assessmentResult": {
+    "assessment": {
       "$ref": "attestation.v1.PolicyAssessmentResult.jsonschema.json",
       "description": "Optional assessment context. See PolicyAssessmentResult."
     },

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.PolicySASTFinding.schema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.PolicySASTFinding.schema.json
@@ -4,10 +4,6 @@
   "additionalProperties": false,
   "description": "Output schema for SAST findings from policy evaluation.\n Used when a policy declares finding_type: SAST.",
   "patternProperties": {
-    "^(assessmentResult)$": {
-      "$ref": "attestation.v1.PolicyAssessmentResult.schema.json",
-      "description": "Optional assessment context. See PolicyAssessmentResult."
-    },
     "^(codeSnippet)$": {
       "description": "Code snippet showing the issue",
       "type": "string"
@@ -43,7 +39,7 @@
     }
   },
   "properties": {
-    "assessment_result": {
+    "assessment": {
       "$ref": "attestation.v1.PolicyAssessmentResult.schema.json",
       "description": "Optional assessment context. See PolicyAssessmentResult."
     },

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.PolicySASTFinding.schema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.PolicySASTFinding.schema.json
@@ -4,6 +4,10 @@
   "additionalProperties": false,
   "description": "Output schema for SAST findings from policy evaluation.\n Used when a policy declares finding_type: SAST.",
   "patternProperties": {
+    "^(assessmentResult)$": {
+      "$ref": "attestation.v1.PolicyAssessmentResult.schema.json",
+      "description": "Optional assessment context. See PolicyAssessmentResult."
+    },
     "^(codeSnippet)$": {
       "description": "Code snippet showing the issue",
       "type": "string"
@@ -39,6 +43,10 @@
     }
   },
   "properties": {
+    "assessment_result": {
+      "$ref": "attestation.v1.PolicyAssessmentResult.schema.json",
+      "description": "Optional assessment context. See PolicyAssessmentResult."
+    },
     "code_snippet": {
       "description": "Code snippet showing the issue",
       "type": "string"

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyVulnerabilityFinding.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyVulnerabilityFinding.jsonschema.json
@@ -4,6 +4,10 @@
   "additionalProperties": false,
   "description": "Output schema for vulnerability findings from policy evaluation.\n Used when a policy declares finding_type: VULNERABILITY.",
   "patternProperties": {
+    "^(assessment_result)$": {
+      "$ref": "attestation.v1.PolicyAssessmentResult.jsonschema.json",
+      "description": "Optional assessment context. See PolicyAssessmentResult."
+    },
     "^(cvss_v3_score)$": {
       "anyOf": [
         {
@@ -32,6 +36,10 @@
     }
   },
   "properties": {
+    "assessmentResult": {
+      "$ref": "attestation.v1.PolicyAssessmentResult.jsonschema.json",
+      "description": "Optional assessment context. See PolicyAssessmentResult."
+    },
     "cvssV3Score": {
       "anyOf": [
         {

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyVulnerabilityFinding.jsonschema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyVulnerabilityFinding.jsonschema.json
@@ -4,10 +4,6 @@
   "additionalProperties": false,
   "description": "Output schema for vulnerability findings from policy evaluation.\n Used when a policy declares finding_type: VULNERABILITY.",
   "patternProperties": {
-    "^(assessment_result)$": {
-      "$ref": "attestation.v1.PolicyAssessmentResult.jsonschema.json",
-      "description": "Optional assessment context. See PolicyAssessmentResult."
-    },
     "^(cvss_v3_score)$": {
       "anyOf": [
         {
@@ -36,7 +32,7 @@
     }
   },
   "properties": {
-    "assessmentResult": {
+    "assessment": {
       "$ref": "attestation.v1.PolicyAssessmentResult.jsonschema.json",
       "description": "Optional assessment context. See PolicyAssessmentResult."
     },

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyVulnerabilityFinding.schema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyVulnerabilityFinding.schema.json
@@ -4,6 +4,10 @@
   "additionalProperties": false,
   "description": "Output schema for vulnerability findings from policy evaluation.\n Used when a policy declares finding_type: VULNERABILITY.",
   "patternProperties": {
+    "^(assessmentResult)$": {
+      "$ref": "attestation.v1.PolicyAssessmentResult.schema.json",
+      "description": "Optional assessment context. See PolicyAssessmentResult."
+    },
     "^(cvssV3Score)$": {
       "anyOf": [
         {
@@ -32,6 +36,10 @@
     }
   },
   "properties": {
+    "assessment_result": {
+      "$ref": "attestation.v1.PolicyAssessmentResult.schema.json",
+      "description": "Optional assessment context. See PolicyAssessmentResult."
+    },
     "cvss_v3_score": {
       "anyOf": [
         {

--- a/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyVulnerabilityFinding.schema.json
+++ b/app/controlplane/api/gen/jsonschema/attestation.v1.PolicyVulnerabilityFinding.schema.json
@@ -4,10 +4,6 @@
   "additionalProperties": false,
   "description": "Output schema for vulnerability findings from policy evaluation.\n Used when a policy declares finding_type: VULNERABILITY.",
   "patternProperties": {
-    "^(assessmentResult)$": {
-      "$ref": "attestation.v1.PolicyAssessmentResult.schema.json",
-      "description": "Optional assessment context. See PolicyAssessmentResult."
-    },
     "^(cvssV3Score)$": {
       "anyOf": [
         {
@@ -36,7 +32,7 @@
     }
   },
   "properties": {
-    "assessment_result": {
+    "assessment": {
       "$ref": "attestation.v1.PolicyAssessmentResult.schema.json",
       "description": "Optional assessment context. See PolicyAssessmentResult."
     },

--- a/pkg/attestation/crafter/api/attestation/v1/crafting_state.pb.go
+++ b/pkg/attestation/crafter/api/attestation/v1/crafting_state.pb.go
@@ -696,9 +696,9 @@ type PolicyVulnerabilityFinding struct {
 	// Version that fixes the vulnerability (e.g., "2.0.1", "1.3.4-patch1")
 	FixedVersion string `protobuf:"bytes,9,opt,name=fixed_version,json=fixedVersion,proto3" json:"fixed_version,omitempty"`
 	// Optional assessment context. See PolicyAssessmentResult.
-	AssessmentResult *PolicyAssessmentResult `protobuf:"bytes,10,opt,name=assessment_result,json=assessmentResult,proto3,oneof" json:"assessment_result,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	Assessment    *PolicyAssessmentResult `protobuf:"bytes,10,opt,name=assessment,proto3,oneof" json:"assessment,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *PolicyVulnerabilityFinding) Reset() {
@@ -794,9 +794,9 @@ func (x *PolicyVulnerabilityFinding) GetFixedVersion() string {
 	return ""
 }
 
-func (x *PolicyVulnerabilityFinding) GetAssessmentResult() *PolicyAssessmentResult {
+func (x *PolicyVulnerabilityFinding) GetAssessment() *PolicyAssessmentResult {
 	if x != nil {
-		return x.AssessmentResult
+		return x.Assessment
 	}
 	return nil
 }
@@ -822,9 +822,9 @@ type PolicySASTFinding struct {
 	// Optional numeric severity score from the scanner (scale is tool-defined)
 	SeverityScore *float64 `protobuf:"fixed64,8,opt,name=severity_score,json=severityScore,proto3,oneof" json:"severity_score,omitempty"`
 	// Optional assessment context. See PolicyAssessmentResult.
-	AssessmentResult *PolicyAssessmentResult `protobuf:"bytes,9,opt,name=assessment_result,json=assessmentResult,proto3,oneof" json:"assessment_result,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	Assessment    *PolicyAssessmentResult `protobuf:"bytes,9,opt,name=assessment,proto3,oneof" json:"assessment,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *PolicySASTFinding) Reset() {
@@ -913,9 +913,9 @@ func (x *PolicySASTFinding) GetSeverityScore() float64 {
 	return 0
 }
 
-func (x *PolicySASTFinding) GetAssessmentResult() *PolicyAssessmentResult {
+func (x *PolicySASTFinding) GetAssessment() *PolicyAssessmentResult {
 	if x != nil {
-		return x.AssessmentResult
+		return x.Assessment
 	}
 	return nil
 }
@@ -939,9 +939,9 @@ type PolicyLicenseViolationFinding struct {
 	// Suggested fix
 	Recommendation string `protobuf:"bytes,7,opt,name=recommendation,proto3" json:"recommendation,omitempty"`
 	// Optional assessment context. See PolicyAssessmentResult.
-	AssessmentResult *PolicyAssessmentResult `protobuf:"bytes,8,opt,name=assessment_result,json=assessmentResult,proto3,oneof" json:"assessment_result,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	Assessment    *PolicyAssessmentResult `protobuf:"bytes,8,opt,name=assessment,proto3,oneof" json:"assessment,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *PolicyLicenseViolationFinding) Reset() {
@@ -1023,9 +1023,9 @@ func (x *PolicyLicenseViolationFinding) GetRecommendation() string {
 	return ""
 }
 
-func (x *PolicyLicenseViolationFinding) GetAssessmentResult() *PolicyAssessmentResult {
+func (x *PolicyLicenseViolationFinding) GetAssessment() *PolicyAssessmentResult {
 	if x != nil {
-		return x.AssessmentResult
+		return x.Assessment
 	}
 	return nil
 }
@@ -2927,7 +2927,7 @@ const file_attestation_v1_crafting_state_proto_rawDesc = "" +
 	"\x05input\x18\x01 \x01(\fR\x05input\x12\x16\n" +
 	"\x06output\x18\x02 \x01(\fR\x06output\"\\\n" +
 	"\x16PolicyEvaluationBundle\x12B\n" +
-	"\vevaluations\x18\x01 \x03(\v2 .attestation.v1.PolicyEvaluationR\vevaluations\"\xe6\x03\n" +
+	"\vevaluations\x18\x01 \x03(\v2 .attestation.v1.PolicyEvaluationR\vevaluations\"\xd2\x03\n" +
 	"\x1aPolicyVulnerabilityFinding\x12 \n" +
 	"\amessage\x18\x01 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\amessage\x12'\n" +
 	"\vexternal_id\x18\x02 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\n" +
@@ -2938,10 +2938,12 @@ const file_attestation_v1_crafting_state_proto_rawDesc = "" +
 	"\x04cwes\x18\x06 \x03(\tR\x04cwes\x12&\n" +
 	"\x0erecommendation\x18\a \x01(\tR\x0erecommendation\x12 \n" +
 	"\vdescription\x18\b \x01(\tR\vdescription\x12#\n" +
-	"\rfixed_version\x18\t \x01(\tR\ffixedVersion\x12X\n" +
-	"\x11assessment_result\x18\n" +
-	" \x01(\v2&.attestation.v1.PolicyAssessmentResultH\x00R\x10assessmentResult\x88\x01\x01B\x14\n" +
-	"\x12_assessment_result\"\xb9\x03\n" +
+	"\rfixed_version\x18\t \x01(\tR\ffixedVersion\x12K\n" +
+	"\n" +
+	"assessment\x18\n" +
+	" \x01(\v2&.attestation.v1.PolicyAssessmentResultH\x00R\n" +
+	"assessment\x88\x01\x01B\r\n" +
+	"\v_assessment\"\xa5\x03\n" +
 	"\x11PolicySASTFinding\x12 \n" +
 	"\amessage\x18\x01 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\amessage\x12\x1f\n" +
 	"\arule_id\x18\x02 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\x06ruleId\x12\"\n" +
@@ -2951,10 +2953,12 @@ const file_attestation_v1_crafting_state_proto_rawDesc = "" +
 	"lineNumber\x12!\n" +
 	"\fcode_snippet\x18\x06 \x01(\tR\vcodeSnippet\x12&\n" +
 	"\x0erecommendation\x18\a \x01(\tR\x0erecommendation\x12*\n" +
-	"\x0eseverity_score\x18\b \x01(\x01H\x00R\rseverityScore\x88\x01\x01\x12X\n" +
-	"\x11assessment_result\x18\t \x01(\v2&.attestation.v1.PolicyAssessmentResultH\x01R\x10assessmentResult\x88\x01\x01B\x11\n" +
-	"\x0f_severity_scoreB\x14\n" +
-	"\x12_assessment_result\"\xa2\x03\n" +
+	"\x0eseverity_score\x18\b \x01(\x01H\x00R\rseverityScore\x88\x01\x01\x12K\n" +
+	"\n" +
+	"assessment\x18\t \x01(\v2&.attestation.v1.PolicyAssessmentResultH\x01R\n" +
+	"assessment\x88\x01\x01B\x11\n" +
+	"\x0f_severity_scoreB\r\n" +
+	"\v_assessment\"\x8e\x03\n" +
 	"\x1dPolicyLicenseViolationFinding\x12 \n" +
 	"\amessage\x18\x01 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\amessage\x12-\n" +
 	"\x0ecomponent_name\x18\x02 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\rcomponentName\x12!\n" +
@@ -2963,9 +2967,11 @@ const file_attestation_v1_crafting_state_proto_rawDesc = "" +
 	"license_id\x18\x04 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\tlicenseId\x12!\n" +
 	"\flicense_name\x18\x05 \x01(\tR\vlicenseName\x12+\n" +
 	"\x11component_version\x18\x06 \x01(\tR\x10componentVersion\x12&\n" +
-	"\x0erecommendation\x18\a \x01(\tR\x0erecommendation\x12X\n" +
-	"\x11assessment_result\x18\b \x01(\v2&.attestation.v1.PolicyAssessmentResultH\x00R\x10assessmentResult\x88\x01\x01B\x14\n" +
-	"\x12_assessment_result\"\x87\x01\n" +
+	"\x0erecommendation\x18\a \x01(\tR\x0erecommendation\x12K\n" +
+	"\n" +
+	"assessment\x18\b \x01(\v2&.attestation.v1.PolicyAssessmentResultH\x00R\n" +
+	"assessment\x88\x01\x01B\r\n" +
+	"\v_assessment\"\x87\x01\n" +
 	"\x16PolicyAssessmentResult\x12)\n" +
 	"\x10effective_status\x18\x01 \x01(\tR\x0feffectiveStatus\x12B\n" +
 	"\vassessments\x18\x02 \x03(\v2 .attestation.v1.PolicyAssessmentR\vassessments\"Z\n" +
@@ -3123,9 +3129,9 @@ var file_attestation_v1_crafting_state_proto_depIdxs = []int32{
 	32, // 19: attestation.v1.PolicyEvaluation.group_reference:type_name -> attestation.v1.PolicyEvaluation.Reference
 	33, // 20: attestation.v1.PolicyEvaluation.raw_results:type_name -> attestation.v1.PolicyEvaluation.RawResult
 	4,  // 21: attestation.v1.PolicyEvaluationBundle.evaluations:type_name -> attestation.v1.PolicyEvaluation
-	9,  // 22: attestation.v1.PolicyVulnerabilityFinding.assessment_result:type_name -> attestation.v1.PolicyAssessmentResult
-	9,  // 23: attestation.v1.PolicySASTFinding.assessment_result:type_name -> attestation.v1.PolicyAssessmentResult
-	9,  // 24: attestation.v1.PolicyLicenseViolationFinding.assessment_result:type_name -> attestation.v1.PolicyAssessmentResult
+	9,  // 22: attestation.v1.PolicyVulnerabilityFinding.assessment:type_name -> attestation.v1.PolicyAssessmentResult
+	9,  // 23: attestation.v1.PolicySASTFinding.assessment:type_name -> attestation.v1.PolicyAssessmentResult
+	9,  // 24: attestation.v1.PolicyLicenseViolationFinding.assessment:type_name -> attestation.v1.PolicyAssessmentResult
 	10, // 25: attestation.v1.PolicyAssessmentResult.assessments:type_name -> attestation.v1.PolicyAssessment
 	37, // 26: attestation.v1.Commit.date:type_name -> google.protobuf.Timestamp
 	34, // 27: attestation.v1.Commit.remotes:type_name -> attestation.v1.Commit.Remote

--- a/pkg/attestation/crafter/api/attestation/v1/crafting_state.pb.go
+++ b/pkg/attestation/crafter/api/attestation/v1/crafting_state.pb.go
@@ -2403,7 +2403,13 @@ type PolicyEvaluation_Violation struct {
 	//	*PolicyEvaluation_Violation_Vulnerability
 	//	*PolicyEvaluation_Violation_Sast
 	//	*PolicyEvaluation_Violation_LicenseViolation
-	Finding       isPolicyEvaluation_Violation_Finding `protobuf_oneof:"finding"`
+	Finding isPolicyEvaluation_Violation_Finding `protobuf_oneof:"finding"`
+	// Suppression hint set by the policy. When true the gate count
+	// excludes this entry, but it is still stored in CAS and ingested
+	// (audit trail preserved). Set by the policy author (typically based
+	// on `assessment.effective_status`) — the engine reads the bool
+	// without interpreting why.
+	Suppress      bool `protobuf:"varint,6,opt,name=suppress,proto3" json:"suppress,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2484,6 +2490,13 @@ func (x *PolicyEvaluation_Violation) GetLicenseViolation() *PolicyLicenseViolati
 		}
 	}
 	return nil
+}
+
+func (x *PolicyEvaluation_Violation) GetSuppress() bool {
+	if x != nil {
+		return x.Suppress
+	}
+	return false
 }
 
 type isPolicyEvaluation_Violation_Finding interface {
@@ -2879,7 +2892,7 @@ const file_attestation_v1_crafting_state_proto_rawDesc = "" +
 	"\venvironment\x18\x02 \x01(\tR\venvironment\x12$\n" +
 	"\rauthenticated\x18\x03 \x01(\bR\rauthenticated\x12I\n" +
 	"\x04type\x18\x04 \x01(\x0e25.workflowcontract.v1.CraftingSchema.Runner.RunnerTypeR\x04type\x12\x10\n" +
-	"\x03url\x18\x05 \x01(\tR\x03url\"\x98\x0e\n" +
+	"\x03url\x18\x05 \x01(\tR\x03url\"\xb4\x0e\n" +
 	"\x10PolicyEvaluation\x12\x97\x01\n" +
 	"\x04name\x18\x01 \x01(\tB\x82\x01\xbaH\x7f\xba\x01|\n" +
 	"\rname.dns-1123\x12:must contain only lowercase letters, numbers, and hyphens.\x1a/this.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')R\x04name\x12#\n" +
@@ -2909,13 +2922,14 @@ const file_attestation_v1_crafting_state_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a7\n" +
 	"\tWithEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a\xc5\x02\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a\xe1\x02\n" +
 	"\tViolation\x12 \n" +
 	"\asubject\x18\x01 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\asubject\x12 \n" +
 	"\amessage\x18\x02 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\amessage\x12R\n" +
 	"\rvulnerability\x18\x03 \x01(\v2*.attestation.v1.PolicyVulnerabilityFindingH\x00R\rvulnerability\x127\n" +
 	"\x04sast\x18\x04 \x01(\v2!.attestation.v1.PolicySASTFindingH\x00R\x04sast\x12\\\n" +
-	"\x11license_violation\x18\x05 \x01(\v2-.attestation.v1.PolicyLicenseViolationFindingH\x00R\x10licenseViolationB\t\n" +
+	"\x11license_violation\x18\x05 \x01(\v2-.attestation.v1.PolicyLicenseViolationFindingH\x00R\x10licenseViolation\x12\x1a\n" +
+	"\bsuppress\x18\x06 \x01(\bR\bsuppressB\t\n" +
 	"\afinding\x1a\xfc\x01\n" +
 	"\tReference\x12\x97\x01\n" +
 	"\x04name\x18\x01 \x01(\tB\x82\x01\xbaH\x7f\xba\x01|\n" +

--- a/pkg/attestation/crafter/api/attestation/v1/crafting_state.pb.go
+++ b/pkg/attestation/crafter/api/attestation/v1/crafting_state.pb.go
@@ -152,7 +152,7 @@ func (x Commit_CommitVerification_VerificationStatus) Number() protoreflect.Enum
 
 // Deprecated: Use Commit_CommitVerification_VerificationStatus.Descriptor instead.
 func (Commit_CommitVerification_VerificationStatus) EnumDescriptor() ([]byte, []int) {
-	return file_attestation_v1_crafting_state_proto_rawDescGZIP(), []int{7, 1, 0}
+	return file_attestation_v1_crafting_state_proto_rawDescGZIP(), []int{9, 1, 0}
 }
 
 type Attestation struct {
@@ -694,9 +694,11 @@ type PolicyVulnerabilityFinding struct {
 	// Optional longer description of the vulnerability
 	Description string `protobuf:"bytes,8,opt,name=description,proto3" json:"description,omitempty"`
 	// Version that fixes the vulnerability (e.g., "2.0.1", "1.3.4-patch1")
-	FixedVersion  string `protobuf:"bytes,9,opt,name=fixed_version,json=fixedVersion,proto3" json:"fixed_version,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	FixedVersion string `protobuf:"bytes,9,opt,name=fixed_version,json=fixedVersion,proto3" json:"fixed_version,omitempty"`
+	// Optional assessment context. See PolicyAssessmentResult.
+	AssessmentResult *PolicyAssessmentResult `protobuf:"bytes,10,opt,name=assessment_result,json=assessmentResult,proto3,oneof" json:"assessment_result,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *PolicyVulnerabilityFinding) Reset() {
@@ -792,6 +794,13 @@ func (x *PolicyVulnerabilityFinding) GetFixedVersion() string {
 	return ""
 }
 
+func (x *PolicyVulnerabilityFinding) GetAssessmentResult() *PolicyAssessmentResult {
+	if x != nil {
+		return x.AssessmentResult
+	}
+	return nil
+}
+
 // Output schema for SAST findings from policy evaluation.
 // Used when a policy declares finding_type: SAST.
 type PolicySASTFinding struct {
@@ -812,8 +821,10 @@ type PolicySASTFinding struct {
 	Recommendation string `protobuf:"bytes,7,opt,name=recommendation,proto3" json:"recommendation,omitempty"`
 	// Optional numeric severity score from the scanner (scale is tool-defined)
 	SeverityScore *float64 `protobuf:"fixed64,8,opt,name=severity_score,json=severityScore,proto3,oneof" json:"severity_score,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// Optional assessment context. See PolicyAssessmentResult.
+	AssessmentResult *PolicyAssessmentResult `protobuf:"bytes,9,opt,name=assessment_result,json=assessmentResult,proto3,oneof" json:"assessment_result,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *PolicySASTFinding) Reset() {
@@ -902,6 +913,13 @@ func (x *PolicySASTFinding) GetSeverityScore() float64 {
 	return 0
 }
 
+func (x *PolicySASTFinding) GetAssessmentResult() *PolicyAssessmentResult {
+	if x != nil {
+		return x.AssessmentResult
+	}
+	return nil
+}
+
 // Output schema for license violation findings from policy evaluation.
 // Used when a policy declares finding_type: LICENSE_VIOLATION.
 type PolicyLicenseViolationFinding struct {
@@ -920,8 +938,10 @@ type PolicyLicenseViolationFinding struct {
 	ComponentVersion string `protobuf:"bytes,6,opt,name=component_version,json=componentVersion,proto3" json:"component_version,omitempty"`
 	// Suggested fix
 	Recommendation string `protobuf:"bytes,7,opt,name=recommendation,proto3" json:"recommendation,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Optional assessment context. See PolicyAssessmentResult.
+	AssessmentResult *PolicyAssessmentResult `protobuf:"bytes,8,opt,name=assessment_result,json=assessmentResult,proto3,oneof" json:"assessment_result,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *PolicyLicenseViolationFinding) Reset() {
@@ -1003,6 +1023,137 @@ func (x *PolicyLicenseViolationFinding) GetRecommendation() string {
 	return ""
 }
 
+func (x *PolicyLicenseViolationFinding) GetAssessmentResult() *PolicyAssessmentResult {
+	if x != nil {
+		return x.AssessmentResult
+	}
+	return nil
+}
+
+// Assessment context attached to a policy finding by the policy engine via
+// the chainloop.effective_assessments builtin. Sent to CAS as part of the
+// PolicyEvaluationBundle.
+type PolicyAssessmentResult struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Precedence-resolved status across `assessments`. Values use the
+	// platform's AssessmentStatus enum names, e.g.
+	// "ASSESSMENT_STATUS_NOT_AFFECTED".
+	EffectiveStatus string `protobuf:"bytes,1,opt,name=effective_status,json=effectiveStatus,proto3" json:"effective_status,omitempty"`
+	// Assessments matching the finding's identity tuple.
+	Assessments   []*PolicyAssessment `protobuf:"bytes,2,rep,name=assessments,proto3" json:"assessments,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PolicyAssessmentResult) Reset() {
+	*x = PolicyAssessmentResult{}
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicyAssessmentResult) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicyAssessmentResult) ProtoMessage() {}
+
+func (x *PolicyAssessmentResult) ProtoReflect() protoreflect.Message {
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicyAssessmentResult.ProtoReflect.Descriptor instead.
+func (*PolicyAssessmentResult) Descriptor() ([]byte, []int) {
+	return file_attestation_v1_crafting_state_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *PolicyAssessmentResult) GetEffectiveStatus() string {
+	if x != nil {
+		return x.EffectiveStatus
+	}
+	return ""
+}
+
+func (x *PolicyAssessmentResult) GetAssessments() []*PolicyAssessment {
+	if x != nil {
+		return x.Assessments
+	}
+	return nil
+}
+
+// Audit-critical subset of an assessment. Full record is reachable via
+// AssessmentService.Get on the platform using `id`.
+type PolicyAssessment struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Platform assessment UUID.
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	// Platform AssessmentStatus enum name, e.g. "ASSESSMENT_STATUS_NOT_AFFECTED".
+	Status string `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`
+	// Platform AssessmentScope enum name, e.g. "ASSESSMENT_SCOPE_PROJECT".
+	Scope         string `protobuf:"bytes,3,opt,name=scope,proto3" json:"scope,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PolicyAssessment) Reset() {
+	*x = PolicyAssessment{}
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicyAssessment) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicyAssessment) ProtoMessage() {}
+
+func (x *PolicyAssessment) ProtoReflect() protoreflect.Message {
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicyAssessment.ProtoReflect.Descriptor instead.
+func (*PolicyAssessment) Descriptor() ([]byte, []int) {
+	return file_attestation_v1_crafting_state_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *PolicyAssessment) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *PolicyAssessment) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+func (x *PolicyAssessment) GetScope() string {
+	if x != nil {
+		return x.Scope
+	}
+	return ""
+}
+
 type Commit struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	Hash  string                 `protobuf:"bytes,1,opt,name=hash,proto3" json:"hash,omitempty"`
@@ -1021,7 +1172,7 @@ type Commit struct {
 
 func (x *Commit) Reset() {
 	*x = Commit{}
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[7]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1033,7 +1184,7 @@ func (x *Commit) String() string {
 func (*Commit) ProtoMessage() {}
 
 func (x *Commit) ProtoReflect() protoreflect.Message {
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[7]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1046,7 +1197,7 @@ func (x *Commit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Commit.ProtoReflect.Descriptor instead.
 func (*Commit) Descriptor() ([]byte, []int) {
-	return file_attestation_v1_crafting_state_proto_rawDescGZIP(), []int{7}
+	return file_attestation_v1_crafting_state_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *Commit) GetHash() string {
@@ -1123,7 +1274,7 @@ type CraftingState struct {
 
 func (x *CraftingState) Reset() {
 	*x = CraftingState{}
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[8]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1135,7 +1286,7 @@ func (x *CraftingState) String() string {
 func (*CraftingState) ProtoMessage() {}
 
 func (x *CraftingState) ProtoReflect() protoreflect.Message {
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[8]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1148,7 +1299,7 @@ func (x *CraftingState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CraftingState.ProtoReflect.Descriptor instead.
 func (*CraftingState) Descriptor() ([]byte, []int) {
-	return file_attestation_v1_crafting_state_proto_rawDescGZIP(), []int{8}
+	return file_attestation_v1_crafting_state_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *CraftingState) GetSchema() isCraftingState_Schema {
@@ -1237,7 +1388,7 @@ type WorkflowMetadata struct {
 
 func (x *WorkflowMetadata) Reset() {
 	*x = WorkflowMetadata{}
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[9]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1249,7 +1400,7 @@ func (x *WorkflowMetadata) String() string {
 func (*WorkflowMetadata) ProtoMessage() {}
 
 func (x *WorkflowMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[9]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1262,7 +1413,7 @@ func (x *WorkflowMetadata) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkflowMetadata.ProtoReflect.Descriptor instead.
 func (*WorkflowMetadata) Descriptor() ([]byte, []int) {
-	return file_attestation_v1_crafting_state_proto_rawDescGZIP(), []int{9}
+	return file_attestation_v1_crafting_state_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *WorkflowMetadata) GetName() string {
@@ -1348,7 +1499,7 @@ type ProjectVersion struct {
 
 func (x *ProjectVersion) Reset() {
 	*x = ProjectVersion{}
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[10]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1360,7 +1511,7 @@ func (x *ProjectVersion) String() string {
 func (*ProjectVersion) ProtoMessage() {}
 
 func (x *ProjectVersion) ProtoReflect() protoreflect.Message {
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[10]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1373,7 +1524,7 @@ func (x *ProjectVersion) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProjectVersion.ProtoReflect.Descriptor instead.
 func (*ProjectVersion) Descriptor() ([]byte, []int) {
-	return file_attestation_v1_crafting_state_proto_rawDescGZIP(), []int{10}
+	return file_attestation_v1_crafting_state_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ProjectVersion) GetVersion() string {
@@ -1421,7 +1572,7 @@ type ResourceDescriptor struct {
 
 func (x *ResourceDescriptor) Reset() {
 	*x = ResourceDescriptor{}
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[11]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1433,7 +1584,7 @@ func (x *ResourceDescriptor) String() string {
 func (*ResourceDescriptor) ProtoMessage() {}
 
 func (x *ResourceDescriptor) ProtoReflect() protoreflect.Message {
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[11]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1446,7 +1597,7 @@ func (x *ResourceDescriptor) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceDescriptor.ProtoReflect.Descriptor instead.
 func (*ResourceDescriptor) Descriptor() ([]byte, []int) {
-	return file_attestation_v1_crafting_state_proto_rawDescGZIP(), []int{11}
+	return file_attestation_v1_crafting_state_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *ResourceDescriptor) GetName() string {
@@ -1525,7 +1676,7 @@ type Attestation_Material struct {
 
 func (x *Attestation_Material) Reset() {
 	*x = Attestation_Material{}
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[14]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1537,7 +1688,7 @@ func (x *Attestation_Material) String() string {
 func (*Attestation_Material) ProtoMessage() {}
 
 func (x *Attestation_Material) ProtoReflect() protoreflect.Message {
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[14]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1691,7 +1842,7 @@ type Attestation_Auth struct {
 
 func (x *Attestation_Auth) Reset() {
 	*x = Attestation_Auth{}
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[16]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1703,7 +1854,7 @@ func (x *Attestation_Auth) String() string {
 func (*Attestation_Auth) ProtoMessage() {}
 
 func (x *Attestation_Auth) ProtoReflect() protoreflect.Message {
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[16]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1747,7 +1898,7 @@ type Attestation_CASBackend struct {
 
 func (x *Attestation_CASBackend) Reset() {
 	*x = Attestation_CASBackend{}
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[17]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1759,7 +1910,7 @@ func (x *Attestation_CASBackend) String() string {
 func (*Attestation_CASBackend) ProtoMessage() {}
 
 func (x *Attestation_CASBackend) ProtoReflect() protoreflect.Message {
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[17]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1808,7 +1959,7 @@ type Attestation_SigningOptions struct {
 
 func (x *Attestation_SigningOptions) Reset() {
 	*x = Attestation_SigningOptions{}
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[18]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1820,7 +1971,7 @@ func (x *Attestation_SigningOptions) String() string {
 func (*Attestation_SigningOptions) ProtoMessage() {}
 
 func (x *Attestation_SigningOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[18]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1865,7 +2016,7 @@ type Attestation_Material_KeyVal struct {
 
 func (x *Attestation_Material_KeyVal) Reset() {
 	*x = Attestation_Material_KeyVal{}
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[20]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1877,7 +2028,7 @@ func (x *Attestation_Material_KeyVal) String() string {
 func (*Attestation_Material_KeyVal) ProtoMessage() {}
 
 func (x *Attestation_Material_KeyVal) ProtoReflect() protoreflect.Message {
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[20]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1943,7 +2094,7 @@ type Attestation_Material_ContainerImage struct {
 
 func (x *Attestation_Material_ContainerImage) Reset() {
 	*x = Attestation_Material_ContainerImage{}
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[21]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1955,7 +2106,7 @@ func (x *Attestation_Material_ContainerImage) String() string {
 func (*Attestation_Material_ContainerImage) ProtoMessage() {}
 
 func (x *Attestation_Material_ContainerImage) ProtoReflect() protoreflect.Message {
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[21]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2057,7 +2208,7 @@ type Attestation_Material_Artifact struct {
 
 func (x *Attestation_Material_Artifact) Reset() {
 	*x = Attestation_Material_Artifact{}
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[22]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2069,7 +2220,7 @@ func (x *Attestation_Material_Artifact) String() string {
 func (*Attestation_Material_Artifact) ProtoMessage() {}
 
 func (x *Attestation_Material_Artifact) ProtoReflect() protoreflect.Message {
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[22]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2133,7 +2284,7 @@ type Attestation_Material_SBOMArtifact struct {
 
 func (x *Attestation_Material_SBOMArtifact) Reset() {
 	*x = Attestation_Material_SBOMArtifact{}
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[23]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2145,7 +2296,7 @@ func (x *Attestation_Material_SBOMArtifact) String() string {
 func (*Attestation_Material_SBOMArtifact) ProtoMessage() {}
 
 func (x *Attestation_Material_SBOMArtifact) ProtoReflect() protoreflect.Message {
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[23]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2190,7 +2341,7 @@ type Attestation_Material_SBOMArtifact_MainComponent struct {
 
 func (x *Attestation_Material_SBOMArtifact_MainComponent) Reset() {
 	*x = Attestation_Material_SBOMArtifact_MainComponent{}
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[24]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2202,7 +2353,7 @@ func (x *Attestation_Material_SBOMArtifact_MainComponent) String() string {
 func (*Attestation_Material_SBOMArtifact_MainComponent) ProtoMessage() {}
 
 func (x *Attestation_Material_SBOMArtifact_MainComponent) ProtoReflect() protoreflect.Message {
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[24]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2259,7 +2410,7 @@ type PolicyEvaluation_Violation struct {
 
 func (x *PolicyEvaluation_Violation) Reset() {
 	*x = PolicyEvaluation_Violation{}
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[27]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2271,7 +2422,7 @@ func (x *PolicyEvaluation_Violation) String() string {
 func (*PolicyEvaluation_Violation) ProtoMessage() {}
 
 func (x *PolicyEvaluation_Violation) ProtoReflect() protoreflect.Message {
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[27]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2369,7 +2520,7 @@ type PolicyEvaluation_Reference struct {
 
 func (x *PolicyEvaluation_Reference) Reset() {
 	*x = PolicyEvaluation_Reference{}
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[28]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2381,7 +2532,7 @@ func (x *PolicyEvaluation_Reference) String() string {
 func (*PolicyEvaluation_Reference) ProtoMessage() {}
 
 func (x *PolicyEvaluation_Reference) ProtoReflect() protoreflect.Message {
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[28]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2437,7 +2588,7 @@ type PolicyEvaluation_RawResult struct {
 
 func (x *PolicyEvaluation_RawResult) Reset() {
 	*x = PolicyEvaluation_RawResult{}
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[29]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2449,7 +2600,7 @@ func (x *PolicyEvaluation_RawResult) String() string {
 func (*PolicyEvaluation_RawResult) ProtoMessage() {}
 
 func (x *PolicyEvaluation_RawResult) ProtoReflect() protoreflect.Message {
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[29]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2489,7 +2640,7 @@ type Commit_Remote struct {
 
 func (x *Commit_Remote) Reset() {
 	*x = Commit_Remote{}
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[30]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2501,7 +2652,7 @@ func (x *Commit_Remote) String() string {
 func (*Commit_Remote) ProtoMessage() {}
 
 func (x *Commit_Remote) ProtoReflect() protoreflect.Message {
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[30]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2514,7 +2665,7 @@ func (x *Commit_Remote) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Commit_Remote.ProtoReflect.Descriptor instead.
 func (*Commit_Remote) Descriptor() ([]byte, []int) {
-	return file_attestation_v1_crafting_state_proto_rawDescGZIP(), []int{7, 0}
+	return file_attestation_v1_crafting_state_proto_rawDescGZIP(), []int{9, 0}
 }
 
 func (x *Commit_Remote) GetName() string {
@@ -2551,7 +2702,7 @@ type Commit_CommitVerification struct {
 
 func (x *Commit_CommitVerification) Reset() {
 	*x = Commit_CommitVerification{}
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[31]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2563,7 +2714,7 @@ func (x *Commit_CommitVerification) String() string {
 func (*Commit_CommitVerification) ProtoMessage() {}
 
 func (x *Commit_CommitVerification) ProtoReflect() protoreflect.Message {
-	mi := &file_attestation_v1_crafting_state_proto_msgTypes[31]
+	mi := &file_attestation_v1_crafting_state_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2576,7 +2727,7 @@ func (x *Commit_CommitVerification) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Commit_CommitVerification.ProtoReflect.Descriptor instead.
 func (*Commit_CommitVerification) Descriptor() ([]byte, []int) {
-	return file_attestation_v1_crafting_state_proto_rawDescGZIP(), []int{7, 1}
+	return file_attestation_v1_crafting_state_proto_rawDescGZIP(), []int{9, 1}
 }
 
 func (x *Commit_CommitVerification) GetAttempted() bool {
@@ -2776,7 +2927,7 @@ const file_attestation_v1_crafting_state_proto_rawDesc = "" +
 	"\x05input\x18\x01 \x01(\fR\x05input\x12\x16\n" +
 	"\x06output\x18\x02 \x01(\fR\x06output\"\\\n" +
 	"\x16PolicyEvaluationBundle\x12B\n" +
-	"\vevaluations\x18\x01 \x03(\v2 .attestation.v1.PolicyEvaluationR\vevaluations\"\xf6\x02\n" +
+	"\vevaluations\x18\x01 \x03(\v2 .attestation.v1.PolicyEvaluationR\vevaluations\"\xe6\x03\n" +
 	"\x1aPolicyVulnerabilityFinding\x12 \n" +
 	"\amessage\x18\x01 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\amessage\x12'\n" +
 	"\vexternal_id\x18\x02 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\n" +
@@ -2787,7 +2938,10 @@ const file_attestation_v1_crafting_state_proto_rawDesc = "" +
 	"\x04cwes\x18\x06 \x03(\tR\x04cwes\x12&\n" +
 	"\x0erecommendation\x18\a \x01(\tR\x0erecommendation\x12 \n" +
 	"\vdescription\x18\b \x01(\tR\vdescription\x12#\n" +
-	"\rfixed_version\x18\t \x01(\tR\ffixedVersion\"\xc9\x02\n" +
+	"\rfixed_version\x18\t \x01(\tR\ffixedVersion\x12X\n" +
+	"\x11assessment_result\x18\n" +
+	" \x01(\v2&.attestation.v1.PolicyAssessmentResultH\x00R\x10assessmentResult\x88\x01\x01B\x14\n" +
+	"\x12_assessment_result\"\xb9\x03\n" +
 	"\x11PolicySASTFinding\x12 \n" +
 	"\amessage\x18\x01 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\amessage\x12\x1f\n" +
 	"\arule_id\x18\x02 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\x06ruleId\x12\"\n" +
@@ -2797,8 +2951,10 @@ const file_attestation_v1_crafting_state_proto_rawDesc = "" +
 	"lineNumber\x12!\n" +
 	"\fcode_snippet\x18\x06 \x01(\tR\vcodeSnippet\x12&\n" +
 	"\x0erecommendation\x18\a \x01(\tR\x0erecommendation\x12*\n" +
-	"\x0eseverity_score\x18\b \x01(\x01H\x00R\rseverityScore\x88\x01\x01B\x11\n" +
-	"\x0f_severity_score\"\xb2\x02\n" +
+	"\x0eseverity_score\x18\b \x01(\x01H\x00R\rseverityScore\x88\x01\x01\x12X\n" +
+	"\x11assessment_result\x18\t \x01(\v2&.attestation.v1.PolicyAssessmentResultH\x01R\x10assessmentResult\x88\x01\x01B\x11\n" +
+	"\x0f_severity_scoreB\x14\n" +
+	"\x12_assessment_result\"\xa2\x03\n" +
 	"\x1dPolicyLicenseViolationFinding\x12 \n" +
 	"\amessage\x18\x01 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\amessage\x12-\n" +
 	"\x0ecomponent_name\x18\x02 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\rcomponentName\x12!\n" +
@@ -2807,7 +2963,16 @@ const file_attestation_v1_crafting_state_proto_rawDesc = "" +
 	"license_id\x18\x04 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\tlicenseId\x12!\n" +
 	"\flicense_name\x18\x05 \x01(\tR\vlicenseName\x12+\n" +
 	"\x11component_version\x18\x06 \x01(\tR\x10componentVersion\x12&\n" +
-	"\x0erecommendation\x18\a \x01(\tR\x0erecommendation\"\xce\x06\n" +
+	"\x0erecommendation\x18\a \x01(\tR\x0erecommendation\x12X\n" +
+	"\x11assessment_result\x18\b \x01(\v2&.attestation.v1.PolicyAssessmentResultH\x00R\x10assessmentResult\x88\x01\x01B\x14\n" +
+	"\x12_assessment_result\"\x87\x01\n" +
+	"\x16PolicyAssessmentResult\x12)\n" +
+	"\x10effective_status\x18\x01 \x01(\tR\x0feffectiveStatus\x12B\n" +
+	"\vassessments\x18\x02 \x03(\v2 .attestation.v1.PolicyAssessmentR\vassessments\"Z\n" +
+	"\x10PolicyAssessment\x12\x18\n" +
+	"\x02id\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01R\x02id\x12\x16\n" +
+	"\x06status\x18\x02 \x01(\tR\x06status\x12\x14\n" +
+	"\x05scope\x18\x03 \x01(\tR\x05scope\"\xce\x06\n" +
 	"\x06Commit\x12\x1b\n" +
 	"\x04hash\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x04hash\x12!\n" +
 	"\fauthor_email\x18\x02 \x01(\tR\vauthorEmail\x12(\n" +
@@ -2888,7 +3053,7 @@ func file_attestation_v1_crafting_state_proto_rawDescGZIP() []byte {
 }
 
 var file_attestation_v1_crafting_state_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_attestation_v1_crafting_state_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
+var file_attestation_v1_crafting_state_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
 var file_attestation_v1_crafting_state_proto_goTypes = []any{
 	(Attestation_Auth_AuthType)(0),                    // 0: attestation.v1.Attestation.Auth.AuthType
 	(Commit_CommitVerification_VerificationStatus)(0), // 1: attestation.v1.Commit.CommitVerification.VerificationStatus
@@ -2899,93 +3064,99 @@ var file_attestation_v1_crafting_state_proto_goTypes = []any{
 	(*PolicyVulnerabilityFinding)(nil),                // 6: attestation.v1.PolicyVulnerabilityFinding
 	(*PolicySASTFinding)(nil),                         // 7: attestation.v1.PolicySASTFinding
 	(*PolicyLicenseViolationFinding)(nil),             // 8: attestation.v1.PolicyLicenseViolationFinding
-	(*Commit)(nil),                                    // 9: attestation.v1.Commit
-	(*CraftingState)(nil),                             // 10: attestation.v1.CraftingState
-	(*WorkflowMetadata)(nil),                          // 11: attestation.v1.WorkflowMetadata
-	(*ProjectVersion)(nil),                            // 12: attestation.v1.ProjectVersion
-	(*ResourceDescriptor)(nil),                        // 13: attestation.v1.ResourceDescriptor
-	nil,                                               // 14: attestation.v1.Attestation.MaterialsEntry
-	nil,                                               // 15: attestation.v1.Attestation.AnnotationsEntry
-	(*Attestation_Material)(nil),                      // 16: attestation.v1.Attestation.Material
-	nil,                                               // 17: attestation.v1.Attestation.EnvVarsEntry
-	(*Attestation_Auth)(nil),                          // 18: attestation.v1.Attestation.Auth
-	(*Attestation_CASBackend)(nil),                    // 19: attestation.v1.Attestation.CASBackend
-	(*Attestation_SigningOptions)(nil),                // 20: attestation.v1.Attestation.SigningOptions
-	nil,                                               // 21: attestation.v1.Attestation.Material.AnnotationsEntry
-	(*Attestation_Material_KeyVal)(nil),               // 22: attestation.v1.Attestation.Material.KeyVal
-	(*Attestation_Material_ContainerImage)(nil),       // 23: attestation.v1.Attestation.Material.ContainerImage
-	(*Attestation_Material_Artifact)(nil),             // 24: attestation.v1.Attestation.Material.Artifact
-	(*Attestation_Material_SBOMArtifact)(nil),         // 25: attestation.v1.Attestation.Material.SBOMArtifact
-	(*Attestation_Material_SBOMArtifact_MainComponent)(nil), // 26: attestation.v1.Attestation.Material.SBOMArtifact.MainComponent
-	nil,                                      // 27: attestation.v1.PolicyEvaluation.AnnotationsEntry
-	nil,                                      // 28: attestation.v1.PolicyEvaluation.WithEntry
-	(*PolicyEvaluation_Violation)(nil),       // 29: attestation.v1.PolicyEvaluation.Violation
-	(*PolicyEvaluation_Reference)(nil),       // 30: attestation.v1.PolicyEvaluation.Reference
-	(*PolicyEvaluation_RawResult)(nil),       // 31: attestation.v1.PolicyEvaluation.RawResult
-	(*Commit_Remote)(nil),                    // 32: attestation.v1.Commit.Remote
-	(*Commit_CommitVerification)(nil),        // 33: attestation.v1.Commit.CommitVerification
-	nil,                                      // 34: attestation.v1.ResourceDescriptor.DigestEntry
-	(*timestamppb.Timestamp)(nil),            // 35: google.protobuf.Timestamp
-	(v1.CraftingSchema_Runner_RunnerType)(0), // 36: workflowcontract.v1.CraftingSchema.Runner.RunnerType
-	(v1.CraftingSchema_Material_MaterialType)(0), // 37: workflowcontract.v1.CraftingSchema.Material.MaterialType
-	(*v1.CraftingSchema)(nil),                    // 38: workflowcontract.v1.CraftingSchema
-	(*v1.CraftingSchemaV2)(nil),                  // 39: workflowcontract.v1.CraftingSchemaV2
-	(*structpb.Struct)(nil),                      // 40: google.protobuf.Struct
-	(*wrapperspb.BoolValue)(nil),                 // 41: google.protobuf.BoolValue
+	(*PolicyAssessmentResult)(nil),                    // 9: attestation.v1.PolicyAssessmentResult
+	(*PolicyAssessment)(nil),                          // 10: attestation.v1.PolicyAssessment
+	(*Commit)(nil),                                    // 11: attestation.v1.Commit
+	(*CraftingState)(nil),                             // 12: attestation.v1.CraftingState
+	(*WorkflowMetadata)(nil),                          // 13: attestation.v1.WorkflowMetadata
+	(*ProjectVersion)(nil),                            // 14: attestation.v1.ProjectVersion
+	(*ResourceDescriptor)(nil),                        // 15: attestation.v1.ResourceDescriptor
+	nil,                                               // 16: attestation.v1.Attestation.MaterialsEntry
+	nil,                                               // 17: attestation.v1.Attestation.AnnotationsEntry
+	(*Attestation_Material)(nil),                      // 18: attestation.v1.Attestation.Material
+	nil,                                               // 19: attestation.v1.Attestation.EnvVarsEntry
+	(*Attestation_Auth)(nil),                          // 20: attestation.v1.Attestation.Auth
+	(*Attestation_CASBackend)(nil),                    // 21: attestation.v1.Attestation.CASBackend
+	(*Attestation_SigningOptions)(nil),                // 22: attestation.v1.Attestation.SigningOptions
+	nil,                                               // 23: attestation.v1.Attestation.Material.AnnotationsEntry
+	(*Attestation_Material_KeyVal)(nil),               // 24: attestation.v1.Attestation.Material.KeyVal
+	(*Attestation_Material_ContainerImage)(nil),       // 25: attestation.v1.Attestation.Material.ContainerImage
+	(*Attestation_Material_Artifact)(nil),             // 26: attestation.v1.Attestation.Material.Artifact
+	(*Attestation_Material_SBOMArtifact)(nil),         // 27: attestation.v1.Attestation.Material.SBOMArtifact
+	(*Attestation_Material_SBOMArtifact_MainComponent)(nil), // 28: attestation.v1.Attestation.Material.SBOMArtifact.MainComponent
+	nil,                                      // 29: attestation.v1.PolicyEvaluation.AnnotationsEntry
+	nil,                                      // 30: attestation.v1.PolicyEvaluation.WithEntry
+	(*PolicyEvaluation_Violation)(nil),       // 31: attestation.v1.PolicyEvaluation.Violation
+	(*PolicyEvaluation_Reference)(nil),       // 32: attestation.v1.PolicyEvaluation.Reference
+	(*PolicyEvaluation_RawResult)(nil),       // 33: attestation.v1.PolicyEvaluation.RawResult
+	(*Commit_Remote)(nil),                    // 34: attestation.v1.Commit.Remote
+	(*Commit_CommitVerification)(nil),        // 35: attestation.v1.Commit.CommitVerification
+	nil,                                      // 36: attestation.v1.ResourceDescriptor.DigestEntry
+	(*timestamppb.Timestamp)(nil),            // 37: google.protobuf.Timestamp
+	(v1.CraftingSchema_Runner_RunnerType)(0), // 38: workflowcontract.v1.CraftingSchema.Runner.RunnerType
+	(v1.CraftingSchema_Material_MaterialType)(0), // 39: workflowcontract.v1.CraftingSchema.Material.MaterialType
+	(*v1.CraftingSchema)(nil),                    // 40: workflowcontract.v1.CraftingSchema
+	(*v1.CraftingSchemaV2)(nil),                  // 41: workflowcontract.v1.CraftingSchemaV2
+	(*structpb.Struct)(nil),                      // 42: google.protobuf.Struct
+	(*wrapperspb.BoolValue)(nil),                 // 43: google.protobuf.BoolValue
 }
 var file_attestation_v1_crafting_state_proto_depIdxs = []int32{
-	35, // 0: attestation.v1.Attestation.initialized_at:type_name -> google.protobuf.Timestamp
-	35, // 1: attestation.v1.Attestation.finished_at:type_name -> google.protobuf.Timestamp
-	11, // 2: attestation.v1.Attestation.workflow:type_name -> attestation.v1.WorkflowMetadata
-	14, // 3: attestation.v1.Attestation.materials:type_name -> attestation.v1.Attestation.MaterialsEntry
-	15, // 4: attestation.v1.Attestation.annotations:type_name -> attestation.v1.Attestation.AnnotationsEntry
-	17, // 5: attestation.v1.Attestation.env_vars:type_name -> attestation.v1.Attestation.EnvVarsEntry
-	36, // 6: attestation.v1.Attestation.runner_type:type_name -> workflowcontract.v1.CraftingSchema.Runner.RunnerType
-	9,  // 7: attestation.v1.Attestation.head:type_name -> attestation.v1.Commit
+	37, // 0: attestation.v1.Attestation.initialized_at:type_name -> google.protobuf.Timestamp
+	37, // 1: attestation.v1.Attestation.finished_at:type_name -> google.protobuf.Timestamp
+	13, // 2: attestation.v1.Attestation.workflow:type_name -> attestation.v1.WorkflowMetadata
+	16, // 3: attestation.v1.Attestation.materials:type_name -> attestation.v1.Attestation.MaterialsEntry
+	17, // 4: attestation.v1.Attestation.annotations:type_name -> attestation.v1.Attestation.AnnotationsEntry
+	19, // 5: attestation.v1.Attestation.env_vars:type_name -> attestation.v1.Attestation.EnvVarsEntry
+	38, // 6: attestation.v1.Attestation.runner_type:type_name -> workflowcontract.v1.CraftingSchema.Runner.RunnerType
+	11, // 7: attestation.v1.Attestation.head:type_name -> attestation.v1.Commit
 	4,  // 8: attestation.v1.Attestation.policy_evaluations:type_name -> attestation.v1.PolicyEvaluation
-	20, // 9: attestation.v1.Attestation.signing_options:type_name -> attestation.v1.Attestation.SigningOptions
+	22, // 9: attestation.v1.Attestation.signing_options:type_name -> attestation.v1.Attestation.SigningOptions
 	3,  // 10: attestation.v1.Attestation.runner_environment:type_name -> attestation.v1.RunnerEnvironment
-	18, // 11: attestation.v1.Attestation.auth:type_name -> attestation.v1.Attestation.Auth
-	19, // 12: attestation.v1.Attestation.cas_backend:type_name -> attestation.v1.Attestation.CASBackend
-	36, // 13: attestation.v1.RunnerEnvironment.type:type_name -> workflowcontract.v1.CraftingSchema.Runner.RunnerType
-	27, // 14: attestation.v1.PolicyEvaluation.annotations:type_name -> attestation.v1.PolicyEvaluation.AnnotationsEntry
-	29, // 15: attestation.v1.PolicyEvaluation.violations:type_name -> attestation.v1.PolicyEvaluation.Violation
-	28, // 16: attestation.v1.PolicyEvaluation.with:type_name -> attestation.v1.PolicyEvaluation.WithEntry
-	37, // 17: attestation.v1.PolicyEvaluation.type:type_name -> workflowcontract.v1.CraftingSchema.Material.MaterialType
-	30, // 18: attestation.v1.PolicyEvaluation.policy_reference:type_name -> attestation.v1.PolicyEvaluation.Reference
-	30, // 19: attestation.v1.PolicyEvaluation.group_reference:type_name -> attestation.v1.PolicyEvaluation.Reference
-	31, // 20: attestation.v1.PolicyEvaluation.raw_results:type_name -> attestation.v1.PolicyEvaluation.RawResult
+	20, // 11: attestation.v1.Attestation.auth:type_name -> attestation.v1.Attestation.Auth
+	21, // 12: attestation.v1.Attestation.cas_backend:type_name -> attestation.v1.Attestation.CASBackend
+	38, // 13: attestation.v1.RunnerEnvironment.type:type_name -> workflowcontract.v1.CraftingSchema.Runner.RunnerType
+	29, // 14: attestation.v1.PolicyEvaluation.annotations:type_name -> attestation.v1.PolicyEvaluation.AnnotationsEntry
+	31, // 15: attestation.v1.PolicyEvaluation.violations:type_name -> attestation.v1.PolicyEvaluation.Violation
+	30, // 16: attestation.v1.PolicyEvaluation.with:type_name -> attestation.v1.PolicyEvaluation.WithEntry
+	39, // 17: attestation.v1.PolicyEvaluation.type:type_name -> workflowcontract.v1.CraftingSchema.Material.MaterialType
+	32, // 18: attestation.v1.PolicyEvaluation.policy_reference:type_name -> attestation.v1.PolicyEvaluation.Reference
+	32, // 19: attestation.v1.PolicyEvaluation.group_reference:type_name -> attestation.v1.PolicyEvaluation.Reference
+	33, // 20: attestation.v1.PolicyEvaluation.raw_results:type_name -> attestation.v1.PolicyEvaluation.RawResult
 	4,  // 21: attestation.v1.PolicyEvaluationBundle.evaluations:type_name -> attestation.v1.PolicyEvaluation
-	35, // 22: attestation.v1.Commit.date:type_name -> google.protobuf.Timestamp
-	32, // 23: attestation.v1.Commit.remotes:type_name -> attestation.v1.Commit.Remote
-	33, // 24: attestation.v1.Commit.platform_verification:type_name -> attestation.v1.Commit.CommitVerification
-	38, // 25: attestation.v1.CraftingState.input_schema:type_name -> workflowcontract.v1.CraftingSchema
-	39, // 26: attestation.v1.CraftingState.schema_v2:type_name -> workflowcontract.v1.CraftingSchemaV2
-	2,  // 27: attestation.v1.CraftingState.attestation:type_name -> attestation.v1.Attestation
-	12, // 28: attestation.v1.WorkflowMetadata.version:type_name -> attestation.v1.ProjectVersion
-	34, // 29: attestation.v1.ResourceDescriptor.digest:type_name -> attestation.v1.ResourceDescriptor.DigestEntry
-	40, // 30: attestation.v1.ResourceDescriptor.annotations:type_name -> google.protobuf.Struct
-	16, // 31: attestation.v1.Attestation.MaterialsEntry.value:type_name -> attestation.v1.Attestation.Material
-	22, // 32: attestation.v1.Attestation.Material.string:type_name -> attestation.v1.Attestation.Material.KeyVal
-	23, // 33: attestation.v1.Attestation.Material.container_image:type_name -> attestation.v1.Attestation.Material.ContainerImage
-	24, // 34: attestation.v1.Attestation.Material.artifact:type_name -> attestation.v1.Attestation.Material.Artifact
-	25, // 35: attestation.v1.Attestation.Material.sbom_artifact:type_name -> attestation.v1.Attestation.Material.SBOMArtifact
-	35, // 36: attestation.v1.Attestation.Material.added_at:type_name -> google.protobuf.Timestamp
-	37, // 37: attestation.v1.Attestation.Material.material_type:type_name -> workflowcontract.v1.CraftingSchema.Material.MaterialType
-	21, // 38: attestation.v1.Attestation.Material.annotations:type_name -> attestation.v1.Attestation.Material.AnnotationsEntry
-	0,  // 39: attestation.v1.Attestation.Auth.type:type_name -> attestation.v1.Attestation.Auth.AuthType
-	41, // 40: attestation.v1.Attestation.Material.ContainerImage.has_latest_tag:type_name -> google.protobuf.BoolValue
-	24, // 41: attestation.v1.Attestation.Material.SBOMArtifact.artifact:type_name -> attestation.v1.Attestation.Material.Artifact
-	26, // 42: attestation.v1.Attestation.Material.SBOMArtifact.main_component:type_name -> attestation.v1.Attestation.Material.SBOMArtifact.MainComponent
-	6,  // 43: attestation.v1.PolicyEvaluation.Violation.vulnerability:type_name -> attestation.v1.PolicyVulnerabilityFinding
-	7,  // 44: attestation.v1.PolicyEvaluation.Violation.sast:type_name -> attestation.v1.PolicySASTFinding
-	8,  // 45: attestation.v1.PolicyEvaluation.Violation.license_violation:type_name -> attestation.v1.PolicyLicenseViolationFinding
-	1,  // 46: attestation.v1.Commit.CommitVerification.status:type_name -> attestation.v1.Commit.CommitVerification.VerificationStatus
-	47, // [47:47] is the sub-list for method output_type
-	47, // [47:47] is the sub-list for method input_type
-	47, // [47:47] is the sub-list for extension type_name
-	47, // [47:47] is the sub-list for extension extendee
-	0,  // [0:47] is the sub-list for field type_name
+	9,  // 22: attestation.v1.PolicyVulnerabilityFinding.assessment_result:type_name -> attestation.v1.PolicyAssessmentResult
+	9,  // 23: attestation.v1.PolicySASTFinding.assessment_result:type_name -> attestation.v1.PolicyAssessmentResult
+	9,  // 24: attestation.v1.PolicyLicenseViolationFinding.assessment_result:type_name -> attestation.v1.PolicyAssessmentResult
+	10, // 25: attestation.v1.PolicyAssessmentResult.assessments:type_name -> attestation.v1.PolicyAssessment
+	37, // 26: attestation.v1.Commit.date:type_name -> google.protobuf.Timestamp
+	34, // 27: attestation.v1.Commit.remotes:type_name -> attestation.v1.Commit.Remote
+	35, // 28: attestation.v1.Commit.platform_verification:type_name -> attestation.v1.Commit.CommitVerification
+	40, // 29: attestation.v1.CraftingState.input_schema:type_name -> workflowcontract.v1.CraftingSchema
+	41, // 30: attestation.v1.CraftingState.schema_v2:type_name -> workflowcontract.v1.CraftingSchemaV2
+	2,  // 31: attestation.v1.CraftingState.attestation:type_name -> attestation.v1.Attestation
+	14, // 32: attestation.v1.WorkflowMetadata.version:type_name -> attestation.v1.ProjectVersion
+	36, // 33: attestation.v1.ResourceDescriptor.digest:type_name -> attestation.v1.ResourceDescriptor.DigestEntry
+	42, // 34: attestation.v1.ResourceDescriptor.annotations:type_name -> google.protobuf.Struct
+	18, // 35: attestation.v1.Attestation.MaterialsEntry.value:type_name -> attestation.v1.Attestation.Material
+	24, // 36: attestation.v1.Attestation.Material.string:type_name -> attestation.v1.Attestation.Material.KeyVal
+	25, // 37: attestation.v1.Attestation.Material.container_image:type_name -> attestation.v1.Attestation.Material.ContainerImage
+	26, // 38: attestation.v1.Attestation.Material.artifact:type_name -> attestation.v1.Attestation.Material.Artifact
+	27, // 39: attestation.v1.Attestation.Material.sbom_artifact:type_name -> attestation.v1.Attestation.Material.SBOMArtifact
+	37, // 40: attestation.v1.Attestation.Material.added_at:type_name -> google.protobuf.Timestamp
+	39, // 41: attestation.v1.Attestation.Material.material_type:type_name -> workflowcontract.v1.CraftingSchema.Material.MaterialType
+	23, // 42: attestation.v1.Attestation.Material.annotations:type_name -> attestation.v1.Attestation.Material.AnnotationsEntry
+	0,  // 43: attestation.v1.Attestation.Auth.type:type_name -> attestation.v1.Attestation.Auth.AuthType
+	43, // 44: attestation.v1.Attestation.Material.ContainerImage.has_latest_tag:type_name -> google.protobuf.BoolValue
+	26, // 45: attestation.v1.Attestation.Material.SBOMArtifact.artifact:type_name -> attestation.v1.Attestation.Material.Artifact
+	28, // 46: attestation.v1.Attestation.Material.SBOMArtifact.main_component:type_name -> attestation.v1.Attestation.Material.SBOMArtifact.MainComponent
+	6,  // 47: attestation.v1.PolicyEvaluation.Violation.vulnerability:type_name -> attestation.v1.PolicyVulnerabilityFinding
+	7,  // 48: attestation.v1.PolicyEvaluation.Violation.sast:type_name -> attestation.v1.PolicySASTFinding
+	8,  // 49: attestation.v1.PolicyEvaluation.Violation.license_violation:type_name -> attestation.v1.PolicyLicenseViolationFinding
+	1,  // 50: attestation.v1.Commit.CommitVerification.status:type_name -> attestation.v1.Commit.CommitVerification.VerificationStatus
+	51, // [51:51] is the sub-list for method output_type
+	51, // [51:51] is the sub-list for method input_type
+	51, // [51:51] is the sub-list for extension type_name
+	51, // [51:51] is the sub-list for extension extendee
+	0,  // [0:51] is the sub-list for field type_name
 }
 
 func init() { file_attestation_v1_crafting_state_proto_init() }
@@ -2993,19 +3164,21 @@ func file_attestation_v1_crafting_state_proto_init() {
 	if File_attestation_v1_crafting_state_proto != nil {
 		return
 	}
+	file_attestation_v1_crafting_state_proto_msgTypes[4].OneofWrappers = []any{}
 	file_attestation_v1_crafting_state_proto_msgTypes[5].OneofWrappers = []any{}
-	file_attestation_v1_crafting_state_proto_msgTypes[7].OneofWrappers = []any{}
-	file_attestation_v1_crafting_state_proto_msgTypes[8].OneofWrappers = []any{
+	file_attestation_v1_crafting_state_proto_msgTypes[6].OneofWrappers = []any{}
+	file_attestation_v1_crafting_state_proto_msgTypes[9].OneofWrappers = []any{}
+	file_attestation_v1_crafting_state_proto_msgTypes[10].OneofWrappers = []any{
 		(*CraftingState_InputSchema)(nil),
 		(*CraftingState_SchemaV2)(nil),
 	}
-	file_attestation_v1_crafting_state_proto_msgTypes[14].OneofWrappers = []any{
+	file_attestation_v1_crafting_state_proto_msgTypes[16].OneofWrappers = []any{
 		(*Attestation_Material_String_)(nil),
 		(*Attestation_Material_ContainerImage_)(nil),
 		(*Attestation_Material_Artifact_)(nil),
 		(*Attestation_Material_SbomArtifact)(nil),
 	}
-	file_attestation_v1_crafting_state_proto_msgTypes[27].OneofWrappers = []any{
+	file_attestation_v1_crafting_state_proto_msgTypes[29].OneofWrappers = []any{
 		(*PolicyEvaluation_Violation_Vulnerability)(nil),
 		(*PolicyEvaluation_Violation_Sast)(nil),
 		(*PolicyEvaluation_Violation_LicenseViolation)(nil),
@@ -3016,7 +3189,7 @@ func file_attestation_v1_crafting_state_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_attestation_v1_crafting_state_proto_rawDesc), len(file_attestation_v1_crafting_state_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   33,
+			NumMessages:   35,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/attestation/crafter/api/attestation/v1/crafting_state.proto
+++ b/pkg/attestation/crafter/api/attestation/v1/crafting_state.proto
@@ -336,6 +336,8 @@ message PolicyVulnerabilityFinding {
   string description = 8;
   // Version that fixes the vulnerability (e.g., "2.0.1", "1.3.4-patch1")
   string fixed_version = 9;
+  // Optional assessment context. See PolicyAssessmentResult.
+  optional PolicyAssessmentResult assessment_result = 10;
 }
 
 // Output schema for SAST findings from policy evaluation.
@@ -357,6 +359,8 @@ message PolicySASTFinding {
   string recommendation = 7;
   // Optional numeric severity score from the scanner (scale is tool-defined)
   optional double severity_score = 8;
+  // Optional assessment context. See PolicyAssessmentResult.
+  optional PolicyAssessmentResult assessment_result = 9;
 }
 
 // Output schema for license violation findings from policy evaluation.
@@ -376,6 +380,31 @@ message PolicyLicenseViolationFinding {
   string component_version = 6;
   // Suggested fix
   string recommendation = 7;
+  // Optional assessment context. See PolicyAssessmentResult.
+  optional PolicyAssessmentResult assessment_result = 8;
+}
+
+// Assessment context attached to a policy finding by the policy engine via
+// the chainloop.effective_assessments builtin. Sent to CAS as part of the
+// PolicyEvaluationBundle.
+message PolicyAssessmentResult {
+  // Precedence-resolved status across `assessments`. Values use the
+  // platform's AssessmentStatus enum names, e.g.
+  // "ASSESSMENT_STATUS_NOT_AFFECTED".
+  string effective_status = 1;
+  // Assessments matching the finding's identity tuple.
+  repeated PolicyAssessment assessments = 2;
+}
+
+// Audit-critical subset of an assessment. Full record is reachable via
+// AssessmentService.Get on the platform using `id`.
+message PolicyAssessment {
+  // Platform assessment UUID.
+  string id = 1 [(buf.validate.field).string.uuid = true];
+  // Platform AssessmentStatus enum name, e.g. "ASSESSMENT_STATUS_NOT_AFFECTED".
+  string status = 2;
+  // Platform AssessmentScope enum name, e.g. "ASSESSMENT_SCOPE_PROJECT".
+  string scope = 3;
 }
 
 message Commit {

--- a/pkg/attestation/crafter/api/attestation/v1/crafting_state.proto
+++ b/pkg/attestation/crafter/api/attestation/v1/crafting_state.proto
@@ -337,7 +337,7 @@ message PolicyVulnerabilityFinding {
   // Version that fixes the vulnerability (e.g., "2.0.1", "1.3.4-patch1")
   string fixed_version = 9;
   // Optional assessment context. See PolicyAssessmentResult.
-  optional PolicyAssessmentResult assessment_result = 10;
+  optional PolicyAssessmentResult assessment = 10;
 }
 
 // Output schema for SAST findings from policy evaluation.
@@ -360,7 +360,7 @@ message PolicySASTFinding {
   // Optional numeric severity score from the scanner (scale is tool-defined)
   optional double severity_score = 8;
   // Optional assessment context. See PolicyAssessmentResult.
-  optional PolicyAssessmentResult assessment_result = 9;
+  optional PolicyAssessmentResult assessment = 9;
 }
 
 // Output schema for license violation findings from policy evaluation.
@@ -381,7 +381,7 @@ message PolicyLicenseViolationFinding {
   // Suggested fix
   string recommendation = 7;
   // Optional assessment context. See PolicyAssessmentResult.
-  optional PolicyAssessmentResult assessment_result = 8;
+  optional PolicyAssessmentResult assessment = 8;
 }
 
 // Assessment context attached to a policy finding by the policy engine via

--- a/pkg/attestation/crafter/api/attestation/v1/crafting_state.proto
+++ b/pkg/attestation/crafter/api/attestation/v1/crafting_state.proto
@@ -284,6 +284,13 @@ message PolicyEvaluation {
       PolicySASTFinding sast = 4;
       PolicyLicenseViolationFinding license_violation = 5;
     }
+
+    // Suppression hint set by the policy. When true the gate count
+    // excludes this entry, but it is still stored in CAS and ingested
+    // (audit trail preserved). Set by the policy author (typically based
+    // on `assessment.effective_status`) — the engine reads the bool
+    // without interpreting why.
+    bool suppress = 6;
   }
 
   message Reference {

--- a/pkg/policies/findings/registry_test.go
+++ b/pkg/policies/findings/registry_test.go
@@ -220,14 +220,14 @@ func TestValidateFinding(t *testing.T) {
 			},
 		},
 		{
-			name:        "vulnerability finding with full assessment_result",
+			name:        "vulnerability finding with full assessment",
 			findingType: "VULNERABILITY",
 			raw: map[string]any{
 				"message":      "Found CVE-2024-1234",
 				"external_id":  "CVE-2024-1234",
 				"package_purl": "pkg:golang/example.com/lib@v1.0.0",
 				"severity":     "CRITICAL",
-				"assessment_result": map[string]any{
+				"assessment": map[string]any{
 					"effective_status": "ASSESSMENT_STATUS_NOT_AFFECTED",
 					"assessments": []any{
 						map[string]any{
@@ -242,8 +242,8 @@ func TestValidateFinding(t *testing.T) {
 				t.Helper()
 				f, ok := msg.(*v1.PolicyVulnerabilityFinding)
 				require.True(t, ok)
-				require.NotNil(t, f.AssessmentResult)
-				ar := f.GetAssessmentResult()
+				require.NotNil(t, f.Assessment)
+				ar := f.GetAssessment()
 				assert.Equal(t, "ASSESSMENT_STATUS_NOT_AFFECTED", ar.GetEffectiveStatus())
 				require.Len(t, ar.GetAssessments(), 1)
 				a := ar.GetAssessments()[0]
@@ -253,7 +253,7 @@ func TestValidateFinding(t *testing.T) {
 			},
 		},
 		{
-			name:        "vulnerability finding without assessment_result stays nil (backward-compatible)",
+			name:        "vulnerability finding without assessment stays nil (backward-compatible)",
 			findingType: "VULNERABILITY",
 			raw: map[string]any{
 				"message":      "Found CVE-2024-1234",
@@ -265,18 +265,18 @@ func TestValidateFinding(t *testing.T) {
 				t.Helper()
 				f, ok := msg.(*v1.PolicyVulnerabilityFinding)
 				require.True(t, ok)
-				assert.Nil(t, f.AssessmentResult)
+				assert.Nil(t, f.Assessment)
 			},
 		},
 		{
-			name:        "SAST finding accepts assessment_result",
+			name:        "SAST finding accepts assessment",
 			findingType: "SAST",
 			raw: map[string]any{
 				"message":  "SQL injection in handler",
 				"rule_id":  "java:S1234",
 				"severity": "HIGH",
 				"location": "src/main/Handler.java",
-				"assessment_result": map[string]any{
+				"assessment": map[string]any{
 					"effective_status": "ASSESSMENT_STATUS_UNDER_INVESTIGATION",
 					"assessments": []any{
 						map[string]any{
@@ -290,21 +290,21 @@ func TestValidateFinding(t *testing.T) {
 				t.Helper()
 				f, ok := msg.(*v1.PolicySASTFinding)
 				require.True(t, ok)
-				require.NotNil(t, f.AssessmentResult)
-				assert.Equal(t, "ASSESSMENT_STATUS_UNDER_INVESTIGATION", f.GetAssessmentResult().GetEffectiveStatus())
-				require.Len(t, f.GetAssessmentResult().GetAssessments(), 1)
-				assert.Equal(t, "11111111-1111-1111-1111-111111111111", f.GetAssessmentResult().GetAssessments()[0].GetId())
+				require.NotNil(t, f.Assessment)
+				assert.Equal(t, "ASSESSMENT_STATUS_UNDER_INVESTIGATION", f.GetAssessment().GetEffectiveStatus())
+				require.Len(t, f.GetAssessment().GetAssessments(), 1)
+				assert.Equal(t, "11111111-1111-1111-1111-111111111111", f.GetAssessment().GetAssessments()[0].GetId())
 			},
 		},
 		{
-			name:        "license violation finding accepts assessment_result",
+			name:        "license violation finding accepts assessment",
 			findingType: "LICENSE_VIOLATION",
 			raw: map[string]any{
 				"message":        "Banned license GPL-3.0",
 				"component_name": "lodash",
 				"license_id":     "GPL-3.0",
 				"package_purl":   "pkg:npm/lodash@4.17.21",
-				"assessment_result": map[string]any{
+				"assessment": map[string]any{
 					"effective_status": "ASSESSMENT_STATUS_NOT_AFFECTED",
 					"assessments": []any{
 						map[string]any{
@@ -319,9 +319,9 @@ func TestValidateFinding(t *testing.T) {
 				t.Helper()
 				f, ok := msg.(*v1.PolicyLicenseViolationFinding)
 				require.True(t, ok)
-				require.NotNil(t, f.AssessmentResult)
-				require.Len(t, f.GetAssessmentResult().GetAssessments(), 1)
-				a := f.GetAssessmentResult().GetAssessments()[0]
+				require.NotNil(t, f.Assessment)
+				require.Len(t, f.GetAssessment().GetAssessments(), 1)
+				a := f.GetAssessment().GetAssessments()[0]
 				assert.Equal(t, "22222222-2222-2222-2222-222222222222", a.GetId())
 				assert.Equal(t, "ASSESSMENT_SCOPE_PROJECT_VERSION", a.GetScope())
 			},
@@ -334,7 +334,7 @@ func TestValidateFinding(t *testing.T) {
 				"external_id":  "CVE-2024-1234",
 				"package_purl": "pkg:golang/example.com/lib@v1.0.0",
 				"severity":     "CRITICAL",
-				"assessment_result": map[string]any{
+				"assessment": map[string]any{
 					"effective_status": "ASSESSMENT_STATUS_NOT_AFFECTED",
 					"assessments": []any{
 						map[string]any{
@@ -354,7 +354,7 @@ func TestValidateFinding(t *testing.T) {
 				"external_id":  "CVE-2024-1234",
 				"package_purl": "pkg:golang/example.com/lib@v1.0.0",
 				"severity":     "CRITICAL",
-				"assessment_result": map[string]any{
+				"assessment": map[string]any{
 					"effective_status": "ASSESSMENT_STATUS_NOT_AFFECTED",
 					"assessments": []any{
 						map[string]any{
@@ -374,7 +374,7 @@ func TestValidateFinding(t *testing.T) {
 				"external_id":  "CVE-2024-1234",
 				"package_purl": "pkg:golang/example.com/lib@v1.0.0",
 				"severity":     "CRITICAL",
-				"assessment_result": map[string]any{
+				"assessment": map[string]any{
 					"effective_status": "ASSESSMENT_STATUS_NOT_AFFECTED",
 					"assessments": []any{
 						map[string]any{
@@ -393,9 +393,9 @@ func TestValidateFinding(t *testing.T) {
 				t.Helper()
 				f, ok := msg.(*v1.PolicyVulnerabilityFinding)
 				require.True(t, ok)
-				require.NotNil(t, f.AssessmentResult)
-				require.Len(t, f.GetAssessmentResult().GetAssessments(), 1)
-				assert.Equal(t, "33333333-3333-3333-3333-333333333333", f.GetAssessmentResult().GetAssessments()[0].GetId())
+				require.NotNil(t, f.Assessment)
+				require.Len(t, f.GetAssessment().GetAssessments(), 1)
+				assert.Equal(t, "33333333-3333-3333-3333-333333333333", f.GetAssessment().GetAssessments()[0].GetId())
 			},
 		},
 		{
@@ -461,14 +461,14 @@ func TestSetViolationFinding(t *testing.T) {
 			},
 		},
 		{
-			name:        "set vulnerability finding with assessment_result",
+			name:        "set vulnerability finding with assessment",
 			findingType: "VULNERABILITY",
 			finding: &v1.PolicyVulnerabilityFinding{
 				Message:     "test",
 				ExternalId:  "CVE-2024-1",
 				PackagePurl: "pkg:npm/foo@1.0",
 				Severity:    "HIGH",
-				AssessmentResult: &v1.PolicyAssessmentResult{
+				Assessment: &v1.PolicyAssessmentResult{
 					EffectiveStatus: "ASSESSMENT_STATUS_NOT_AFFECTED",
 					Assessments: []*v1.PolicyAssessment{
 						{
@@ -483,10 +483,10 @@ func TestSetViolationFinding(t *testing.T) {
 				t.Helper()
 				f := v.GetVulnerability()
 				require.NotNil(t, f)
-				require.NotNil(t, f.GetAssessmentResult())
-				assert.Equal(t, "ASSESSMENT_STATUS_NOT_AFFECTED", f.GetAssessmentResult().GetEffectiveStatus())
-				require.Len(t, f.GetAssessmentResult().GetAssessments(), 1)
-				assert.Equal(t, "24e0e054-5cd0-49d3-92bb-908b8f7159d4", f.GetAssessmentResult().GetAssessments()[0].GetId())
+				require.NotNil(t, f.GetAssessment())
+				assert.Equal(t, "ASSESSMENT_STATUS_NOT_AFFECTED", f.GetAssessment().GetEffectiveStatus())
+				require.Len(t, f.GetAssessment().GetAssessments(), 1)
+				assert.Equal(t, "24e0e054-5cd0-49d3-92bb-908b8f7159d4", f.GetAssessment().GetAssessments()[0].GetId())
 			},
 		},
 		{

--- a/pkg/policies/findings/registry_test.go
+++ b/pkg/policies/findings/registry_test.go
@@ -220,6 +220,185 @@ func TestValidateFinding(t *testing.T) {
 			},
 		},
 		{
+			name:        "vulnerability finding with full assessment_result",
+			findingType: "VULNERABILITY",
+			raw: map[string]any{
+				"message":      "Found CVE-2024-1234",
+				"external_id":  "CVE-2024-1234",
+				"package_purl": "pkg:golang/example.com/lib@v1.0.0",
+				"severity":     "CRITICAL",
+				"assessment_result": map[string]any{
+					"effective_status": "ASSESSMENT_STATUS_NOT_AFFECTED",
+					"assessments": []any{
+						map[string]any{
+							"id":     "24e0e054-5cd0-49d3-92bb-908b8f7159d4",
+							"status": "ASSESSMENT_STATUS_NOT_AFFECTED",
+							"scope":  "ASSESSMENT_SCOPE_PROJECT",
+						},
+					},
+				},
+			},
+			checkFn: func(t *testing.T, msg interface{}) {
+				t.Helper()
+				f, ok := msg.(*v1.PolicyVulnerabilityFinding)
+				require.True(t, ok)
+				require.NotNil(t, f.AssessmentResult)
+				ar := f.GetAssessmentResult()
+				assert.Equal(t, "ASSESSMENT_STATUS_NOT_AFFECTED", ar.GetEffectiveStatus())
+				require.Len(t, ar.GetAssessments(), 1)
+				a := ar.GetAssessments()[0]
+				assert.Equal(t, "24e0e054-5cd0-49d3-92bb-908b8f7159d4", a.GetId())
+				assert.Equal(t, "ASSESSMENT_STATUS_NOT_AFFECTED", a.GetStatus())
+				assert.Equal(t, "ASSESSMENT_SCOPE_PROJECT", a.GetScope())
+			},
+		},
+		{
+			name:        "vulnerability finding without assessment_result stays nil (backward-compatible)",
+			findingType: "VULNERABILITY",
+			raw: map[string]any{
+				"message":      "Found CVE-2024-1234",
+				"external_id":  "CVE-2024-1234",
+				"package_purl": "pkg:golang/example.com/lib@v1.0.0",
+				"severity":     "CRITICAL",
+			},
+			checkFn: func(t *testing.T, msg interface{}) {
+				t.Helper()
+				f, ok := msg.(*v1.PolicyVulnerabilityFinding)
+				require.True(t, ok)
+				assert.Nil(t, f.AssessmentResult)
+			},
+		},
+		{
+			name:        "SAST finding accepts assessment_result",
+			findingType: "SAST",
+			raw: map[string]any{
+				"message":  "SQL injection in handler",
+				"rule_id":  "java:S1234",
+				"severity": "HIGH",
+				"location": "src/main/Handler.java",
+				"assessment_result": map[string]any{
+					"effective_status": "ASSESSMENT_STATUS_UNDER_INVESTIGATION",
+					"assessments": []any{
+						map[string]any{
+							"id":     "11111111-1111-1111-1111-111111111111",
+							"status": "ASSESSMENT_STATUS_UNDER_INVESTIGATION",
+						},
+					},
+				},
+			},
+			checkFn: func(t *testing.T, msg interface{}) {
+				t.Helper()
+				f, ok := msg.(*v1.PolicySASTFinding)
+				require.True(t, ok)
+				require.NotNil(t, f.AssessmentResult)
+				assert.Equal(t, "ASSESSMENT_STATUS_UNDER_INVESTIGATION", f.GetAssessmentResult().GetEffectiveStatus())
+				require.Len(t, f.GetAssessmentResult().GetAssessments(), 1)
+				assert.Equal(t, "11111111-1111-1111-1111-111111111111", f.GetAssessmentResult().GetAssessments()[0].GetId())
+			},
+		},
+		{
+			name:        "license violation finding accepts assessment_result",
+			findingType: "LICENSE_VIOLATION",
+			raw: map[string]any{
+				"message":        "Banned license GPL-3.0",
+				"component_name": "lodash",
+				"license_id":     "GPL-3.0",
+				"package_purl":   "pkg:npm/lodash@4.17.21",
+				"assessment_result": map[string]any{
+					"effective_status": "ASSESSMENT_STATUS_NOT_AFFECTED",
+					"assessments": []any{
+						map[string]any{
+							"id":     "22222222-2222-2222-2222-222222222222",
+							"status": "ASSESSMENT_STATUS_NOT_AFFECTED",
+							"scope":  "ASSESSMENT_SCOPE_PROJECT_VERSION",
+						},
+					},
+				},
+			},
+			checkFn: func(t *testing.T, msg interface{}) {
+				t.Helper()
+				f, ok := msg.(*v1.PolicyLicenseViolationFinding)
+				require.True(t, ok)
+				require.NotNil(t, f.AssessmentResult)
+				require.Len(t, f.GetAssessmentResult().GetAssessments(), 1)
+				a := f.GetAssessmentResult().GetAssessments()[0]
+				assert.Equal(t, "22222222-2222-2222-2222-222222222222", a.GetId())
+				assert.Equal(t, "ASSESSMENT_SCOPE_PROJECT_VERSION", a.GetScope())
+			},
+		},
+		{
+			name:        "assessment with missing required id fails validation",
+			findingType: "VULNERABILITY",
+			raw: map[string]any{
+				"message":      "Found CVE-2024-1234",
+				"external_id":  "CVE-2024-1234",
+				"package_purl": "pkg:golang/example.com/lib@v1.0.0",
+				"severity":     "CRITICAL",
+				"assessment_result": map[string]any{
+					"effective_status": "ASSESSMENT_STATUS_NOT_AFFECTED",
+					"assessments": []any{
+						map[string]any{
+							// missing "id"
+							"status": "ASSESSMENT_STATUS_NOT_AFFECTED",
+						},
+					},
+				},
+			},
+			wantErr: "finding validation failed",
+		},
+		{
+			name:        "assessment with non-uuid id fails validation",
+			findingType: "VULNERABILITY",
+			raw: map[string]any{
+				"message":      "Found CVE-2024-1234",
+				"external_id":  "CVE-2024-1234",
+				"package_purl": "pkg:golang/example.com/lib@v1.0.0",
+				"severity":     "CRITICAL",
+				"assessment_result": map[string]any{
+					"effective_status": "ASSESSMENT_STATUS_NOT_AFFECTED",
+					"assessments": []any{
+						map[string]any{
+							"id":     "not-a-uuid",
+							"status": "ASSESSMENT_STATUS_NOT_AFFECTED",
+						},
+					},
+				},
+			},
+			wantErr: "finding validation failed",
+		},
+		{
+			name:        "assessment with unknown ui-only fields is accepted (DiscardUnknown drops them)",
+			findingType: "VULNERABILITY",
+			raw: map[string]any{
+				"message":      "Found CVE-2024-1234",
+				"external_id":  "CVE-2024-1234",
+				"package_purl": "pkg:golang/example.com/lib@v1.0.0",
+				"severity":     "CRITICAL",
+				"assessment_result": map[string]any{
+					"effective_status": "ASSESSMENT_STATUS_NOT_AFFECTED",
+					"assessments": []any{
+						map[string]any{
+							"id":                 "33333333-3333-3333-3333-333333333333",
+							"status":             "ASSESSMENT_STATUS_NOT_AFFECTED",
+							"scope":              "ASSESSMENT_SCOPE_PROJECT",
+							"remediation_pr_url": "https://github.com/example/repo/pull/42",
+							"confidence_breakdown": map[string]any{
+								"schema_version": "2",
+							},
+						},
+					},
+				},
+			},
+			checkFn: func(t *testing.T, msg interface{}) {
+				t.Helper()
+				f, ok := msg.(*v1.PolicyVulnerabilityFinding)
+				require.True(t, ok)
+				require.NotNil(t, f.AssessmentResult)
+				require.Len(t, f.GetAssessmentResult().GetAssessments(), 1)
+				assert.Equal(t, "33333333-3333-3333-3333-333333333333", f.GetAssessmentResult().GetAssessments()[0].GetId())
+			},
+		},
+		{
 			name:        "unknown finding type",
 			findingType: "UNKNOWN",
 			raw:         map[string]any{"message": "test"},
@@ -279,6 +458,35 @@ func TestSetViolationFinding(t *testing.T) {
 				f := v.GetVulnerability()
 				require.NotNil(t, f)
 				assert.Equal(t, "CVE-2024-1", f.GetExternalId())
+			},
+		},
+		{
+			name:        "set vulnerability finding with assessment_result",
+			findingType: "VULNERABILITY",
+			finding: &v1.PolicyVulnerabilityFinding{
+				Message:     "test",
+				ExternalId:  "CVE-2024-1",
+				PackagePurl: "pkg:npm/foo@1.0",
+				Severity:    "HIGH",
+				AssessmentResult: &v1.PolicyAssessmentResult{
+					EffectiveStatus: "ASSESSMENT_STATUS_NOT_AFFECTED",
+					Assessments: []*v1.PolicyAssessment{
+						{
+							Id:     "24e0e054-5cd0-49d3-92bb-908b8f7159d4",
+							Status: "ASSESSMENT_STATUS_NOT_AFFECTED",
+							Scope:  "ASSESSMENT_SCOPE_PROJECT",
+						},
+					},
+				},
+			},
+			checkFn: func(t *testing.T, v *v1.PolicyEvaluation_Violation) {
+				t.Helper()
+				f := v.GetVulnerability()
+				require.NotNil(t, f)
+				require.NotNil(t, f.GetAssessmentResult())
+				assert.Equal(t, "ASSESSMENT_STATUS_NOT_AFFECTED", f.GetAssessmentResult().GetEffectiveStatus())
+				require.Len(t, f.GetAssessmentResult().GetAssessments(), 1)
+				assert.Equal(t, "24e0e054-5cd0-49d3-92bb-908b8f7159d4", f.GetAssessmentResult().GetAssessments()[0].GetId())
 			},
 		},
 		{

--- a/pkg/policies/policies.go
+++ b/pkg/policies/policies.go
@@ -808,6 +808,16 @@ func splitArgs(s string) []string {
 	return result
 }
 
+// extractSuppress pulls the optional "suppress" boolean from a structured
+// rego finding. Returns false for plain-string violations or when absent.
+func extractSuppress(raw map[string]any) bool {
+	if raw == nil {
+		return false
+	}
+	v, _ := raw["suppress"].(bool)
+	return v
+}
+
 func engineEvaluationsToAPIViolations(results []*engine.EvaluationResult, findingType string) ([]*v12.PolicyEvaluation_Violation, []string, error) {
 	res := make([]*v12.PolicyEvaluation_Violation, 0)
 	var warnings []string
@@ -817,8 +827,9 @@ func engineEvaluationsToAPIViolations(results []*engine.EvaluationResult, findin
 	for _, r := range results {
 		for _, v := range r.Violations {
 			apiV := &v12.PolicyEvaluation_Violation{
-				Subject: v.Subject,
-				Message: v.Violation,
+				Subject:  v.Subject,
+				Message:  v.Violation,
+				Suppress: extractSuppress(v.RawFinding),
 			}
 
 			hasStructuredData := v.RawFinding != nil

--- a/pkg/policies/policies_test.go
+++ b/pkg/policies/policies_test.go
@@ -1712,6 +1712,51 @@ func (s *testSuite) TestEngineEvaluationsToAPIViolationsBehaviorMatrix() {
 			violations:     []*engine.PolicyViolation{},
 			wantViolations: 0,
 		},
+		{
+			name:        "structured violation with suppress=true round-trips to API Violation",
+			findingType: "VULNERABILITY",
+			violations: []*engine.PolicyViolation{
+				{Subject: "p1", Violation: "vuln found", RawFinding: map[string]any{
+					"message":      "vuln found",
+					"external_id":  "CVE-2024-1234",
+					"package_purl": "pkg:golang/example.com/lib@v1.0.0",
+					"severity":     "HIGH",
+					"suppress":     true,
+				}},
+			},
+			wantViolations: 1,
+			checkFn: func(violations []*v1.PolicyEvaluation_Violation) {
+				s.True(violations[0].GetSuppress())
+				s.Equal("CVE-2024-1234", violations[0].GetVulnerability().GetExternalId())
+			},
+		},
+		{
+			name:        "structured violation without suppress defaults to false",
+			findingType: "VULNERABILITY",
+			violations: []*engine.PolicyViolation{
+				{Subject: "p1", Violation: "vuln found", RawFinding: map[string]any{
+					"message":      "vuln found",
+					"external_id":  "CVE-2024-1234",
+					"package_purl": "pkg:golang/example.com/lib@v1.0.0",
+					"severity":     "HIGH",
+				}},
+			},
+			wantViolations: 1,
+			checkFn: func(violations []*v1.PolicyEvaluation_Violation) {
+				s.False(violations[0].GetSuppress())
+			},
+		},
+		{
+			name:        "plain string violation has suppress=false",
+			findingType: "",
+			violations: []*engine.PolicyViolation{
+				{Subject: "p1", Violation: "plain string"},
+			},
+			wantViolations: 1,
+			checkFn: func(violations []*v1.PolicyEvaluation_Violation) {
+				s.False(violations[0].GetSuppress())
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

Extends `PolicyVulnerabilityFinding`, `PolicySASTFinding` and `PolicyLicenseViolationFinding` with an optional `PolicyAssessmentResult` field, plus a new `PolicyAssessment` message capturing `id`, `status` and `scope`. The policy engine populates these via the `chainloop.effective_assessments` builtin; the result round-trips through `ValidateFinding` into the CAS-stored `PolicyEvaluationBundle` with no other code changes thanks to existing `protojson` + `DiscardUnknown` handling.

This is the OSS-side schema change for Spec 051 Phase 1.c. Rego policy edits to populate the new fields land in a follow-up PR.

Replaces #3093.

> Disclosure: AI-assisted using Claude Code.