### PR TITLE
fix: build release images with matching target architecture

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,6 +13,7 @@ builds:
       - -X main.Version={{ .Version }}
     targets:
       - linux_amd64
+      - linux_arm64
   - binary: artifact-cas
     id: artifact-cas
     main: ./app/artifact-cas/cmd
@@ -22,6 +23,7 @@ builds:
       - -X main.Version={{ .Version }}
     targets:
       - linux_amd64
+      - linux_arm64
   - binary: chainloop
     id: cli
     main: ./app/cli
@@ -43,18 +45,21 @@ builds:
     main: ./app/controlplane/plugins/core/discord-webhook/v1/cmd
     targets:
       - linux_amd64
+      - linux_arm64
     ldflags: ["{{ .Env.COMMON_LDFLAGS }}"]
   - binary: chainloop-plugin-smtp
     id: chainloop-plugin-smtp
     main: ./app/controlplane/plugins/core/smtp/v1/cmd
     targets:
       - linux_amd64
+      - linux_arm64
     ldflags: ["{{ .Env.COMMON_LDFLAGS }}"]
   - binary: chainloop-plugin-dependency-track
     id: chainloop-plugin-dependency-track
     main: ./app/controlplane/plugins/core/dependency-track/v1/cmd
     targets:
       - linux_amd64
+      - linux_arm64
 archives:
   - format: binary
     id: binaries-cli
@@ -98,6 +103,7 @@ dockers:
       - chainloop-plugin-dependency-track
     image_templates:
       - "ghcr.io/chainloop-dev/chainloop/control-plane:{{ .Tag }}-amd64"
+    goarch: amd64
     use: buildx
     build_flag_templates:
       - "--pull"
@@ -111,6 +117,7 @@ dockers:
       - chainloop-plugin-dependency-track
     image_templates:
       - "ghcr.io/chainloop-dev/chainloop/control-plane:{{ .Tag }}-arm64"
+    goarch: arm64
     use: buildx
     build_flag_templates:
       - "--pull"
@@ -123,6 +130,7 @@ dockers:
       - app/controlplane/pkg/data/ent/migrate/migrations
     image_templates:
       - "ghcr.io/chainloop-dev/chainloop/control-plane-migrations:{{ .Tag }}-amd64"
+    goarch: amd64
     use: buildx
     build_flag_templates:
       - "--pull"
@@ -133,6 +141,7 @@ dockers:
       - app/controlplane/pkg/data/ent/migrate/migrations
     image_templates:
       - "ghcr.io/chainloop-dev/chainloop/control-plane-migrations:{{ .Tag }}-arm64"
+    goarch: arm64
     use: buildx
     build_flag_templates:
       - "--pull"
@@ -145,6 +154,7 @@ dockers:
       - artifact-cas
     image_templates:
       - "ghcr.io/chainloop-dev/chainloop/artifact-cas:{{ .Tag }}-amd64"
+    goarch: amd64
     use: buildx
     build_flag_templates:
       - "--pull"
@@ -155,6 +165,7 @@ dockers:
       - artifact-cas
     image_templates:
       - "ghcr.io/chainloop-dev/chainloop/artifact-cas:{{ .Tag }}-arm64"
+    goarch: arm64
     use: buildx
     build_flag_templates:
       - "--pull"
@@ -167,6 +178,7 @@ dockers:
       - cli
     image_templates:
       - "ghcr.io/chainloop-dev/chainloop/cli:{{ .Tag }}-amd64"
+    goarch: amd64
     use: buildx
     build_flag_templates:
       - "--pull"
@@ -177,6 +189,7 @@ dockers:
       - cli
     image_templates:
       - "ghcr.io/chainloop-dev/chainloop/cli:{{ .Tag }}-arm64"
+    goarch: arm64
     use: buildx
     build_flag_templates:
       - "--pull"

--- a/docs/build-and-packaging.md
+++ b/docs/build-and-packaging.md
@@ -19,9 +19,9 @@ All binaries and container images are built via [GoReleaser](https://goreleaser.
 | `control-plane` | linux/amd64, linux/arm64 | Main backend service |
 | `artifact-cas` | linux/amd64, linux/arm64 | Content-addressable storage proxy |
 | `chainloop` (CLI) | darwin/amd64, darwin/arm64, linux/amd64, linux/arm64 | Multi-platform client |
-| `chainloop-plugin-discord-webhook` | linux/amd64 | Bundled into control-plane image |
-| `chainloop-plugin-smtp` | linux/amd64 | Bundled into control-plane image |
-| `chainloop-plugin-dependency-track` | linux/amd64 | Bundled into control-plane image |
+| `chainloop-plugin-discord-webhook` | linux/amd64, linux/arm64 | Bundled into control-plane image |
+| `chainloop-plugin-smtp` | linux/amd64, linux/arm64 | Bundled into control-plane image |
+| `chainloop-plugin-dependency-track` | linux/amd64, linux/arm64 | Bundled into control-plane image |
 
 All binaries are statically compiled (`CGO_ENABLED=0`) and stripped (`-s -w`). Version info is injected via `-ldflags` from the git tag. CLI binaries are published as GitHub Release assets alongside a `checksums.txt`.
 


### PR DESCRIPTION
## Summary

Fix the release image build for arm64.

The release config now builds the service binaries and copied plugins for `linux_arm64`. It also sets `goarch` on each Docker image entry. This makes GoReleaser use the correct binary set for each image architecture.

Closes #3324

## Root Cause

The arm64 Docker images used `--platform=linux/arm64`, but the Docker build context still received amd64 binaries. The service binaries and copied plugins were only built for `linux_amd64`. The Docker entries also did not select an architecture-specific artifact set.

## Changes

- Build `control-plane` for `linux_arm64`.
- Build `artifact-cas` for `linux_arm64`.
- Build the copied control-plane plugins for `linux_arm64`.
- Set `goarch: amd64` or `goarch: arm64` on Docker image entries.

## Verification

Ran:

```sh
goreleaser release --clean --snapshot --skip sign,sbom,publish
```

Verified that the rebuilt local arm64 images are labeled `linux/arm64`.

Extracted these binaries from the rebuilt arm64 images and verified each one is `ARM aarch64`:

- `/control-plane`
- `/artifact-cas`
- `/plugins/chainloop-plugin-dependency-track`
- `/plugins/chainloop-plugin-discord-webhook`
- `/plugins/chainloop-plugin-smtp`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chainloop-dev/chainloop/pull/3325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

