### PR TITLE
fix(cli): correct registered integration add usage string to --opt

### DIFF
--- a/app/cli/cmd/registered_integration_add.go
+++ b/app/cli/cmd/registered_integration_add.go
@@ -33,7 +33,7 @@ func newRegisteredIntegrationAddCmd() *cobra.Command {
 	var integrationDescription, integrationName string
 
 	cmd := &cobra.Command{
-		Use:     "add INTEGRATION_ID --name [registration-name] --options key=value,key=value",
+		Use:     "add INTEGRATION_ID --name [registration-name] --opt key=value",
 		Short:   "Register a new instance of an integration",
 		Example: `  chainloop integration registered add dependencytrack --name send-to-prod --opt instance=https://deptrack.company.com,apiKey=1234567890 --opt username=chainloop`,
 		Args:    cobra.ExactArgs(1),


### PR DESCRIPTION
The cobra Use string advertised a --options flag that does not exist; the actual flag is --opt (as already shown in the command Example). This corrects the usage string so help output and generated CLI reference docs reflect the real flag.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chainloop-dev/chainloop/pull/3271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

