### PR TITLE
fix: validate project_id when creating CAS mappings

### DIFF
--- a/app/controlplane/pkg/biz/casmapping.go
+++ b/app/controlplane/pkg/biz/casmapping.go
@@ -142,7 +142,7 @@ func (uc *CASMappingUseCase) FindCASMappingForDownloadByOrg(ctx context.Context,
 	if err != nil {
 		return nil, fmt.Errorf("failed to find cas mapping in orgs: %w", err)
 	} else if mapping == nil {
-		uc.logger.Warnw("msg", "digest not accessible to the requesting orgs", "digest", digest, "orgs", orgs)
+		uc.logger.Warnw("msg", "digest not accessible to the requesting orgs", "digest", digest, "orgs", orgs, "projectIDs", projectIDs)
 		return nil, NewErrNotFound("digest not found in any mapping")
 	}
 

--- a/app/controlplane/pkg/biz/casmapping_integration_test.go
+++ b/app/controlplane/pkg/biz/casmapping_integration_test.go
@@ -18,6 +18,7 @@ package biz_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/biz"
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/biz/testhelpers"
@@ -264,6 +265,12 @@ func (s *casMappingIntegrationSuite) TestCreate() {
 	foreignProject, err := s.Project.Create(ctx, s.org2.ID, randomName())
 	require.NoError(s.T(), err)
 
+	// A soft-deleted project. Nothing sets projects.deleted_at today, so it is set directly here to
+	// cover the guard against a project that is no longer live.
+	deletedProject, err := s.Project.Create(ctx, s.org1.ID, randomName())
+	require.NoError(s.T(), err)
+	require.NoError(s.T(), s.Data.DB.Project.UpdateOneID(deletedProject.ID).SetDeletedAt(time.Now()).Exec(ctx))
+
 	testCases := []struct {
 		name          string
 		digest        string
@@ -348,6 +355,13 @@ func (s *casMappingIntegrationSuite) TestCreate() {
 			digest:       validDigest,
 			casBackendID: s.casBackend1.ID,
 			projectID:    biz.ToPtr(foreignProject.ID),
+			wantErr:      true,
+		},
+		{
+			name:         "soft-deleted project",
+			digest:       validDigest,
+			casBackendID: s.casBackend1.ID,
+			projectID:    biz.ToPtr(deletedProject.ID),
 			wantErr:      true,
 		},
 	}

--- a/app/controlplane/pkg/biz/casmapping_integration_test.go
+++ b/app/controlplane/pkg/biz/casmapping_integration_test.go
@@ -253,11 +253,23 @@ func (s *casMappingIntegrationSuite) TestCASMappingForDownloadSkipsSoftDeleted()
 }
 
 func (s *casMappingIntegrationSuite) TestCreate() {
+	ctx := context.Background()
+
+	// A project version ID is not a project ID. Storing one in cas_mappings.project_id makes the
+	// mapping unreachable for any role whose downloads are filtered by project RBAC.
+	projectVersion, err := s.ProjectVersion.Create(ctx, s.projectID.String(), "v1.0.0", false)
+	require.NoError(s.T(), err)
+
+	// A project living in a different organization than the CAS backend.
+	foreignProject, err := s.Project.Create(ctx, s.org2.ID, randomName())
+	require.NoError(s.T(), err)
+
 	testCases := []struct {
 		name          string
 		digest        string
 		casBackendID  uuid.UUID
 		workflowRunID *uuid.UUID
+		projectID     *uuid.UUID
 		wantErr       bool
 	}{
 		{
@@ -311,6 +323,33 @@ func (s *casMappingIntegrationSuite) TestCreate() {
 			digest:       validDigest,
 			casBackendID: s.casBackend1.ID,
 		},
+		{
+			name:         "associated to a project",
+			digest:       validDigest,
+			casBackendID: s.casBackend1.ID,
+			projectID:    biz.ToPtr(s.projectID),
+		},
+		{
+			name:         "non-existing project",
+			digest:       validDigest,
+			casBackendID: s.casBackend1.ID,
+			projectID:    biz.ToPtr(uuid.New()),
+			wantErr:      true,
+		},
+		{
+			name:         "a project version ID is not a valid project ID",
+			digest:       validDigest,
+			casBackendID: s.casBackend1.ID,
+			projectID:    biz.ToPtr(projectVersion.ID),
+			wantErr:      true,
+		},
+		{
+			name:         "project from another organization",
+			digest:       validDigest,
+			casBackendID: s.casBackend1.ID,
+			projectID:    biz.ToPtr(foreignProject.ID),
+			wantErr:      true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -324,8 +363,12 @@ func (s *casMappingIntegrationSuite) TestCreate() {
 			want.WorkflowRunID = *tc.workflowRunID
 		}
 
+		if tc.projectID != nil {
+			want.ProjectID = *tc.projectID
+		}
+
 		s.Run(tc.name, func() {
-			got, err := s.CASMapping.Create(context.TODO(), tc.digest, tc.casBackendID.String(), &biz.CASMappingCreateOpts{WorkflowRunID: tc.workflowRunID})
+			got, err := s.CASMapping.Create(ctx, tc.digest, tc.casBackendID.String(), &biz.CASMappingCreateOpts{WorkflowRunID: tc.workflowRunID, ProjectID: tc.projectID})
 			if tc.wantErr {
 				s.Error(err)
 			} else {

--- a/app/controlplane/pkg/data/casmapping.go
+++ b/app/controlplane/pkg/data/casmapping.go
@@ -25,6 +25,7 @@ import (
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/data/ent/casbackend"
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/data/ent/casmapping"
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/data/ent/predicate"
+	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/data/ent/project"
 	"github.com/chainloop-dev/chainloop/app/controlplane/pkg/data/ent/workflowrun"
 	"github.com/chainloop-dev/chainloop/pkg/otelx"
 	"github.com/go-kratos/kratos/v2/log"
@@ -66,6 +67,23 @@ func (r *CASMappingRepo) Create(ctx context.Context, digest string, casBackendID
 			return nil, fmt.Errorf("failed to check workflow run: %w", err)
 		} else if !exists {
 			return nil, biz.NewErrNotFound("workflow run")
+		}
+	}
+
+	// project_id is not enforced at the database level, so an ID that belongs to no project (a
+	// project version ID, for instance) writes cleanly. Validate it here: a mapping whose project_id
+	// is not a real project of the backend's organization can never match the
+	// "organization_id = <org> AND project_id IN (<visible projects>)" filter used by
+	// FindByDigestInOrgs, making the artifact undownloadable for every role with RBAC enabled.
+	if opts != nil && opts.ProjectID != nil {
+		exists, err := r.data.DB.Project.Query().Where(
+			project.ID(*opts.ProjectID),
+			project.OrganizationID(casBackend.OrganizationID),
+		).Exist(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check project: %w", err)
+		} else if !exists {
+			return nil, biz.NewErrNotFound(fmt.Sprintf("project %s in organization %s", opts.ProjectID, casBackend.OrganizationID))
 		}
 	}
 

--- a/app/controlplane/pkg/data/casmapping.go
+++ b/app/controlplane/pkg/data/casmapping.go
@@ -72,13 +72,14 @@ func (r *CASMappingRepo) Create(ctx context.Context, digest string, casBackendID
 
 	// project_id is not enforced at the database level, so an ID that belongs to no project (a
 	// project version ID, for instance) writes cleanly. Validate it here: a mapping whose project_id
-	// is not a real project of the backend's organization can never match the
+	// is not a live project of the backend's organization can never match the
 	// "organization_id = <org> AND project_id IN (<visible projects>)" filter used by
 	// FindByDigestInOrgs, making the artifact undownloadable for every role with RBAC enabled.
 	if opts != nil && opts.ProjectID != nil {
 		exists, err := r.data.DB.Project.Query().Where(
 			project.ID(*opts.ProjectID),
 			project.OrganizationID(casBackend.OrganizationID),
+			project.DeletedAtIsNil(),
 		).Exist(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to check project: %w", err)


### PR DESCRIPTION
Closes chainloop-dev/chainloop#3358

`cas_mappings.project_id` is not enforced at the database level, so `CASMappingRepo.Create` accepted any UUID — including a `project_versions.id`, which has been observed in real data. A mapping carrying such a value never matches the `organization_id = <org> AND project_id IN (<visible project ids>)` predicate used to resolve downloads, so the artifact is unreachable for roles with project RBAC enabled while org owners and admins can still download it.

`Create` now validates that the referenced project exists and belongs to the CAS backend's organization, so a bad write fails at creation time rather than producing a mapping only some roles can read. This mirrors the existing validation of the other database-unenforced reference on the same write, `workflow_run_id`.

The check is deliberately at the application level rather than a foreign key: it is a single indexed lookup on a path that already resolves the CAS backend and validates the workflow run, and it avoids a table-wide constraint on a high-volume write path.

The download lookup also logs the visible project IDs when a digest is not accessible, which is the information needed to tell an RBAC filter miss apart from a genuinely absent mapping.

Repairing existing rows and correcting writers that pass a project version ID are out of scope.

AI assistance: implemented with Claude Code.

![Review in cubic](https://camo.githubusercontent.com/bd9efce2efa0a4d0a92a581dc73a4b2dc621085d3ac789eccf3330c974d2dae0/68747470733a2f2f7777772e63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)