### PR TITLE
fix(cli): make "run" the canonical name of the workflow run command

### DIFF
--- a/app/cli/cmd/workflow_workflow_run.go
+++ b/app/cli/cmd/workflow_workflow_run.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 The Chainloop Authors.
+// Copyright 2023-2026 The Chainloop Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,8 +21,10 @@ import (
 
 func newWorkflowWorkflowRunCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "workflow-run",
-		Aliases: []string{"run"},
+		// Keep "run" as the canonical name so the usage and help output read
+		// "chainloop workflow run" instead of "chainloop workflow workflow-run".
+		Use:     "run",
+		Aliases: []string{"workflow-run"},
 		Short:   "Workflow Runs related operations",
 	}
 

--- a/app/cli/cmd/workflow_workflow_run_test.go
+++ b/app/cli/cmd/workflow_workflow_run_test.go
@@ -1,0 +1,72 @@
+//
+// Copyright 2026 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The workflow run command is reachable both as "run" and through its legacy
+// "workflow-run" alias, but the usage/help output must always advertise the
+// canonical "chainloop workflow run" path.
+func TestWorkflowRunCommandPath(t *testing.T) {
+	const (
+		workflowCmd  = "workflow"
+		canonicalRun = "chainloop workflow run"
+	)
+
+	testCases := []struct {
+		name         string
+		args         []string
+		expectedPath string
+	}{
+		{
+			name:         "canonical name",
+			args:         []string{workflowCmd, "run"},
+			expectedPath: canonicalRun,
+		},
+		{
+			name:         "legacy workflow-run alias",
+			args:         []string{workflowCmd, "workflow-run"},
+			expectedPath: canonicalRun,
+		},
+		{
+			name:         "canonical name through the workflow alias",
+			args:         []string{"wf", "run"},
+			expectedPath: canonicalRun,
+		},
+		{
+			name:         "subcommand keeps the canonical parent path",
+			args:         []string{workflowCmd, "workflow-run", "describe"},
+			expectedPath: "chainloop workflow run describe",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := &cobra.Command{Use: appName}
+			root.AddCommand(newWorkflowCmd())
+
+			cmd, _, err := root.Find(tc.args)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedPath, cmd.CommandPath())
+		})
+	}
+}

--- a/app/cli/documentation/cli-reference.mdx
+++ b/app/cli/documentation/cli-reference.mdx
@@ -4110,50 +4110,14 @@ Options inherited from parent commands
 -y, --yes                       Skip confirmation
 ```
 
-### chainloop workflow update
-
-Update an existing workflow
-
-```
-chainloop workflow update [flags]
-```
-
-Options
-
-```
---contract string      the name of an existing contract
---description string   workflow description
--h, --help                 help for update
---name string          workflow name
---project string       project name
---team string          team name
-```
-
-Options inherited from parent commands
-
-```
---artifact-cas string       URL for the Artifacts Content Addressable Storage API ($CHAINLOOP_ARTIFACT_CAS_API) (default "api.cas.chainloop.dev:443")
---artifact-cas-ca string    CUSTOM CA file for the Artifacts CAS API (optional) ($CHAINLOOP_ARTIFACT_CAS_API_CA)
--c, --config string             Path to an existing config file (default is $HOME/.config/chainloop/config.toml)
---control-plane string      URL for the Control Plane API ($CHAINLOOP_CONTROL_PLANE_API) (default "api.cp.chainloop.dev:443")
---control-plane-ca string   CUSTOM CA file for the Control Plane API (optional) ($CHAINLOOP_CONTROL_PLANE_API_CA)
---debug                     Enable debug/verbose logging mode
--i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
---max-recv-msg-size int     Max size in bytes for incoming gRPC messages (0 = default 33554432) ($CHAINLOOP_API_MAX_RECV_MSG_SIZE)
--n, --org string                organization name
--o, --output string             Output format, valid options are json and table (default "table")
--t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
--y, --yes                       Skip confirmation
-```
-
-### chainloop workflow workflow-run
+### chainloop workflow run
 
 Workflow Runs related operations
 
 Options
 
 ```
--h, --help   help for workflow-run
+-h, --help   help for run
 ```
 
 Options inherited from parent commands
@@ -4173,12 +4137,12 @@ Options inherited from parent commands
 -y, --yes                       Skip confirmation
 ```
 
-#### chainloop workflow workflow-run describe
+#### chainloop workflow run describe
 
 View a Workflow Run
 
 ```
-chainloop workflow workflow-run describe [flags]
+chainloop workflow run describe [flags]
 ```
 
 Options
@@ -4210,17 +4174,17 @@ Options inherited from parent commands
 -y, --yes                       Skip confirmation
 ```
 
-#### chainloop workflow workflow-run help
+#### chainloop workflow run help
 
 Help about any command
 
 Synopsis
 
 Help provides help for any command in the application.
-Simply type workflow-run help [path to command] for full details.
+Simply type run help [path to command] for full details.
 
 ```
-chainloop workflow workflow-run help [command] [flags]
+chainloop workflow run help [command] [flags]
 ```
 
 Options
@@ -4246,12 +4210,12 @@ Options inherited from parent commands
 -y, --yes                       Skip confirmation
 ```
 
-#### chainloop workflow workflow-run list
+#### chainloop workflow run list
 
 List workflow runs
 
 ```
-chainloop workflow workflow-run list [flags]
+chainloop workflow run list [flags]
 ```
 
 Options
@@ -4266,6 +4230,42 @@ Options
 --status string          filter by workflow run status: [CANCELLED EXPIRED FAILED INITIALIZED SUCCEEDED]
 --version string         project version name, e.g. v1.2.0 (requires --project)
 --workflow string        workflow name
+```
+
+Options inherited from parent commands
+
+```
+--artifact-cas string       URL for the Artifacts Content Addressable Storage API ($CHAINLOOP_ARTIFACT_CAS_API) (default "api.cas.chainloop.dev:443")
+--artifact-cas-ca string    CUSTOM CA file for the Artifacts CAS API (optional) ($CHAINLOOP_ARTIFACT_CAS_API_CA)
+-c, --config string             Path to an existing config file (default is $HOME/.config/chainloop/config.toml)
+--control-plane string      URL for the Control Plane API ($CHAINLOOP_CONTROL_PLANE_API) (default "api.cp.chainloop.dev:443")
+--control-plane-ca string   CUSTOM CA file for the Control Plane API (optional) ($CHAINLOOP_CONTROL_PLANE_API_CA)
+--debug                     Enable debug/verbose logging mode
+-i, --insecure                  Skip TLS transport during connection to the control plane ($CHAINLOOP_API_INSECURE)
+--max-recv-msg-size int     Max size in bytes for incoming gRPC messages (0 = default 33554432) ($CHAINLOOP_API_MAX_RECV_MSG_SIZE)
+-n, --org string                organization name
+-o, --output string             Output format, valid options are json and table (default "table")
+-t, --token string              API token. NOTE: Alternatively use the env variable CHAINLOOP_TOKEN
+-y, --yes                       Skip confirmation
+```
+
+### chainloop workflow update
+
+Update an existing workflow
+
+```
+chainloop workflow update [flags]
+```
+
+Options
+
+```
+--contract string      the name of an existing contract
+--description string   workflow description
+-h, --help                 help for update
+--name string          workflow name
+--project string       project name
+--team string          team name
 ```
 
 Options inherited from parent commands


### PR DESCRIPTION
The workflow run command was registered as `workflow-run` with `run` as an alias, so its usage and help output advertised the redundant `chainloop workflow workflow-run` path.

Swaps them: `run` is now the canonical name and `workflow-run` remains an alias, so existing invocations keep working. The generated CLI reference documentation is updated accordingly.

Closes PFM-7268

Assisted-by: Claude Code

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chainloop-dev/chainloop/pull/3431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

