### PR TITLE
fix(attestation): omit inline policy evaluations when CAS ref is set

### DIFF
--- a/pkg/attestation/renderer/chainloop/v02.go
+++ b/pkg/attestation/renderer/chainloop/v02.go
@@ -291,6 +291,12 @@ func (r *RendererV02) predicate() (*structpb.Struct, error) {
 		SigningTSA:                  r.att.GetSigningOptions().GetTimestampAuthorityUrl(),
 	}
 
+	// When evaluations are offloaded to CAS (ref set), keep only the ref and drop
+	// the inline copy; the summary counters above are derived independently.
+	if r.policyEvaluationsRef != nil {
+		p.PolicyEvaluations = nil
+	}
+
 	// transform to structpb.Struct in a two steps process
 	// 1 - ProvenancePredicate -> json
 	// 2 - json -> structpb.Struct

--- a/pkg/attestation/renderer/chainloop/v02_test.go
+++ b/pkg/attestation/renderer/chainloop/v02_test.go
@@ -480,6 +480,8 @@ func TestPredicatePolicyEvaluationsRef(t *testing.T) {
 
 			if !tc.wantRef {
 				assert.Nil(t, predicate.PolicyEvaluationsRef)
+				// Without a ref (no-CAS backend) the evaluations stay inline.
+				assert.NotEmpty(t, predicate.PolicyEvaluations)
 				return
 			}
 
@@ -487,6 +489,10 @@ func TestPredicatePolicyEvaluationsRef(t *testing.T) {
 			assert.Equal(t, tc.ref.Name, predicate.PolicyEvaluationsRef.Name)
 			assert.Equal(t, tc.ref.MediaType, predicate.PolicyEvaluationsRef.MediaType)
 			assert.Equal(t, tc.ref.Digest["sha256"], predicate.PolicyEvaluationsRef.Digest["sha256"])
+
+			// With a ref present (CAS offload) the predicate must not also carry
+			// the inline evaluations.
+			assert.Empty(t, predicate.PolicyEvaluations)
 		})
 	}
 }


### PR DESCRIPTION
When an external CAS backend is enabled, the attestation push uploads the PolicyEvaluationBundle to CAS and adds a `policyEvaluationsRef` to the predicate, but it also still embedded the full inline `policyEvaluations`. The payload carried the evaluations twice and could exceed the control-plane gRPC receive limit at push time.

This drops the inline `policyEvaluations` from the predicate once the ref is emitted. The no-CAS / inline-backend path keeps the inline copy, and consumers keep the fallback for attestations that predate the ref. Predicate summary counters are derived from the attestation directly, so they remain accurate.