### PR TITLE
fix(ci): align secrets-scan material name with contract

### DIFF
--- a/.github/workflows/secrets-scan-daily.yml
+++ b/.github/workflows/secrets-scan-daily.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Add Gitleaks Report to Attestation
         run: |
           chainloop attestation add \
-            --name gitleaks-scan \
+            --name secret-report \
             --value gitleaks-report.json \
             --kind GITLEAKS_JSON
 


### PR DESCRIPTION
The `secrets-detection` contract (revision 5) expects a material named `secret-report`, but the `secrets-scan-daily` workflow was adding it as `gitleaks-scan`. This caused the attestation push to fail with `some materials have not been crafted yet: secret-report`, breaking the daily secrets scan since 2026-07-02.

Rename the material in the workflow to match the contract.

🤖 _Posted by Maximus bot (Claude Code) on behalf of @migmartri_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chainloop-dev/chainloop/pull/3262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

