### PR TITLE
feat(dagger): expose --mark-latest flag on attestation init

### DIFF
--- a/extras/dagger/main.go
+++ b/extras/dagger/main.go
@@ -156,6 +156,10 @@ func (m *Chainloop) Init(
 	// mark the version as release
 	// +optional
 	release bool,
+	// Explicitly mark the project version as latest (use =false to skip promotion).
+	// When unset, the server decides automatically (defaults to latest for new versions).
+	// +optional
+	markLatest *bool,
 	// Github event file for PR detection (when running in Github Actions)
 	// +optional
 	githubEventFile *dagger.File,
@@ -281,6 +285,10 @@ func (m *Chainloop) Init(
 		args = append(args,
 			"--release",
 		)
+	}
+
+	if markLatest != nil {
+		args = append(args, fmt.Sprintf("--mark-latest=%t", *markLatest))
 	}
 
 	info, err := att.


### PR DESCRIPTION
Forwards the new CLI flag added in #3151 through the Dagger module so callers can explicitly mark (or skip marking) a project version as latest when initializing an attestation.