### PR TITLE
feat(devel): allow buf.build egress in the sandbox kit

### DIFF
--- a/devel/sandbox-kit/spec.yaml
+++ b/devel/sandbox-kit/spec.yaml
@@ -368,6 +368,9 @@ permissions:                                 # v1: `network.allowedDomains:`
       - "timestamp.digicert.com:80"          # RFC 3161 timestamp authority (plain HTTP, signed response)
                                              # used during attestation signing; host comes from the
                                              # control plane's signing options
+      - "buf.build:443"                      # Buf Schema Registry - `make api` / `buf generate`
+                                             # resolve the buf.yaml module deps and the remote
+                                             # plugins declared in the buf.gen.yaml files
       - "dl.chainloop.dev:443"               # EE CLI installer
       - "chainloop-baafegchfnekdcde.z02.azurefd.net:443"  # EE CLI download CDN
       - "github.com:443"                     # git push over HTTPS in persistent mode - the


### PR DESCRIPTION
Adds `buf.build:443` to the Docker Sandboxes kit egress allowlist so protobuf code generation works inside the sandbox. The Buf Schema Registry is dialed by `make api` / `buf generate` to resolve both the `buf.yaml` module dependencies and the remote plugins declared in the `buf.gen.yaml` files.

AI disclosure: this change was produced with the assistance of Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chainloop-dev/chainloop/pull/3385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

