### PR TITLE
ci: bump docker/login-action to v4.4.0

### DIFF
--- a/.github/workflows/build_external_container_images.yaml
+++ b/.github/workflows/build_external_container_images.yaml
@@ -105,7 +105,7 @@ jobs:
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to the Container registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/package_chart.yaml
+++ b/.github/workflows/package_chart.yaml
@@ -26,7 +26,7 @@ jobs:
           curl -sfL https://dl.chainloop.dev/cli/install.sh | bash -s
 
       - name: Docker login to Github Packages
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,7 +82,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker login to Github Packages
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
## Summary

Updates all docker/login-action usages to v4.4.0 (digest-pinned).

Two of the three workflows (release, package_chart) were pinned to v2.2.0, which runs on the deprecated node16 runtime; build_external_container_images was on v3. All are now aligned on v4.4.0.

The login inputs (registry/username/password) are unchanged across majors, so this is a runtime bump (node16/node20 -> node24) with no configuration changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chainloop-dev/chainloop/pull/3261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

