### PR TITLE
fix: update s3 backend MinIO test image

### DIFF
--- a/pkg/blobmanager/s3/backend_test.go
+++ b/pkg/blobmanager/s3/backend_test.go
@@ -345,7 +345,9 @@ func newMinioInstance(t *testing.T) *minioInstance {
 	const port = "9000/tcp"
 
 	req := testcontainers.ContainerRequest{
-		Image:        "minio/minio:RELEASE.2023-09-04T19-57-37Z",
+		// Pinned to a fixed digest to keep the test reproducible; update the digest manually to adopt new MinIO releases.
+		// https://quay.io/repository/minio/minio/manifest/sha256:a1a8bd4ac40ad7881a245bab97323e18f971e4d4cba2c2007ec1bedd21cbaba2
+		Image:        "quay.io/minio/minio@sha256:a1a8bd4ac40ad7881a245bab97323e18f971e4d4cba2c2007ec1bedd21cbaba2",
 		ExposedPorts: []string{port},
 		Env: map[string]string{
 			"MINIO_ROOT_USER":     "root",


### PR DESCRIPTION
It seems that the DockerHub mirror for `minio` was removed, this PR changes it to the one in Quay.io:
https://quay.io/organization/minio


## Summary

- Update the MinIO image reference used by the S3 backend test suite.
- Keep the test container dependency pinned to a stable image reference.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chainloop-dev/chainloop/pull/3437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

