### PR TITLE
fix(dagger): rename debug parameter to avoid conflict with built-in flag

### DIFF
--- a/extras/dagger/main.go
+++ b/extras/dagger/main.go
@@ -394,9 +394,9 @@ func (att *Attestation) AddRawEvidence(
 	// Skip strict schema validation for structured materials (SBOM_CYCLONEDX_JSON, OPENAPI_SPEC, ASYNCAPI_SPEC)
 	// +optional
 	noStrictValidation bool,
-	// Enable debug/verbose logging
+	// Enable debug logging
 	// +optional
-	debug bool,
+	debugMode bool,
 ) (*Attestation, error) {
 	args := []string{
 		"attestation", "add",
@@ -426,7 +426,7 @@ func (att *Attestation) AddRawEvidence(
 		args = append(args, "--no-strict-validation")
 	}
 
-	if debug {
+	if debugMode {
 		args = append(args, "--debug")
 	}
 
@@ -458,9 +458,9 @@ func (att *Attestation) AddFileEvidence(
 	// Skip strict schema validation for structured materials (SBOM_CYCLONEDX_JSON, OPENAPI_SPEC, ASYNCAPI_SPEC)
 	// +optional
 	noStrictValidation bool,
-	// Enable debug/verbose logging
+	// Enable debug logging
 	// +optional
-	debug bool,
+	debugMode bool,
 ) (*Attestation, error) {
 	filename, err := path.Name(ctx)
 	if err != nil {
@@ -497,7 +497,7 @@ func (att *Attestation) AddFileEvidence(
 		args = append(args, "--no-strict-validation")
 	}
 
-	if debug {
+	if debugMode {
 		args = append(args, "--debug")
 	}
 


### PR DESCRIPTION
Rename the `debug` parameter to `debugMode` in `AddRawEvidence` and `AddFileEvidence` in the Dagger module. Both `--debug` and `--verbose` are reserved Dagger global flags, so `debugMode` (exposed as `--debug-mode` on the CLI) is used instead. The underlying `--debug` argument passed to the Chainloop CLI remains unchanged.

Fixes runtime `flag already exists: debug` errors when invoking these functions via Dagger.