### PR TITLE
feat(dagger): expose mark-latest as a tri-state enum on attestation init

### DIFF
--- a/extras/dagger/README.md
+++ b/extras/dagger/README.md
@@ -80,9 +80,11 @@ dagger call -m github.com/chainloop-dev/chainloop \
 
 The optional `--mark-latest` flag controls whether the project version is promoted to `latest`. It is an enum with three values:
 
-- `ON_CREATE` (default): newly created versions become `latest`; existing/pre-release versions are left unchanged.
+- `ON_CREATE` (default): newly created versions become `latest`; existing versions are left unchanged.
 - `TRUE`: force-promote a pre-release version to `latest`.
-- `FALSE`: skip `latest` promotion entirely, even for newly created versions.
+- `FALSE`: do not promote the version to `latest`.
+
+`TRUE` and `FALSE` only affect promotion: they never demote a version that is already `latest`. In particular, `FALSE` prevents a newly created version from becoming `latest`, but it has no effect on an existing version (its `latest` status is left untouched).
 
 ```sh
 dagger call -m github.com/chainloop-dev/chainloop \
@@ -91,7 +93,7 @@ dagger call -m github.com/chainloop-dev/chainloop \
   --workflow-name the-name-of-the-workflow \
   --project-name the-name-of-the-project \
   --version 1.0.0 \
-  --mark-latest FALSE # create the version without promoting it to latest
+  --mark-latest FALSE # create the new version 1.0.0 without making it latest
 ```
 
 #### 2 - Get the status ([docs](https://docs.chainloop.dev/getting-started/attestation-crafting#inspecting-the-crafting-status))

--- a/extras/dagger/README.md
+++ b/extras/dagger/README.md
@@ -76,6 +76,24 @@ dagger call -m github.com/chainloop-dev/chainloop \
   --contract-name my-existing-contract \ # optional flag to specify an existing contract that will be used during the creation of a workflow
 ```
 
+##### Controlling "latest" promotion
+
+The optional `--mark-latest` flag controls whether the project version is promoted to `latest`. It is an enum with three values:
+
+- `ON_CREATE` (default): newly created versions become `latest`; existing/pre-release versions are left unchanged.
+- `TRUE`: force-promote a pre-release version to `latest`.
+- `FALSE`: skip `latest` promotion entirely, even for newly created versions.
+
+```sh
+dagger call -m github.com/chainloop-dev/chainloop \
+  init \
+  --token env:CHAINLOOP_TOKEN \
+  --workflow-name the-name-of-the-workflow \
+  --project-name the-name-of-the-project \
+  --version 1.0.0 \
+  --mark-latest FALSE # create the version without promoting it to latest
+```
+
 #### 2 - Get the status ([docs](https://docs.chainloop.dev/getting-started/attestation-crafting#inspecting-the-crafting-status))
 
 Resuming a previous attestation

--- a/extras/dagger/main.go
+++ b/extras/dagger/main.go
@@ -156,6 +156,12 @@ func (m *Chainloop) Init(
 	// mark the version as release
 	// +optional
 	release bool,
+	// Control whether this project version is promoted to "latest".
+	// ON_CREATE (default): new versions become latest, existing ones are untouched.
+	// TRUE: force-promote a pre-release version. FALSE: skip promotion entirely.
+	// +optional
+	// +default="ON_CREATE"
+	markLatest MarkLatest,
 	// Github event file for PR detection (when running in Github Actions)
 	// +optional
 	githubEventFile *dagger.File,
@@ -281,6 +287,19 @@ func (m *Chainloop) Init(
 		args = append(args,
 			"--release",
 		)
+	}
+
+	// Map the tri-state enum onto the CLI's --mark-latest flag. ON_CREATE omits
+	// the flag so the server applies its default behavior. An enum (non-empty
+	// string) is used instead of *bool because Dagger v0.19.11 collapses *bool
+	// to bool in the generated SDK and drops the false value (see PFM-6269).
+	switch markLatest {
+	case MarkLatestTrue:
+		args = append(args, "--mark-latest=true")
+	case MarkLatestFalse:
+		args = append(args, "--mark-latest=false")
+	case MarkLatestOnCreate:
+		// omit the flag → CLI sends no value → server applies its default
 	}
 
 	info, err := att.
@@ -697,6 +716,23 @@ type OutputFormat string
 const (
 	OutputFormatTable OutputFormat = "table"
 	OutputFormatJSON  OutputFormat = "json"
+)
+
+// MarkLatest controls whether a project version is promoted to "latest" during
+// attestation init. It is modelled as an enum rather than a *bool because the
+// Dagger v0.19.11 SDK collapses *bool parameters to bool and drops the false
+// value before it reaches the wire, making the "skip promotion" state
+// unreachable (see PFM-6269). A non-empty string survives that check.
+type MarkLatest string
+
+const (
+	// MarkLatestOnCreate keeps the server default: a newly created version
+	// becomes latest, while existing/pre-release versions are left unchanged.
+	MarkLatestOnCreate MarkLatest = "ON_CREATE"
+	// MarkLatestTrue force-promotes a pre-release version to latest.
+	MarkLatestTrue MarkLatest = "TRUE"
+	// MarkLatestFalse skips latest promotion, even for newly created versions.
+	MarkLatestFalse MarkLatest = "FALSE"
 )
 
 // Generate, sign and push the attestation to the chainloop control plane


### PR DESCRIPTION
## Summary

Adds support for controlling "latest" promotion from the Dagger module's `Init`, exposed as a `MarkLatest` enum with three values:

- `ON_CREATE` (default): newly created versions become latest; existing/pre-release versions are left unchanged.
- `TRUE`: force-promote a pre-release version to latest.
- `FALSE`: skip latest promotion entirely, even for newly created versions.

The flag is modelled as an enum rather than a `*bool` because the Dagger v0.19.11 SDK collapses `*bool` parameters to plain `bool` and drops the false value before it reaches the wire, making the skip-promotion state unreachable through consuming modules. A non-empty string enum makes all three states reachable.

The enum maps onto the existing CLI `--mark-latest` flag: `TRUE` → `--mark-latest=true`, `FALSE` → `--mark-latest=false`, `ON_CREATE` → flag omitted (server default).

## AI disclosure

Assisted by Claude Code.