### PR TITLE
fix(controlplane): remediate migrations image and moby/moby vulnerabilities

### DIFF
--- a/app/controlplane/Dockerfile.migrations
+++ b/app/controlplane/Dockerfile.migrations
@@ -1,9 +1,9 @@
 # Container image built by go-releaser that's used to run migrations against the database during deployment
 # See https://atlasgo.io/guides/deploying/image
-# from: arigaio/atlas:latest (v1.2.1-3ca392d-canary)
-# docker run arigaio/atlas@sha256:29668819bfe510e06ccf84cfbf795ad504a0b310a9edbb695c1cd277edac11cb version
-# atlas version v1.2.1-3ca392d-canary
-FROM arigaio/atlas@sha256:29668819bfe510e06ccf84cfbf795ad504a0b310a9edbb695c1cd277edac11cb as base
+# from: arigaio/atlas:latest (v1.2.3-97b7881-canary)
+# docker run arigaio/atlas@sha256:7470216c7ecc93db7a51d895fbc9c3e7d3885763c424f07d115b1da9410256bb version
+# atlas version v1.2.3-97b7881-canary
+FROM arigaio/atlas@sha256:7470216c7ecc93db7a51d895fbc9c3e7d3885763c424f07d115b1da9410256bb as base
 
 FROM scratch
 # Update permissions to make it readable by the user

--- a/app/controlplane/pkg/biz/biz.go
+++ b/app/controlplane/pkg/biz/biz.go
@@ -78,7 +78,7 @@ type IdentityReference struct {
 	Name *string
 }
 
-// generate a DNS1123-valid random name using moby's namesgenerator
+// generate a DNS1123-valid random name from the given prefix
 // plus an additional random number
 func generateValidDNS1123WithSuffix(prefix string) (string, error) {
 	// Append a random number to it

--- a/app/controlplane/pkg/biz/organization.go
+++ b/app/controlplane/pkg/biz/organization.go
@@ -29,7 +29,6 @@ import (
 	"github.com/chainloop-dev/chainloop/pkg/servicelogger"
 	"github.com/go-kratos/kratos/v2/log"
 	"github.com/google/uuid"
-	"github.com/moby/moby/pkg/namesgenerator"
 )
 
 var organizationTracer = otelx.Tracer("chainloop-controlplane", "biz/organization")
@@ -140,8 +139,8 @@ func (uc *OrganizationUseCase) CreateWithRandomName(ctx context.Context, opts ..
 
 	// Try 10 times to create a random name
 	for i := 0; i < RandomNameMaxTries; i++ {
-		// Create a random name
-		prefix := namesgenerator.GetRandomName(0)
+		// Create a random name using a short unique prefix
+		prefix := "org-" + uuid.NewString()[:8]
 		name, err := generateValidDNS1123WithSuffix(prefix)
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate random name: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,6 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.8.0
 	github.com/joshdk/go-junit v1.0.0
 	github.com/lib/pq v1.12.3
-	github.com/moby/moby v28.5.2+incompatible
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/rs/zerolog v1.35.1

--- a/go.sum
+++ b/go.sum
@@ -917,8 +917,6 @@ github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3N
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/go-archive v0.1.0 h1:Kk/5rdW/g+H8NHdJW2gsXyZ7UnzvJNOy6VKJqueWdcQ=
 github.com/moby/go-archive v0.1.0/go.mod h1:G9B+YoujNohJmrIYFBpSd54GTUB4lt9S+xVQvsJyFuo=
-github.com/moby/moby v28.5.2+incompatible h1:hIn6qcenb3JY1E3STwqEbBvJ8bha+u1LpqjX4CBvNCk=
-github.com/moby/moby v28.5.2+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=
 github.com/moby/patternmatcher v0.6.0 h1:GmP9lR19aU5GqSSFko+5pRqHi+Ohk1O69aFiKkVGiPk=
 github.com/moby/patternmatcher v0.6.0/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
 github.com/moby/sys/atomicwriter v0.1.0 h1:kw5D/EqkBwsBFi0ss9v1VG3wIkVhzGvLklJ+w3A14Sw=


### PR DESCRIPTION
## Summary

Remediates the vulnerability policy violations flagged for chainloop v1.100.7.

- Bumps the `arigaio/atlas` base image in the control-plane migrations Dockerfile to a build with an updated Go toolchain and `golang.org/x/crypto` / `golang.org/x/net`, resolving 13 vulnerabilities (7 critical, 6 high) in the migrations image.
- Removes the `github.com/moby/moby` dependency, which was pulled in only for its `pkg/namesgenerator` helper used to generate random organization names in test setups. That legacy `+incompatible` import path carried 5 high-severity advisories in unrelated daemon/engine code and has no fixed version available. The helper is replaced with a short UUID-based prefix, eliminating the dependency and all 5 advisories.

## AI assistance

This change was produced with the assistance of Claude Code.

🤖 _Posted by Maximus bot (Claude Code) on behalf of @migmartri_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chainloop-dev/chainloop/pull/3207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

