### PR TITLE
feat(integrations): mark SMTP password and Dependency-Track API key as password

### DIFF
--- a/app/controlplane/plugins/core/dependency-track/v1/README.md
+++ b/app/controlplane/plugins/core/dependency-track/v1/README.md
@@ -10,7 +10,7 @@ See https://docs.chainloop.dev/guides/dependency-track/
 |Field|Type|Required|Description|
 |---|---|---|---|
 |allowAutoCreate|boolean|no|Support of creating projects on demand|
-|apiKey|string|yes|The API key to use for authentication|
+|apiKey|string (password)|yes|The API key to use for authentication|
 |instanceURI|string (uri)|yes|The URL of the Dependency-Track instance|
 
 ```json
@@ -25,6 +25,7 @@ See https://docs.chainloop.dev/guides/dependency-track/
     },
     "apiKey": {
       "type": "string",
+      "format": "password",
       "description": "The API key to use for authentication"
     },
     "allowAutoCreate": {

--- a/app/controlplane/plugins/core/dependency-track/v1/extension.go
+++ b/app/controlplane/plugins/core/dependency-track/v1/extension.go
@@ -38,7 +38,7 @@ type DependencyTrack struct {
 type registrationRequest struct {
 	// The URL of the Dependency-Track instance
 	InstanceURI string `json:"instanceURI" jsonschema:"format=uri,description=The URL of the Dependency-Track instance"`
-	APIKey      string `json:"apiKey" jsonschema:"description=The API key to use for authentication"`
+	APIKey      string `json:"apiKey" jsonschema:"format=password,description=The API key to use for authentication"`
 	// Support the option to automatically create projects if requested (optional)
 	AllowAutoCreate bool `json:"allowAutoCreate,omitempty" jsonschema:"description=Support of creating projects on demand"`
 }

--- a/app/controlplane/plugins/core/smtp/v1/README.md
+++ b/app/controlplane/plugins/core/smtp/v1/README.md
@@ -31,7 +31,7 @@ Starting now, every time a workflow run occurs, an email notification will be se
 |---|---|---|---|
 |from|string (email)|yes|The email address of the sender.|
 |host|string|yes|The host to use for the SMTP authentication.|
-|password|string|yes|The password to use for the SMTP authentication.|
+|password|string (password)|yes|The password to use for the SMTP authentication.|
 |port|string|yes|The port to use for the SMTP authentication|
 |to|string (email)|yes|The email address to send the email to.|
 |user|string|yes|The username to use for the SMTP authentication.|
@@ -58,6 +58,7 @@ Starting now, every time a workflow run occurs, an email notification will be se
     },
     "password": {
       "type": "string",
+      "format": "password",
       "description": "The password to use for the SMTP authentication."
     },
     "host": {

--- a/app/controlplane/plugins/core/smtp/v1/extension.go
+++ b/app/controlplane/plugins/core/smtp/v1/extension.go
@@ -33,7 +33,7 @@ type registrationRequest struct {
 	To       string `json:"to" jsonschema:"format=email,description=The email address to send the email to."`
 	From     string `json:"from" jsonschema:"format=email,description=The email address of the sender."`
 	User     string `json:"user" jsonschema:"minLength=1,description=The username to use for the SMTP authentication."`
-	Password string `json:"password" jsonschema:"description=The password to use for the SMTP authentication."`
+	Password string `json:"password" jsonschema:"format=password,description=The password to use for the SMTP authentication."`
 	Host     string `json:"host" jsonschema:"description=The host to use for the SMTP authentication."`
 	// TODO: Make the port an integer
 	Port string `json:"port" jsonschema:"description=The port to use for the SMTP authentication"`


### PR DESCRIPTION
Tag the SMTP password and Dependency-Track API key registration fields with `format=password`.