### PR TITLE
feat(audit): emit OrgUserRemoved when admins remove members

### DIFF
--- a/app/controlplane/pkg/auditor/events/organization.go
+++ b/app/controlplane/pkg/auditor/events/organization.go
@@ -134,8 +134,8 @@ func (p *OrgUserRemoved) Description() string {
 }
 
 func (p *OrgUserRemoved) ActionInfo() (json.RawMessage, error) {
-	if p.OrgName == "" || p.OrgID == nil || p.RemovedUserID == uuid.Nil {
-		return nil, errors.New("org name, org id and removed user id are required")
+	if p.OrgName == "" || p.OrgID == nil || p.RemovedUserID == uuid.Nil || p.RemovedUserEmail == "" {
+		return nil, errors.New("org name, org id, removed user id and removed user email are required")
 	}
 
 	return json.Marshal(&p)

--- a/app/controlplane/pkg/auditor/events/organization.go
+++ b/app/controlplane/pkg/auditor/events/organization.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2024 The Chainloop Authors.
+// Copyright 2024-2026 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,15 +27,17 @@ import (
 var (
 	_ auditor.LogEntry = (*OrgUserJoined)(nil)
 	_ auditor.LogEntry = (*OrgUserLeft)(nil)
+	_ auditor.LogEntry = (*OrgUserRemoved)(nil)
 	_ auditor.LogEntry = (*OrgCreated)(nil)
 )
 
 const (
-	OrgType                    auditor.TargetType = "Organization"
-	userJoinedOrgActionType    string             = "UserJoined"
-	userLeftOrgActionType      string             = "UserLeft"
-	userInvitedToOrgActionType string             = "InvitationCreated"
-	orgCreatedActionType       string             = "OrganizationCreated"
+	OrgType                      auditor.TargetType = "Organization"
+	userJoinedOrgActionType      string             = "UserJoined"
+	userLeftOrgActionType        string             = "UserLeft"
+	userRemovedFromOrgActionType string             = "UserRemoved"
+	userInvitedToOrgActionType   string             = "InvitationCreated"
+	orgCreatedActionType         string             = "OrganizationCreated"
 )
 
 type OrgBase struct {
@@ -114,6 +116,29 @@ func (p *OrgUserLeft) ActionType() string {
 
 func (p *OrgUserLeft) Description() string {
 	return fmt.Sprintf("%s has left the organization %s", auditor.GetActorIdentifier(), p.OrgName)
+}
+
+// OrgUserRemoved is emitted when an admin removes another user from an org.
+type OrgUserRemoved struct {
+	*OrgBase
+	RemovedUserID    uuid.UUID `json:"removed_user_id,omitempty"`
+	RemovedUserEmail string    `json:"removed_user_email,omitempty"`
+}
+
+func (p *OrgUserRemoved) ActionType() string {
+	return userRemovedFromOrgActionType
+}
+
+func (p *OrgUserRemoved) Description() string {
+	return fmt.Sprintf("%s removed %s from the organization %s", auditor.GetActorIdentifier(), p.RemovedUserEmail, p.OrgName)
+}
+
+func (p *OrgUserRemoved) ActionInfo() (json.RawMessage, error) {
+	if p.OrgName == "" || p.OrgID == nil || p.RemovedUserID == uuid.Nil {
+		return nil, errors.New("org name, org id and removed user id are required")
+	}
+
+	return json.Marshal(&p)
 }
 
 // user got invited to the organization

--- a/app/controlplane/pkg/auditor/events/organization_test.go
+++ b/app/controlplane/pkg/auditor/events/organization_test.go
@@ -1,0 +1,91 @@
+//
+// Copyright 2026 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/auditor"
+	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/auditor/events"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOrganizationEvents(t *testing.T) {
+	actorUUID, err := uuid.Parse("1089bb36-e27b-428b-8009-d015c8737c54")
+	require.NoError(t, err)
+	orgUUID, err := uuid.Parse("2089bb36-e27b-428b-8009-d015c8737c54")
+	require.NoError(t, err)
+	removedUserUUID, err := uuid.Parse("3089bb36-e27b-428b-8009-d015c8737c54")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		event    auditor.LogEntry
+		expected string
+	}{
+		{
+			name: "User removed by admin",
+			event: &events.OrgUserRemoved{
+				OrgBase: &events.OrgBase{
+					OrgID:   uuidPtr(orgUUID),
+					OrgName: "cyberdyne",
+				},
+				RemovedUserID:    removedUserUUID,
+				RemovedUserEmail: "sarah@cyberdyne.io",
+			},
+			expected: "testdata/organization/user_removed.json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := []auditor.GeneratorOption{
+				auditor.WithActor(auditor.ActorTypeUser, actorUUID, testEmail, testName),
+				auditor.WithOrgID(orgUUID),
+			}
+
+			eventPayload, err := auditor.GenerateAuditEvent(tt.event, opts...)
+			require.NoError(t, err)
+
+			want, err := json.MarshalIndent(eventPayload.Data, "", "  ")
+			require.NoError(t, err)
+
+			if updateGolden {
+				err := os.MkdirAll(filepath.Dir(tt.expected), 0750)
+				require.NoError(t, err)
+				err = os.WriteFile(filepath.Clean(tt.expected), want, 0600)
+				require.NoError(t, err)
+			}
+
+			gotRaw, err := os.ReadFile(filepath.Clean(tt.expected))
+			require.NoError(t, err)
+
+			var gotPayload auditor.AuditEventPayload
+			err = json.Unmarshal(gotRaw, &gotPayload)
+			require.NoError(t, err)
+			got, err := json.MarshalIndent(gotPayload, "", "  ")
+			require.NoError(t, err)
+
+			assert.Equal(t, string(want), string(got))
+		})
+	}
+}

--- a/app/controlplane/pkg/auditor/events/testdata/organization/user_removed.json
+++ b/app/controlplane/pkg/auditor/events/testdata/organization/user_removed.json
@@ -1,0 +1,18 @@
+{
+  "ActionType": "UserRemoved",
+  "TargetType": "Organization",
+  "TargetID": "2089bb36-e27b-428b-8009-d015c8737c54",
+  "ActorType": "USER",
+  "ActorID": "1089bb36-e27b-428b-8009-d015c8737c54",
+  "ActorEmail": "john@cyberdyne.io",
+  "ActorName": "John Connor",
+  "OrgID": "2089bb36-e27b-428b-8009-d015c8737c54",
+  "Description": "John Connor removed sarah@cyberdyne.io from the organization cyberdyne",
+  "Info": {
+    "org_id": "2089bb36-e27b-428b-8009-d015c8737c54",
+    "org_name": "cyberdyne",
+    "removed_user_id": "3089bb36-e27b-428b-8009-d015c8737c54",
+    "removed_user_email": "sarah@cyberdyne.io"
+  },
+  "Digest": "sha256:853c98ec28f3280ebf859cbd8e422b5924a7113907922ca5fae1b0628f688ac5"
+}

--- a/app/controlplane/pkg/biz/membership.go
+++ b/app/controlplane/pkg/biz/membership.go
@@ -143,6 +143,20 @@ func (uc *MembershipUseCase) DeleteOther(ctx context.Context, orgID, userID, mem
 		return fmt.Errorf("failed to delete membership: %w", err)
 	}
 
+	removedUserUUID, err := uuid.Parse(m.User.ID)
+	if err != nil {
+		uc.logger.Warnw("msg", "could not parse removed user id for audit event", "user_id", m.User.ID, "err", err)
+	} else {
+		uc.auditor.Dispatch(ctx, &events.OrgUserRemoved{
+			OrgBase: &events.OrgBase{
+				OrgID:   &m.OrganizationID,
+				OrgName: m.Org.Name,
+			},
+			RemovedUserID:    removedUserUUID,
+			RemovedUserEmail: m.User.Email,
+		}, &m.OrganizationID)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Added a new `OrgUserRemoved` audit event and dispatched from `MembershipUseCase.DeleteOther`.