### PR TITLE
fix(cli): decouple PR mode from latest promotion

### DIFF
--- a/app/cli/cmd/attestation_init.go
+++ b/app/cli/cmd/attestation_init.go
@@ -201,7 +201,7 @@ func newAttestationInitCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&existingVersion, "existing-version", false, "return an error if the version doesn't exist in the project")
 	cmd.Flags().StringSliceVar(&collectors, "collectors", nil, "comma-separated list of additional collectors to enable (e.g. aiconfig)")
 	cmd.Flags().BoolVar(&markAsLatest, "mark-latest", true, "explicitly mark the project version as latest (default: automatic for new versions; use =false to skip promotion)")
-	cmd.Flags().BoolVar(&prMode, "pr", false, "mark this attestation as a pull/merge request build (skips latest promotion and sets the chainloop.dev/is-pull-request annotation; auto-detected from CI env if not set)")
+	cmd.Flags().BoolVar(&prMode, "pr", false, "mark this attestation as a pull/merge request build (sets the chainloop.dev/is-pull-request annotation; auto-detected from CI env if not set)")
 
 	return cmd
 }

--- a/app/cli/pkg/action/attestation_init.go
+++ b/app/cli/pkg/action/attestation_init.go
@@ -194,15 +194,12 @@ func (action *AttestationInit) Run(ctx context.Context, opts *AttestationInitRun
 	}
 
 	// Resolve PR mode: explicit --pr flag wins, otherwise auto-detect from the
-	// CI runner environment. When in PR mode, default mark-latest=false unless
-	// the user explicitly passed --mark-latest=true.
+	// CI runner environment. PR mode only tags the attestation with the
+	// chainloop.dev/is-pull-request annotation; it does not alter latest
+	// promotion (use --mark-latest=false explicitly to skip promotion).
 	isPR, err := action.resolvePRMode(ctx, discoveredRunner, opts.PRMode)
 	if err != nil {
 		action.Logger.Warn().Err(err).Msg("failed to detect PR context")
-	}
-	if isPR && !explicitMarkAsLatestTrue(opts.MarkAsLatest) {
-		falseVal := false
-		opts.MarkAsLatest = &falseVal
 	}
 
 	// Parse the raw contract to get V2 schema if available
@@ -568,11 +565,4 @@ func (action *AttestationInit) resolvePRMode(ctx context.Context, runner crafter
 		return false, err
 	}
 	return detected, nil
-}
-
-// explicitMarkAsLatestTrue returns true only when the user explicitly passed
-// --mark-latest=true. A nil pointer (flag not set) or an explicit false do not
-// count, so PR mode can safely override them to false.
-func explicitMarkAsLatestTrue(v *bool) bool {
-	return v != nil && *v
 }

--- a/app/cli/pkg/action/attestation_init_test.go
+++ b/app/cli/pkg/action/attestation_init_test.go
@@ -342,36 +342,6 @@ func TestParseContractV2(t *testing.T) {
 	}
 }
 
-func TestExplicitMarkAsLatestTrue(t *testing.T) {
-	cases := []struct {
-		name string
-		v    *bool
-		want bool
-	}{
-		{
-			name: "nil pointer (flag not set) is not explicit-true",
-			v:    nil,
-			want: false,
-		},
-		{
-			name: "explicit false is not explicit-true",
-			v:    boolPtr(false),
-			want: false,
-		},
-		{
-			name: "explicit true is explicit-true",
-			v:    boolPtr(true),
-			want: true,
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, explicitMarkAsLatestTrue(tc.v))
-		})
-	}
-}
-
 func TestResolvePRMode(t *testing.T) {
 	// resolvePRMode uses the override when provided (explicit --pr flag),
 	// otherwise falls back to DetectPRContext from the runner environment.


### PR DESCRIPTION
## What

PR mode for attestations no longer forces `mark-latest=false`. It now only tags the attestation with the `chainloop.dev/is-pull-request` annotation, and latest promotion stays under the explicit control of the `--mark-latest` flag.

This removes the implicit skip-latest-promotion side-effect introduced in chainloop-dev/chainloop#3268 while keeping the PR-mode detection and annotation behavior intact.

cc @jiparis @javirln — reopening chainloop-dev/chainloop#3265 so we can review the approach for the skip-latest-promotion behavior separately.

This PR was produced with AI assistance (Claude Code).

Assisted-by: Claude Code

🤖 *Posted by Maximus bot (Claude Code) on behalf of* @migmartri

[![Review in cubic](https://uploads.linear.app/81dd9680-e8d5-4393-8e29-c3f90e44a95e/b7c0b19b-afb1-46ce-9fe6-d3e55a0a1248/deb41fab-5fbf-457e-9667-509c060265bf?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzgxZGQ5NjgwLWU4ZDUtNDM5My04ZTI5LWMzZjkwZTQ0YTk1ZS9iN2MwYjE5Yi1hZmIxLTQ2Y2UtOWZlNi1kM2U1NWEwYTEyNDgvZGViNDFmYWItNWZiZi00NTdlLTk2NjctNTA5YzA2MDI2NWJmIiwiaWF0IjoxNzg0MTMzOTM1LCJleHAiOjE4MTU3MDQ0OTV9.MXt5Eyq9lpsAhqVgiAdQ3g6lKTuOme8JvYk7DnvWbV4)](<https://cubic.dev/pr/chainloop-dev/chainloop/pull/3289?utm_source=github>)