### PR TITLE
fix(jsonfilter): Sanitize input when parsing filters

### DIFF
--- a/app/controlplane/pkg/biz/workflow_integration_test.go
+++ b/app/controlplane/pkg/biz/workflow_integration_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/biz/testhelpers"
 	"github.com/chainloop-dev/chainloop/pkg/credentials"
 	creds "github.com/chainloop-dev/chainloop/pkg/credentials/mocks"
+	"github.com/chainloop-dev/chainloop/pkg/jsonfilter"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
@@ -560,6 +561,35 @@ func (s *workflowListIntegrationTestSuite) TestList() {
 		s.NoError(err)
 		s.Len(workflows, 1)
 		s.Equal(2, count)
+	})
+
+	s.Run("rejects a JSON filter with an unsafe field path as a validation error", func() {
+		opts := &biz.WorkflowListOpts{
+			JSONFilters: []*jsonfilter.JSONFilter{
+				{
+					// SQL injection attempt: a single quote breaks out of the JSON path literal.
+					FieldPath: "x'='x' OR (SELECT 1 FROM pg_sleep(2)) IS NOT NULL OR 'z",
+					Operator:  jsonfilter.OpEQ,
+					Value:     "true",
+				},
+			},
+		}
+
+		workflows, _, err := s.Workflow.List(ctx, s.org.ID, opts, nil)
+		s.Error(err)
+		s.True(biz.IsErrValidation(err), "unsafe field path must surface as a validation error, got: %v", err)
+		s.Nil(workflows)
+	})
+
+	s.Run("accepts a JSON filter with a safe field path", func() {
+		opts := &biz.WorkflowListOpts{
+			JSONFilters: []*jsonfilter.JSONFilter{
+				{FieldPath: "needsAttention", Operator: jsonfilter.OpEQ, Value: "true"},
+			},
+		}
+
+		_, _, err := s.Workflow.List(ctx, s.org.ID, opts, nil)
+		s.NoError(err)
 	})
 }
 

--- a/app/controlplane/pkg/data/workflow.go
+++ b/app/controlplane/pkg/data/workflow.go
@@ -281,7 +281,10 @@ func (r *WorkflowRepo) List(ctx context.Context, orgID uuid.UUID, filter *biz.Wo
 	wfQuery := baseQuery.Where(workflow.DeletedAtIsNil())
 
 	// Apply additional filters to the Workflow query based on the provided options
-	wfQuery = applyWorkflowFilters(wfQuery, filter)
+	wfQuery, err := applyWorkflowFilters(wfQuery, filter)
+	if err != nil {
+		return nil, 0, err
+	}
 
 	// Get the count of all filtered rows without the limit and offset
 	count, err := wfQuery.Count(ctx)
@@ -339,7 +342,7 @@ func applyWorkflowRunFilters(baseQuery *ent.WorkflowQuery, opts *biz.WorkflowLis
 }
 
 // applyWorkflowFilters applies filters to the Workflow query based on the provided options
-func applyWorkflowFilters(wfQuery *ent.WorkflowQuery, opts *biz.WorkflowListOpts) *ent.WorkflowQuery {
+func applyWorkflowFilters(wfQuery *ent.WorkflowQuery, opts *biz.WorkflowListOpts) (*ent.WorkflowQuery, error) {
 	if opts != nil {
 		if opts.WorkflowPublic != nil {
 			wfQuery = wfQuery.Where(workflow.Public(*opts.WorkflowPublic))
@@ -364,16 +367,21 @@ func applyWorkflowFilters(wfQuery *ent.WorkflowQuery, opts *biz.WorkflowListOpts
 
 		// Append the JSON Filters to the query
 		if len(opts.JSONFilters) != 0 {
-			wfQuery = wfQuery.Where(func(selector *sql.Selector) {
-				// Build the predicates for each JSON filter
-				predicates := make([]*sql.Predicate, 0, len(opts.JSONFilters))
-				for _, filter := range opts.JSONFilters {
-					// Include the column where the filter is applied
-					filter.Column = workflow.FieldMetadata
-					jsonPredicate, _ := jsonfilter.BuildEntSelectorFromJSONFilter(filter)
-					predicates = append(predicates, jsonPredicate)
+			// Build the predicates for each JSON filter up front so that any
+			// validation error (e.g. an unsafe field path) is surfaced instead
+			// of being silently ignored inside the query builder closure.
+			predicates := make([]*sql.Predicate, 0, len(opts.JSONFilters))
+			for _, filter := range opts.JSONFilters {
+				// Include the column where the filter is applied
+				filter.Column = workflow.FieldMetadata
+				jsonPredicate, err := jsonfilter.BuildEntSelectorFromJSONFilter(filter)
+				if err != nil {
+					return nil, biz.NewErrValidation(fmt.Errorf("invalid JSON filter: %w", err))
 				}
-				// Combine the predicates using OR logic
+				predicates = append(predicates, jsonPredicate)
+			}
+			wfQuery = wfQuery.Where(func(selector *sql.Selector) {
+				// Combine the predicates using AND logic
 				selector.Where(sql.And(predicates...))
 			})
 		}
@@ -396,7 +404,7 @@ func applyWorkflowFilters(wfQuery *ent.WorkflowQuery, opts *biz.WorkflowListOpts
 		}
 	}
 
-	return wfQuery
+	return wfQuery, nil
 }
 
 // GetOrgScoped Gets a workflow making sure it belongs to a given org

--- a/pkg/jsonfilter/jsonfilter.go
+++ b/pkg/jsonfilter/jsonfilter.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2025 The Chainloop Authors.
+// Copyright 2025-2026 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,11 +18,23 @@ package jsonfilter
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 
 	entsql "entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqljson"
 )
+
+// fieldPathRegexp matches a safe JSON field path expressed in dot notation.
+// A path is a dot-separated sequence of identifiers (starting with a letter or
+// underscore) optionally followed by numeric array indices, e.g. "name",
+// "labels.env" or "items[0].name".
+//
+// This allowlist is security-critical: the underlying ent sqljson helpers
+// concatenate path segments verbatim into single-quoted PostgreSQL JSON path
+// literals without escaping, so any character outside this set (e.g. a single
+// quote) would allow breaking out of the literal and injecting arbitrary SQL.
+var fieldPathRegexp = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*|\[[0-9]+\])*$`)
 
 // JSONOperator represents supported JSON filter operators.
 type JSONOperator string
@@ -52,6 +64,13 @@ type JSONFilter struct {
 func BuildEntSelectorFromJSONFilter(jsonFilter *JSONFilter) (*entsql.Predicate, error) {
 	if jsonFilter.Column == "" || jsonFilter.Operator == "" {
 		return nil, errors.New("invalid filter: column and operator are required")
+	}
+
+	// Validate the field path before it reaches the SQL builder. The ent
+	// sqljson helpers concatenate the path segments unescaped into the query,
+	// so an unsafe value would allow SQL injection.
+	if err := validateFieldPath(jsonFilter.FieldPath); err != nil {
+		return nil, err
 	}
 
 	// Convert the dot notation to the path that Ent expects.
@@ -84,4 +103,19 @@ func BuildEntSelectorFromJSONFilter(jsonFilter *JSONFilter) (*entsql.Predicate, 
 	default:
 		return nil, fmt.Errorf("unsupported operator: %s", jsonFilter.Operator)
 	}
+}
+
+// validateFieldPath ensures the JSON field path only contains safe characters
+// before it is concatenated into the SQL query by the ent sqljson helpers.
+// An empty path is allowed: it targets the column itself and is not injectable.
+func validateFieldPath(fieldPath string) error {
+	if fieldPath == "" {
+		return nil
+	}
+
+	if !fieldPathRegexp.MatchString(fieldPath) {
+		return fmt.Errorf("invalid field path %q: must be dot-separated identifiers with optional numeric array indices", fieldPath)
+	}
+
+	return nil
 }

--- a/pkg/jsonfilter/jsonfilter_test.go
+++ b/pkg/jsonfilter/jsonfilter_test.go
@@ -22,6 +22,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// errInvalidFieldPath is the common prefix returned when a field path fails validation.
+const errInvalidFieldPath = "invalid field path"
+
 func TestBuildEntSelectorFromJSONFilter(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -81,13 +84,52 @@ func TestBuildEntSelectorFromJSONFilter(t *testing.T) {
 			filter:  &JSONFilter{Column: "metadata", FieldPath: "env", Operator: OpIN, Value: []string{"prod", "dev"}},
 			wantErr: "invalid value for 'in' operator: must be a slice of strings",
 		},
+		{
+			name:   "field path with array index",
+			filter: &JSONFilter{Column: "metadata", FieldPath: "items[0].name", Operator: OpEQ, Value: "foo"},
+		},
+		{
+			name:    "field path with single quote breaks out of literal",
+			filter:  &JSONFilter{Column: "metadata", FieldPath: "x'='x' OR (SELECT 1 FROM pg_sleep(2)) IS NOT NULL OR 'z", Operator: OpEQ, Value: "true"},
+			wantErr: errInvalidFieldPath,
+		},
+		{
+			name:    "field path with double quote",
+			filter:  &JSONFilter{Column: "metadata", FieldPath: `name"`, Operator: OpEQ, Value: "foo"},
+			wantErr: errInvalidFieldPath,
+		},
+		{
+			name:    "field path with semicolon",
+			filter:  &JSONFilter{Column: "metadata", FieldPath: "name;DROP TABLE workflows", Operator: OpEQ, Value: "foo"},
+			wantErr: errInvalidFieldPath,
+		},
+		{
+			name:    "field path with whitespace",
+			filter:  &JSONFilter{Column: "metadata", FieldPath: "name OR 1=1", Operator: OpEQ, Value: "foo"},
+			wantErr: errInvalidFieldPath,
+		},
+		{
+			name:    "field path with parenthesis",
+			filter:  &JSONFilter{Column: "metadata", FieldPath: "pg_sleep(2)", Operator: OpEQ, Value: "foo"},
+			wantErr: errInvalidFieldPath,
+		},
+		{
+			name:    "field path with leading digit segment",
+			filter:  &JSONFilter{Column: "metadata", FieldPath: "1name", Operator: OpEQ, Value: "foo"},
+			wantErr: errInvalidFieldPath,
+		},
+		{
+			name:    "field path with trailing dot",
+			filter:  &JSONFilter{Column: "metadata", FieldPath: "name.", Operator: OpEQ, Value: "foo"},
+			wantErr: errInvalidFieldPath,
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			pred, err := BuildEntSelectorFromJSONFilter(tc.filter)
 			if tc.wantErr != "" {
-				require.EqualError(t, err, tc.wantErr)
+				require.ErrorContains(t, err, tc.wantErr)
 				assert.Nil(t, pred)
 			} else {
 				require.NoError(t, err)


### PR DESCRIPTION
This pull request strengthens the security of JSON field path filtering in workflow queries by validating user-supplied field paths to prevent SQL injection. It introduces a strict allowlist for field path syntax, surfaces validation errors to the API, and adds comprehensive tests to ensure only safe paths are accepted.

**Security improvements for JSON field path filtering:**

* Added a regular expression (`fieldPathRegexp`) in `pkg/jsonfilter/jsonfilter.go` to strictly validate JSON field paths, allowing only dot-separated identifiers and numeric array indices, and rejecting any unsafe characters that could lead to SQL injection.
* Implemented the `validateFieldPath` function in `pkg/jsonfilter/jsonfilter.go` to enforce this validation before building SQL predicates. [[1]](diffhunk://#diff-328aafb63dd5a6f8413b8ab005eed04b71ca4c6412458d349af56ed44a00103eR69-R75) [[2]](diffhunk://#diff-328aafb63dd5a6f8413b8ab005eed04b71ca4c6412458d349af56ed44a00103eR107-R121)
* Updated `BuildEntSelectorFromJSONFilter` to return an error if the field path is unsafe, preventing unsafe queries from being constructed.

**Workflow query logic and error handling:**

* Refactored `applyWorkflowFilters` in `app/controlplane/pkg/data/workflow.go` to return an error if any JSON filter is invalid, ensuring validation errors are surfaced instead of silently ignored. [[1]](diffhunk://#diff-5415b90492c3d90d14a6b7804b9ec2ffb5f90897625ea59561db899811d02dd6L342-R345) [[2]](diffhunk://#diff-5415b90492c3d90d14a6b7804b9ec2ffb5f90897625ea59561db899811d02dd6L367-R384) [[3]](diffhunk://#diff-5415b90492c3d90d14a6b7804b9ec2ffb5f90897625ea59561db899811d02dd6L399-R407) [[4]](diffhunk://#diff-5415b90492c3d90d14a6b7804b9ec2ffb5f90897625ea59561db899811d02dd6L284-R287)
* Updated integration tests in `app/controlplane/pkg/biz/workflow_integration_test.go` to verify that unsafe field paths are rejected with a validation error, and safe paths are accepted.

**Test coverage:**

* Expanded unit tests in `pkg/jsonfilter/jsonfilter_test.go` to cover a wide range of valid and invalid field path scenarios, ensuring the validator correctly allows safe paths and rejects unsafe ones. [[1]](diffhunk://#diff-bf4c21fe94b5279ac9fff64ef3614726914ffe0aabd7322a414ca56a2e9165eaR25-R27) [[2]](diffhunk://#diff-bf4c21fe94b5279ac9fff64ef3614726914ffe0aabd7322a414ca56a2e9165eaR87-R132)

**Other:**

* Updated copyright years in `pkg/jsonfilter/jsonfilter.go`.
* Added missing import for `jsonfilter` in integration tests.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chainloop-dev/chainloop/pull/3205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

