### PR TITLE
feat(devel): allow download.chainloop.dev egress in the sandbox kit

### DIFF
--- a/devel/sandbox-kit/spec.yaml
+++ b/devel/sandbox-kit/spec.yaml
@@ -372,6 +372,7 @@ permissions:                                 # v1: `network.allowedDomains:`
                                              # resolve the buf.yaml module deps and the remote
                                              # plugins declared in the buf.gen.yaml files
       - "dl.chainloop.dev:443"               # EE CLI installer
+      - "download.chainloop.dev:443"         # CLI binary downloads the installer fetches
       - "chainloop-baafegchfnekdcde.z02.azurefd.net:443"  # EE CLI download CDN
       - "github.com:443"                     # git push over HTTPS in persistent mode - the
                                              # pre-push attestation egresses on push. Other


### PR DESCRIPTION
Adds `download.chainloop.dev:443` to the traced sandbox kit's egress allowlist, alongside the existing `dl.chainloop.dev` installer host, so CLI binary downloads are not blocked by the deny-by-default network policy.

AI disclosure: this change was produced with Claude Code.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chainloop-dev/chainloop/pull/3391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

