### PR TITLE
feat(cli): accept an archive of -M metadata files as one RADAMSA_REPORT material

### DIFF
--- a/pkg/attestation/crafter/api/attestation/v1/crafting_state.go
+++ b/pkg/attestation/crafter/api/attestation/v1/crafting_state.go
@@ -190,7 +190,15 @@ func (m *Attestation_Material) ingestMaterialToJSON(rawMaterial []byte, value st
 	case v1.CraftingSchema_Material_RADAMSA_REPORT:
 		// radamsa's -M metadata log is one record per generated iteration; render
 		// it as a JSON array so the policy engine exposes it as input.elements.
-		records, err := materialsradamsa.Parse(bytes.NewReader(rawMaterial))
+		//
+		// The value may be a single -M log or an archive of per-run logs, so the
+		// records are merged across every archive entry here. Doing this only at
+		// craft time is not enough: the policy is evaluated against this projection,
+		// so an archive that was not expanded here would hand the engine zip/tar.gz
+		// bytes, which parse to no records and make the gate skip — a clean-looking
+		// false pass. ParseReportBytes shares its detection and parse rules with the
+		// crafter's InspectReport so the two cannot disagree.
+		records, err := materialsradamsa.ParseReportBytes(rawMaterial)
 		if err != nil {
 			return nil, fmt.Errorf("invalid radamsa -M metadata log: %w", err)
 		}

--- a/pkg/attestation/crafter/api/attestation/v1/crafting_state_test.go
+++ b/pkg/attestation/crafter/api/attestation/v1/crafting_state_test.go
@@ -16,8 +16,13 @@
 package v1
 
 import (
+	"archive/tar"
+	"archive/zip"
 	"bytes"
+	"compress/gzip"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	schemaapi "github.com/chainloop-dev/chainloop/app/controlplane/api/workflowcontract/v1"
@@ -365,6 +370,79 @@ func TestDranzerBundleIsEvaluable(t *testing.T) {
 
 	// The CSV companion is not a report, so only the four modes are listed.
 	assert.Len(t, decoded["reports"], 4)
+}
+
+// TestRadamsaReportArchiveIsEvaluable guards that a RADAMSA_REPORT material whose
+// value is an archive of per-run -M logs projects to input.elements holding the
+// records merged across every entry. Recording the archive whole without merging
+// here would hand the policy engine zip/tar.gz bytes, which parse to no records,
+// so radamsa-min-iterations reads a non-array input.elements and *skips* — a
+// clean-looking false pass on a fuzzing-coverage gate.
+func TestRadamsaReportArchiveIsEvaluable(t *testing.T) {
+	// Two per-run logs, three -M records each => six merged records.
+	logA := []byte("seed: 1\nmuta-num: 1, generator: file\nbyte-dec: 1, generator: jump\n")
+	logB := []byte("seed: 2\nmuta-num: 2, generator: file\nbyte-dec: 2, generator: jump\n")
+
+	dir := t.TempDir()
+	tarGz := filepath.Join(dir, "report.tar.gz")
+	writeReportTarGz(t, tarGz, map[string][]byte{"meta_1.log": logA, "meta_2.log": logB})
+	zipPath := filepath.Join(dir, "report.zip")
+	writeReportZip(t, zipPath, map[string][]byte{"meta_1.log": logA, "meta_2.log": logB})
+
+	for _, tc := range []struct{ name, path string }{
+		{"tar.gz", tarGz},
+		{"zip", zipPath},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &Attestation_Material{
+				MaterialType: schemaapi.CraftingSchema_Material_RADAMSA_REPORT,
+				M: &Attestation_Material_Artifact_{
+					Artifact: &Attestation_Material_Artifact{Name: "fuzz-report", Digest: "sha256:deadbeef"},
+				},
+			}
+
+			content, err := m.GetEvaluableContent(tc.path)
+			require.NoError(t, err)
+
+			var decoded map[string]any
+			require.NoError(t, json.NewDecoder(bytes.NewReader(content)).Decode(&decoded))
+
+			elements, ok := decoded["elements"].([]any)
+			require.True(t, ok, "input.elements must be an array so the gate does not skip")
+			assert.Len(t, elements, 6, "records from every archive entry must be merged")
+		})
+	}
+}
+
+func writeReportTarGz(t *testing.T, path string, files map[string][]byte) {
+	t.Helper()
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+	gz := gzip.NewWriter(f)
+	tw := tar.NewWriter(gz)
+	for name, content := range files {
+		require.NoError(t, tw.WriteHeader(&tar.Header{Name: name, Mode: 0o600, Size: int64(len(content)), Typeflag: tar.TypeReg}))
+		_, err := tw.Write(content)
+		require.NoError(t, err)
+	}
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+}
+
+func writeReportZip(t *testing.T, path string, files map[string][]byte) {
+	t.Helper()
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+	zw := zip.NewWriter(f)
+	for name, content := range files {
+		w, err := zw.Create(name)
+		require.NoError(t, err)
+		_, err = w.Write(content)
+		require.NoError(t, err)
+	}
+	require.NoError(t, zw.Close())
 }
 
 // TestCoberturaEmptyReportIsEvaluable guards the requirement that a legitimate

--- a/pkg/attestation/crafter/materials/radamsa.go
+++ b/pkg/attestation/crafter/materials/radamsa.go
@@ -38,6 +38,12 @@ import (
 // inputs recorded in a RADAMSA_CRASHES material (0 means no crash).
 const AnnotationRadamsaCrashesCount = "chainloop.material.radamsa.crashes.count"
 
+// AnnotationRadamsaReportRecordsCount is the annotation holding the total number
+// of -M metadata records recorded in a RADAMSA_REPORT material, summed across all
+// entries when the input is an archive. It is informational: the gate reads the
+// records projected into input.elements, not this annotation.
+const AnnotationRadamsaReportRecordsCount = "chainloop.material.radamsa.report.records.count"
+
 const radamsaToolName = "radamsa"
 
 // RadamsaReportCrafter crafts a RADAMSA_REPORT material out of radamsa's -M
@@ -58,14 +64,19 @@ func NewRadamsaReportCrafter(schema *schemaapi.CraftingSchema_Material, backend 
 }
 
 func (c *RadamsaReportCrafter) Craft(ctx context.Context, filePath string) (*api.Attestation_Material, error) {
-	f, err := os.Open(filePath)
+	// InspectReport applies the same content detection and per-entry parse the
+	// policy projection (radamsa.ParseReportBytes) applies at eval time, so a
+	// material accepted here is guaranteed to be evaluable. The archive itself is
+	// stored in CAS as-is; the records are merged into input.elements at eval time,
+	// not here.
+	records, err := radamsa.InspectReport(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("can't open the file: %w", err)
-	}
-	defer f.Close()
-
-	if _, err := radamsa.Parse(f); err != nil {
-		return nil, fmt.Errorf("invalid radamsa -M metadata log: %w: %w", ErrInvalidMaterialType, err)
+		// Only invalid content is a material-type error; a file-access failure is a
+		// system problem the user can fix, so it is surfaced as-is.
+		if errors.Is(err, radamsa.ErrInvalidReport) {
+			return nil, fmt.Errorf("invalid radamsa -M metadata log: %w: %w", ErrInvalidMaterialType, err)
+		}
+		return nil, err
 	}
 
 	m, err := uploadAndCraft(ctx, c.input, c.backend, filePath, c.logger)
@@ -76,6 +87,7 @@ func (c *RadamsaReportCrafter) Craft(ctx context.Context, filePath string) (*api
 		m.Annotations = make(map[string]string)
 	}
 	m.Annotations[AnnotationToolNameKey] = radamsaToolName
+	m.Annotations[AnnotationRadamsaReportRecordsCount] = strconv.Itoa(records)
 	return m, nil
 }
 

--- a/pkg/attestation/crafter/materials/radamsa/parse.go
+++ b/pkg/attestation/crafter/materials/radamsa/parse.go
@@ -25,10 +25,17 @@ import (
 	"strings"
 )
 
+// ErrNoRecords means a -M log held no parseable records (an empty or blank-only
+// log). It is distinct from a malformed-line error so callers can tell a valid but
+// empty report — zero fuzzing iterations — from content that is not a -M log at
+// all.
+var ErrNoRecords = errors.New("no radamsa -M records found")
+
 // Parse reads a radamsa -M metadata log and returns one record per non-blank
 // line. Each record is a map of key -> value, where quoted values are unquoted
 // strings, integer-looking bare values are int64, and other bare tokens are
-// strings. It errors if no parseable record is found.
+// strings. It returns ErrNoRecords when no record is found and a distinct error
+// when a line is malformed.
 func Parse(r io.Reader) ([]map[string]any, error) {
 	scanner := bufio.NewScanner(r)
 	// radamsa lines can be long (many fields); raise the buffer ceiling.
@@ -50,7 +57,7 @@ func Parse(r io.Reader) ([]map[string]any, error) {
 		return nil, err
 	}
 	if len(records) == 0 {
-		return nil, errors.New("no radamsa -M records found")
+		return nil, ErrNoRecords
 	}
 	return records, nil
 }

--- a/pkg/attestation/crafter/materials/radamsa/report.go
+++ b/pkg/attestation/crafter/materials/radamsa/report.go
@@ -1,0 +1,294 @@
+//
+// Copyright 2026 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package radamsa
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+
+	"github.com/chainloop-dev/chainloop/pkg/attestation/crafter/materials/archiveio"
+)
+
+// ErrInvalidReport marks content that is not valid radamsa -M evidence: a
+// malformed log, an archive entry that does not parse, a corrupt gzip stream, or a
+// report that exceeds maxReportRecords. It is deliberately distinct from a
+// file-access error so a caller can tell "bad evidence" (an invalid material) from
+// "couldn't read the file" (a fixable I/O problem).
+var ErrInvalidReport = errors.New("invalid radamsa -M report")
+
+// maxReportRecords caps the total number of -M records a report may contribute to
+// input.elements. The eval-time projection (ParseReportBytes) must hold every
+// record in memory as a map and marshal it to JSON, so an unbounded record count
+// would OOM the evaluator. Craft (InspectReport) enforces the SAME cap while only
+// streaming and counting, so a report accepted at craft time is guaranteed to be
+// evaluable — the two sides share the bound and cannot disagree about it.
+const maxReportRecords = 5_000_000
+
+// reportLimits bounds RADAMSA_REPORT archive expansion. The entry cap is far
+// higher than archiveio's generic 10,000-entry default because the intended input
+// is one -M metadata file per fuzzing run and a campaign routinely has well over
+// ten thousand runs, which would otherwise trip the generic cap. The total
+// uncompressed-size cap guards against a zip bomb; maxReportRecords separately
+// bounds the parsed footprint, which is what the eval projection actually holds.
+func reportLimits() archiveio.Limits {
+	return archiveio.Limits{MaxEntries: 2_000_000, MaxTotalSize: 1 << 30}
+}
+
+// parseEntry parses one -M log. An empty log (zero fuzzing iterations) is valid
+// evidence and yields no records; malformed content is ErrInvalidReport. It is the
+// single definition of the per-entry parse rule, so InspectReport (craft time) and
+// ParseReportBytes (eval time) cannot drift apart on what a report contains — the
+// drift that would let a material be attested and then fail or skip its gate at
+// eval. This mirrors dranzer.parseReportEntry.
+func parseEntry(r io.Reader) ([]map[string]any, error) {
+	recs, err := Parse(r)
+	switch {
+	case errors.Is(err, ErrNoRecords):
+		// An empty log is a valid report of zero iterations, not bad evidence; it
+		// contributes no records and the gate decides whether zero is acceptable.
+		return nil, nil
+	case err != nil:
+		return nil, fmt.Errorf("%w: %w", ErrInvalidReport, err)
+	}
+	// Enforce the record cap here — the one chokepoint every path flows through —
+	// so a single standalone log is bounded exactly as an archive entry is, and no
+	// path can hand the eval projection an unbounded record set.
+	if len(recs) > maxReportRecords {
+		return nil, fmt.Errorf("%w: exceeds %d records", ErrInvalidReport, maxReportRecords)
+	}
+	return recs, nil
+}
+
+// parseSingle parses one standalone -M log and always returns a non-nil slice, so a
+// zero-iteration log marshals to `[]` (a real 0 < min violation the gate can read)
+// rather than `null` (an absent input.elements the gate would skip on).
+func parseSingle(r io.Reader) ([]map[string]any, error) {
+	recs, err := parseEntry(r)
+	if err != nil {
+		return nil, err
+	}
+	if recs == nil {
+		recs = []map[string]any{}
+	}
+	return recs, nil
+}
+
+// isTarStream reports whether r is a tar archive by peeking its first header. An
+// empty-but-valid tar (only end-of-archive blocks) reads as io.EOF and still counts
+// as a tar; a non-tar stream (e.g. a plain-gzipped -M log) yields a different error.
+func isTarStream(r io.Reader) bool {
+	_, err := tar.NewReader(r).Next()
+	return err == nil || errors.Is(err, io.EOF)
+}
+
+// ParseReportBytes parses radamsa -M metadata already held in memory — a single -M
+// log, a plain-gzipped log, or an archive (zip/tar/tar.gz) of logs — and returns
+// the records merged across every entry. Zero records is a valid, empty result
+// (the gate then decides on zero iterations); malformed content is ErrInvalidReport
+// and a malformed archive entry fails the whole material rather than being dropped.
+//
+// This and InspectReport are the single shared definition of what a RADAMSA_REPORT
+// material contains — same content detection, per-entry parse, and record cap — so
+// the crafter's craft-time validation and the policy engine's eval-time projection
+// cannot disagree. Were they to disagree, a material could be attested at craft
+// time and then fail or silently skip policy evaluation, which on a compliance gate
+// reads as a clean pass.
+func ParseReportBytes(data []byte) ([]map[string]any, error) {
+	switch format := archiveio.DetectBytes(data); format {
+	case archiveio.None:
+		return parseSingle(bytes.NewReader(data))
+	case archiveio.Zip, archiveio.Tar:
+		return mergeArchiveBytes(data, format)
+	case archiveio.TarGz:
+		// The gzip magic marks both a real tar.gz and a plain-gzipped single -M
+		// log; decompress and route on the actual content so a gzipped log is not
+		// misread as a (non-)tar and rejected.
+		raw, err := gunzip(data)
+		if err != nil {
+			return nil, err
+		}
+		if isTarStream(bytes.NewReader(raw)) {
+			return mergeArchiveBytes(raw, archiveio.Tar)
+		}
+		return parseSingle(bytes.NewReader(raw))
+	default:
+		return nil, fmt.Errorf("%w: unsupported archive format", ErrInvalidReport)
+	}
+}
+
+// mergeArchiveBytes walks an in-memory archive, parses every entry, and returns the
+// records merged in a deterministic (entry-name) order so input.elements does not
+// depend on archive iteration order. A malformed entry is fatal.
+func mergeArchiveBytes(data []byte, format archiveio.Format) ([]map[string]any, error) {
+	type namedRecords struct {
+		name string
+		recs []map[string]any
+	}
+	var entries []namedRecords
+	total := 0
+	err := archiveio.WalkBytes(data, format, reportLimits(), func(name string, r io.Reader) error {
+		recs, perr := parseEntry(r)
+		if perr != nil {
+			return perr
+		}
+		if len(recs) == 0 {
+			return nil
+		}
+		total += len(recs)
+		if total > maxReportRecords {
+			return fmt.Errorf("%w: exceeds %d records", ErrInvalidReport, maxReportRecords)
+		}
+		entries = append(entries, namedRecords{name: name, recs: recs})
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("reading radamsa archive: %w", err)
+	}
+
+	sort.Slice(entries, func(i, j int) bool { return entries[i].name < entries[j].name })
+	// Non-nil even when empty so a zero-record archive marshals to `[]`, not `null`:
+	// the gate reads an empty array (a real 0 < min violation), not an absent field
+	// (which it would skip on).
+	records := make([]map[string]any, 0, total)
+	for _, e := range entries {
+		records = append(records, e.recs...)
+	}
+	return records, nil
+}
+
+// InspectReport validates a RADAMSA_REPORT material on disk — a single -M log, a
+// plain-gzipped log, or an archive of logs — and returns the total number of
+// parsed -M records. Archives are streamed rather than held in memory. It shares
+// its content detection, per-entry parse, and record cap with ParseReportBytes (see
+// that function) so the two cannot disagree about what a material contains.
+//
+// Content problems are reported as ErrInvalidReport; file-access errors are
+// surfaced as-is so callers can tell an invalid report from an unreadable file.
+func InspectReport(path string) (int, error) {
+	format, err := archiveio.DetectFile(path)
+	if err != nil {
+		return 0, fmt.Errorf("inspecting %q: %w", path, err)
+	}
+
+	switch format {
+	case archiveio.None:
+		return countSingle(path)
+	case archiveio.Zip, archiveio.Tar:
+		return countArchive(path, format)
+	case archiveio.TarGz:
+		isTar, err := gzipIsTar(path)
+		if err != nil {
+			return 0, err
+		}
+		if isTar {
+			return countArchive(path, archiveio.TarGz)
+		}
+		return countGzipSingle(path)
+	default:
+		return 0, fmt.Errorf("%w: unsupported archive format", ErrInvalidReport)
+	}
+}
+
+func countSingle(path string) (int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, fmt.Errorf("can't open the file: %w", err)
+	}
+	defer f.Close()
+	recs, err := parseEntry(f)
+	if err != nil {
+		return 0, err
+	}
+	return len(recs), nil
+}
+
+func countGzipSingle(path string) (int, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, fmt.Errorf("can't open the file: %w", err)
+	}
+	raw, err := gunzip(data)
+	if err != nil {
+		return 0, err
+	}
+	recs, err := parseEntry(bytes.NewReader(raw))
+	if err != nil {
+		return 0, err
+	}
+	return len(recs), nil
+}
+
+func countArchive(path string, format archiveio.Format) (int, error) {
+	total := 0
+	err := archiveio.WalkPath(path, format, reportLimits(), func(_ string, r io.Reader) error {
+		recs, perr := parseEntry(r)
+		if perr != nil {
+			return perr
+		}
+		total += len(recs)
+		if total > maxReportRecords {
+			return fmt.Errorf("%w: exceeds %d records", ErrInvalidReport, maxReportRecords)
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("reading radamsa archive: %w", err)
+	}
+	return total, nil
+}
+
+// gzipIsTar reports whether the gzip stream at path decompresses to a tar (a real
+// tar.gz) rather than a plain-gzipped file, by peeking the first tar header. A
+// corrupt gzip stream is ErrInvalidReport; a file-access error is surfaced as-is.
+func gzipIsTar(path string) (bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return false, fmt.Errorf("can't open the file: %w", err)
+	}
+	defer f.Close()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return false, fmt.Errorf("%w: %w", ErrInvalidReport, err)
+	}
+	defer gz.Close()
+	return isTarStream(gz), nil
+}
+
+// gunzip decompresses a gzip blob, bounding the output to the archive size limit so
+// a gzip bomb cannot exhaust memory. A corrupt or oversized stream is ErrInvalidReport.
+func gunzip(data []byte) ([]byte, error) {
+	gz, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidReport, err)
+	}
+	defer gz.Close()
+
+	maxSize := reportLimits().MaxTotalSize
+	out, err := io.ReadAll(io.LimitReader(gz, maxSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidReport, err)
+	}
+	if int64(len(out)) > maxSize {
+		return nil, fmt.Errorf("%w: gzip content exceeds %d bytes", ErrInvalidReport, maxSize)
+	}
+	return out, nil
+}

--- a/pkg/attestation/crafter/materials/radamsa/report_test.go
+++ b/pkg/attestation/crafter/materials/radamsa/report_test.go
@@ -1,0 +1,181 @@
+//
+// Copyright 2026 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package radamsa_test
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/chainloop-dev/chainloop/pkg/attestation/crafter/materials/radamsa"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// each of these logs holds two parseable -M records.
+var (
+	metaA = []byte("seed: 1\nmuta-num: 1, generator: file\n")
+	metaB = []byte("seed: 2\nmuta-num: 2, generator: jump\n")
+	bad   = []byte("this is not a radamsa metadata log")
+)
+
+func TestParseReportBytes(t *testing.T) {
+	tests := []struct {
+		name        string
+		data        []byte
+		wantRecords int
+		wantErr     bool
+		wantInvalid bool // err should be classified as ErrInvalidReport
+	}{
+		{name: "single valid log", data: metaA, wantRecords: 2},
+		{name: "single malformed log is fatal", data: bad, wantErr: true, wantInvalid: true},
+		{name: "single empty log is a valid zero-iteration report", data: []byte("\n \n"), wantRecords: 0},
+		{name: "plain gzip single log", data: gzipBytes(t, metaA), wantRecords: 2},
+		{name: "plain gzip malformed log is fatal", data: gzipBytes(t, bad), wantErr: true, wantInvalid: true},
+		{name: "tar.gz merges records", data: tarGzBytes(t, map[string][]byte{"m_1.log": metaA, "m_2.log": metaB}), wantRecords: 4},
+		{name: "zip merges records", data: zipBytes(t, map[string][]byte{"m_1.log": metaA, "m_2.log": metaB}), wantRecords: 4},
+		{name: "malformed archive entry is fatal", data: tarGzBytes(t, map[string][]byte{"m_1.log": metaA, "bad.log": bad}), wantErr: true, wantInvalid: true},
+		{name: "archive with only empty entries yields empty array", data: zipBytes(t, map[string][]byte{"empty.log": []byte(" \n")}), wantRecords: 0},
+		{name: "empty archive yields empty array", data: tarGzBytes(t, nil), wantRecords: 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			recs, err := radamsa.ParseReportBytes(tc.data)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Equal(t, tc.wantInvalid, errors.Is(err, radamsa.ErrInvalidReport))
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, recs, tc.wantRecords)
+			assert.NotNil(t, recs, "records must be a non-nil slice so it marshals to [] not null")
+		})
+	}
+}
+
+// TestParseReportBytesDeterministicOrder guards that merged records are ordered by
+// archive entry name, independent of the order the archive stores them, so
+// input.elements is reproducible.
+func TestParseReportBytesDeterministicOrder(t *testing.T) {
+	// a.log's record carries seed 1, b.log's carries seed 2.
+	data := zipBytes(t, map[string][]byte{"b.log": []byte("seed: 2\n"), "a.log": []byte("seed: 1\n")})
+	recs, err := radamsa.ParseReportBytes(data)
+	require.NoError(t, err)
+	require.Len(t, recs, 2)
+	assert.EqualValues(t, 1, recs[0]["seed"], "a.log must sort before b.log")
+	assert.EqualValues(t, 2, recs[1]["seed"])
+}
+
+func TestInspectReport(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "meta.txt", metaA)
+	writeFile(t, dir, "empty.txt", []byte(" \n"))
+	writeFile(t, dir, "invalid.txt", bad)
+	writeFile(t, dir, "single.log.gz", gzipBytes(t, metaA))
+	writeFile(t, dir, "r.tar.gz", tarGzBytes(t, map[string][]byte{"m_1.log": metaA, "m_2.log": metaB}))
+	writeFile(t, dir, "onebad.zip", zipBytes(t, map[string][]byte{"m_1.log": metaA, "bad.log": bad}))
+
+	tests := []struct {
+		name        string
+		file        string
+		wantRecords int
+		wantErr     bool
+		wantInvalid bool
+	}{
+		{name: "single valid log", file: "meta.txt", wantRecords: 2},
+		{name: "single empty log is valid", file: "empty.txt", wantRecords: 0},
+		{name: "single malformed log is fatal", file: "invalid.txt", wantErr: true, wantInvalid: true},
+		{name: "plain gzip single log", file: "single.log.gz", wantRecords: 2},
+		{name: "tar.gz merges records", file: "r.tar.gz", wantRecords: 4},
+		{name: "malformed archive entry is fatal", file: "onebad.zip", wantErr: true, wantInvalid: true},
+		{name: "missing file is a file error not an invalid report", file: "nope.txt", wantErr: true, wantInvalid: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			recs, err := radamsa.InspectReport(filepath.Join(dir, tc.file))
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Equal(t, tc.wantInvalid, errors.Is(err, radamsa.ErrInvalidReport))
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantRecords, recs)
+		})
+	}
+}
+
+// TestReportArchiveAboveGenericEntryCap guards that the report path accepts an
+// archive with more entries than archiveio's generic 10,000-entry default, which
+// the "one -M file per run, >10,000 runs" use case exceeds.
+func TestReportArchiveAboveGenericEntryCap(t *testing.T) {
+	files := make(map[string][]byte, 10001)
+	for i := 0; i < 10001; i++ {
+		files["m_"+strconv.Itoa(i)+".log"] = []byte("seed: 1\n")
+	}
+	recs, err := radamsa.ParseReportBytes(zipBytes(t, files))
+	require.NoError(t, err)
+	assert.Len(t, recs, 10001)
+}
+
+func writeFile(t *testing.T, dir, name string, content []byte) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), content, 0o600))
+}
+
+func gzipBytes(t *testing.T, content []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	_, err := gz.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, gz.Close())
+	return buf.Bytes()
+}
+
+func zipBytes(t *testing.T, files map[string][]byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for name, content := range files {
+		w, err := zw.Create(name)
+		require.NoError(t, err)
+		_, err = w.Write(content)
+		require.NoError(t, err)
+	}
+	require.NoError(t, zw.Close())
+	return buf.Bytes()
+}
+
+func tarGzBytes(t *testing.T, files map[string][]byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for name, content := range files {
+		require.NoError(t, tw.WriteHeader(&tar.Header{Name: name, Mode: 0o600, Size: int64(len(content)), Typeflag: tar.TypeReg}))
+		_, err := tw.Write(content)
+		require.NoError(t, err)
+	}
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+	return buf.Bytes()
+}

--- a/pkg/attestation/crafter/materials/radamsa_test.go
+++ b/pkg/attestation/crafter/materials/radamsa_test.go
@@ -56,14 +56,35 @@ func TestNewRadamsaReportCrafter(t *testing.T) {
 }
 
 func TestRadamsaReportCrafter_Craft(t *testing.T) {
+	dir := t.TempDir()
+	// Each file holds two parseable -M records.
+	meta := []byte("seed: 123\nmuta-num: 1, generator: file\n")
+	badMeta := []byte("this is not a radamsa metadata log")
+	twoTar := filepath.Join(dir, "report.tar.gz")
+	writeTarGz(t, twoTar, map[string][]byte{"meta_1.log": meta, "meta_2.log": meta})
+	twoZip := filepath.Join(dir, "report.zip")
+	writeZip(t, twoZip, map[string][]byte{"meta_1.log": meta, "meta_2.log": meta})
+	badTar := filepath.Join(dir, "report-bad.tar.gz")
+	writeTarGz(t, badTar, map[string][]byte{"meta_1.log": meta, "bad.log": badMeta})
+	emptyTar := filepath.Join(dir, "report-empty.tar.gz")
+	writeTarGz(t, emptyTar, nil)
+	emptyFile := filepath.Join(dir, "empty.log")
+	require.NoError(t, os.WriteFile(emptyFile, []byte(" \n"), 0o600))
+
 	tests := []struct {
-		name     string
-		filePath string
-		wantErr  string
+		name      string
+		filePath  string
+		wantErr   string
+		wantCount string
 	}{
 		{name: "invalid path", filePath: "./testdata/nope.log", wantErr: "no such file"},
 		{name: "not a meta log", filePath: "./testdata/radamsa-meta-invalid.txt", wantErr: "invalid radamsa -M metadata log"},
-		{name: "valid -M log", filePath: "./testdata/radamsa-meta.txt"},
+		{name: "valid -M log", filePath: "./testdata/radamsa-meta.txt", wantCount: "3"},
+		{name: "tar.gz of two meta files => merged records", filePath: twoTar, wantCount: "4"},
+		{name: "zip of two meta files => merged records", filePath: twoZip, wantCount: "4"},
+		{name: "archive with a malformed entry fails the whole material", filePath: badTar, wantErr: "invalid radamsa -M metadata log"},
+		{name: "empty archive is a valid zero-iteration report", filePath: emptyTar, wantCount: "0"},
+		{name: "empty single log is a valid zero-iteration report", filePath: emptyFile, wantCount: "0"},
 	}
 	schema := &contractAPI.CraftingSchema_Material{Name: "report", Type: contractAPI.CraftingSchema_Material_RADAMSA_REPORT}
 	l := zerolog.Nop()
@@ -86,6 +107,7 @@ func TestRadamsaReportCrafter_Craft(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, contractAPI.CraftingSchema_Material_RADAMSA_REPORT.String(), got.MaterialType.String())
 			assert.Equal(t, "radamsa", got.Annotations["chainloop.material.tool.name"])
+			assert.Equal(t, tc.wantCount, got.Annotations["chainloop.material.radamsa.report.records.count"])
 			assert.True(t, got.UploadedToCas)
 		})
 	}

--- a/pkg/policies/engine/rego/radamsa_report_test.go
+++ b/pkg/policies/engine/rego/radamsa_report_test.go
@@ -1,0 +1,182 @@
+//
+// Copyright 2026 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rego
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	schemaapi "github.com/chainloop-dev/chainloop/app/controlplane/api/workflowcontract/v1"
+	v1 "github.com/chainloop-dev/chainloop/pkg/attestation/crafter/api/attestation/v1"
+	"github.com/chainloop-dev/chainloop/pkg/policies/engine"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// minIterationsGate is a representative min-iterations gate — the count(input.elements)
+// shape a real fuzzing-coverage policy uses — authored here as test scaffolding. It
+// is deliberately not a copy of any shipped policy (those live in their own repo);
+// what matters for this test is only that the gate reads input.elements as an array
+// and counts it.
+const minIterationsGate = `package radamsa_report_gate_test
+
+import rego.v1
+
+result := {"skipped": skipped, "violations": violations, "skip_reason": skip_reason}
+
+default skip_reason := ""
+skip_reason := "input.elements is not an array" if not valid_input
+
+default skipped := true
+skipped := false if valid_input
+
+valid_input if is_array(input.elements)
+
+default min_iterations := 100000
+min_iterations := to_number(input.args.min_iterations) if input.args.min_iterations
+
+iteration_count := count(input.elements)
+
+violations contains msg if {
+	valid_input
+	iteration_count < min_iterations
+	msg := sprintf("records %d fuzzing iteration(s), fewer than the required minimum of %d", [iteration_count, min_iterations])
+}
+`
+
+// TestRadamsaMinIterationsAgainstArchiveMaterial is the end-to-end guard the
+// synthetic-elements policy tests cannot provide: it runs a min-iterations gate
+// over the input the ingestion pipeline actually produces for a RADAMSA_REPORT
+// material whose value is an archive of per-run -M logs. It proves the gate
+// ENFORCES (skipped == false) on the merged record count, rather than skipping
+// because input.elements never got populated — the false-assurance failure mode
+// when an archive is stored whole and not merged.
+func TestRadamsaMinIterationsAgainstArchiveMaterial(t *testing.T) {
+	policy := &engine.Policy{Name: "radamsa-min-iterations", Source: []byte(minIterationsGate)}
+
+	// Each log holds three -M records.
+	logA := []byte("seed: 1\nmuta-num: 1, generator: file\nbyte-dec: 1, generator: jump\n")
+	logB := []byte("seed: 2\nmuta-num: 2, generator: file\nbyte-dec: 2, generator: jump\n")
+	badLog := []byte("this is not a radamsa metadata log")
+
+	dir := t.TempDir()
+	// tar.gz and zip of two good logs => six merged records.
+	sixTar := filepath.Join(dir, "six.tar.gz")
+	writeTarGzFile(t, sixTar, map[string][]byte{"meta_1.log": logA, "meta_2.log": logB})
+	sixZip := filepath.Join(dir, "six.zip")
+	writeZipFile(t, sixZip, map[string][]byte{"meta_1.log": logA, "meta_2.log": logB})
+	// zip with one malformed entry => the whole material is rejected at ingestion.
+	withBad := filepath.Join(dir, "withbad.zip")
+	writeZipFile(t, withBad, map[string][]byte{"meta_1.log": logA, "broken.log": badLog})
+	// plain-gzipped single log (not a tar.gz) => three records.
+	gzLog := filepath.Join(dir, "single.log.gz")
+	writeGzipFile(t, gzLog, logA)
+	// empty archive => zero iterations => the gate must FAIL (not skip, not error).
+	emptyArchive := filepath.Join(dir, "empty.tar.gz")
+	writeTarGzFile(t, emptyArchive, nil)
+
+	tests := []struct {
+		name          string
+		path          string
+		minIterations string
+		wantViolation bool
+		wantIngestErr bool // malformed content is rejected before evaluation
+	}{
+		{name: "tar.gz meets minimum", path: sixTar, minIterations: "6", wantViolation: false},
+		{name: "tar.gz misses minimum", path: sixTar, minIterations: "7", wantViolation: true},
+		{name: "zip meets minimum", path: sixZip, minIterations: "6", wantViolation: false},
+		{name: "zip misses minimum", path: sixZip, minIterations: "7", wantViolation: true},
+		{name: "plain gzip single log meets minimum", path: gzLog, minIterations: "3", wantViolation: false},
+		{name: "plain gzip single log misses minimum", path: gzLog, minIterations: "4", wantViolation: true},
+		{name: "zero-iteration report fails the gate rather than skipping", path: emptyArchive, minIterations: "1", wantViolation: true},
+		{name: "malformed archive entry is rejected at ingestion", path: withBad, minIterations: "1", wantIngestErr: true},
+	}
+
+	r := NewEngine()
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &v1.Attestation_Material{
+				MaterialType: schemaapi.CraftingSchema_Material_RADAMSA_REPORT,
+				M: &v1.Attestation_Material_Artifact_{
+					Artifact: &v1.Attestation_Material_Artifact{Name: "fuzz-report", Digest: "sha256:deadbeef"},
+				},
+			}
+			input, err := m.GetEvaluableContent(tc.path)
+			if tc.wantIngestErr {
+				require.Error(t, err, "malformed evidence must be rejected, not silently dropped")
+				return
+			}
+			require.NoError(t, err)
+
+			result, err := r.Verify(context.TODO(), policy, input, map[string]any{"min_iterations": tc.minIterations})
+			require.NoError(t, err)
+
+			assert.False(t, result.Skipped, "gate must enforce on an archive-sourced material, not skip")
+			if tc.wantViolation {
+				assert.NotEmpty(t, result.Violations, "record count below the minimum must be a violation")
+			} else {
+				assert.Empty(t, result.Violations)
+			}
+		})
+	}
+}
+
+func writeGzipFile(t *testing.T, path string, content []byte) {
+	t.Helper()
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+	gz := gzip.NewWriter(f)
+	_, err = gz.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, gz.Close())
+}
+
+func writeTarGzFile(t *testing.T, path string, files map[string][]byte) {
+	t.Helper()
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+	gz := gzip.NewWriter(f)
+	tw := tar.NewWriter(gz)
+	for name, content := range files {
+		require.NoError(t, tw.WriteHeader(&tar.Header{Name: name, Mode: 0o600, Size: int64(len(content)), Typeflag: tar.TypeReg}))
+		_, err := tw.Write(content)
+		require.NoError(t, err)
+	}
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+}
+
+func writeZipFile(t *testing.T, path string, files map[string][]byte) {
+	t.Helper()
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+	zw := zip.NewWriter(f)
+	for name, content := range files {
+		w, err := zw.Create(name)
+		require.NoError(t, err)
+		_, err = w.Write(content)
+		require.NoError(t, err)
+	}
+	require.NoError(t, zw.Close())
+}


### PR DESCRIPTION
## Summary

Add archive input support for the RADAMSA_REPORT material. The crafter now accepts a zip/tar/tar.gz archive of radamsa `-M` metadata logs, or a plain-gzipped single log, in addition to a single log. Previously each per-run `-M` log had to be concatenated by hand before attesting.

The archive is stored in CAS as-is. At policy evaluation time its entries are parsed and their records merged into `input.elements`, so a min-iterations gate enforces on the merged count rather than skipping. A malformed archive entry fails the whole material, and an empty report projects to an empty element set so the gate reports a violation instead of an error. Craft-time validation and eval-time projection share one definition of what a report contains and a common record cap, so a material accepted at craft time is always evaluable.

## AI assistance

This contribution was produced with the assistance of Claude Code.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chainloop-dev/chainloop/pull/3327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

