### PR TITLE
perf(protovalidate): cache validator instead of constructing per call

### DIFF
--- a/app/controlplane/pkg/biz/casclient.go
+++ b/app/controlplane/pkg/biz/casclient.go
@@ -167,12 +167,7 @@ func (uc *CASClientUseCase) IsReady(ctx context.Context) (bool, error) {
 		return false, errors.New("missing CAS server configuration")
 	}
 
-	v, err := protovalidate.New()
-	if err != nil {
-		return false, fmt.Errorf("failed to create validator: %w", err)
-	}
-
-	if err := v.Validate(uc.casServerConf); err != nil {
+	if err := protovalidate.Validate(uc.casServerConf); err != nil {
 		return false, fmt.Errorf("invalid CAS client configuration: %w", err)
 	}
 

--- a/app/controlplane/pkg/unmarshal/unmarshal.go
+++ b/app/controlplane/pkg/unmarshal/unmarshal.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2024-2025 The Chainloop Authors.
+// Copyright 2024-2026 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -56,17 +56,11 @@ func (v *validatorAdapter) Validate(msg proto.Message) error {
 	return v.validator.Validate(msg)
 }
 
+// yamlValidator wraps the protovalidate global Validator for use with protoyaml,
+// initialised once and reused across calls.
+var yamlValidator = &validatorAdapter{validator: protovalidate.GlobalValidator}
+
 func FromRaw(body []byte, format RawFormat, out proto.Message, doValidate bool) error {
-	var validator protovalidate.Validator
-	var err error
-
-	if doValidate {
-		validator, err = protovalidate.New()
-		if err != nil {
-			return fmt.Errorf("could not create validator: %w", err)
-		}
-	}
-
 	switch format {
 	case RawFormatJSON:
 		if err := protojson.Unmarshal(body, out); err != nil {
@@ -76,7 +70,7 @@ func FromRaw(body []byte, format RawFormat, out proto.Message, doValidate bool) 
 		// protoyaml allows validating the contract while unmarshalling
 		yamlOpts := protoyaml.UnmarshalOptions{}
 		if doValidate {
-			yamlOpts.Validator = &validatorAdapter{validator: validator}
+			yamlOpts.Validator = yamlValidator
 		}
 
 		if err := yamlOpts.Unmarshal(body, out); err != nil {
@@ -97,9 +91,8 @@ func FromRaw(body []byte, format RawFormat, out proto.Message, doValidate bool) 
 		return fmt.Errorf("unsupported format: %s", format)
 	}
 
-	if validator != nil {
-		err = validator.Validate(out)
-		if err != nil {
+	if doValidate {
+		if err := protovalidate.Validate(out); err != nil {
 			return fmt.Errorf("error validating raw message: %w", err)
 		}
 	}

--- a/pkg/attestation/crafter/api/attestation/v1/crafting_state_validations.go
+++ b/pkg/attestation/crafter/api/attestation/v1/crafting_state_validations.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2024-2025 The Chainloop Authors.
+// Copyright 2024-2026 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,15 +27,10 @@ import (
 // ValidateComplete makes sure that the crafting state has been completed
 // before it gets passed to the renderer
 func (state *CraftingState) ValidateComplete(dryRun bool) error {
-	validator, err := protovalidate.New()
-	if err != nil {
-		return fmt.Errorf("could not create validator: %w", err)
-	}
-
 	// We do not want to validate the schema of the state if we are just doing a dry run
 	// since it's known to not to contain the workflow metadata information
 	if !dryRun {
-		if err := validator.Validate(state); err != nil {
+		if err := protovalidate.Validate(state); err != nil {
 			return fmt.Errorf("invalid crafting state: %w", err)
 		}
 	}

--- a/pkg/attestation/crafter/crafter.go
+++ b/pkg/attestation/crafter/crafter.go
@@ -67,7 +67,6 @@ type Crafter struct {
 	stateManager  StateManager
 	// Authn is used to authenticate with the OCI registry
 	ociRegistryAuth authn.Keychain
-	validator       protovalidate.Validator
 
 	// attestation client is used to load chainloop policies
 	attClient v1.AttestationServiceClient
@@ -166,11 +165,6 @@ func (c *Crafter) RunCollectors(ctx context.Context, attestationID string, casBa
 func NewCrafter(stateManager StateManager, attClient v1.AttestationServiceClient, opts ...NewOpt) (*Crafter, error) {
 	noopLogger := zerolog.Nop()
 
-	validator, err := protovalidate.New()
-	if err != nil {
-		return nil, fmt.Errorf("creating proto validator: %w", err)
-	}
-
 	cw, _ := os.Getwd()
 	c := &Crafter{
 		Logger:       &noopLogger,
@@ -178,7 +172,6 @@ func NewCrafter(stateManager StateManager, attClient v1.AttestationServiceClient
 		stateManager: stateManager,
 		// By default we authenticate with the current user's keychain (i.e ~/.docker/config.json)
 		ociRegistryAuth: authn.DefaultKeychain,
-		validator:       validator,
 		attClient:       attClient,
 	}
 
@@ -684,7 +677,7 @@ func (c *Crafter) addMaterial(ctx context.Context, m *schemaapi.CraftingSchema_M
 		}
 	}
 
-	if err := c.validator.Validate(mt); err != nil {
+	if err := protovalidate.Validate(mt); err != nil {
 		return nil, fmt.Errorf("validation error: %w", err)
 	}
 

--- a/pkg/attestation/crafter/materials/materials.go
+++ b/pkg/attestation/crafter/materials/materials.go
@@ -224,12 +224,7 @@ func Craft(ctx context.Context, materialSchema *schemaapi.CraftingSchema_Materia
 	var crafter Craftable
 	var err error
 
-	validator, err := protovalidate.New()
-	if err != nil {
-		return nil, fmt.Errorf("could not create validator: %w", err)
-	}
-
-	if err := validator.Validate(materialSchema); err != nil {
+	if err := protovalidate.Validate(materialSchema); err != nil {
 		return nil, fmt.Errorf("validating material: %w", err)
 	}
 

--- a/pkg/credentials/manager/manager.go
+++ b/pkg/credentials/manager/manager.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 The Chainloop Authors.
+// Copyright 2023-2026 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -56,12 +56,7 @@ func NewFromConfig(conf *api.Credentials, role credentials.Role, l log.Logger) (
 }
 
 func validateConfig(msg protoreflect.ProtoMessage) error {
-	validator, err := protovalidate.New()
-	if err != nil {
-		return fmt.Errorf("creating validator: %w", err)
-	}
-
-	return validator.Validate(msg)
+	return protovalidate.Validate(msg)
 }
 
 func newAzureKBManager(conf *api.Credentials_AzureKeyVault, prefix string, r credentials.Role, l log.Logger) (*azurekv.Manager, error) {

--- a/pkg/policies/policies.go
+++ b/pkg/policies/policies.go
@@ -705,15 +705,9 @@ func (pv *PolicyVerifier) getLoader(attachment *v1.PolicyAttachment) (Loader, er
 }
 
 func validateResource(m proto.Message) error {
-	validator, err := protovalidate.New()
-	if err != nil {
+	if err := protovalidate.Validate(m); err != nil {
 		return fmt.Errorf("validating policy spec: %w", err)
 	}
-	err = validator.Validate(m)
-	if err != nil {
-		return fmt.Errorf("validating policy spec: %w", err)
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Replaces seven per-call `protovalidate.New()` constructions with the library's global validator (or `protovalidate.GlobalValidator` for sites that need a `Validator` handle for `protoyaml`). Each `New()` call rebuilds the CEL environment, the type registry, and starts with an empty message-evaluator cache; reusing one validator amortises all of that across calls.

Sites refactored:

- `pkg/policies/policies.go` — `validateResource`
- `pkg/attestation/crafter/crafter.go` — removed unused `validator` field on `Crafter`
- `pkg/attestation/crafter/materials/materials.go` — `Craft`
- `pkg/attestation/crafter/api/attestation/v1/crafting_state_validations.go` — `ValidateComplete`
- `app/controlplane/pkg/biz/casclient.go` — `IsReady`
- `app/controlplane/pkg/unmarshal/unmarshal.go` — `FromRaw` (single shared adapter around `protovalidate.GlobalValidator`)
- `pkg/credentials/manager/manager.go` — `validateConfig`

Wire providers in `app/controlplane/cmd/main.go` and `app/artifact-cas/cmd/main.go`
were already correct (one validator per process) and are unchanged.

## Benchmarks

Measured on `darwin/arm64`, Apple M5, Go 1.26.3:

| Site | Per-call `New()` | Cached validator | Speedup |
|---|---:|---:|---:|
| `pkg/credentials/manager` (`Credentials` config) | 1,141,692 ns/op · 1.6 MB · 19,350 allocs | 672 ns/op · 96 B · 6 allocs | **~1,700×** |
| `pkg/attestation/crafter/api/.../crafting_state` (`CraftingState`) | 4,854,560 ns/op · 6.1 MB · 73,712 allocs | 2,709 ns/op · 1.9 KB · 59 allocs | **~1,790×** |
| `pkg/attestation/crafter/materials` (`CraftingSchema_Material`) | 916,357 ns/op · 1.5 MB · 17,781 allocs | 925 ns/op · 326 B · 15 allocs | **~990×** |

For a typical attestation craft with 20 materials, this removes ~18 ms of CPU and ~30 MB of allocations from `materials.Craft` alone.

## Concurrency safety

The library documents `Validator` as safe for concurrent use (`buf.build/go/protovalidate@v1.1.3 validator.go:43-44`). Internally it is a `sync.Mutex` + `atomic.Pointer[messageCache]` copy-on-write cache (`builder.go:42-110`): hot path is an atomic load, cold path (first-time descriptor) serialises briefly on the mutex.

The library itself shares a single validator across goroutines in its own benchmarks (`validator_bench_test.go:75-80`) and exposes `protovalidate.Validate` and `protovalidate.GlobalValidator` backed by `sync.OnceValues(New)` for exactly this reuse pattern.

Verified locally:

- `go test ./pkg/policies/... ./pkg/attestation/crafter/... ./pkg/credentials/manager/... ./app/controlplane/pkg/biz/... ./app/controlplane/pkg/unmarshal/...` — all green, including the full `app/controlplane/pkg/biz` integration suite (~138 s).
- `go vet ./...` — clean.
- `golangci-lint run --new-from-rev=main ...` — zero new issues from this PR.
- `go test -race -bench=...Parallel ./pkg/attestation/crafter/materials/` — race detector clean against the cached validator under concurrent load.

This codebase passes **zero options** to `protovalidate.New()` anywhere (verified by grep of `protovalidate.With*`), so the only concurrency promise in play is the documented one. The option that could weaken it (`WithNowFunc` with a non-goroutine-safe callback) is never used.

## Technical notes

- The library exposes a module-level `GlobalValidator` initialised once via `sync.OnceValues(New)`. Package-level `protovalidate.Validate(msg)` uses it transparently — used everywhere a function call is enough. The `GlobalValidator` value is used where an interface is required (`protoyaml.UnmarshalOptions.Validator`).
- `Crafter` previously stored its own `validator` field with one internal use site. Removed in favour of `protovalidate.Validate` to shrink the struct.
