### PR TITLE
fix(ci): pin the organization on attestation init in GitHub workflows

### DIFF
--- a/.github/workflows/author_verification.yml
+++ b/.github/workflows/author_verification.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Initialize Attestation
         run: |
-          chainloop attestation init --workflow $CHAINLOOP_WORKFLOW_NAME --project $CHAINLOOP_PROJECT --collectors aiconfig
+          chainloop attestation init --org chainloop --workflow $CHAINLOOP_WORKFLOW_NAME --project $CHAINLOOP_PROJECT --collectors aiconfig
         env:
           # Needed for commit signature verification: https://docs.chainloop.dev/concepts/attestations#commit-verification
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Initialize Attestation
         if: ${{ github.event_name != 'pull_request' }}
         run: |
-          chainloop attestation init --workflow $CHAINLOOP_WORKFLOW_NAME --project $CHAINLOOP_PROJECT
+          chainloop attestation init --org chainloop --workflow $CHAINLOOP_WORKFLOW_NAME --project $CHAINLOOP_PROJECT
         env:
           # Needed for commit signature verification: https://docs.chainloop.dev/concepts/attestations#commit-verification
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package_chart.yaml
+++ b/.github/workflows/package_chart.yaml
@@ -57,7 +57,7 @@ jobs:
           # Force the version that's inside the Chart.yaml file
           # and make sure it exists in the project by passing the --existing-version flag
           # if it doesn't exist, the attestation will fail, and first we need to create/update/rename the version in the project and re-run the job
-          chainloop attestation init --workflow ${CHAINLOOP_WORKFLOW_NAME} --project ${CHAINLOOP_PROJECT} --version ${app_version} --existing-version
+          chainloop attestation init --org chainloop --workflow ${CHAINLOOP_WORKFLOW_NAME} --project ${CHAINLOOP_PROJECT} --version ${app_version} --existing-version
 
           # Attest Control plane image
           chainloop attestation add --name control-plane-image --value "${CONTAINER_CP}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Run Release Gate Attestation
         run: |
-          chainloop attestation init --workflow release-gate --project chainloop
+          chainloop attestation init --org chainloop --workflow release-gate --project chainloop
           chainloop attestation push
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -77,7 +77,7 @@ jobs:
       - name: Initialize Attestation
         id: init_attestation
         run: |
-          attestation_id=$(chainloop attestation init --workflow ${CHAINLOOP_WORKFLOW_NAME} --project ${CHAINLOOP_PROJECT_NAME} --release --remote-state -o json | jq -r .attestationID)
+          attestation_id=$(chainloop attestation init --org chainloop --workflow ${CHAINLOOP_WORKFLOW_NAME} --project ${CHAINLOOP_PROJECT_NAME} --release --remote-state -o json | jq -r .attestationID)
           echo "attestation_id=$attestation_id" >> $GITHUB_OUTPUT
         env:
           CHAINLOOP_WORKFLOW_NAME: "release"

--- a/.github/workflows/scm_configuration_check.yaml
+++ b/.github/workflows/scm_configuration_check.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Initialize Attestation
         run: |
-          chainloop attestation init --workflow ${CHAINLOOP_WORKFLOW_NAME} --project ${CHAINLOOP_PROJECT_NAME}
+          chainloop attestation init --org chainloop --workflow ${CHAINLOOP_WORKFLOW_NAME} --project ${CHAINLOOP_PROJECT_NAME}
 
       - name: Generate a token
         id: generate-token

--- a/.github/workflows/secrets-scan-daily.yml
+++ b/.github/workflows/secrets-scan-daily.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Initialize Attestation
         run: |
-          chainloop attestation init --workflow ${CHAINLOOP_WORKFLOW_NAME} --project ${CHAINLOOP_PROJECT_NAME}
+          chainloop attestation init --org chainloop --workflow ${CHAINLOOP_WORKFLOW_NAME} --project ${CHAINLOOP_PROJECT_NAME}
 
       - name: Install Gitleaks
         run: |


### PR DESCRIPTION
Attestations authenticating via OIDC could resolve an organization other than the intended one, causing several workflow runs to fail.

`chainloop attestation init` now receives an explicit `--org chainloop` in all GitHub workflows that craft attestations, which pins the organization for the whole attestation lifecycle. Only `init` needs the flag: the organization is persisted afterwards, so the remaining `add`/`push`/`reset` commands resolve it on their own.

Workflows updated: author verification, codeql, helm chart packaging, release (release gate and release jobs), SCM configuration check, and the daily secrets scan.

Note that `scorecards.yml` is not covered here, since it delegates attestation crafting to a reusable workflow in `chainloop-dev/labs` that does not expose an organization input.

Resolves PFM-6860.

AI disclosure: this change was produced with the assistance of Claude Code.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chainloop-dev/chainloop/pull/3318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

