### PR TITLE
perf: use hex.EncodeToString instead of fmt.Sprintf("%x", ...)

### DIFF
--- a/app/artifact-cas/internal/service/bytestream.go
+++ b/app/artifact-cas/internal/service/bytestream.go
@@ -21,6 +21,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/gob"
+	"encoding/hex"
 	"fmt"
 	"hash"
 	"io"
@@ -326,5 +327,5 @@ func (sw *streamWriter) Write(data []byte) (int, error) {
 
 // GetChecksum retrieves the sha256 checksum of the read contents
 func (sw *streamWriter) GetChecksum() string {
-	return fmt.Sprintf("%x", sw.gotChecksum.Sum(nil))
+	return hex.EncodeToString(sw.gotChecksum.Sum(nil))
 }

--- a/app/artifact-cas/internal/service/download.go
+++ b/app/artifact-cas/internal/service/download.go
@@ -18,6 +18,7 @@ package service
 import (
 	"bytes"
 	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
@@ -125,7 +126,7 @@ func (s *DownloadService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Verify the checksum
-	if got, want := fmt.Sprintf("%x", gotChecksum.Sum(nil)), wantChecksum.Hex; got != want {
+	if got, want := hex.EncodeToString(gotChecksum.Sum(nil)), wantChecksum.Hex; got != want {
 		msg := fmt.Sprintf("checksums mismatch: got: %s, want: %s", got, want)
 		s.log.Info(msg)
 		http.Error(w, msg, http.StatusUnauthorized)

--- a/app/cli/cmd/root.go
+++ b/app/cli/cmd/root.go
@@ -18,6 +18,7 @@ package cmd
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -490,7 +491,8 @@ func extractCmdLineFromCommand(cmd *cobra.Command) string {
 // hashControlPlaneURL returns a hash of the control plane URL
 func hashControlPlaneURL() (url string, hash string) {
 	url = viper.GetString(confOptions.controlplaneAPI.viperKey)
-	return url, fmt.Sprintf("%x", sha256.Sum256([]byte(url)))
+	sum := sha256.Sum256([]byte(url))
+	return url, hex.EncodeToString(sum[:])
 }
 
 func apiInsecure() bool {

--- a/app/cli/cmd/version.go
+++ b/app/cli/cmd/version.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 The Chainloop Authors.
+// Copyright 2023-2026 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package cmd
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"hash"
 	"io"
@@ -88,7 +89,7 @@ func executableInfo() (*info, error) {
 
 	return &info{
 		Version: Version,
-		Digest:  fmt.Sprintf("sha256:%x", h.Sum(nil)),
+		Digest:  "sha256:" + hex.EncodeToString(h.Sum(nil)),
 	}, nil
 }
 

--- a/app/cli/pkg/action/artifact_download.go
+++ b/app/cli/pkg/action/artifact_download.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2023-2025 The Chainloop Authors.
+// Copyright 2023-2026 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package action
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -106,7 +107,7 @@ func (a *ArtifactDownload) Run(downloadPath, outputFile, digest string) error {
 		return errors.New("problem downloading file")
 	}
 
-	if got, want := fmt.Sprintf("%x", hash.Sum(nil)), h.Hex; got != want {
+	if got, want := hex.EncodeToString(hash.Sum(nil)), h.Hex; got != want {
 		return fmt.Errorf("checksums mismatch: got: %s, expected: %s", got, want)
 	}
 

--- a/app/cli/pkg/action/attestation_push.go
+++ b/app/cli/pkg/action/attestation_push.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -348,8 +349,9 @@ func uploadPolicyEvaluationsBundle(ctx context.Context, evaluations []*v1.Policy
 		return nil, fmt.Errorf("marshaling policy evaluation bundle: %w", err)
 	}
 
-	hexDigest := fmt.Sprintf("%x", sha256.Sum256(data))
-	digest := fmt.Sprintf("sha256:%s", hexDigest)
+	sum := sha256.Sum256(data)
+	hexDigest := hex.EncodeToString(sum[:])
+	digest := "sha256:" + hexDigest
 
 	if _, err := uploader.Upload(ctx, bytes.NewReader(data), "policy-evaluations.json", digest); err != nil {
 		return nil, fmt.Errorf("uploading policy evaluation bundle: %w", err)

--- a/app/controlplane/pkg/biz/signing.go
+++ b/app/controlplane/pkg/biz/signing.go
@@ -22,6 +22,7 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net/url"
@@ -229,7 +230,8 @@ func (s *SigningUseCase) GetTrustedRoot(ctx context.Context) (*TrustedRoot, erro
 		if len(chain) == 0 {
 			continue
 		}
-		keyID := fmt.Sprintf("%x", sha256.Sum256(chain[0].SubjectKeyId))
+		keyIDSum := sha256.Sum256(chain[0].SubjectKeyId)
+		keyID := hex.EncodeToString(keyIDSum[:])
 		for _, cert := range chain {
 			pemCert, err := cryptoutils.MarshalCertificateToPEM(cert)
 			if err != nil {
@@ -244,7 +246,8 @@ func (s *SigningUseCase) GetTrustedRoot(ctx context.Context) (*TrustedRoot, erro
 			if len(authority.CertChain) == 0 {
 				continue
 			}
-			authorityKeyID := fmt.Sprintf("%x", sha256.Sum256(authority.CertChain[0].SubjectKeyId))
+			authorityKeyIDSum := sha256.Sum256(authority.CertChain[0].SubjectKeyId)
+			authorityKeyID := hex.EncodeToString(authorityKeyIDSum[:])
 			for _, cert := range authority.CertChain {
 				pemCert, err := cryptoutils.MarshalCertificateToPEM(cert)
 				if err != nil {

--- a/pkg/attestation/verifier/verifier.go
+++ b/pkg/attestation/verifier/verifier.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2025 The Chainloop Authors.
+// Copyright 2025-2026 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"crypto/x509"
+	"encoding/hex"
 	"errors"
 	"fmt"
 
@@ -67,7 +68,8 @@ func VerifyBundle(ctx context.Context, bundleBytes []byte, tr *TrustedRoot) erro
 		hasVerificationMaterial = true
 		signingCert := vc.Certificate()
 
-		aki := fmt.Sprintf("%x", sha256.Sum256(signingCert.AuthorityKeyId))
+		akiSum := sha256.Sum256(signingCert.AuthorityKeyId)
+		aki := hex.EncodeToString(akiSum[:])
 		chain, ok := tr.Keys[aki]
 		if !ok {
 			return fmt.Errorf("trusted root not found for signing key with AKI %s", aki)


### PR DESCRIPTION
## Summary

Replace `fmt.Sprintf("%x", ...)` hex-encoding calls with `hex.EncodeToString` across the CAS, CLI, control plane signing, and attestation verifier code paths.

`hex.EncodeToString` avoids the `fmt` reflection machinery and is roughly 5x faster, which matters on hot paths such as per-chunk checksum stringification in the CAS bytestream service and per-certificate key-ID derivation in signing and verification.
