### PR TITLE
Revert "feat(dagger): expose --mark-latest flag on attestation init (#3165)"

### DIFF
--- a/extras/dagger/main.go
+++ b/extras/dagger/main.go
@@ -156,10 +156,6 @@ func (m *Chainloop) Init(
 	// mark the version as release
 	// +optional
 	release bool,
-	// Explicitly mark the project version as latest (use =false to skip promotion).
-	// When unset, the server decides automatically (defaults to latest for new versions).
-	// +optional
-	markLatest *bool,
 	// Github event file for PR detection (when running in Github Actions)
 	// +optional
 	githubEventFile *dagger.File,
@@ -285,10 +281,6 @@ func (m *Chainloop) Init(
 		args = append(args,
 			"--release",
 		)
-	}
-
-	if markLatest != nil {
-		args = append(args, fmt.Sprintf("--mark-latest=%t", *markLatest))
 	}
 
 	info, err := att.


### PR DESCRIPTION
This reverts commit 8331435efdb063a20478bb22324d941cd55583fe since it does not work as expected.