### PR TITLE
fix(controlplane): allow workflow-scoped API tokens in find-or-create

### DIFF
--- a/app/controlplane/internal/service/attestation.go
+++ b/app/controlplane/internal/service/attestation.go
@@ -757,8 +757,8 @@ func (s *AttestationService) FindOrCreateWorkflow(ctx context.Context, req *cpAP
 		return nil, errors.NotFound("not found", "neither robot account nor API token found")
 	}
 
-	// Workflow-scoped API tokens cannot create or look up other workflows.
-	if token := entities.CurrentAPIToken(ctx); token != nil && token.WorkflowID != nil {
+	// Workflow-scoped API tokens may only target their own workflow.
+	if token := entities.CurrentAPIToken(ctx); token != nil && token.WorkflowName != nil && *token.WorkflowName != req.GetWorkflowName() {
 		return nil, errors.Forbidden("forbidden", "API token is workflow-scoped and cannot create or look up other workflows")
 	}
 


### PR DESCRIPTION
## Summary

`AttestationService.FindOrCreateWorkflow` rejected every workflow-scoped API token (`token.WorkflowID != nil`), so a token issued for workflow `X` could not even call `FindOrCreate` against `X` itself. The check now compares the request's workflow name to the token's own `WorkflowName` and only forbids cross-workflow calls.

This contribution was made with the assistance of AI (Claude Code).