### PR TITLE
feat(controlplane): increase long-lived user token expiration to 1 week

### DIFF
--- a/app/controlplane/internal/service/auth.go
+++ b/app/controlplane/internal/service/auth.go
@@ -56,9 +56,9 @@ const (
 	// default
 	shortLivedDuration = 10 * time.Second
 	// opt-in
-	longLivedDuration = 24 * time.Hour
+	longLivedDuration = 7 * 24 * time.Hour
 	// dev only
-	devUserDuration = 30 * longLivedDuration
+	devUserDuration = 30 * 24 * time.Hour
 )
 
 type oauthResp struct {


### PR DESCRIPTION
## Summary
- Bump the opt-in long-lived user token duration from 24h to 7 days
- Pin the dev-mode token duration to an explicit 30 days so it no longer scales with the long-lived constant

Assisted-by: Claude Code