### PR TITLE
fix(migrations): upgrade atlas image to clear CVE-2026-42501

### DIFF
--- a/app/controlplane/Dockerfile.migrations
+++ b/app/controlplane/Dockerfile.migrations
@@ -1,9 +1,9 @@
 # Container image built by go-releaser that's used to run migrations against the database during deployment
 # See https://atlasgo.io/guides/deploying/image
-# from: arigaio/atlas:latest (v1.2.1-29c7cc3-canary)
-# docker run arigaio/atlas@sha256:c9a0e6135c1f9c2761f5ef08b1db7a033ee37eb23a68173fd3909e231fdc2919 version
-# atlas version v1.2.1-29c7cc3-canary
-FROM arigaio/atlas@sha256:c9a0e6135c1f9c2761f5ef08b1db7a033ee37eb23a68173fd3909e231fdc2919 as base
+# from: arigaio/atlas:latest (v1.2.1-3ca392d-canary)
+# docker run arigaio/atlas@sha256:29668819bfe510e06ccf84cfbf795ad504a0b310a9edbb695c1cd277edac11cb version
+# atlas version v1.2.1-3ca392d-canary
+FROM arigaio/atlas@sha256:29668819bfe510e06ccf84cfbf795ad504a0b310a9edbb695c1cd277edac11cb as base
 
 FROM scratch
 # Update permissions to make it readable by the user


### PR DESCRIPTION
## Summary

- Upgrade `arigaio/atlas` base image in `app/controlplane/Dockerfile.migrations` to `v1.2.1-3ca392d-canary` (digest `sha256:29668819bfe510e06ccf84cfbf795ad504a0b310a9edbb695c1cd277edac11cb`, currently tagged as `:latest`).
- Clears 11 fixable Go stdlib CVEs (including High-severity `CVE-2026-42501`) that remain in the previous canary pin on `main` (`v1.2.1-29c7cc3-canary`, built on go1.26.2).
- Verified with `grype` against the new digest: no fixable vulnerabilities reported.

_AI disclosure: this contribution was assisted by Claude Code._