### PR TITLE
docs: regenerate CLI reference for registered integration add usage

### DIFF
--- a/app/cli/documentation/cli-reference.mdx
+++ b/app/cli/documentation/cli-reference.mdx
@@ -1991,7 +1991,7 @@ Options inherited from parent commands
 Register a new instance of an integration
 
 ```
-chainloop integration registered add INTEGRATION_ID --name [registration-name] --options key=value,key=value [flags]
+chainloop integration registered add INTEGRATION_ID --name [registration-name] --opt key=value [flags]
 ```
 
 Examples


### PR DESCRIPTION
## Summary

Regenerates `app/cli/documentation/cli-reference.mdx` so the committed docs match the current CLI command definitions. The `integration registered add` usage string was updated to `--opt` in #3271 without regenerating the reference doc, causing the "Check all ent generated code is checked in" CI step to fail on main:

- https://github.com/chainloop-dev/chainloop/actions/runs/29044708803/job/86210360754
- https://github.com/chainloop-dev/chainloop/actions/runs/29060311396/job/86260527044

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chainloop-dev/chainloop/pull/3279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

