### PR TITLE
ensure organization ID is always present for cas backend

### DIFF
--- a/app/controlplane/pkg/data/casbackend.go
+++ b/app/controlplane/pkg/data/casbackend.go
@@ -47,7 +47,7 @@ func (r *CASBackendRepo) List(ctx context.Context, orgID uuid.UUID) ([]*biz.CASB
 	ctx, span := otelx.Start(ctx, casBackendRepoTracer, "CASBackendRepo.List")
 	defer span.End()
 
-	backends, err := orgScopedQuery(r.data.DB, orgID).QueryCasBackends().WithOrganization().
+	backends, err := orgScopedQuery(r.data.DB, orgID).QueryCasBackends().
 		Where(casbackend.DeletedAtIsNil()).
 		Order(ent.Desc(casbackend.FieldCreatedAt)).
 		All(ctx)
@@ -68,7 +68,7 @@ func (r *CASBackendRepo) FindDefaultBackend(ctx context.Context, orgID uuid.UUID
 	ctx, span := otelx.Start(ctx, casBackendRepoTracer, "CASBackendRepo.FindDefaultBackend")
 	defer span.End()
 
-	backend, err := orgScopedQuery(r.data.DB, orgID).QueryCasBackends().WithOrganization().
+	backend, err := orgScopedQuery(r.data.DB, orgID).QueryCasBackends().
 		Where(casbackend.Default(true), casbackend.DeletedAtIsNil()).
 		Only(ctx)
 	if err != nil && !ent.IsNotFound(err) {
@@ -83,7 +83,7 @@ func (r *CASBackendRepo) FindFallbackBackend(ctx context.Context, orgID uuid.UUI
 	ctx, span := otelx.Start(ctx, casBackendRepoTracer, "CASBackendRepo.FindFallbackBackend")
 	defer span.End()
 
-	backend, err := orgScopedQuery(r.data.DB, orgID).QueryCasBackends().WithOrganization().
+	backend, err := orgScopedQuery(r.data.DB, orgID).QueryCasBackends().
 		Where(casbackend.Fallback(true), casbackend.DeletedAtIsNil()).
 		Only(ctx)
 	if err != nil && !ent.IsNotFound(err) {
@@ -98,7 +98,7 @@ func (r *CASBackendRepo) FindInlineBackend(ctx context.Context, orgID uuid.UUID)
 	ctx, span := otelx.Start(ctx, casBackendRepoTracer, "CASBackendRepo.FindInlineBackend")
 	defer span.End()
 
-	backend, err := orgScopedQuery(r.data.DB, orgID).QueryCasBackends().WithOrganization().
+	backend, err := orgScopedQuery(r.data.DB, orgID).QueryCasBackends().
 		Where(casbackend.ProviderEQ(biz.CASBackendInline), casbackend.DeletedAtIsNil()).
 		Only(ctx)
 	if err != nil && !ent.IsNotFound(err) {
@@ -264,7 +264,7 @@ func (r *CASBackendRepo) FindByID(ctx context.Context, id uuid.UUID) (*biz.CASBa
 	ctx, span := otelx.Start(ctx, casBackendRepoTracer, "CASBackendRepo.FindByID")
 	defer span.End()
 
-	backend, err := r.data.DB.CASBackend.Query().WithOrganization().
+	backend, err := r.data.DB.CASBackend.Query().
 		Where(casbackend.ID(id), casbackend.DeletedAtIsNil()).Only(ctx)
 	if err != nil && !ent.IsNotFound(err) {
 		return nil, err
@@ -281,7 +281,7 @@ func (r *CASBackendRepo) FindByIDInOrg(ctx context.Context, orgID, id uuid.UUID)
 	ctx, span := otelx.Start(ctx, casBackendRepoTracer, "CASBackendRepo.FindByIDInOrg")
 	defer span.End()
 
-	backend, err := orgScopedQuery(r.data.DB, orgID).QueryCasBackends().WithOrganization().
+	backend, err := orgScopedQuery(r.data.DB, orgID).QueryCasBackends().
 		Where(casbackend.ID(id), casbackend.DeletedAtIsNil()).Only(ctx)
 	if err != nil && !ent.IsNotFound(err) {
 		return nil, err
@@ -298,7 +298,6 @@ func (r *CASBackendRepo) FindByNameInOrg(ctx context.Context, orgID uuid.UUID, n
 
 	backend, err := orgScopedQuery(r.data.DB, orgID).
 		QueryCasBackends().
-		WithOrganization().
 		Where(casbackend.Name(name), casbackend.DeletedAtIsNil()).Only(ctx)
 	if err != nil {
 		if ent.IsNotFound(err) {
@@ -352,7 +351,6 @@ func (r *CASBackendRepo) ListBackends(ctx context.Context, defaultsOrFallbacks b
 	defer span.End()
 
 	query := r.data.DB.CASBackend.Query().
-		WithOrganization().
 		Where(casbackend.DeletedAtIsNil(),
 			casbackend.ProviderNEQ(biz.CASBackendInline),
 			casbackend.HasOrganizationWith(
@@ -406,10 +404,7 @@ func entCASBackendToBiz(backend *ent.CASBackend) *biz.CASBackend {
 		Limits:           limits,
 		Fallback:         backend.Fallback,
 		Managed:          backend.Managed,
-	}
-
-	if org := backend.Edges.Organization; org != nil {
-		r.OrganizationID = org.ID
+		OrganizationID:   backend.OrganizationCasBackends,
 	}
 
 	return r

--- a/app/controlplane/pkg/data/ent/casbackend.go
+++ b/app/controlplane/pkg/data/ent/casbackend.go
@@ -50,11 +50,12 @@ type CASBackend struct {
 	Managed bool `json:"managed,omitempty"`
 	// MaxBlobSizeBytes holds the value of the "max_blob_size_bytes" field.
 	MaxBlobSizeBytes int64 `json:"max_blob_size_bytes,omitempty"`
+	// OrganizationCasBackends holds the value of the "organization_cas_backends" field.
+	OrganizationCasBackends uuid.UUID `json:"organization_cas_backends,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the CASBackendQuery when eager-loading is set.
-	Edges                     CASBackendEdges `json:"edges"`
-	organization_cas_backends *uuid.UUID
-	selectValues              sql.SelectValues
+	Edges        CASBackendEdges `json:"edges"`
+	selectValues sql.SelectValues
 }
 
 // CASBackendEdges holds the relations/edges for other nodes in the graph.
@@ -101,10 +102,8 @@ func (*CASBackend) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullString)
 		case casbackend.FieldCreatedAt, casbackend.FieldUpdatedAt, casbackend.FieldValidatedAt, casbackend.FieldDeletedAt:
 			values[i] = new(sql.NullTime)
-		case casbackend.FieldID:
+		case casbackend.FieldID, casbackend.FieldOrganizationCasBackends:
 			values[i] = new(uuid.UUID)
-		case casbackend.ForeignKeys[0]: // organization_cas_backends
-			values[i] = &sql.NullScanner{S: new(uuid.UUID)}
 		default:
 			values[i] = new(sql.UnknownType)
 		}
@@ -216,12 +215,11 @@ func (_m *CASBackend) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				_m.MaxBlobSizeBytes = value.Int64
 			}
-		case casbackend.ForeignKeys[0]:
-			if value, ok := values[i].(*sql.NullScanner); !ok {
+		case casbackend.FieldOrganizationCasBackends:
+			if value, ok := values[i].(*uuid.UUID); !ok {
 				return fmt.Errorf("unexpected type %T for field organization_cas_backends", values[i])
-			} else if value.Valid {
-				_m.organization_cas_backends = new(uuid.UUID)
-				*_m.organization_cas_backends = *value.S.(*uuid.UUID)
+			} else if value != nil {
+				_m.OrganizationCasBackends = *value
 			}
 		default:
 			_m.selectValues.Set(columns[i], values[i])
@@ -313,6 +311,9 @@ func (_m *CASBackend) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("max_blob_size_bytes=")
 	builder.WriteString(fmt.Sprintf("%v", _m.MaxBlobSizeBytes))
+	builder.WriteString(", ")
+	builder.WriteString("organization_cas_backends=")
+	builder.WriteString(fmt.Sprintf("%v", _m.OrganizationCasBackends))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/app/controlplane/pkg/data/ent/casbackend/casbackend.go
+++ b/app/controlplane/pkg/data/ent/casbackend/casbackend.go
@@ -47,6 +47,8 @@ const (
 	FieldManaged = "managed"
 	// FieldMaxBlobSizeBytes holds the string denoting the max_blob_size_bytes field in the database.
 	FieldMaxBlobSizeBytes = "max_blob_size_bytes"
+	// FieldOrganizationCasBackends holds the string denoting the organization_cas_backends field in the database.
+	FieldOrganizationCasBackends = "organization_cas_backends"
 	// EdgeOrganization holds the string denoting the organization edge name in mutations.
 	EdgeOrganization = "organization"
 	// EdgeWorkflowRun holds the string denoting the workflow_run edge name in mutations.
@@ -85,12 +87,7 @@ var Columns = []string{
 	FieldFallback,
 	FieldManaged,
 	FieldMaxBlobSizeBytes,
-}
-
-// ForeignKeys holds the SQL foreign-keys that are owned by the "cas_backends"
-// table and are not defined as standalone fields in the schema.
-var ForeignKeys = []string{
-	"organization_cas_backends",
+	FieldOrganizationCasBackends,
 }
 
 var (
@@ -103,11 +100,6 @@ var (
 func ValidColumn(column string) bool {
 	for i := range Columns {
 		if column == Columns[i] {
-			return true
-		}
-	}
-	for i := range ForeignKeys {
-		if column == ForeignKeys[i] {
 			return true
 		}
 	}
@@ -236,6 +228,11 @@ func ByManaged(opts ...sql.OrderTermOption) OrderOption {
 // ByMaxBlobSizeBytes orders the results by the max_blob_size_bytes field.
 func ByMaxBlobSizeBytes(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldMaxBlobSizeBytes, opts...).ToFunc()
+}
+
+// ByOrganizationCasBackends orders the results by the organization_cas_backends field.
+func ByOrganizationCasBackends(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldOrganizationCasBackends, opts...).ToFunc()
 }
 
 // ByOrganizationField orders the results by organization field.

--- a/app/controlplane/pkg/data/ent/casbackend/where.go
+++ b/app/controlplane/pkg/data/ent/casbackend/where.go
@@ -122,6 +122,11 @@ func MaxBlobSizeBytes(v int64) predicate.CASBackend {
 	return predicate.CASBackend(sql.FieldEQ(FieldMaxBlobSizeBytes, v))
 }
 
+// OrganizationCasBackends applies equality check predicate on the "organization_cas_backends" field. It's identical to OrganizationCasBackendsEQ.
+func OrganizationCasBackends(v uuid.UUID) predicate.CASBackend {
+	return predicate.CASBackend(sql.FieldEQ(FieldOrganizationCasBackends, v))
+}
+
 // LocationEQ applies the EQ predicate on the "location" field.
 func LocationEQ(v string) predicate.CASBackend {
 	return predicate.CASBackend(sql.FieldEQ(FieldLocation, v))
@@ -765,6 +770,26 @@ func MaxBlobSizeBytesLT(v int64) predicate.CASBackend {
 // MaxBlobSizeBytesLTE applies the LTE predicate on the "max_blob_size_bytes" field.
 func MaxBlobSizeBytesLTE(v int64) predicate.CASBackend {
 	return predicate.CASBackend(sql.FieldLTE(FieldMaxBlobSizeBytes, v))
+}
+
+// OrganizationCasBackendsEQ applies the EQ predicate on the "organization_cas_backends" field.
+func OrganizationCasBackendsEQ(v uuid.UUID) predicate.CASBackend {
+	return predicate.CASBackend(sql.FieldEQ(FieldOrganizationCasBackends, v))
+}
+
+// OrganizationCasBackendsNEQ applies the NEQ predicate on the "organization_cas_backends" field.
+func OrganizationCasBackendsNEQ(v uuid.UUID) predicate.CASBackend {
+	return predicate.CASBackend(sql.FieldNEQ(FieldOrganizationCasBackends, v))
+}
+
+// OrganizationCasBackendsIn applies the In predicate on the "organization_cas_backends" field.
+func OrganizationCasBackendsIn(vs ...uuid.UUID) predicate.CASBackend {
+	return predicate.CASBackend(sql.FieldIn(FieldOrganizationCasBackends, vs...))
+}
+
+// OrganizationCasBackendsNotIn applies the NotIn predicate on the "organization_cas_backends" field.
+func OrganizationCasBackendsNotIn(vs ...uuid.UUID) predicate.CASBackend {
+	return predicate.CASBackend(sql.FieldNotIn(FieldOrganizationCasBackends, vs...))
 }
 
 // HasOrganization applies the HasEdge predicate on the "organization" edge.

--- a/app/controlplane/pkg/data/ent/casbackend_create.go
+++ b/app/controlplane/pkg/data/ent/casbackend_create.go
@@ -197,6 +197,12 @@ func (_c *CASBackendCreate) SetMaxBlobSizeBytes(v int64) *CASBackendCreate {
 	return _c
 }
 
+// SetOrganizationCasBackends sets the "organization_cas_backends" field.
+func (_c *CASBackendCreate) SetOrganizationCasBackends(v uuid.UUID) *CASBackendCreate {
+	_c.mutation.SetOrganizationCasBackends(v)
+	return _c
+}
+
 // SetID sets the "id" field.
 func (_c *CASBackendCreate) SetID(v uuid.UUID) *CASBackendCreate {
 	_c.mutation.SetID(v)
@@ -354,6 +360,9 @@ func (_c *CASBackendCreate) check() error {
 	if _, ok := _c.mutation.MaxBlobSizeBytes(); !ok {
 		return &ValidationError{Name: "max_blob_size_bytes", err: errors.New(`ent: missing required field "CASBackend.max_blob_size_bytes"`)}
 	}
+	if _, ok := _c.mutation.OrganizationCasBackends(); !ok {
+		return &ValidationError{Name: "organization_cas_backends", err: errors.New(`ent: missing required field "CASBackend.organization_cas_backends"`)}
+	}
 	if len(_c.mutation.OrganizationIDs()) == 0 {
 		return &ValidationError{Name: "organization", err: errors.New(`ent: missing required edge "CASBackend.organization"`)}
 	}
@@ -467,7 +476,7 @@ func (_c *CASBackendCreate) createSpec() (*CASBackend, *sqlgraph.CreateSpec) {
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		_node.organization_cas_backends = &nodes[0]
+		_node.OrganizationCasBackends = nodes[0]
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := _c.mutation.WorkflowRunIDs(); len(nodes) > 0 {
@@ -691,6 +700,18 @@ func (u *CASBackendUpsert) UpdateMaxBlobSizeBytes() *CASBackendUpsert {
 // AddMaxBlobSizeBytes adds v to the "max_blob_size_bytes" field.
 func (u *CASBackendUpsert) AddMaxBlobSizeBytes(v int64) *CASBackendUpsert {
 	u.Add(casbackend.FieldMaxBlobSizeBytes, v)
+	return u
+}
+
+// SetOrganizationCasBackends sets the "organization_cas_backends" field.
+func (u *CASBackendUpsert) SetOrganizationCasBackends(v uuid.UUID) *CASBackendUpsert {
+	u.Set(casbackend.FieldOrganizationCasBackends, v)
+	return u
+}
+
+// UpdateOrganizationCasBackends sets the "organization_cas_backends" field to the value that was provided on create.
+func (u *CASBackendUpsert) UpdateOrganizationCasBackends() *CASBackendUpsert {
+	u.SetExcluded(casbackend.FieldOrganizationCasBackends)
 	return u
 }
 
@@ -933,6 +954,20 @@ func (u *CASBackendUpsertOne) AddMaxBlobSizeBytes(v int64) *CASBackendUpsertOne 
 func (u *CASBackendUpsertOne) UpdateMaxBlobSizeBytes() *CASBackendUpsertOne {
 	return u.Update(func(s *CASBackendUpsert) {
 		s.UpdateMaxBlobSizeBytes()
+	})
+}
+
+// SetOrganizationCasBackends sets the "organization_cas_backends" field.
+func (u *CASBackendUpsertOne) SetOrganizationCasBackends(v uuid.UUID) *CASBackendUpsertOne {
+	return u.Update(func(s *CASBackendUpsert) {
+		s.SetOrganizationCasBackends(v)
+	})
+}
+
+// UpdateOrganizationCasBackends sets the "organization_cas_backends" field to the value that was provided on create.
+func (u *CASBackendUpsertOne) UpdateOrganizationCasBackends() *CASBackendUpsertOne {
+	return u.Update(func(s *CASBackendUpsert) {
+		s.UpdateOrganizationCasBackends()
 	})
 }
 
@@ -1342,6 +1377,20 @@ func (u *CASBackendUpsertBulk) AddMaxBlobSizeBytes(v int64) *CASBackendUpsertBul
 func (u *CASBackendUpsertBulk) UpdateMaxBlobSizeBytes() *CASBackendUpsertBulk {
 	return u.Update(func(s *CASBackendUpsert) {
 		s.UpdateMaxBlobSizeBytes()
+	})
+}
+
+// SetOrganizationCasBackends sets the "organization_cas_backends" field.
+func (u *CASBackendUpsertBulk) SetOrganizationCasBackends(v uuid.UUID) *CASBackendUpsertBulk {
+	return u.Update(func(s *CASBackendUpsert) {
+		s.SetOrganizationCasBackends(v)
+	})
+}
+
+// UpdateOrganizationCasBackends sets the "organization_cas_backends" field to the value that was provided on create.
+func (u *CASBackendUpsertBulk) UpdateOrganizationCasBackends() *CASBackendUpsertBulk {
+	return u.Update(func(s *CASBackendUpsert) {
+		s.UpdateOrganizationCasBackends()
 	})
 }
 

--- a/app/controlplane/pkg/data/ent/casbackend_query.go
+++ b/app/controlplane/pkg/data/ent/casbackend_query.go
@@ -29,7 +29,6 @@ type CASBackendQuery struct {
 	predicates       []predicate.CASBackend
 	withOrganization *OrganizationQuery
 	withWorkflowRun  *WorkflowRunQuery
-	withFKs          bool
 	modifiers        []func(*sql.Selector)
 	// intermediate query (i.e. traversal path).
 	sql  *sql.Selector
@@ -411,19 +410,12 @@ func (_q *CASBackendQuery) prepareQuery(ctx context.Context) error {
 func (_q *CASBackendQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*CASBackend, error) {
 	var (
 		nodes       = []*CASBackend{}
-		withFKs     = _q.withFKs
 		_spec       = _q.querySpec()
 		loadedTypes = [2]bool{
 			_q.withOrganization != nil,
 			_q.withWorkflowRun != nil,
 		}
 	)
-	if _q.withOrganization != nil {
-		withFKs = true
-	}
-	if withFKs {
-		_spec.Node.Columns = append(_spec.Node.Columns, casbackend.ForeignKeys...)
-	}
 	_spec.ScanValues = func(columns []string) ([]any, error) {
 		return (*CASBackend).scanValues(nil, columns)
 	}
@@ -465,10 +457,7 @@ func (_q *CASBackendQuery) loadOrganization(ctx context.Context, query *Organiza
 	ids := make([]uuid.UUID, 0, len(nodes))
 	nodeids := make(map[uuid.UUID][]*CASBackend)
 	for i := range nodes {
-		if nodes[i].organization_cas_backends == nil {
-			continue
-		}
-		fk := *nodes[i].organization_cas_backends
+		fk := nodes[i].OrganizationCasBackends
 		if _, ok := nodeids[fk]; !ok {
 			ids = append(ids, fk)
 		}
@@ -582,6 +571,9 @@ func (_q *CASBackendQuery) querySpec() *sqlgraph.QuerySpec {
 			if fields[i] != casbackend.FieldID {
 				_spec.Node.Columns = append(_spec.Node.Columns, fields[i])
 			}
+		}
+		if _q.withOrganization != nil {
+			_spec.Node.AddColumnOnce(casbackend.FieldOrganizationCasBackends)
 		}
 	}
 	if ps := _q.predicates; len(ps) > 0 {

--- a/app/controlplane/pkg/data/ent/casbackend_update.go
+++ b/app/controlplane/pkg/data/ent/casbackend_update.go
@@ -204,6 +204,20 @@ func (_u *CASBackendUpdate) AddMaxBlobSizeBytes(v int64) *CASBackendUpdate {
 	return _u
 }
 
+// SetOrganizationCasBackends sets the "organization_cas_backends" field.
+func (_u *CASBackendUpdate) SetOrganizationCasBackends(v uuid.UUID) *CASBackendUpdate {
+	_u.mutation.SetOrganizationCasBackends(v)
+	return _u
+}
+
+// SetNillableOrganizationCasBackends sets the "organization_cas_backends" field if the given value is not nil.
+func (_u *CASBackendUpdate) SetNillableOrganizationCasBackends(v *uuid.UUID) *CASBackendUpdate {
+	if v != nil {
+		_u.SetOrganizationCasBackends(*v)
+	}
+	return _u
+}
+
 // SetOrganizationID sets the "organization" edge to the Organization entity by ID.
 func (_u *CASBackendUpdate) SetOrganizationID(id uuid.UUID) *CASBackendUpdate {
 	_u.mutation.SetOrganizationID(id)
@@ -638,6 +652,20 @@ func (_u *CASBackendUpdateOne) SetNillableMaxBlobSizeBytes(v *int64) *CASBackend
 // AddMaxBlobSizeBytes adds value to the "max_blob_size_bytes" field.
 func (_u *CASBackendUpdateOne) AddMaxBlobSizeBytes(v int64) *CASBackendUpdateOne {
 	_u.mutation.AddMaxBlobSizeBytes(v)
+	return _u
+}
+
+// SetOrganizationCasBackends sets the "organization_cas_backends" field.
+func (_u *CASBackendUpdateOne) SetOrganizationCasBackends(v uuid.UUID) *CASBackendUpdateOne {
+	_u.mutation.SetOrganizationCasBackends(v)
+	return _u
+}
+
+// SetNillableOrganizationCasBackends sets the "organization_cas_backends" field if the given value is not nil.
+func (_u *CASBackendUpdateOne) SetNillableOrganizationCasBackends(v *uuid.UUID) *CASBackendUpdateOne {
+	if v != nil {
+		_u.SetOrganizationCasBackends(*v)
+	}
 	return _u
 }
 

--- a/app/controlplane/pkg/data/ent/mutation.go
+++ b/app/controlplane/pkg/data/ent/mutation.go
@@ -2490,6 +2490,42 @@ func (m *CASBackendMutation) ResetMaxBlobSizeBytes() {
 	m.addmax_blob_size_bytes = nil
 }
 
+// SetOrganizationCasBackends sets the "organization_cas_backends" field.
+func (m *CASBackendMutation) SetOrganizationCasBackends(u uuid.UUID) {
+	m.organization = &u
+}
+
+// OrganizationCasBackends returns the value of the "organization_cas_backends" field in the mutation.
+func (m *CASBackendMutation) OrganizationCasBackends() (r uuid.UUID, exists bool) {
+	v := m.organization
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldOrganizationCasBackends returns the old "organization_cas_backends" field's value of the CASBackend entity.
+// If the CASBackend object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *CASBackendMutation) OldOrganizationCasBackends(ctx context.Context) (v uuid.UUID, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldOrganizationCasBackends is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldOrganizationCasBackends requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldOrganizationCasBackends: %w", err)
+	}
+	return oldValue.OrganizationCasBackends, nil
+}
+
+// ResetOrganizationCasBackends resets all changes to the "organization_cas_backends" field.
+func (m *CASBackendMutation) ResetOrganizationCasBackends() {
+	m.organization = nil
+}
+
 // SetOrganizationID sets the "organization" edge to the Organization entity by id.
 func (m *CASBackendMutation) SetOrganizationID(id uuid.UUID) {
 	m.organization = &id
@@ -2498,6 +2534,7 @@ func (m *CASBackendMutation) SetOrganizationID(id uuid.UUID) {
 // ClearOrganization clears the "organization" edge to the Organization entity.
 func (m *CASBackendMutation) ClearOrganization() {
 	m.clearedorganization = true
+	m.clearedFields[casbackend.FieldOrganizationCasBackends] = struct{}{}
 }
 
 // OrganizationCleared reports if the "organization" edge to the Organization entity was cleared.
@@ -2617,7 +2654,7 @@ func (m *CASBackendMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *CASBackendMutation) Fields() []string {
-	fields := make([]string, 0, 15)
+	fields := make([]string, 0, 16)
 	if m.location != nil {
 		fields = append(fields, casbackend.FieldLocation)
 	}
@@ -2663,6 +2700,9 @@ func (m *CASBackendMutation) Fields() []string {
 	if m.max_blob_size_bytes != nil {
 		fields = append(fields, casbackend.FieldMaxBlobSizeBytes)
 	}
+	if m.organization != nil {
+		fields = append(fields, casbackend.FieldOrganizationCasBackends)
+	}
 	return fields
 }
 
@@ -2701,6 +2741,8 @@ func (m *CASBackendMutation) Field(name string) (ent.Value, bool) {
 		return m.Managed()
 	case casbackend.FieldMaxBlobSizeBytes:
 		return m.MaxBlobSizeBytes()
+	case casbackend.FieldOrganizationCasBackends:
+		return m.OrganizationCasBackends()
 	}
 	return nil, false
 }
@@ -2740,6 +2782,8 @@ func (m *CASBackendMutation) OldField(ctx context.Context, name string) (ent.Val
 		return m.OldManaged(ctx)
 	case casbackend.FieldMaxBlobSizeBytes:
 		return m.OldMaxBlobSizeBytes(ctx)
+	case casbackend.FieldOrganizationCasBackends:
+		return m.OldOrganizationCasBackends(ctx)
 	}
 	return nil, fmt.Errorf("unknown CASBackend field %s", name)
 }
@@ -2853,6 +2897,13 @@ func (m *CASBackendMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetMaxBlobSizeBytes(v)
+		return nil
+	case casbackend.FieldOrganizationCasBackends:
+		v, ok := value.(uuid.UUID)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetOrganizationCasBackends(v)
 		return nil
 	}
 	return fmt.Errorf("unknown CASBackend field %s", name)
@@ -2983,6 +3034,9 @@ func (m *CASBackendMutation) ResetField(name string) error {
 		return nil
 	case casbackend.FieldMaxBlobSizeBytes:
 		m.ResetMaxBlobSizeBytes()
+		return nil
+	case casbackend.FieldOrganizationCasBackends:
+		m.ResetOrganizationCasBackends()
 		return nil
 	}
 	return fmt.Errorf("unknown CASBackend field %s", name)

--- a/app/controlplane/pkg/data/ent/organization_query.go
+++ b/app/controlplane/pkg/data/ent/organization_query.go
@@ -898,7 +898,9 @@ func (_q *OrganizationQuery) loadCasBackends(ctx context.Context, query *CASBack
 			init(nodes[i])
 		}
 	}
-	query.withFKs = true
+	if len(query.ctx.Fields) > 0 {
+		query.ctx.AppendFieldOnce(casbackend.FieldOrganizationCasBackends)
+	}
 	query.Where(predicate.CASBackend(func(s *sql.Selector) {
 		s.Where(sql.InValues(s.C(organization.CasBackendsColumn), fks...))
 	}))
@@ -907,13 +909,10 @@ func (_q *OrganizationQuery) loadCasBackends(ctx context.Context, query *CASBack
 		return err
 	}
 	for _, n := range neighbors {
-		fk := n.organization_cas_backends
-		if fk == nil {
-			return fmt.Errorf(`foreign-key "organization_cas_backends" is nil for node %v`, n.ID)
-		}
-		node, ok := nodeids[*fk]
+		fk := n.OrganizationCasBackends
+		node, ok := nodeids[fk]
 		if !ok {
-			return fmt.Errorf(`unexpected referenced foreign-key "organization_cas_backends" returned %v for node %v`, *fk, n.ID)
+			return fmt.Errorf(`unexpected referenced foreign-key "organization_cas_backends" returned %v for node %v`, fk, n.ID)
 		}
 		assign(node, n)
 	}

--- a/app/controlplane/pkg/data/ent/schema/casbackend.go
+++ b/app/controlplane/pkg/data/ent/schema/casbackend.go
@@ -63,12 +63,13 @@ func (CASBackend) Fields() []ent.Field {
 		// managed indicates this backend is provisioned and operated by Chainloop
 		field.Bool("managed").Default(false),
 		field.Int64("max_blob_size_bytes"),
+		field.UUID("organization_cas_backends", uuid.UUID{}),
 	}
 }
 
 func (CASBackend) Edges() []ent.Edge {
 	return []ent.Edge{
-		edge.From("organization", Organization.Type).Ref("cas_backends").Unique().Required(),
+		edge.From("organization", Organization.Type).Ref("cas_backends").Unique().Field("organization_cas_backends").Required(),
 		// WorkflowRuns might be associated with multiple CASBackends
 		edge.From("workflow_run", WorkflowRun.Type).Ref("cas_backends"),
 	}


### PR DESCRIPTION
Fixes https://github.com/chainloop-dev/chainloop/issues/3133 by exposing the FK OrganizationID field in Ent generated code. This also saves some queries, since it doesn't require eager loading the Organization record.
