### PR TITLE
fix(migrations): upgrade atlas image to v1.3.2 to clear Go CVEs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Generate migrations
         if: ${{ matrix.app == 'controlplane' }}
         env:
-          ATLAS_VERSION: v1.2.0
+          ATLAS_VERSION: v1.3.2
         run: |
           wget -q https://release.ariga.io/atlas/atlas-linux-amd64-$ATLAS_VERSION -O /tmp/atlas
           sudo install /tmp/atlas /usr/local/bin/atlas

--- a/app/controlplane/Dockerfile.migrations
+++ b/app/controlplane/Dockerfile.migrations
@@ -1,9 +1,9 @@
 # Container image built by go-releaser that's used to run migrations against the database during deployment
 # See https://atlasgo.io/guides/deploying/image
-# from: arigaio/atlas:latest (v1.2.3-97b7881-canary)
-# docker run arigaio/atlas@sha256:7470216c7ecc93db7a51d895fbc9c3e7d3885763c424f07d115b1da9410256bb version
-# atlas version v1.2.3-97b7881-canary
-FROM arigaio/atlas@sha256:7470216c7ecc93db7a51d895fbc9c3e7d3885763c424f07d115b1da9410256bb as base
+# from: arigaio/atlas:1.3.2
+# docker run arigaio/atlas@sha256:1e4fe2e242281555f8fc41a95f09b94ccd47f85ee3a6bc1e808e1e48d27e4b39 version
+# atlas version v1.3.2
+FROM arigaio/atlas@sha256:1e4fe2e242281555f8fc41a95f09b94ccd47f85ee3a6bc1e808e1e48d27e4b39 as base
 
 FROM scratch
 # Update permissions to make it readable by the user

--- a/common.mk
+++ b/common.mk
@@ -9,7 +9,7 @@ init: init-api-tools
 	# in the community version anymore https://github.com/ariga/atlas/issues/2388#issuecomment-1864287189
 	# install golangci-lint with Go 1.25 support
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v2.4.0
-	curl -sSf https://atlasgo.sh | ATLAS_VERSION=v1.2.0 sh -s -- -y
+	curl -sSf https://atlasgo.sh | ATLAS_VERSION=v1.3.2 sh -s -- -y
 
 # initialize API tooling
 .PHONY: init-api-tools


### PR DESCRIPTION
## Summary

- Bump the pinned `arigaio/atlas` base image in `app/controlplane/Dockerfile.migrations` from `v1.2.3-97b7881-canary` to the `v1.3.2` stable release (`sha256:1e4fe2e2…`), which is built with an updated Go toolchain and dependencies.
- Clears all 15 High findings previously reported against the `/atlas` binary in the `control-plane-migrations` image, covering Go stdlib (CVE-2026-56862, CVE-2026-56864, CVE-2026-56865, CVE-2026-46600, CVE-2026-39822, GO-2026-6089, GO-2026-5942, GO-2026-4970), `golang.org/x/net` (GO-2026-5942), `golang.org/x/text` (GO-2026-5970), `golang.org/x/mod` (GO-2026-6179, GO-2026-6180) and `google.golang.org/grpc` (GHSA-hrxh-6v49-42gf).
- Align the `ATLAS_VERSION` used to install the atlas CLI in `common.mk` and `.github/workflows/test.yml` with the same `v1.3.2` release.

AI disclosure: this change was produced with the assistance of Claude Code.

🤖 _Posted by Maximus bot (Claude Code) on behalf of @migmartri_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chainloop-dev/chainloop/pull/3378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

