### PR TITLE
fix(controlplane): exclude soft-deleted rows when finding a project version by name

### DIFF
--- a/app/controlplane/pkg/biz/projectversion_integration_test.go
+++ b/app/controlplane/pkg/biz/projectversion_integration_test.go
@@ -198,6 +198,35 @@ func (s *ProjectVersionIntegrationTestSuite) TestMarkAsLatestInvalidUUID() {
 	require.Error(t, err)
 }
 
+// Regression test for PFM-6470: a version that was deleted and recreated with the
+// same name leaves a soft-deleted row alongside the active one. Looking the version
+// up by name must return the active row instead of crashing because the query matched
+// more than one row.
+func (s *ProjectVersionIntegrationTestSuite) TestFindByProjectAndVersionIgnoresSoftDeleted() {
+	t := s.T()
+	ctx := context.Background()
+
+	// Create a version and soft-delete it, simulating a delete from the UI/API.
+	deleted, err := s.ProjectVersion.Create(ctx, s.project.ID.String(), "v17", true)
+	require.NoError(t, err)
+
+	_, err = s.Data.DB.ProjectVersion.UpdateOneID(deleted.ID).SetDeletedAt(time.Now()).Save(ctx)
+	require.NoError(t, err)
+
+	// Recreate a version with the same name; now two rows share version "v17"
+	// (one soft-deleted, one active).
+	recreated, err := s.ProjectVersion.Create(ctx, s.project.ID.String(), "v17", true)
+	require.NoError(t, err)
+	require.NotEqual(t, deleted.ID, recreated.ID)
+
+	// Looking up "v17" must return the active row, not error out because the query
+	// matched both the soft-deleted and the active row.
+	found, err := s.ProjectVersion.FindByProjectAndVersion(ctx, s.project.ID.String(), "v17")
+	require.NoError(t, err)
+	require.NotNil(t, found)
+	require.Equal(t, recreated.ID, found.ID)
+}
+
 func TestProjectVersionUseCase(t *testing.T) {
 	suite.Run(t, new(ProjectVersionIntegrationTestSuite))
 }

--- a/app/controlplane/pkg/data/projectversion.go
+++ b/app/controlplane/pkg/data/projectversion.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/biz"
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/data/ent"
-	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/data/ent/project"
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/data/ent/projectversion"
 	"github.com/chainloop-dev/chainloop/pkg/otelx"
 	"github.com/go-kratos/kratos/v2/log"
@@ -46,7 +45,7 @@ func (r *ProjectVersionRepo) FindByProjectAndVersion(ctx context.Context, projec
 	ctx, span := otelx.Start(ctx, projectVersionRepoTracer, "ProjectVersionRepo.FindByProjectAndVersion")
 	defer span.End()
 
-	pv, err := r.data.DB.ProjectVersion.Query().Where(projectversion.HasProjectWith(project.ID(projectID)), projectversion.VersionEQ(version)).Only(ctx)
+	pv, err := findProjectVersionWithClient(ctx, r.data.DB, projectID, version)
 	if err != nil && !ent.IsNotFound(err) {
 		return nil, err
 	} else if pv == nil {


### PR DESCRIPTION
Looking up a project version by name did not exclude soft-deleted rows. When a version name had been deleted and recreated, the lookup matched both the soft-deleted and the active row, causing the workflow run list to fail when filtering by that version.

This change scopes the lookup to non-deleted versions so the active version is returned, consistent with the other project-version queries in the same repository.

Closes #3236

## AI disclosure
This change was produced with the assistance of Claude Code.

🤖 _Posted by Maximus bot (Claude Code) on behalf of @migmartri_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chainloop-dev/chainloop/pull/3237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

