### PR TITLE
feat(dagger): add no-strict-validation and debug flags to attestation add

### DIFF
--- a/extras/dagger/main.go
+++ b/extras/dagger/main.go
@@ -391,6 +391,12 @@ func (att *Attestation) AddRawEvidence(
 	// "key1=value1,key2=value2"
 	// +optional
 	annotations []string,
+	// Skip strict schema validation for structured materials (SBOM_CYCLONEDX_JSON, OPENAPI_SPEC, ASYNCAPI_SPEC)
+	// +optional
+	noStrictValidation bool,
+	// Enable debug/verbose logging
+	// +optional
+	debug bool,
 ) (*Attestation, error) {
 	args := []string{
 		"attestation", "add",
@@ -414,6 +420,14 @@ func (att *Attestation) AddRawEvidence(
 		args = append(args,
 			"--annotation", annotation,
 		)
+	}
+
+	if noStrictValidation {
+		args = append(args, "--no-strict-validation")
+	}
+
+	if debug {
+		args = append(args, "--debug")
 	}
 
 	_, err := att.
@@ -441,6 +455,12 @@ func (att *Attestation) AddFileEvidence(
 	// "key1=value1,key2=value2"
 	// +optional
 	annotations []string,
+	// Skip strict schema validation for structured materials (SBOM_CYCLONEDX_JSON, OPENAPI_SPEC, ASYNCAPI_SPEC)
+	// +optional
+	noStrictValidation bool,
+	// Enable debug/verbose logging
+	// +optional
+	debug bool,
 ) (*Attestation, error) {
 	filename, err := path.Name(ctx)
 	if err != nil {
@@ -471,6 +491,14 @@ func (att *Attestation) AddFileEvidence(
 		args = append(args,
 			"--name", name,
 		)
+	}
+
+	if noStrictValidation {
+		args = append(args, "--no-strict-validation")
+	}
+
+	if debug {
+		args = append(args, "--debug")
 	}
 
 	_, err = att.


### PR DESCRIPTION
This pull request adds new options to the `AddRawEvidence` and `AddFileEvidence` methods in `extras/dagger/main.go`, allowing users to skip strict schema validation and enable debug logging when adding evidence. These enhancements provide more flexibility and control over the attestation process.

New evidence handling options:

* Added `noStrictValidation` parameter to both `AddRawEvidence` and `AddFileEvidence` methods, allowing users to skip strict schema validation for certain structured materials (e.g., SBOM_CYCLONEDX_JSON, OPENAPI_SPEC, ASYNCAPI_SPEC). When set, the `--no-strict-validation` flag is passed to the underlying command. [[1]](diffhunk://#diff-3c3d22e7e56b22d040f0298fee1b79c30493a0bf441cb5b5a7e8163946de4d3fR394-R399) [[2]](diffhunk://#diff-3c3d22e7e56b22d040f0298fee1b79c30493a0bf441cb5b5a7e8163946de4d3fR458-R463) [[3]](diffhunk://#diff-3c3d22e7e56b22d040f0298fee1b79c30493a0bf441cb5b5a7e8163946de4d3fR425-R432) [[4]](diffhunk://#diff-3c3d22e7e56b22d040f0298fee1b79c30493a0bf441cb5b5a7e8163946de4d3fR496-R503)
* Added `debug` parameter to both methods, enabling verbose/debug logging by passing the `--debug` flag when set. [[1]](diffhunk://#diff-3c3d22e7e56b22d040f0298fee1b79c30493a0bf441cb5b5a7e8163946de4d3fR394-R399) [[2]](diffhunk://#diff-3c3d22e7e56b22d040f0298fee1b79c30493a0bf441cb5b5a7e8163946de4d3fR458-R463) [[3]](diffhunk://#diff-3c3d22e7e56b22d040f0298fee1b79c30493a0bf441cb5b5a7e8163946de4d3fR425-R432) [[4]](diffhunk://#diff-3c3d22e7e56b22d040f0298fee1b79c30493a0bf441cb5b5a7e8163946de4d3fR496-R503)