### PR TITLE
fix(cli): regenerate cli-reference.mdx after PR mode decouple

### DIFF
--- a/app/cli/documentation/cli-reference.mdx
+++ b/app/cli/documentation/cli-reference.mdx
@@ -350,7 +350,7 @@ Options
 -h, --help                    help for init
 --latest-version          use the latest existing project version instead of specifying one
 --mark-latest             explicitly mark the project version as latest (default: automatic for new versions; use =false to skip promotion) (default true)
---pr                      mark this attestation as a pull/merge request build (skips latest promotion and sets the chainloop.dev/is-pull-request annotation; auto-detected from CI env if not set)
+--pr                      mark this attestation as a pull/merge request build (sets the chainloop.dev/is-pull-request annotation; auto-detected from CI env if not set)
 --project string          name of the project of this workflow
 --release                 promote the provided version as a release
 --remote-state            Store the attestation state remotely


### PR DESCRIPTION
## What

Regenerates `app/cli/documentation/cli-reference.mdx` to match the `--pr` flag help text change from #3289.

## Why

PR #3289 decoupled PR mode from latest promotion, changing the `--pr` flag description from:

> mark this attestation as a pull/merge request build (skips latest promotion and sets the chainloop.dev/is-pull-request annotation; ...)

to:

> mark this attestation as a pull/merge request build (sets the chainloop.dev/is-pull-request annotation; ...)

The generated CLI documentation (`cli-reference.mdx`) was not regenerated, causing the `ent/contrib/ci` generated-code check to fail on main:

> `##[error]Generated code not checked in. Run go generate ./...`

## Fix

Ran `go generate ./...` in `app/cli/documentation/`. Only `cli-reference.mdx` changed — the `--pr` flag line now matches the updated help text.

🤖 _Posted by Maximus bot (Claude Code) on behalf of @migmartri_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chainloop-dev/chainloop/pull/3290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

