### PR TITLE
ci: bump ossf/scorecard-action to v2.4.4

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -47,7 +47,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
Closes PFM-7296

## Summary

Upgrades `ossf/scorecard-action` from v2.4.0 to v2.4.4 in the Scorecard supply-chain security workflow.

v2.4.0 pulls its container image from `gcr.io/openssf/scorecard-action`, which now fails with a "billing not enabled" error because OpenSSF has wound down its Google Cloud infrastructure (ossf/scorecard#5208). The Scorecard analysis job fails at the image pull step before any analysis runs. v2.4.4 pulls the container from GitHub Container Registry and is the minimum version OpenSSF recommends after the migration.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chainloop-dev/chainloop/pull/3438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

