### PR TITLE
feat(authz): forward CAS backend creation to external authorizer

### DIFF
--- a/app/controlplane/pkg/authz/authz.go
+++ b/app/controlplane/pkg/authz/authz.go
@@ -375,7 +375,7 @@ var ServerOperationsMap = map[string]*OperationPolicy{
 	// CAS Backend listing
 	"/controlplane.v1.CASBackendService/List":       {Policies: []*Policy{PolicyCASBackendList}},
 	"/controlplane.v1.CASBackendService/Revalidate": {Policies: []*Policy{PolicyCASBackendUpdate}},
-	"/controlplane.v1.CASBackendService/Create":     {Policies: []*Policy{PolicyCASBackendCreate}},
+	"/controlplane.v1.CASBackendService/Create":     {Policies: []*Policy{PolicyCASBackendCreate}, ExternalAuthz: true},
 	// Available integrations
 	"/controlplane.v1.IntegrationsService/ListAvailable": {Policies: []*Policy{PolicyAvailableIntegrationList, PolicyAvailableIntegrationRead}},
 	// Registered integrations

--- a/app/controlplane/pkg/authz/authz_test.go
+++ b/app/controlplane/pkg/authz/authz_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2024-2025 The Chainloop Authors.
+// Copyright 2024-2026 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -127,6 +127,36 @@ func TestDoSync(t *testing.T) {
 	assert.Equal(t, "bar", got[0][0])
 	assert.Equal(t, "integration_attached", got[0][1])
 	assert.Equal(t, "delete", got[0][2])
+}
+
+func TestRequiresExternalAuthz(t *testing.T) {
+	testCases := []struct {
+		name      string
+		operation string
+		want      bool
+	}{
+		{
+			name:      "CAS backend creation is forwarded to the external authorizer",
+			operation: "/controlplane.v1.CASBackendService/Create",
+			want:      true,
+		},
+		{
+			name:      "operations without external authz flag are not forwarded",
+			operation: "/controlplane.v1.WorkflowService/List",
+			want:      false,
+		},
+		{
+			name:      "unknown operations are not forwarded",
+			operation: "/controlplane.v1.UnknownService/Unknown",
+			want:      false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, RequiresExternalAuthz(tc.operation))
+		})
+	}
 }
 
 func testEnforcer(t *testing.T) (*CasbinEnforcer, io.Closer) {


### PR DESCRIPTION
## Summary

Flags \`/controlplane.v1.CASBackendService/Create\` with \`ExternalAuthz: true\` so the operation authorization middleware introduced in #3021 forwards Create requests to the configured external authorization provider. When the provider is disabled (default for self-hosted), behaviour is unchanged.

This is the first real consumer of the external authorization middleware. It unblocks gating CAS backend creation behind an entitlement check performed by an external SaaS service.

Refs [PFM-6118](https://linear.app/chainloop/issue/PFM-6118).

This PR was developed with the assistance of Claude Code.