### PR TITLE
chore: use dynamic configuration for authorized operations

### DIFF
--- a/app/controlplane/configs/config.devel.yaml
+++ b/app/controlplane/configs/config.devel.yaml
@@ -118,6 +118,8 @@ enable_profiler: true
 # operation_authorization_provider:
 #   enabled: true
 #   url: http://localhost:8002/v1/authorize
+#   operations:
+#     - /controlplane.v1.WorkflowRunService/Create
 
 ui_dashboard_url: http://localhost:3000
 

--- a/app/controlplane/internal/conf/controlplane/config/v1/conf.pb.go
+++ b/app/controlplane/internal/conf/controlplane/config/v1/conf.pb.go
@@ -321,7 +321,9 @@ type OperationAuthorizationProvider struct {
 	// URL of the authorization endpoint
 	Url string `protobuf:"bytes,1,opt,name=url,proto3" json:"url,omitempty"`
 	// Whether to enable the operation authorization
-	Enabled       bool `protobuf:"varint,2,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	Enabled bool `protobuf:"varint,2,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	// authorized operations list
+	Operations    []string `protobuf:"bytes,3,rep,name=operations,proto3" json:"operations,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -368,6 +370,13 @@ func (x *OperationAuthorizationProvider) GetEnabled() bool {
 		return x.Enabled
 	}
 	return false
+}
+
+func (x *OperationAuthorizationProvider) GetOperations() []string {
+	if x != nil {
+		return x.Operations
+	}
+	return nil
 }
 
 type FederatedAuthentication struct {
@@ -1841,10 +1850,13 @@ const file_controlplane_config_v1_conf_proto_rawDesc = "" +
 	"\breplicas\x18\x03 \x01(\x05R\breplicasB\x10\n" +
 	"\x0eauthentication\"6\n" +
 	"\fAttestations\x12&\n" +
-	"\x0fskip_db_storage\x18\x01 \x01(\bR\rskipDbStorage\"V\n" +
+	"\x0fskip_db_storage\x18\x01 \x01(\bR\rskipDbStorage\"v\n" +
 	"\x1eOperationAuthorizationProvider\x12\x1a\n" +
 	"\x03url\x18\x01 \x01(\tB\b\xbaH\x05r\x03\x88\x01\x01R\x03url\x12\x18\n" +
-	"\aenabled\x18\x02 \x01(\bR\aenabled\"O\n" +
+	"\aenabled\x18\x02 \x01(\bR\aenabled\x12\x1e\n" +
+	"\n" +
+	"operations\x18\x03 \x03(\tR\n" +
+	"operations\"O\n" +
 	"\x17FederatedAuthentication\x12\x1a\n" +
 	"\x03url\x18\x01 \x01(\tB\b\xbaH\x05r\x03\x88\x01\x01R\x03url\x12\x18\n" +
 	"\aenabled\x18\x02 \x01(\bR\aenabled\"\xee\x01\n" +

--- a/app/controlplane/internal/conf/controlplane/config/v1/conf.proto
+++ b/app/controlplane/internal/conf/controlplane/config/v1/conf.proto
@@ -143,6 +143,8 @@ message OperationAuthorizationProvider {
   string url = 1 [(buf.validate.field).string.uri = true];
   // Whether to enable the operation authorization
   bool enabled = 2;
+  // authorized operations list
+  repeated string operations = 3;
 }
 
 message FederatedAuthentication {

--- a/app/controlplane/internal/usercontext/operation_authorization_middleware.go
+++ b/app/controlplane/internal/usercontext/operation_authorization_middleware.go
@@ -21,11 +21,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"slices"
 	"time"
 
 	conf "github.com/chainloop-dev/chainloop/app/controlplane/internal/conf/controlplane/config/v1"
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/usercontext/entities"
-	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/authz"
 	errorsAPI "github.com/go-kratos/kratos/v2/errors"
 	"github.com/go-kratos/kratos/v2/log"
 	"github.com/go-kratos/kratos/v2/middleware"
@@ -61,7 +61,7 @@ func WithOperationAuthorizationMiddleware(conf *conf.OperationAuthorizationProvi
 			}
 
 			operation := info.Operation()
-			if !authz.RequiresExternalAuthz(operation) {
+			if !slices.Contains(conf.GetOperations(), operation) {
 				return handler(ctx, req)
 			}
 

--- a/app/controlplane/internal/usercontext/operation_authorization_middleware_test.go
+++ b/app/controlplane/internal/usercontext/operation_authorization_middleware_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	conf "github.com/chainloop-dev/chainloop/app/controlplane/internal/conf/controlplane/config/v1"
-	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/authz"
 	"github.com/go-kratos/kratos/v2/log"
 	"github.com/go-kratos/kratos/v2/transport"
 	"github.com/stretchr/testify/assert"
@@ -32,14 +31,6 @@ import (
 )
 
 const testExternalAuthzOp = "/test.v1.ExternalAuthzTestService/Target"
-
-func registerTestExternalAuthzOp(t *testing.T) {
-	t.Helper()
-	authz.ServerOperationsMap[testExternalAuthzOp] = &authz.OperationPolicy{ExternalAuthz: true}
-	t.Cleanup(func() {
-		delete(authz.ServerOperationsMap, testExternalAuthzOp)
-	})
-}
 
 // fakeTransport implements transport.Transporter for testing middleware operation matching.
 type fakeTransport struct {
@@ -106,7 +97,6 @@ func TestWithOperationAuthorizationMiddleware(t *testing.T) {
 	})
 
 	t.Run("target operation allowed", func(t *testing.T) {
-		registerTestExternalAuthzOp(t)
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			var req operationAuthRequest
 			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
@@ -117,7 +107,7 @@ func TestWithOperationAuthorizationMiddleware(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		cfg := &conf.OperationAuthorizationProvider{Enabled: true, Url: srv.URL}
+		cfg := &conf.OperationAuthorizationProvider{Enabled: true, Url: srv.URL, Operations: []string{testExternalAuthzOp}}
 		m := WithOperationAuthorizationMiddleware(cfg, logHelper)
 
 		ctx := ctxWithOperation(context.Background(), testExternalAuthzOp)
@@ -128,14 +118,13 @@ func TestWithOperationAuthorizationMiddleware(t *testing.T) {
 	})
 
 	t.Run("target operation denied", func(t *testing.T) {
-		registerTestExternalAuthzOp(t)
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(operationAuthResponse{Allowed: false, Reason: "org limit reached"}) //nolint:errcheck
 		}))
 		defer srv.Close()
 
-		cfg := &conf.OperationAuthorizationProvider{Enabled: true, Url: srv.URL}
+		cfg := &conf.OperationAuthorizationProvider{Enabled: true, Url: srv.URL, Operations: []string{testExternalAuthzOp}}
 		m := WithOperationAuthorizationMiddleware(cfg, logHelper)
 
 		ctx := ctxWithOperation(context.Background(), testExternalAuthzOp)
@@ -147,8 +136,7 @@ func TestWithOperationAuthorizationMiddleware(t *testing.T) {
 	})
 
 	t.Run("provider unreachable is fail-closed", func(t *testing.T) {
-		registerTestExternalAuthzOp(t)
-		cfg := &conf.OperationAuthorizationProvider{Enabled: true, Url: "http://127.0.0.1:1"}
+		cfg := &conf.OperationAuthorizationProvider{Enabled: true, Url: "http://127.0.0.1:1", Operations: []string{testExternalAuthzOp}}
 		m := WithOperationAuthorizationMiddleware(cfg, logHelper)
 
 		ctx := ctxWithOperation(context.Background(), testExternalAuthzOp)
@@ -160,13 +148,12 @@ func TestWithOperationAuthorizationMiddleware(t *testing.T) {
 	})
 
 	t.Run("provider returns 500 is fail-closed", func(t *testing.T) {
-		registerTestExternalAuthzOp(t)
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusInternalServerError)
 		}))
 		defer srv.Close()
 
-		cfg := &conf.OperationAuthorizationProvider{Enabled: true, Url: srv.URL}
+		cfg := &conf.OperationAuthorizationProvider{Enabled: true, Url: srv.URL, Operations: []string{testExternalAuthzOp}}
 		m := WithOperationAuthorizationMiddleware(cfg, logHelper)
 
 		ctx := ctxWithOperation(context.Background(), testExternalAuthzOp)
@@ -178,7 +165,6 @@ func TestWithOperationAuthorizationMiddleware(t *testing.T) {
 	})
 
 	t.Run("bearer token is forwarded", func(t *testing.T) {
-		registerTestExternalAuthzOp(t)
 		var gotAuth string
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			gotAuth = r.Header.Get("Authorization")
@@ -187,7 +173,7 @@ func TestWithOperationAuthorizationMiddleware(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		cfg := &conf.OperationAuthorizationProvider{Enabled: true, Url: srv.URL}
+		cfg := &conf.OperationAuthorizationProvider{Enabled: true, Url: srv.URL, Operations: []string{testExternalAuthzOp}}
 		m := WithOperationAuthorizationMiddleware(cfg, logHelper)
 
 		ft := &fakeTransport{

--- a/app/controlplane/pkg/authz/authz.go
+++ b/app/controlplane/pkg/authz/authz.go
@@ -373,7 +373,7 @@ var ServerOperationsMap = map[string]*OperationPolicy{
 	// CAS Backend listing
 	"/controlplane.v1.CASBackendService/List":       {Policies: []*Policy{PolicyCASBackendList}},
 	"/controlplane.v1.CASBackendService/Revalidate": {Policies: []*Policy{PolicyCASBackendUpdate}},
-	"/controlplane.v1.CASBackendService/Create":     {Policies: []*Policy{PolicyCASBackendCreate}, ExternalAuthz: true},
+	"/controlplane.v1.CASBackendService/Create":     {Policies: []*Policy{PolicyCASBackendCreate}},
 	// Available integrations
 	"/controlplane.v1.IntegrationsService/ListAvailable": {Policies: []*Policy{PolicyAvailableIntegrationList, PolicyAvailableIntegrationRead}},
 	// Registered integrations

--- a/app/controlplane/pkg/authz/authz.go
+++ b/app/controlplane/pkg/authz/authz.go
@@ -23,10 +23,8 @@ type Policy struct {
 }
 
 // OperationPolicy describes both the local Casbin policies required for an operation
-// and whether the operation also requires external authorization.
 type OperationPolicy struct {
-	Policies      []*Policy
-	ExternalAuthz bool
+	Policies []*Policy
 }
 
 type Role string
@@ -457,14 +455,6 @@ var ServerOperationsMap = map[string]*OperationPolicy{
 
 	// Org invitations
 	"/controlplane.v1.OrgInvitationService/Create": {Policies: []*Policy{PolicyOrganizationInvitationsCreate}},
-}
-
-// RequiresExternalAuthz returns whether the given operation requires external authorization.
-func RequiresExternalAuthz(operation string) bool {
-	if entry, ok := ServerOperationsMap[operation]; ok {
-		return entry.ExternalAuthz
-	}
-	return false
 }
 
 // Implements https://pkg.go.dev/entgo.io/ent/schema/field#EnumValues

--- a/app/controlplane/pkg/authz/authz_test.go
+++ b/app/controlplane/pkg/authz/authz_test.go
@@ -129,36 +129,6 @@ func TestDoSync(t *testing.T) {
 	assert.Equal(t, "delete", got[0][2])
 }
 
-func TestRequiresExternalAuthz(t *testing.T) {
-	testCases := []struct {
-		name      string
-		operation string
-		want      bool
-	}{
-		{
-			name:      "CAS backend creation is forwarded to the external authorizer",
-			operation: "/controlplane.v1.CASBackendService/Create",
-			want:      true,
-		},
-		{
-			name:      "operations without external authz flag are not forwarded",
-			operation: "/controlplane.v1.WorkflowService/List",
-			want:      false,
-		},
-		{
-			name:      "unknown operations are not forwarded",
-			operation: "/controlplane.v1.UnknownService/Unknown",
-			want:      false,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, RequiresExternalAuthz(tc.operation))
-		})
-	}
-}
-
 func testEnforcer(t *testing.T) (*CasbinEnforcer, io.Closer) {
 	f, err := os.CreateTemp(t.TempDir(), "policy*.csv")
 	if err != nil {

--- a/deployment/chainloop/Chart.yaml
+++ b/deployment/chainloop/Chart.yaml
@@ -7,7 +7,7 @@ description: Chainloop is an open source software supply chain control plane, a 
 
 type: application
 # Bump the patch (not minor, not major) version on each change in the Chart Source code
-version: 1.385.0
+version: 1.385.1
 # Do not update appVersion, this is handled automatically by the release process
 appVersion: v1.98.4
 

--- a/deployment/chainloop/values.yaml
+++ b/deployment/chainloop/values.yaml
@@ -183,9 +183,11 @@ controlplane:
   ## @extra controlplane.operationAuthorizationProvider Enable external operation authorization
   ## @param controlplane.operationAuthorizationProvider.enabled Enable operation authorization
   ## @param controlplane.operationAuthorizationProvider.url URL of the authorization endpoint
+  ## @param controlplane.operationAuthorizationProvider.operations List of gRPC operations that require external authorization (e.g. "/controlplane.v1.WorkflowRunService/Create")
   operationAuthorizationProvider:
     enabled: false
     url: ""
+    operations: []
 
   ## @skip controlplane.restrictOrgCreation Restrict organization creation to instance admins
   restrictOrgCreation: false


### PR DESCRIPTION
Previously, authorized operations were a static hardcoded configuration in authz.go. This PR moves it to a proper dynamic setting.

