### PR TITLE
fix(controlplane): promote managed CAS backend over inline as default

### DIFF
--- a/app/controlplane/pkg/biz/casbackend.go
+++ b/app/controlplane/pkg/biz/casbackend.go
@@ -158,6 +158,7 @@ type CASBackendRepo interface {
 	FindDefaultBackend(ctx context.Context, orgID uuid.UUID) (*CASBackend, error)
 	FindFallbackBackend(ctx context.Context, orgID uuid.UUID) (*CASBackend, error)
 	FindInlineBackend(ctx context.Context, orgID uuid.UUID) (*CASBackend, error)
+	FindManagedBackend(ctx context.Context, orgID uuid.UUID) (*CASBackend, error)
 	FindByID(ctx context.Context, ID uuid.UUID) (*CASBackend, error)
 	FindByIDInOrg(ctx context.Context, OrgID, ID uuid.UUID) (*CASBackend, error)
 	FindByNameInOrg(ctx context.Context, OrgID uuid.UUID, name string) (*CASBackend, error)
@@ -371,30 +372,52 @@ func (uc *CASBackendUseCase) CreateInlineBackend(ctx context.Context, orgID stri
 }
 
 // promoteNextAvailableBackend promotes the next available backend to default.
-// Promotion priority: try fallback backend first, then inline backend if no fallback exists.
-func (uc *CASBackendUseCase) promoteNextAvailableBackend(ctx context.Context, orgID string) (*CASBackend, error) {
+// Promotion priority: fallback > managed > inline. excludeID, when non-nil,
+// is skipped during the lookup so the just-demoted backend cannot be
+// re-promoted to itself (e.g. when the caller is demoting the current
+// default to fallback in the same transaction).
+func (uc *CASBackendUseCase) promoteNextAvailableBackend(ctx context.Context, orgID string, excludeID *uuid.UUID) (*CASBackend, error) {
 	orgUUID, err := uuid.Parse(orgID)
 	if err != nil {
 		return nil, NewErrInvalidUUID(err)
 	}
 
-	backend, err := uc.repo.FindFallbackBackend(ctx, orgUUID)
+	candidate, err := uc.findPromotionCandidate(ctx, orgUUID, excludeID)
 	if err != nil {
 		return nil, err
 	}
+	if candidate == nil {
+		return nil, nil
+	}
 
-	if backend == nil {
-		// If there is no fallback backend, try to find and use inline backend
-		backend, err = uc.repo.FindInlineBackend(ctx, orgUUID)
+	return uc.repo.Update(ctx, &CASBackendUpdateOpts{ID: candidate.ID, CASBackendOpts: &CASBackendOpts{Default: ToPtr(true)}})
+}
+
+// findPromotionCandidate returns the backend that should become the new
+// default, applying the fallback > managed > inline priority order and
+// honoring excludeID.
+func (uc *CASBackendUseCase) findPromotionCandidate(ctx context.Context, orgUUID uuid.UUID, excludeID *uuid.UUID) (*CASBackend, error) {
+	finders := []func(context.Context, uuid.UUID) (*CASBackend, error){
+		uc.repo.FindFallbackBackend,
+		uc.repo.FindManagedBackend,
+		uc.repo.FindInlineBackend,
+	}
+
+	for _, find := range finders {
+		backend, err := find(ctx, orgUUID)
 		if err != nil {
 			return nil, err
 		}
 		if backend == nil {
-			return nil, nil
+			continue
 		}
+		if excludeID != nil && backend.ID == *excludeID {
+			continue
+		}
+		return backend, nil
 	}
 
-	return uc.repo.Update(ctx, &CASBackendUpdateOpts{ID: backend.ID, CASBackendOpts: &CASBackendOpts{Default: ToPtr(true)}})
+	return nil, nil
 }
 
 func (uc *CASBackendUseCase) Create(ctx context.Context, orgID, name, location, description string, provider CASBackendProvider, creds any, defaultB bool, fallbackB bool, maxBytes *int64) (*CASBackend, error) {
@@ -566,9 +589,11 @@ func (uc *CASBackendUseCase) Update(ctx context.Context, orgID, id string, descr
 		}
 	}
 
-	// If we just updated the backend from default=true => default=false, we need to promote the next available backend
+	// If we just updated the backend from default=true => default=false, we need to promote the next available backend.
+	// Exclude the just-updated backend to avoid self-promotion when the
+	// caller demoted it to fallback in the same call.
 	if before.Default && !after.Default {
-		if _, err := uc.promoteNextAvailableBackend(ctx, orgID); err != nil {
+		if _, err := uc.promoteNextAvailableBackend(ctx, orgID, &after.ID); err != nil {
 			return nil, fmt.Errorf("promoting next available backend to default: %w", err)
 		}
 	}
@@ -676,9 +701,11 @@ func (uc *CASBackendUseCase) SoftDelete(ctx context.Context, orgID, id string) e
 		return err
 	}
 
-	// If we just deleted the default backend, we need to promote the next available backend
+	// If we just deleted the default backend, we need to promote the next available backend.
+	// The deleted backend is filtered out by DeletedAtIsNil in the finders,
+	// so no exclusion needed here.
 	if backend.Default {
-		if _, err := uc.promoteNextAvailableBackend(ctx, orgID); err != nil {
+		if _, err := uc.promoteNextAvailableBackend(ctx, orgID, nil); err != nil {
 			return fmt.Errorf("promoting next available backend to default: %w", err)
 		}
 	}

--- a/app/controlplane/pkg/biz/casbackend_test.go
+++ b/app/controlplane/pkg/biz/casbackend_test.go
@@ -353,6 +353,121 @@ func (s *casBackendTestSuite) TestUpdateRotatesCredentialsInPlace() {
 	}
 }
 
+// TestSoftDeletePromotesNextBackend verifies the priority of the promotion
+// logic when the current default backend is soft-deleted. The expected order
+// is fallback > managed > inline.
+func (s *casBackendTestSuite) TestSoftDeletePromotesNextBackend() {
+	ctx := context.Background()
+
+	fallbackID := uuid.New()
+	managedID := uuid.New()
+	inlineID := uuid.New()
+
+	fallback := &biz.CASBackend{ID: fallbackID, Provider: backendType, Fallback: true}
+	managed := &biz.CASBackend{ID: managedID, Provider: backendType, Managed: true}
+	inline := &biz.CASBackend{ID: inlineID, Provider: biz.CASBackendInline, Inline: true}
+
+	tests := []struct {
+		name           string
+		fallback       *biz.CASBackend
+		managed        *biz.CASBackend
+		inline         *biz.CASBackend
+		expectPromoted *uuid.UUID
+	}{
+		{
+			name:           "fallback wins over managed and inline",
+			fallback:       fallback,
+			managed:        managed,
+			inline:         inline,
+			expectPromoted: &fallbackID,
+		},
+		{
+			name:           "managed wins over inline when no fallback",
+			fallback:       nil,
+			managed:        managed,
+			inline:         inline,
+			expectPromoted: &managedID,
+		},
+		{
+			name:           "inline is last resort",
+			fallback:       nil,
+			managed:        nil,
+			inline:         inline,
+			expectPromoted: &inlineID,
+		},
+		{
+			name:           "no candidates means no promotion",
+			fallback:       nil,
+			managed:        nil,
+			inline:         nil,
+			expectPromoted: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			s.resetMock()
+
+			deletedID := uuid.New()
+			toDelete := &biz.CASBackend{ID: deletedID, Provider: backendType, Default: true}
+
+			s.repo.On("FindByIDInOrg", mock.Anything, s.validUUID, deletedID).Return(toDelete, nil)
+			s.repo.On("SoftDelete", mock.Anything, deletedID).Return(nil)
+			s.repo.On("FindFallbackBackend", mock.Anything, s.validUUID).Return(tc.fallback, nil)
+			if tc.fallback == nil {
+				s.repo.On("FindManagedBackend", mock.Anything, s.validUUID).Return(tc.managed, nil)
+				if tc.managed == nil {
+					s.repo.On("FindInlineBackend", mock.Anything, s.validUUID).Return(tc.inline, nil)
+				}
+			}
+			if tc.expectPromoted != nil {
+				promoted := &biz.CASBackend{ID: *tc.expectPromoted, Default: true}
+				s.repo.On("Update", mock.Anything, mock.MatchedBy(func(opts *biz.CASBackendUpdateOpts) bool {
+					return opts.ID == *tc.expectPromoted && opts.Default != nil && *opts.Default
+				})).Return(promoted, nil)
+			}
+
+			err := s.useCase.SoftDelete(ctx, s.validUUID.String(), deletedID.String())
+			s.Require().NoError(err)
+		})
+	}
+}
+
+// TestUpdateDemoteToFallbackPromotesManaged verifies that when the user
+// demotes the current default by setting fallback=true, the promotion logic
+// excludes the just-updated backend and promotes the managed backend instead
+// of looping back onto itself.
+func (s *casBackendTestSuite) TestUpdateDemoteToFallbackPromotesManaged() {
+	ctx := context.Background()
+
+	demotedID := uuid.New()
+	managedID := uuid.New()
+
+	before := &biz.CASBackend{ID: demotedID, Provider: backendType, Default: true}
+	// After the repo Update, the demoted backend is fallback=true, default=false.
+	afterUpdate := &biz.CASBackend{ID: demotedID, Provider: backendType, Default: false, Fallback: true}
+	managed := &biz.CASBackend{ID: managedID, Provider: backendType, Managed: true}
+
+	s.repo.On("FindByIDInOrg", mock.Anything, s.validUUID, demotedID).Return(before, nil)
+	// First Update call: the demote itself. Match on the demote opts.
+	s.repo.On("Update", mock.Anything, mock.MatchedBy(func(opts *biz.CASBackendUpdateOpts) bool {
+		return opts.ID == demotedID && opts.Fallback != nil && *opts.Fallback
+	})).Return(afterUpdate, nil).Once()
+
+	// Promotion finds the just-updated backend as the fallback, but
+	// excludeID skips it, so we fall through to FindManagedBackend.
+	s.repo.On("FindFallbackBackend", mock.Anything, s.validUUID).Return(afterUpdate, nil)
+	s.repo.On("FindManagedBackend", mock.Anything, s.validUUID).Return(managed, nil)
+	// Second Update call: the promotion of the managed backend.
+	promoted := &biz.CASBackend{ID: managedID, Default: true}
+	s.repo.On("Update", mock.Anything, mock.MatchedBy(func(opts *biz.CASBackendUpdateOpts) bool {
+		return opts.ID == managedID && opts.Default != nil && *opts.Default
+	})).Return(promoted, nil).Once()
+
+	_, err := s.useCase.Update(ctx, s.validUUID.String(), demotedID.String(), nil, nil, nil, toPtrBool(true), nil)
+	s.Require().NoError(err)
+}
+
 // Run all the tests
 func TestCASBackend(t *testing.T) {
 	suite.Run(t, new(casBackendTestSuite))

--- a/app/controlplane/pkg/biz/mocks/CASBackendRepo.go
+++ b/app/controlplane/pkg/biz/mocks/CASBackendRepo.go
@@ -584,6 +584,74 @@ func (_c *CASBackendRepo_FindInlineBackend_Call) RunAndReturn(run func(ctx conte
 	return _c
 }
 
+// FindManagedBackend provides a mock function for the type CASBackendRepo
+func (_mock *CASBackendRepo) FindManagedBackend(ctx context.Context, orgID uuid.UUID) (*biz.CASBackend, error) {
+	ret := _mock.Called(ctx, orgID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FindManagedBackend")
+	}
+
+	var r0 *biz.CASBackend
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID) (*biz.CASBackend, error)); ok {
+		return returnFunc(ctx, orgID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID) *biz.CASBackend); ok {
+		r0 = returnFunc(ctx, orgID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*biz.CASBackend)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, uuid.UUID) error); ok {
+		r1 = returnFunc(ctx, orgID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// CASBackendRepo_FindManagedBackend_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FindManagedBackend'
+type CASBackendRepo_FindManagedBackend_Call struct {
+	*mock.Call
+}
+
+// FindManagedBackend is a helper method to define mock.On call
+//   - ctx context.Context
+//   - orgID uuid.UUID
+func (_e *CASBackendRepo_Expecter) FindManagedBackend(ctx interface{}, orgID interface{}) *CASBackendRepo_FindManagedBackend_Call {
+	return &CASBackendRepo_FindManagedBackend_Call{Call: _e.mock.On("FindManagedBackend", ctx, orgID)}
+}
+
+func (_c *CASBackendRepo_FindManagedBackend_Call) Run(run func(ctx context.Context, orgID uuid.UUID)) *CASBackendRepo_FindManagedBackend_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uuid.UUID
+		if args[1] != nil {
+			arg1 = args[1].(uuid.UUID)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *CASBackendRepo_FindManagedBackend_Call) Return(cASBackend *biz.CASBackend, err error) *CASBackendRepo_FindManagedBackend_Call {
+	_c.Call.Return(cASBackend, err)
+	return _c
+}
+
+func (_c *CASBackendRepo_FindManagedBackend_Call) RunAndReturn(run func(ctx context.Context, orgID uuid.UUID) (*biz.CASBackend, error)) *CASBackendRepo_FindManagedBackend_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // List provides a mock function for the type CASBackendRepo
 func (_mock *CASBackendRepo) List(ctx context.Context, orgID uuid.UUID) ([]*biz.CASBackend, error) {
 	ret := _mock.Called(ctx, orgID)

--- a/app/controlplane/pkg/data/casbackend.go
+++ b/app/controlplane/pkg/data/casbackend.go
@@ -108,6 +108,23 @@ func (r *CASBackendRepo) FindInlineBackend(ctx context.Context, orgID uuid.UUID)
 	return entCASBackendToBiz(backend), nil
 }
 
+// FindManagedBackend finds the managed CAS backend for the given organization.
+// Managed backends are provisioned and operated by Chainloop. Only one is
+// expected per organization.
+func (r *CASBackendRepo) FindManagedBackend(ctx context.Context, orgID uuid.UUID) (*biz.CASBackend, error) {
+	ctx, span := otelx.Start(ctx, casBackendRepoTracer, "CASBackendRepo.FindManagedBackend")
+	defer span.End()
+
+	backend, err := orgScopedQuery(r.data.DB, orgID).QueryCasBackends().
+		Where(casbackend.Managed(true), casbackend.DeletedAtIsNil()).
+		Only(ctx)
+	if err != nil && !ent.IsNotFound(err) {
+		return nil, err
+	}
+
+	return entCASBackendToBiz(backend), nil
+}
+
 // Create creates a new CAS backend in the given organization
 // If it's set as default, it will unset the previous default backend
 func (r *CASBackendRepo) Create(ctx context.Context, opts *biz.CASBackendCreateOpts) (*biz.CASBackend, error) {


### PR DESCRIPTION
## Summary

Support for managed backends (s3 endpoints) was added at https://github.com/chainloop-dev/chainloop/issues/3114. The default CAS backend promotion logic walked `fallback -> inline` and never considered the managed (Chainloop-provisioned) backend, so deleting a custom default left the inline backend as the new default instead of the managed one. The same code path also self-promoted a backend when the user demoted the current default by marking it as `fallback`.

Promotion now walks `fallback -> managed -> inline` and accepts an `excludeID` so the just-updated backend cannot win the promotion against itself.

## AI assistance

Implementation assisted by Claude Code.