### PR TITLE
chore(devel): enable CLI telemetry in the traced sandbox kit

### DIFF
--- a/devel/sandbox-kit/spec.yaml
+++ b/devel/sandbox-kit/spec.yaml
@@ -258,7 +258,6 @@ environment:
     # MUST share it (transcript discovery is os.UserHomeDir()-based; a mismatch
     # silently loses usage/cost/tools), but sbx already sets HOME=/home/agent on
     # PID 1, so every child inherits it - verified in a plain `claude` sandbox.
-    DO_NOT_TRACK: "1"                        # silence PostHog telemetry under restricted egress
     # Mode selection - see the traceMode arg above for what each value does.
     CHAINLOOP_TRACE_MODE: ${{ kit.args.traceMode }}
     # `trace run` identity ONLY. Empty in persistent mode, where the identity
@@ -365,6 +364,7 @@ permissions:                                 # v1: `network.allowedDomains:`
       - "api.cp.chainloop.dev:443"           # control plane - ALWAYS (attest + keyless signing CSR)
       - "api.cas.chainloop.dev:443"          # CAS - only if the org CAS backend is external
       - "api.app.chainloop.dev:443"          # platform backend - the EE CLI also dials this
+      - "crb.chainloop.dev:443"              # CLI usage telemetry (PostHog)
       - "timestamp.digicert.com:80"          # RFC 3161 timestamp authority (plain HTTP, signed response)
                                              # used during attestation signing; host comes from the
                                              # control plane's signing options


### PR DESCRIPTION
The traced-Claude sandbox kit (`devel/sandbox-kit`) set `DO_NOT_TRACK=1` and did not allow egress to the telemetry endpoint, so CLI usage from sessions run inside the sandbox was never reported.

This removes the `DO_NOT_TRACK` environment variable from the kit and adds `crb.chainloop.dev:443` to the kit's network allow rules, so those sessions report usage like any other CLI invocation. The host is deliberately kept out of `NO_PROXY`, since telemetry is plain HTTPS and does not need the proxy bypass that the gRPC endpoints require.

AI disclosure: this change was produced with the assistance of Claude Code.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chainloop-dev/chainloop/pull/3382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

