### PR TITLE
refactor(controlplane): make CAS source_internal resolution best-effort

### DIFF
--- a/app/controlplane/internal/service/cascredential.go
+++ b/app/controlplane/internal/service/cascredential.go
@@ -58,10 +58,7 @@ func (s *CASCredentialsService) Get(ctx context.Context, req *pb.CASCredentialsS
 	}
 
 	// Internal platform traffic can be flagged so the CAS skips audit event emission for it
-	sourceInternal, err := resolveSourceInternal(req.GetSourceInternal(), currentAPIToken)
-	if err != nil {
-		return nil, err
-	}
+	sourceInternal := resolveSourceInternal(req.GetSourceInternal(), currentAPIToken)
 
 	currentOrg, err := requireCurrentOrg(ctx)
 	if err != nil {
@@ -167,17 +164,12 @@ func (s *CASCredentialsService) Get(ctx context.Context, req *pb.CASCredentialsS
 	}, nil
 }
 
-// resolveSourceInternal returns whether the minted CAS token must be flagged as internal
-// platform traffic. Only system API tokens can request it since they are minted exclusively
-// by internal code paths; any other caller asking for it is rejected.
-func resolveSourceInternal(requested bool, token *entities.APIToken) (bool, error) {
-	if !requested {
-		return false, nil
-	}
-
-	if token == nil || !token.IsSystem {
-		return false, errors.Forbidden("forbidden", "source_internal is restricted to system API tokens")
-	}
-
-	return true, nil
+// resolveSourceInternal returns whether the minted CAS token should be flagged as internal
+// platform traffic. It is only flagged when a system API token explicitly requests it, since
+// these tokens are minted exclusively by internal code paths.
+//
+// This is best-effort: any other caller requesting it (for example an outdated system whose
+// token store does not yet mark its tokens as system) is simply not flagged rather than rejected.
+func resolveSourceInternal(requested bool, token *entities.APIToken) bool {
+	return requested && token != nil && token.IsSystem
 }

--- a/app/controlplane/internal/service/cascredential_test.go
+++ b/app/controlplane/internal/service/cascredential_test.go
@@ -19,9 +19,7 @@ import (
 	"testing"
 
 	"github.com/chainloop-dev/chainloop/app/controlplane/internal/usercontext/entities"
-	"github.com/go-kratos/kratos/v2/errors"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestResolveSourceInternal(t *testing.T) {
@@ -30,7 +28,6 @@ func TestResolveSourceInternal(t *testing.T) {
 		requested bool
 		token     *entities.APIToken
 		want      bool
-		wantErr   bool
 	}{
 		{
 			name:      "not requested, no token (user auth)",
@@ -57,29 +54,24 @@ func TestResolveSourceInternal(t *testing.T) {
 			want:      true,
 		},
 		{
-			name:      "requested by regular API token is forbidden",
+			// best-effort: a non-system token requesting it is ignored, not rejected,
+			// to tolerate outdated systems whose tokens are not yet marked as system
+			name:      "requested by regular API token falls back to false",
 			requested: true,
 			token:     &entities.APIToken{},
-			wantErr:   true,
+			want:      false,
 		},
 		{
-			name:      "requested by user auth is forbidden",
+			name:      "requested by user auth falls back to false",
 			requested: true,
 			token:     nil,
-			wantErr:   true,
+			want:      false,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := resolveSourceInternal(tc.requested, tc.token)
-			if tc.wantErr {
-				require.Error(t, err)
-				assert.True(t, errors.IsForbidden(err))
-				return
-			}
-
-			require.NoError(t, err)
+			got := resolveSourceInternal(tc.requested, tc.token)
 			assert.Equal(t, tc.want, got)
 		})
 	}


### PR DESCRIPTION
## Summary

Follow-up to #3199.

Resolving whether a CAS credential should be flagged as internal platform traffic (`source_internal`) is now best-effort. The flag is set only when a system API token explicitly requests it. Any other caller requesting it is silently not flagged instead of being rejected with a `Forbidden` error.

This tolerates outdated systems whose token store does not yet mark their tokens as system: rather than failing the request, the credential is simply minted without the internal flag.

## AI assistance

This change was developed with the assistance of Claude Code.

🤖 _Posted by Maximus bot (Claude Code) on behalf of @migmartri_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chainloop-dev/chainloop/pull/3201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

