### PR TITLE
perf(cli): compile ANSI strip regex once at package scope

### DIFF
--- a/app/cli/cmd/attestation_status.go
+++ b/app/cli/cmd/attestation_status.go
@@ -307,10 +307,11 @@ func versionStringAttFinal(p *action.ProjectVersion) string {
 	return p.Version
 }
 
-// removeAnsiCharactersFromBytes removes ANSI escape codes from bytes slices.
+// ansiPattern matches ANSI escape codes.
 // Credits to: https://github.com/acarl005/stripansi
+var ansiPattern = regexp.MustCompile("[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))")
+
+// removeAnsiCharactersFromBytes removes ANSI escape codes from bytes slices.
 func removeAnsiCharactersFromBytes(input []byte) []byte {
-	const ansiPattern = "[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))"
-	re := regexp.MustCompile(ansiPattern)
-	return re.ReplaceAll(input, []byte(""))
+	return ansiPattern.ReplaceAll(input, nil)
 }


### PR DESCRIPTION
## Summary

`removeAnsiCharactersFromBytes` was recompiling the ANSI escape-code regex on every call. Move the compiled pattern to a package-level `var` so it is built once at init time and reused on subsequent calls.

This is a small but worthwhile cleanup on a hot path: the function is invoked per attestation push when sanitizing captured terminal output.
