### PR TITLE
fix(crafter): exclude radamsa -M seed header line from RADAMSA_REPORT iteration count

### DIFF
--- a/pkg/attestation/crafter/api/attestation/v1/crafting_state_test.go
+++ b/pkg/attestation/crafter/api/attestation/v1/crafting_state_test.go
@@ -379,7 +379,8 @@ func TestDranzerBundleIsEvaluable(t *testing.T) {
 // so radamsa-min-iterations reads a non-array input.elements and *skips* — a
 // clean-looking false pass on a fuzzing-coverage gate.
 func TestRadamsaReportArchiveIsEvaluable(t *testing.T) {
-	// Two per-run logs, three -M records each => six merged records.
+	// Two per-run logs, two mutation records each (the seed header line is not a
+	// fuzzing iteration and is not counted) => four merged records.
 	logA := []byte("seed: 1\nmuta-num: 1, generator: file\nbyte-dec: 1, generator: jump\n")
 	logB := []byte("seed: 2\nmuta-num: 2, generator: file\nbyte-dec: 2, generator: jump\n")
 
@@ -409,7 +410,7 @@ func TestRadamsaReportArchiveIsEvaluable(t *testing.T) {
 
 			elements, ok := decoded["elements"].([]any)
 			require.True(t, ok, "input.elements must be an array so the gate does not skip")
-			assert.Len(t, elements, 6, "records from every archive entry must be merged")
+			assert.Len(t, elements, 4, "mutation records from every archive entry must be merged")
 		})
 	}
 }

--- a/pkg/attestation/crafter/materials/radamsa/report.go
+++ b/pkg/attestation/crafter/materials/radamsa/report.go
@@ -69,6 +69,14 @@ func parseEntry(r io.Reader) ([]map[string]any, error) {
 	case err != nil:
 		return nil, fmt.Errorf("%w: %w", ErrInvalidReport, err)
 	}
+	// Drop the per-run header line(s). radamsa emits a single `seed: <n>` line at the
+	// start of each run to identify it, not to report a mutation; counting it would
+	// inflate the iteration count by one per -M log (the bug this guards against). A
+	// concatenated multi-run log carries one header per run, so every seed-bearing
+	// record is dropped, not just the first. radamsa's per-output meta lines describe
+	// a single mutation and never carry a `seed` field, so presence of `seed` is the
+	// header marker.
+	recs = dropRunHeaders(recs)
 	// Enforce the record cap here — the one chokepoint every path flows through —
 	// so a single standalone log is bounded exactly as an archive entry is, and no
 	// path can hand the eval projection an unbounded record set.
@@ -76,6 +84,21 @@ func parseEntry(r io.Reader) ([]map[string]any, error) {
 		return nil, fmt.Errorf("%w: exceeds %d records", ErrInvalidReport, maxReportRecords)
 	}
 	return recs, nil
+}
+
+// dropRunHeaders returns recs with radamsa's per-run header lines removed. The
+// header is the `seed: <n>` line radamsa writes once per run; it identifies the run,
+// not a fuzzing iteration, so it must not be counted or projected into
+// input.elements. Records are filtered in place, preserving order.
+func dropRunHeaders(recs []map[string]any) []map[string]any {
+	kept := recs[:0]
+	for _, rec := range recs {
+		if _, isHeader := rec["seed"]; isHeader {
+			continue
+		}
+		kept = append(kept, rec)
+	}
+	return kept
 }
 
 // parseSingle parses one standalone -M log and always returns a non-nil slice, so a

--- a/pkg/attestation/crafter/materials/radamsa/report_test.go
+++ b/pkg/attestation/crafter/materials/radamsa/report_test.go
@@ -31,7 +31,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// each of these logs holds two parseable -M records.
+// each of these logs holds a `seed:` run header (not a fuzzing iteration, so not
+// counted) followed by one mutation record.
 var (
 	metaA = []byte("seed: 1\nmuta-num: 1, generator: file\n")
 	metaB = []byte("seed: 2\nmuta-num: 2, generator: jump\n")
@@ -46,13 +47,13 @@ func TestParseReportBytes(t *testing.T) {
 		wantErr     bool
 		wantInvalid bool // err should be classified as ErrInvalidReport
 	}{
-		{name: "single valid log", data: metaA, wantRecords: 2},
+		{name: "single valid log", data: metaA, wantRecords: 1},
 		{name: "single malformed log is fatal", data: bad, wantErr: true, wantInvalid: true},
 		{name: "single empty log is a valid zero-iteration report", data: []byte("\n \n"), wantRecords: 0},
-		{name: "plain gzip single log", data: gzipBytes(t, metaA), wantRecords: 2},
+		{name: "plain gzip single log", data: gzipBytes(t, metaA), wantRecords: 1},
 		{name: "plain gzip malformed log is fatal", data: gzipBytes(t, bad), wantErr: true, wantInvalid: true},
-		{name: "tar.gz merges records", data: tarGzBytes(t, map[string][]byte{"m_1.log": metaA, "m_2.log": metaB}), wantRecords: 4},
-		{name: "zip merges records", data: zipBytes(t, map[string][]byte{"m_1.log": metaA, "m_2.log": metaB}), wantRecords: 4},
+		{name: "tar.gz merges records", data: tarGzBytes(t, map[string][]byte{"m_1.log": metaA, "m_2.log": metaB}), wantRecords: 2},
+		{name: "zip merges records", data: zipBytes(t, map[string][]byte{"m_1.log": metaA, "m_2.log": metaB}), wantRecords: 2},
 		{name: "malformed archive entry is fatal", data: tarGzBytes(t, map[string][]byte{"m_1.log": metaA, "bad.log": bad}), wantErr: true, wantInvalid: true},
 		{name: "archive with only empty entries yields empty array", data: zipBytes(t, map[string][]byte{"empty.log": []byte(" \n")}), wantRecords: 0},
 		{name: "empty archive yields empty array", data: tarGzBytes(t, nil), wantRecords: 0},
@@ -72,17 +73,74 @@ func TestParseReportBytes(t *testing.T) {
 	}
 }
 
+// oneMutation is a single radamsa -M mutation line carrying an nth field, the shape
+// a real per-output meta line has.
+func oneMutation(nth int) string {
+	return "muta-num: 1, generator: file, checksum: \"AB\", nth: " + strconv.Itoa(nth) + ", output: file-writer, length: 10, pattern: burst\n"
+}
+
+// runLog builds a -M log the way radamsa writes one: a single `seed:` header line
+// followed by one line per mutation.
+func runLog(seed, mutations int) []byte {
+	log := "seed: " + strconv.Itoa(seed) + "\n"
+	for i := 1; i <= mutations; i++ {
+		log += oneMutation(i)
+	}
+	return []byte(log)
+}
+
+// TestReportCountsMutationsNotSeedHeader is the regression guard for the bug where
+// the per-run `seed:` header line was counted as a fuzzing iteration, inflating the
+// count by one per -M log. A log with a seed header and N mutation lines is N
+// iterations, not N+1; and an archive of two such logs (the real-world shape) counts
+// only the mutations across both.
+func TestReportCountsMutationsNotSeedHeader(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+		want int
+	}{
+		{name: "seed header plus five mutations counts five", data: runLog(1, 5), want: 5},
+		{name: "seed-only log is zero iterations", data: []byte("seed: 12345\n"), want: 0},
+		{name: "log without a seed header counts every mutation", data: []byte(oneMutation(1) + oneMutation(2)), want: 2},
+		{
+			name: "two logs of five mutations each merge to ten, not twelve",
+			data: zipBytes(t, map[string][]byte{"meta_1.log": runLog(11, 5), "meta_2.log": runLog(22, 5)}),
+			want: 10,
+		},
+		{
+			// A concatenated multi-run log carries one seed header per run; every
+			// header must be dropped, not just the first.
+			name: "multiple seed headers in one log are all dropped",
+			data: []byte("seed: 1\n" + oneMutation(1) + oneMutation(2) + "seed: 2\n" + oneMutation(1)),
+			want: 3,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			recs, err := radamsa.ParseReportBytes(tc.data)
+			require.NoError(t, err)
+			assert.Len(t, recs, tc.want)
+			for _, r := range recs {
+				_, hasSeed := r["seed"]
+				assert.False(t, hasSeed, "no counted record may be a seed header")
+			}
+		})
+	}
+}
+
 // TestParseReportBytesDeterministicOrder guards that merged records are ordered by
 // archive entry name, independent of the order the archive stores them, so
 // input.elements is reproducible.
 func TestParseReportBytesDeterministicOrder(t *testing.T) {
-	// a.log's record carries seed 1, b.log's carries seed 2.
-	data := zipBytes(t, map[string][]byte{"b.log": []byte("seed: 2\n"), "a.log": []byte("seed: 1\n")})
+	// a.log's mutation carries nth 1, b.log's carries nth 2; entries must merge in
+	// entry-name order regardless of how the archive stores them.
+	data := zipBytes(t, map[string][]byte{"b.log": []byte(oneMutation(2)), "a.log": []byte(oneMutation(1))})
 	recs, err := radamsa.ParseReportBytes(data)
 	require.NoError(t, err)
 	require.Len(t, recs, 2)
-	assert.EqualValues(t, 1, recs[0]["seed"], "a.log must sort before b.log")
-	assert.EqualValues(t, 2, recs[1]["seed"])
+	assert.EqualValues(t, 1, recs[0]["nth"], "a.log must sort before b.log")
+	assert.EqualValues(t, 2, recs[1]["nth"])
 }
 
 func TestInspectReport(t *testing.T) {
@@ -101,11 +159,11 @@ func TestInspectReport(t *testing.T) {
 		wantErr     bool
 		wantInvalid bool
 	}{
-		{name: "single valid log", file: "meta.txt", wantRecords: 2},
+		{name: "single valid log", file: "meta.txt", wantRecords: 1},
 		{name: "single empty log is valid", file: "empty.txt", wantRecords: 0},
 		{name: "single malformed log is fatal", file: "invalid.txt", wantErr: true, wantInvalid: true},
-		{name: "plain gzip single log", file: "single.log.gz", wantRecords: 2},
-		{name: "tar.gz merges records", file: "r.tar.gz", wantRecords: 4},
+		{name: "plain gzip single log", file: "single.log.gz", wantRecords: 1},
+		{name: "tar.gz merges records", file: "r.tar.gz", wantRecords: 2},
 		{name: "malformed archive entry is fatal", file: "onebad.zip", wantErr: true, wantInvalid: true},
 		{name: "missing file is a file error not an invalid report", file: "nope.txt", wantErr: true, wantInvalid: false},
 	}
@@ -129,7 +187,7 @@ func TestInspectReport(t *testing.T) {
 func TestReportArchiveAboveGenericEntryCap(t *testing.T) {
 	files := make(map[string][]byte, 10001)
 	for i := 0; i < 10001; i++ {
-		files["m_"+strconv.Itoa(i)+".log"] = []byte("seed: 1\n")
+		files["m_"+strconv.Itoa(i)+".log"] = []byte(oneMutation(1))
 	}
 	recs, err := radamsa.ParseReportBytes(zipBytes(t, files))
 	require.NoError(t, err)

--- a/pkg/attestation/crafter/materials/radamsa_test.go
+++ b/pkg/attestation/crafter/materials/radamsa_test.go
@@ -57,7 +57,8 @@ func TestNewRadamsaReportCrafter(t *testing.T) {
 
 func TestRadamsaReportCrafter_Craft(t *testing.T) {
 	dir := t.TempDir()
-	// Each file holds two parseable -M records.
+	// Each file holds a `seed:` run header (not a fuzzing iteration, so not counted)
+	// and one mutation record.
 	meta := []byte("seed: 123\nmuta-num: 1, generator: file\n")
 	badMeta := []byte("this is not a radamsa metadata log")
 	twoTar := filepath.Join(dir, "report.tar.gz")
@@ -79,9 +80,9 @@ func TestRadamsaReportCrafter_Craft(t *testing.T) {
 	}{
 		{name: "invalid path", filePath: "./testdata/nope.log", wantErr: "no such file"},
 		{name: "not a meta log", filePath: "./testdata/radamsa-meta-invalid.txt", wantErr: "invalid radamsa -M metadata log"},
-		{name: "valid -M log", filePath: "./testdata/radamsa-meta.txt", wantCount: "3"},
-		{name: "tar.gz of two meta files => merged records", filePath: twoTar, wantCount: "4"},
-		{name: "zip of two meta files => merged records", filePath: twoZip, wantCount: "4"},
+		{name: "valid -M log", filePath: "./testdata/radamsa-meta.txt", wantCount: "2"},
+		{name: "tar.gz of two meta files => merged records", filePath: twoTar, wantCount: "2"},
+		{name: "zip of two meta files => merged records", filePath: twoZip, wantCount: "2"},
 		{name: "archive with a malformed entry fails the whole material", filePath: badTar, wantErr: "invalid radamsa -M metadata log"},
 		{name: "empty archive is a valid zero-iteration report", filePath: emptyTar, wantCount: "0"},
 		{name: "empty single log is a valid zero-iteration report", filePath: emptyFile, wantCount: "0"},

--- a/pkg/policies/engine/rego/radamsa_report_test.go
+++ b/pkg/policies/engine/rego/radamsa_report_test.go
@@ -72,21 +72,23 @@ violations contains msg if {
 func TestRadamsaMinIterationsAgainstArchiveMaterial(t *testing.T) {
 	policy := &engine.Policy{Name: "radamsa-min-iterations", Source: []byte(minIterationsGate)}
 
-	// Each log holds three -M records.
+	// Each log holds a `seed:` run header (not a fuzzing iteration, so not counted)
+	// and two mutation records.
 	logA := []byte("seed: 1\nmuta-num: 1, generator: file\nbyte-dec: 1, generator: jump\n")
 	logB := []byte("seed: 2\nmuta-num: 2, generator: file\nbyte-dec: 2, generator: jump\n")
 	badLog := []byte("this is not a radamsa metadata log")
 
 	dir := t.TempDir()
-	// tar.gz and zip of two good logs => six merged records.
-	sixTar := filepath.Join(dir, "six.tar.gz")
-	writeTarGzFile(t, sixTar, map[string][]byte{"meta_1.log": logA, "meta_2.log": logB})
-	sixZip := filepath.Join(dir, "six.zip")
-	writeZipFile(t, sixZip, map[string][]byte{"meta_1.log": logA, "meta_2.log": logB})
+	// tar.gz and zip of two good logs => four merged records (two per log; the seed
+	// header line is not a fuzzing iteration and is not counted).
+	fourTar := filepath.Join(dir, "four.tar.gz")
+	writeTarGzFile(t, fourTar, map[string][]byte{"meta_1.log": logA, "meta_2.log": logB})
+	fourZip := filepath.Join(dir, "four.zip")
+	writeZipFile(t, fourZip, map[string][]byte{"meta_1.log": logA, "meta_2.log": logB})
 	// zip with one malformed entry => the whole material is rejected at ingestion.
 	withBad := filepath.Join(dir, "withbad.zip")
 	writeZipFile(t, withBad, map[string][]byte{"meta_1.log": logA, "broken.log": badLog})
-	// plain-gzipped single log (not a tar.gz) => three records.
+	// plain-gzipped single log (not a tar.gz) => two records.
 	gzLog := filepath.Join(dir, "single.log.gz")
 	writeGzipFile(t, gzLog, logA)
 	// empty archive => zero iterations => the gate must FAIL (not skip, not error).
@@ -100,12 +102,12 @@ func TestRadamsaMinIterationsAgainstArchiveMaterial(t *testing.T) {
 		wantViolation bool
 		wantIngestErr bool // malformed content is rejected before evaluation
 	}{
-		{name: "tar.gz meets minimum", path: sixTar, minIterations: "6", wantViolation: false},
-		{name: "tar.gz misses minimum", path: sixTar, minIterations: "7", wantViolation: true},
-		{name: "zip meets minimum", path: sixZip, minIterations: "6", wantViolation: false},
-		{name: "zip misses minimum", path: sixZip, minIterations: "7", wantViolation: true},
-		{name: "plain gzip single log meets minimum", path: gzLog, minIterations: "3", wantViolation: false},
-		{name: "plain gzip single log misses minimum", path: gzLog, minIterations: "4", wantViolation: true},
+		{name: "tar.gz meets minimum", path: fourTar, minIterations: "4", wantViolation: false},
+		{name: "tar.gz misses minimum", path: fourTar, minIterations: "5", wantViolation: true},
+		{name: "zip meets minimum", path: fourZip, minIterations: "4", wantViolation: false},
+		{name: "zip misses minimum", path: fourZip, minIterations: "5", wantViolation: true},
+		{name: "plain gzip single log meets minimum", path: gzLog, minIterations: "2", wantViolation: false},
+		{name: "plain gzip single log misses minimum", path: gzLog, minIterations: "3", wantViolation: true},
 		{name: "zero-iteration report fails the gate rather than skipping", path: emptyArchive, minIterations: "1", wantViolation: true},
 		{name: "malformed archive entry is rejected at ingestion", path: withBad, minIterations: "1", wantIngestErr: true},
 	}


### PR DESCRIPTION
## Summary

Excludes radamsa's per-run `seed:` header line from the RADAMSA_REPORT iteration count.

radamsa writes each `-M` metadata log as a single `seed:` header line (identifying the run) followed by one line per mutation. The parser counted every non-blank line as a record, so the `seed:` header was counted as a fuzzing iteration, inflating the count by one per log. This affected both the craft-time records annotation and the eval-time `input.elements` that a `radamsa-min-iterations` gate counts, making the gate more lenient than intended.

The fix drops run-header records (those carrying a `seed` key) in `parseEntry`, the single chokepoint shared by `InspectReport` (craft) and `ParseReportBytes` (eval), so both sides reflect only real mutations. All seed-bearing records are dropped, so a concatenated multi-run log is handled correctly. `radamsa.Parse` remains a faithful line parser.

Fixes PFM-6903.

## AI disclosure

Assisted by Claude Code.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chainloop-dev/chainloop/pull/3332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

