### PR TITLE
ci: publish GitHub release as a draft until post-release steps succeed

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -275,6 +275,16 @@ jobs:
           # Update the release notes and ignore if it fails since we might be lacking permissions to update the release notes
           gh release edit $RELEASE_TAG -n "$modified_notes" || echo -n "Not enough permissions to edit the release notes. Skipping..."
 
+      # GoReleaser publishes the release as a draft (see release.draft in .goreleaser.yml).
+      # Flip it to published only after every post-release step above has succeeded so a
+      # failure leaves the release as a draft for a human to inspect/retry rather than
+      # publishing a broken release.
+      - name: Publish release
+        if: ${{ success() }}
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: gh release edit "$RELEASE_TAG" --draft=false
+
       - name: Mark attestation as failed
         if: ${{ failure() }}
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -196,9 +196,13 @@ jobs:
           ATTESTATION_ID: ${{ steps.init_attestation.outputs.attestation_id }}
           RELEASE_TAG: ${{ github.ref_name }}
         run: |
-          # This needs to run AFTER goreleaser to make sure the source code is available
-
-          gh release download $RELEASE_TAG -A tar.gz -O /tmp/source-code.tar.gz
+          # This needs to run AFTER goreleaser to make sure the source code is available.
+          # Fetch the tag's source archive directly instead of via `gh release download -A`:
+          # GitHub only exposes the auto-built "Source code (tar.gz)" release asset once a
+          # release is published, but our release is still a draft at this point. The archive
+          # URL depends only on the git tag (which already exists), so it works either way and
+          # produces the same auto-generated tarball.
+          curl -sfL "https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/${RELEASE_TAG}.tar.gz" -o /tmp/source-code.tar.gz
           chainloop attestation add --name source-code --value /tmp/source-code.tar.gz --kind ARTIFACT --attestation-id ${{ env.ATTESTATION_ID }}
 
       - name: Read current project version

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -238,5 +238,10 @@ docker_manifests:
       - "ghcr.io/chainloop-dev/chainloop/cli:{{ .Tag }}-arm64"
 
 release:
+  # Publish the release as a draft first. The workflow performs all post-release
+  # work (SBOMs, attestation, release-note edits) against the draft and only flips
+  # it to published once every step succeeds, so a failure never leaves a public
+  # but incomplete release.
+  draft: true
   extra_files:
     - glob: ./.github/workflows/cosign.pub


### PR DESCRIPTION
## Summary

The release workflow used to publish the GitHub release immediately via GoReleaser and then keep adding post-release artifacts (SBOMs, vulnerability reports, Chainloop attestation link, source-code attestation, release-note edits). When one of those post-release steps failed, the release was already public but incomplete.

This makes the release atomic from a user's perspective:

- `.goreleaser.yml`: the `release:` block now sets `draft: true`, so GoReleaser creates the release as a draft.
- `.github/workflows/release.yaml`: all existing post-release steps run against the draft (they reference it by tag). A final `success()`-gated **Publish release** step flips the draft to published only after every post-release step has succeeded.

If any post-release step fails, the release stays a draft for a human to inspect or retry, rather than a broken release going public.

Refs PFM-6883.

Assisted-by: Claude Code

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chainloop-dev/chainloop/pull/3348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

