### PR TITLE
feat(dagger): Allow to use enterprise CLI from Dagger OSS module

### DIFF
--- a/.github/workflows/utils/bump-chart-and-dagger-version.sh
+++ b/.github/workflows/utils/bump-chart-and-dagger-version.sh
@@ -53,3 +53,9 @@ sed -i "s/tag: .*/tag: \"${semVer}\"/g" "${values_yaml}"
 ## Update Dagger version
 sed -i "s/chainloopVersion = \"v.*\"/chainloopVersion = \"${semVer}\"/" "${dagger_main}"
 
+## Update platform (enterprise) CLI version from infoz endpoint
+platform_version=$(curl -sf https://api.app.chainloop.dev/infoz | jq -r '.version')
+if [[ -n "${platform_version}" && "${platform_version}" != "null" ]]; then
+    sed -i "s/platformVersion  = \"v.*\"/platformVersion  = \"${platform_version}\"/" "${dagger_main}"
+fi
+

--- a/extras/dagger/main.go
+++ b/extras/dagger/main.go
@@ -78,6 +78,10 @@ type InstanceInfo struct {
 	CASAPI string
 	// path to a custom CA for the CAS API
 	CASCAPath *dagger.File
+	// hostname for the Platform API i.e api.app.chainloop.dev:443
+	PlatformAPI string
+	// path to a custom CA for the Platform API
+	PlatformCAPath *dagger.File
 	// Password to use when authenticating to the registry
 	Insecure bool
 }
@@ -373,6 +377,11 @@ func (m *Chainloop) WithInstance(
 	// Path to custom CA certificate for the Control Plane API
 	// +optional
 	controlplaneCA *dagger.File,
+	// Example: "api.app.chainloop.dev:443"
+	platformAPI string,
+	// Path to custom CA certificate for the Platform API
+	// +optional
+	platformCA *dagger.File,
 	// Whether to skip TLS verification
 	// +optional
 	insecure bool,
@@ -383,6 +392,8 @@ func (m *Chainloop) WithInstance(
 		Insecure:           insecure,
 		CASCAPath:          casCA,
 		ControlplaneCAPath: controlplaneCA,
+		PlatformAPI:        platformAPI,
+		PlatformCAPath:     platformCA,
 	}
 
 	return m
@@ -633,6 +644,14 @@ func cliContainer(ttl int, token *dagger.Secret, instance InstanceInfo, parentCI
 
 	if cas := instance.CASAPI; cas != "" {
 		ctr = ctr.WithEnvVariable("CHAINLOOP_ARTIFACT_CAS_API", cas)
+	}
+
+	if platformAPI := instance.PlatformAPI; platformAPI != "" {
+		ctr = ctr.WithEnvVariable("CHAINLOOP_PLATFORM_API", platformAPI)
+	}
+
+	if ca := instance.PlatformCAPath; ca != nil {
+		ctr = ctr.WithFile("/platform-ca.pem", ca).WithEnvVariable("CHAINLOOP_PLATFORM_API_CA", "/platform-ca.pem")
 	}
 
 	if instance.Insecure {

--- a/extras/dagger/main.go
+++ b/extras/dagger/main.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	chainloopVersion = "v1.98.4"
+	platformVersion  = "v1.77.8"
 )
 
 var execOpts = dagger.ContainerWithExecOpts{
@@ -20,6 +21,25 @@ var execOpts = dagger.ContainerWithExecOpts{
 type Chainloop struct {
 	// +private
 	Instance InstanceInfo
+	// +private
+	Enterprise bool
+	// +private
+	CLIVersion string
+}
+
+// New creates a new Chainloop module client.
+func New(
+	// Use the enterprise CLI image (ghcr.io/chainloop-dev/platform/cli)
+	// +optional
+	enterprise bool,
+	// Pin a specific CLI version (overrides the built-in default)
+	// +optional
+	cliVersion string,
+) *Chainloop {
+	return &Chainloop{
+		Enterprise: enterprise,
+		CLIVersion: cliVersion,
+	}
 }
 
 // A Chainloop attestation
@@ -515,13 +535,23 @@ func (att *Attestation) Debug() *dagger.Container {
 	return att.Container(0).Terminal()
 }
 
-func cliContainer(ttl int, token *dagger.Secret, instance InstanceInfo, parentCI *ParentCIContext, githubEventFile *dagger.File) *dagger.Container {
+func cliContainer(ttl int, token *dagger.Secret, instance InstanceInfo, parentCI *ParentCIContext, githubEventFile *dagger.File, enterprise bool, cliVersionOverride string) *dagger.Container {
+	image := "ghcr.io/chainloop-dev/chainloop/cli"
+	version := chainloopVersion
+	if enterprise {
+		image = "ghcr.io/chainloop-dev/platform/cli"
+		version = platformVersion
+	}
+	if cliVersionOverride != "" {
+		version = cliVersionOverride
+	}
+
 	ctr := dag.Container().
-		From(fmt.Sprintf("ghcr.io/chainloop-dev/chainloop/cli:%s", chainloopVersion)).
-		WithEntrypoint([]string{"/chainloop"}). // Be explicit to prepare for possible API change
-		WithEnvVariable("CHAINLOOP_DAGGER_CLIENT", chainloopVersion).
-		WithUser("").                                                                                     // Our images come with pre-defined user set, so we need to reset it
-		WithEnvVariable("DAGGER_CACHE_KEY", time.Now().Truncate(time.Duration(ttl)*time.Second).String()) // Cache TTL
+		From(fmt.Sprintf("%s:%s", image, version)).
+		WithEntrypoint([]string{"/chainloop"}).
+		WithEnvVariable("CHAINLOOP_DAGGER_CLIENT", version).
+		WithUser("").
+		WithEnvVariable("DAGGER_CACHE_KEY", time.Now().Truncate(time.Duration(ttl)*time.Second).String())
 
 	// Inject parent CI context if provided
 	if parentCI != nil {
@@ -631,7 +661,7 @@ func (att *Attestation) Container(
 	// +default=0
 	ttl int,
 ) *dagger.Container {
-	ctr := cliContainer(ttl, att.Token, att.Client.Instance, att.parentCIContext, att.githubEventFile)
+	ctr := cliContainer(ttl, att.Token, att.Client.Instance, att.parentCIContext, att.githubEventFile, att.Client.Enterprise, att.Client.CLIVersion)
 	if att.repository != nil {
 		ctr = ctr.WithDirectory(".", att.repository)
 	}
@@ -778,7 +808,7 @@ func (m *Chainloop) WorkflowCreate(
 	// +optional
 	skipIfExists bool,
 ) (string, error) {
-	return cliContainer(0, token, m.Instance, nil, nil).
+	return cliContainer(0, token, m.Instance, nil, nil, m.Enterprise, m.CLIVersion).
 		WithExec([]string{
 			"workflow", "create",
 			"--name", name,

--- a/extras/dagger/main.go
+++ b/extras/dagger/main.go
@@ -23,8 +23,6 @@ type Chainloop struct {
 	Instance InstanceInfo
 	// +private
 	Enterprise bool
-	// +private
-	CLIVersion string
 }
 
 // New creates a new Chainloop module client.
@@ -32,13 +30,10 @@ func New(
 	// Use the enterprise CLI image (ghcr.io/chainloop-dev/platform/cli)
 	// +optional
 	enterprise bool,
-	// Pin a specific CLI version (overrides the built-in default)
-	// +optional
-	cliVersion string,
+
 ) *Chainloop {
 	return &Chainloop{
 		Enterprise: enterprise,
-		CLIVersion: cliVersion,
 	}
 }
 
@@ -535,15 +530,12 @@ func (att *Attestation) Debug() *dagger.Container {
 	return att.Container(0).Terminal()
 }
 
-func cliContainer(ttl int, token *dagger.Secret, instance InstanceInfo, parentCI *ParentCIContext, githubEventFile *dagger.File, enterprise bool, cliVersionOverride string) *dagger.Container {
+func cliContainer(ttl int, token *dagger.Secret, instance InstanceInfo, parentCI *ParentCIContext, githubEventFile *dagger.File, enterprise bool) *dagger.Container {
 	image := "ghcr.io/chainloop-dev/chainloop/cli"
 	version := chainloopVersion
 	if enterprise {
 		image = "ghcr.io/chainloop-dev/platform/cli"
 		version = platformVersion
-	}
-	if cliVersionOverride != "" {
-		version = cliVersionOverride
 	}
 
 	ctr := dag.Container().
@@ -661,7 +653,7 @@ func (att *Attestation) Container(
 	// +default=0
 	ttl int,
 ) *dagger.Container {
-	ctr := cliContainer(ttl, att.Token, att.Client.Instance, att.parentCIContext, att.githubEventFile, att.Client.Enterprise, att.Client.CLIVersion)
+	ctr := cliContainer(ttl, att.Token, att.Client.Instance, att.parentCIContext, att.githubEventFile, att.Client.Enterprise)
 	if att.repository != nil {
 		ctr = ctr.WithDirectory(".", att.repository)
 	}
@@ -808,7 +800,7 @@ func (m *Chainloop) WorkflowCreate(
 	// +optional
 	skipIfExists bool,
 ) (string, error) {
-	return cliContainer(0, token, m.Instance, nil, nil, m.Enterprise, m.CLIVersion).
+	return cliContainer(0, token, m.Instance, nil, nil, m.Enterprise).
 		WithExec([]string{
 			"workflow", "create",
 			"--name", name,

--- a/extras/dagger/main.go
+++ b/extras/dagger/main.go
@@ -548,7 +548,7 @@ func cliContainer(ttl int, token *dagger.Secret, instance InstanceInfo, parentCI
 
 	ctr := dag.Container().
 		From(fmt.Sprintf("%s:%s", image, version)).
-		WithEntrypoint([]string{"/chainloop"}). // Be explicit to prerare for possible API change
+		WithEntrypoint([]string{"/chainloop"}). // Be explicit to prepare for possible API change
 		WithEnvVariable("CHAINLOOP_DAGGER_CLIENT", version).
 		WithUser("").                                                                                     // Our images come with pre-defined user set, so we need to reset it
 		WithEnvVariable("DAGGER_CACHE_KEY", time.Now().Truncate(time.Duration(ttl)*time.Second).String()) // Cache TTL

--- a/extras/dagger/main.go
+++ b/extras/dagger/main.go
@@ -548,10 +548,10 @@ func cliContainer(ttl int, token *dagger.Secret, instance InstanceInfo, parentCI
 
 	ctr := dag.Container().
 		From(fmt.Sprintf("%s:%s", image, version)).
-		WithEntrypoint([]string{"/chainloop"}).
+		WithEntrypoint([]string{"/chainloop"}). // Be explicit to prerare for possible API change
 		WithEnvVariable("CHAINLOOP_DAGGER_CLIENT", version).
-		WithUser("").
-		WithEnvVariable("DAGGER_CACHE_KEY", time.Now().Truncate(time.Duration(ttl)*time.Second).String())
+		WithUser("").                                                                                     // Our images come with pre-defined user set, so we need to reset it
+		WithEnvVariable("DAGGER_CACHE_KEY", time.Now().Truncate(time.Duration(ttl)*time.Second).String()) // Cache TTL
 
 	// Inject parent CI context if provided
 	if parentCI != nil {


### PR DESCRIPTION
This pull request introduces support for using the enterprise version of the Chainloop CLI in the Dagger integration, along with enhanced configuration for the platform API and improved flexibility in CLI container setup. The main changes add the ability to select between the open-source and enterprise CLI images, configure the platform API endpoint and custom CA, and ensure these options are properly propagated throughout the codebase.

**Enterprise CLI Support**
- Added a new `Enterprise` field and constructor argument to the `Chainloop` struct, allowing users to specify whether to use the enterprise CLI image (`ghcr.io/chainloop-dev/platform/cli`) or the open-source CLI image (`ghcr.io/chainloop-dev/chainloop/cli`). The correct image and version are now selected based on this flag. [[1]](diffhunk://#diff-3c3d22e7e56b22d040f0298fee1b79c30493a0bf441cb5b5a7e8163946de4d3fR14) [[2]](diffhunk://#diff-3c3d22e7e56b22d040f0298fee1b79c30493a0bf441cb5b5a7e8163946de4d3fR24-R37) [[3]](diffhunk://#diff-3c3d22e7e56b22d040f0298fee1b79c30493a0bf441cb5b5a7e8163946de4d3fL518-R555) [[4]](diffhunk://#diff-3c3d22e7e56b22d040f0298fee1b79c30493a0bf441cb5b5a7e8163946de4d3fL634-R675) [[5]](diffhunk://#diff-3c3d22e7e56b22d040f0298fee1b79c30493a0bf441cb5b5a7e8163946de4d3fL781-R822)

- Updated the automation script `.github/workflows/utils/bump-chart-and-dagger-version.sh` to automatically fetch and update the enterprise CLI version from the platform info endpoint.

**Platform API Configuration**
- Extended the `InstanceInfo` struct and related methods to support specifying a custom platform API endpoint and custom CA file, which are now passed as environment variables and files to the CLI container. [[1]](diffhunk://#diff-3c3d22e7e56b22d040f0298fee1b79c30493a0bf441cb5b5a7e8163946de4d3fR81-R84) [[2]](diffhunk://#diff-3c3d22e7e56b22d040f0298fee1b79c30493a0bf441cb5b5a7e8163946de4d3fR380-R384) [[3]](diffhunk://#diff-3c3d22e7e56b22d040f0298fee1b79c30493a0bf441cb5b5a7e8163946de4d3fR395-R396) [[4]](diffhunk://#diff-3c3d22e7e56b22d040f0298fee1b79c30493a0bf441cb5b5a7e8163946de4d3fR649-R656)

These changes provide more flexibility for users with enterprise requirements and improve the configuration options for connecting to different Chainloop platform environments.