### PR TITLE
fix(policies): split comma-separated values on each merged input line

### DIFF
--- a/pkg/policies/policies.go
+++ b/pkg/policies/policies.go
@@ -773,22 +773,19 @@ func getInputArguments(inputs map[string]string) map[string]any {
 	args := make(map[string]any)
 
 	for k, v := range inputs {
-		// scan for multiple values
+		// Normalize consistently: split on newlines first (multi-value inputs,
+		// e.g. a comma-separated contract value merged with runtime values by
+		// mergeRuntimeInputs), then split each line on commas. Doing both means a
+		// comma-separated segment is always expanded into separate values,
+		// regardless of whether it arrived as a single line or as one of several
+		// merged lines.
 		lines := strings.Split(strings.TrimRight(v, "\n"), "\n")
-		value := getValue(lines)
-
-		if value == nil {
-			continue
-		}
-		s, ok := value.(string)
-		if !ok {
-			// case for multivalued argument
-			args[k] = value
+		values := make([]string, 0, len(lines))
+		for _, line := range lines {
+			values = append(values, splitArgs(line)...)
 		}
 
-		// Single string, let's check for CSV and escaped commas `\,`
-		lines = splitArgs(s)
-		value = getValue(lines)
+		value := getValue(values)
 		if value == nil {
 			continue
 		}

--- a/pkg/policies/policies_test.go
+++ b/pkg/policies/policies_test.go
@@ -800,6 +800,33 @@ func (s *testSuite) TestGetInputArguments() {
 			expected: map[string]any{"foo": []string{"bar1", "bar2", "bar3"}},
 		},
 		{
+			// A comma-separated contract value merged with runtime values (which
+			// mergeRuntimeInputs joins with newlines) must still split the
+			// comma-joined line into separate values instead of collapsing it into
+			// a single literal glob containing commas.
+			name:     "multiline input where a line is comma-separated",
+			inputs:   map[string]string{"foo": "**/vendor/**,**/redist/**\nC:/a\nC:/b"},
+			expected: map[string]any{"foo": []string{"**/vendor/**", "**/redist/**", "C:/a", "C:/b"}},
+		},
+		{
+			name:     "multiline input where several lines are comma-separated",
+			inputs:   map[string]string{"foo": "a,b\nc,d\ne"},
+			expected: map[string]any{"foo": []string{"a", "b", "c", "d", "e"}},
+		},
+		{
+			name:     "multiline input with escaped comma on a line",
+			inputs:   map[string]string{"foo": "a\\,b,c\nd"},
+			expected: map[string]any{"foo": []string{"a,b", "c", "d"}},
+		},
+		{
+			// A multiline input that reduces to a single non-empty value after
+			// blank-line filtering must return a plain string, not a one-element
+			// slice, so the two-stage split never over-wraps single values.
+			name:     "multiline input collapsing to a single value",
+			inputs:   map[string]string{"foo": "\nbar\n"},
+			expected: map[string]any{"foo": "bar"},
+		},
+		{
 			name:     "no input",
 			inputs:   nil,
 			expected: map[string]any{},


### PR DESCRIPTION
## Summary

When a policy input is declared as a **comma-separated** value in a workflow contract and the *same* input is also supplied at runtime via `--policy-input-from-file` (#3244), the additive merge produced a malformed glob: the contract's comma-joined segment was never re-split on commas, collapsing into a single literal value containing commas that matched nothing.

`getInputArguments` split the merged string on newlines first and, as soon as there was more than one line, returned the multi-line slice as-is — the per-value comma splitting only ran on the single-line branch. As a result a contract value such as `**/vendor/**,**/redist/**` merged with runtime values yielded `["**/vendor/**,**/redist/**", ...]`, whose first element is a single glob still containing commas.

This normalizes multi-value inputs consistently: each line is now split on commas as well, so a comma-separated segment is always expanded into separate values regardless of whether a runtime value was appended. Escaped-comma (`\,`) handling is preserved.

## AI assistance

This contribution was produced with the assistance of Claude Code.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chainloop-dev/chainloop/pull/3257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

