### PR TITLE
chore(devel): allow download.chainloop.dev egress in the sandbox kit

### DIFF
--- a/devel/sandbox-kit/spec.yaml
+++ b/devel/sandbox-kit/spec.yaml
@@ -369,7 +369,9 @@ permissions:                                 # v1: `network.allowedDomains:`
                                              # used during attestation signing; host comes from the
                                              # control plane's signing options
       - "dl.chainloop.dev:443"               # EE CLI installer
-      - "chainloop-baafegchfnekdcde.z02.azurefd.net:443"  # EE CLI download CDN
+      - "download.chainloop.dev:443"         # EE CLI download CDN (vanity host in front of the
+                                             # azurefd origin below; newer installers use it)
+      - "chainloop-baafegchfnekdcde.z02.azurefd.net:443"  # EE CLI download CDN (azurefd origin)
       - "github.com:443"                     # git push over HTTPS in persistent mode - the
                                              # pre-push attestation egresses on push. Other
                                              # forges/self-hosted: add your own host here.


### PR DESCRIPTION
Adds `download.chainloop.dev:443` to the traced Docker sandbox kit's network allowlist (`devel/sandbox-kit/spec.yaml`), alongside the existing azurefd CDN origin, so the EE CLI installer can fetch binaries through the vanity download host.

AI disclosure: this change was produced with the assistance of Claude Code; the commit carries an `Assisted-by: Claude Code` trailer.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chainloop-dev/chainloop/pull/3389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

