### PR TITLE
fix(jsonfilter): validate column identifier before building selector

### DIFF
--- a/pkg/jsonfilter/jsonfilter.go
+++ b/pkg/jsonfilter/jsonfilter.go
@@ -36,6 +36,16 @@ import (
 // quote) would allow breaking out of the literal and injecting arbitrary SQL.
 var fieldPathRegexp = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*|\[[0-9]+\])*$`)
 
+// columnRegexp matches a safe SQL column identifier (a single unqualified
+// identifier such as "metadata").
+//
+// This allowlist is security-critical: the underlying ent sqljson helpers emit
+// the column verbatim into the query and, for PostgreSQL, a column containing a
+// double quote bypasses ent's identifier quoting entirely and is written raw,
+// allowing SQL injection identical to the field-path case. Restricting the
+// column to a bare identifier removes every character an injection would need.
+var columnRegexp = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
 // JSONOperator represents supported JSON filter operators.
 type JSONOperator string
 
@@ -64,6 +74,13 @@ type JSONFilter struct {
 func BuildEntSelectorFromJSONFilter(jsonFilter *JSONFilter) (*entsql.Predicate, error) {
 	if jsonFilter.Column == "" || jsonFilter.Operator == "" {
 		return nil, errors.New("invalid filter: column and operator are required")
+	}
+
+	// Validate the column before it reaches the SQL builder. Like the field
+	// path, the column is emitted into the query by the ent sqljson helpers
+	// without reliable escaping, so an unsafe value would allow SQL injection.
+	if err := validateColumn(jsonFilter.Column); err != nil {
+		return nil, err
 	}
 
 	// Validate the field path before it reaches the SQL builder. The ent
@@ -103,6 +120,18 @@ func BuildEntSelectorFromJSONFilter(jsonFilter *JSONFilter) (*entsql.Predicate, 
 	default:
 		return nil, fmt.Errorf("unsupported operator: %s", jsonFilter.Operator)
 	}
+}
+
+// validateColumn ensures the JSON column is a bare SQL identifier before it is
+// emitted into the query by the ent sqljson helpers. Callers are expected to set
+// it to a known column constant, but validating here keeps safety from depending
+// on every caller remembering to do so.
+func validateColumn(column string) error {
+	if !columnRegexp.MatchString(column) {
+		return fmt.Errorf("invalid column %q: must be a valid identifier", column)
+	}
+
+	return nil
 }
 
 // validateFieldPath ensures the JSON field path only contains safe characters

--- a/pkg/jsonfilter/jsonfilter_test.go
+++ b/pkg/jsonfilter/jsonfilter_test.go
@@ -25,6 +25,9 @@ import (
 // errInvalidFieldPath is the common prefix returned when a field path fails validation.
 const errInvalidFieldPath = "invalid field path"
 
+// errInvalidColumn is the common prefix returned when a column fails validation.
+const errInvalidColumn = "invalid column"
+
 func TestBuildEntSelectorFromJSONFilter(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -45,6 +48,38 @@ func TestBuildEntSelectorFromJSONFilter(t *testing.T) {
 			name:    "unsupported operator",
 			filter:  &JSONFilter{Column: "metadata", Operator: "gt", Value: "foo"},
 			wantErr: "unsupported operator: gt",
+		},
+		{
+			// A double quote in the column breaks out of the identifier quoting
+			// performed by ent's builder, allowing raw SQL injection.
+			name:    "column with double quote breaks out of identifier",
+			filter:  &JSONFilter{Column: `metadata" OR "1"="1`, FieldPath: "name", Operator: OpEQ, Value: "foo"},
+			wantErr: errInvalidColumn,
+		},
+		{
+			name:    "column with single quote",
+			filter:  &JSONFilter{Column: `metadata' OR '1'='1`, FieldPath: "name", Operator: OpEQ, Value: "foo"},
+			wantErr: errInvalidColumn,
+		},
+		{
+			name:    "column with whitespace",
+			filter:  &JSONFilter{Column: "metadata OR 1=1", FieldPath: "name", Operator: OpEQ, Value: "foo"},
+			wantErr: errInvalidColumn,
+		},
+		{
+			name:    "column with parenthesis",
+			filter:  &JSONFilter{Column: "pg_sleep(2)", FieldPath: "name", Operator: OpEQ, Value: "foo"},
+			wantErr: errInvalidColumn,
+		},
+		{
+			name:    "column starting with digit",
+			filter:  &JSONFilter{Column: "1metadata", FieldPath: "name", Operator: OpEQ, Value: "foo"},
+			wantErr: errInvalidColumn,
+		},
+		{
+			name:    "column with dot qualifier",
+			filter:  &JSONFilter{Column: "workflow.metadata", FieldPath: "name", Operator: OpEQ, Value: "foo"},
+			wantErr: errInvalidColumn,
 		},
 		{
 			name:   "eq operator with string value",


### PR DESCRIPTION
Adds allowlist validation for the JSON filter column in `BuildEntSelectorFromJSONFilter`, restricting it to a bare SQL identifier before it reaches the query builder. This mirrors the existing field-path validation so input safety no longer depends on every caller hardcoding the column.

Defense-in-depth hardening: the only current caller already sets the column to a known constant.

🤖 _Posted by Maximus bot (Claude Code) on behalf of @migmartri_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chainloop-dev/chainloop/pull/3210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

