### PR TITLE
feat(db): Expose workflow template ID

### DIFF
--- a/app/controlplane/pkg/biz/workflow.go
+++ b/app/controlplane/pkg/biz/workflow.go
@@ -47,6 +47,8 @@ type Workflow struct {
 	// This field is also used to calculate if an user can download attestations/materials from the CAS
 	Public    bool
 	ProjectID uuid.UUID
+	// WorkflowTemplateID references the platform workflow template this workflow was created from
+	WorkflowTemplateID *uuid.UUID
 }
 
 // WorkflowRef is a reference to a workflow
@@ -88,6 +90,8 @@ type WorkflowCreateOpts struct {
 	UserIsOrgAdmin bool
 	// OrgRestrictContractCreationToAdmins is the organization's setting for restricting contract creation
 	OrgRestrictContractCreationToAdmins bool
+	// WorkflowTemplateID optionally references the platform workflow template this workflow is created from
+	WorkflowTemplateID *uuid.UUID
 }
 
 type WorkflowUpdateOpts struct {

--- a/app/controlplane/pkg/data/workflow.go
+++ b/app/controlplane/pkg/data/workflow.go
@@ -209,6 +209,7 @@ func (r *WorkflowRepo) Create(ctx context.Context, opts *biz.WorkflowCreateOpts)
 			SetContractID(contractUUID).
 			SetOrganizationID(orgUUID).
 			SetDescription(opts.Description).
+			SetNillableWorkflowTemplateID(opts.WorkflowTemplateID).
 			Save(ctx)
 		if err != nil {
 			if ent.IsConstraintError(err) {
@@ -492,12 +493,13 @@ func (r *WorkflowRepo) SoftDelete(ctx context.Context, id uuid.UUID) (err error)
 
 func entWFToBizWF(ctx context.Context, w *ent.Workflow) (*biz.Workflow, error) {
 	wf := &biz.Workflow{Name: w.Name, ID: w.ID,
-		CreatedAt: toTimePtr(w.CreatedAt), Team: w.Team,
-		RunsCounter: w.RunsCount,
-		Public:      w.Public,
-		Description: w.Description,
-		OrgID:       w.OrganizationID,
-		ProjectID:   w.ProjectID,
+		CreatedAt:          toTimePtr(w.CreatedAt), Team: w.Team,
+		RunsCounter:        w.RunsCount,
+		Public:             w.Public,
+		Description:        w.Description,
+		OrgID:              w.OrganizationID,
+		ProjectID:          w.ProjectID,
+		WorkflowTemplateID: w.WorkflowTemplateID,
 	}
 
 	// Set p either pre-loaded or queried


### PR DESCRIPTION
This pull request adds support for associating a workflow with a workflow template. The changes introduce a new `WorkflowTemplateID` field to the workflow data model and ensure it is properly handled during workflow creation and data mapping.

**Workflow Template Association:**

* Added a `WorkflowTemplateID` field to the `Workflow` struct to reference the platform workflow template from which the workflow was created.
* Added an optional `WorkflowTemplateID` field to the `WorkflowCreateOpts` struct to allow specifying a template when creating a workflow.

**Data Persistence and Mapping:**

* Updated the workflow creation logic in `WorkflowRepo.Create` to persist the `WorkflowTemplateID` field when present.
* Updated the `entWFToBizWF` function to map the `WorkflowTemplateID` from the database entity to the business model.