### PR TITLE
fix(controlplane): authorize GroupService/ListProjects at the service layer

### DIFF
--- a/app/controlplane/internal/service/group.go
+++ b/app/controlplane/internal/service/group.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2025 The Chainloop Authors.
+// Copyright 2025-2026 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -526,6 +526,15 @@ func (g *GroupService) ListProjects(ctx context.Context, req *pb.GroupServiceLis
 	id, name, err := req.GetGroupReference().Parse()
 	if err != nil {
 		return nil, errors.BadRequest("invalid", fmt.Sprintf("invalid group reference: %s", err.Error()))
+	}
+
+	// Authorize before resolving results. This mirrors the sibling group sub-resource handlers
+	// (ListMembers, etc.): only org admins/owners or a maintainer of the target group may read a
+	// group's project attachments. The visibleProjects row filter alone is insufficient because it
+	// returns nil ("no filter") for callers where RBAC is not applied (e.g. a legacy RoleViewer or
+	// an org-scoped API token), which the data layer treats as full visibility.
+	if err = g.userHasPermissionOnGroupMembershipsWithPolicy(ctx, currentOrg.ID, req.GetGroupReference(), authz.PolicyGroupListMemberships); err != nil {
+		return nil, err
 	}
 
 	// Initialize the options for getting projects


### PR DESCRIPTION
Closes PFM-6695

## Summary

`GroupService/ListProjects` was the only group sub-resource handler that resolved results without a service-layer permission check, relying solely on the `visibleProjects` row filter. That filter returns `nil` ("RBAC not applied") for legacy `RoleViewer` users and for org-scoped API tokens, and the data layer treats `nil` as "no filter" — so those callers received the full group→project attachment map that the design restricts to org admins/maintainers.

This change adds the same `PolicyGroupListMemberships` guard the sibling handlers already use before resolving projects, matching the earlier `ListMembers` fix.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chainloop-dev/chainloop/pull/3293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

